### PR TITLE
chore(backoffice): rename popup to event in visible UI labels

### DIFF
--- a/backoffice/src/routes/_layout/popups/index.tsx
+++ b/backoffice/src/routes/_layout/popups/index.tsx
@@ -70,7 +70,7 @@ export const Route = createFileRoute("/_layout/popups/")({
   component: Popups,
   validateSearch: validateTableSearch,
   head: () => ({
-    meta: [{ title: "Popups - EdgeOS" }],
+    meta: [{ title: "Events - EdgeOS" }],
   }),
 })
 
@@ -79,7 +79,7 @@ function AddPopupButton() {
     <Button asChild>
       <Link to="/popups/new">
         <Plus className="mr-2 h-4 w-4" />
-        Add Popup
+        Add Event
       </Link>
     </Button>
   )
@@ -99,7 +99,7 @@ function DeletePopup({
   const mutation = useMutation({
     mutationFn: () => PopupsService.deletePopup({ popupId: popup.id }),
     onSuccess: () => {
-      showSuccessToast("Popup deleted successfully")
+      showSuccessToast("Event deleted successfully")
       setIsOpen(false)
       onSuccess()
     },
@@ -119,7 +119,7 @@ function DeletePopup({
       </DropdownMenuItem>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete Popup</DialogTitle>
+          <DialogTitle>Delete Event</DialogTitle>
           <DialogDescription>
             Are you sure you want to delete "{popup.name}"? This action cannot
             be undone.
@@ -149,7 +149,7 @@ function PopupActionsMenu({ popup }: { popup: PopupPublic }) {
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" aria-label="Popup actions">
+        <Button variant="ghost" size="icon" aria-label="Event actions">
           <EllipsisVertical className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
@@ -263,13 +263,13 @@ function PopupsTableContent() {
         !search ? (
           <EmptyState
             icon={CalendarDays}
-            title="No popups yet"
-            description="Create your first popup to start managing events."
+            title="No events yet"
+            description="Create your first event to start managing them."
             action={
               <Button asChild>
                 <Link to="/popups/new">
                   <Plus className="mr-2 h-4 w-4" />
-                  Add Popup
+                  Add Event
                 </Link>
               </Button>
             }
@@ -303,15 +303,15 @@ function Popups() {
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>Select a tenant</AlertTitle>
           <AlertDescription>
-            Please select a tenant from the sidebar to view and manage popups.
+            Please select a tenant from the sidebar to view and manage events.
           </AlertDescription>
         </Alert>
       )}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Popups</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Events</h1>
           <p className="text-muted-foreground">
-            Manage your popups and their configurations
+            Manage your events and their configurations
           </p>
         </div>
         {canManagePopups && <AddPopupButton />}


### PR DESCRIPTION
## Summary

Rename visible "Popup" labels to "Event" in the backoffice popups index page to align with the naming already used in the create and edit views.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Changes Made

- Renamed all user-visible "Popup" strings to "Event" in `backoffice/src/routes/_layout/popups/index.tsx` (page title, headings, buttons, dialogs, toasts, empty state)

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality
- [x] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [ ] Database migrations are included if schema changed