### PR TITLE
fix(invoice): remove redundant title, use SimpleFi ID, and fix NaN payment ID in portal

### DIFF
--- a/backend/app/core/invoice.py
+++ b/backend/app/core/invoice.py
@@ -179,10 +179,6 @@ def generate_invoice_pdf(
                 "Failed to load invoice header image from %s", header_image_url
             )
 
-    # ---- Title ---------------------------------------------------------------
-    flow.append(Paragraph("Invoice", styles["Header"]))
-    flow.append(Spacer(1, 6))
-
     # ---- Two-column header (seller | invoice meta) ---------------------------
     left = [
         Paragraph(escape(invoice_company_name), styles["Body"]),
@@ -191,7 +187,7 @@ def generate_invoice_pdf(
     ]
     right = [
         Paragraph(f"Date: {_format_date(payment.created_at)}", styles["Right"]),
-        Paragraph(f"Invoice #: {payment.id}", styles["Right"]),
+        Paragraph(f"Invoice #: {payment.external_id or payment.id}", styles["Right"]),
         Paragraph(f"Bill to: {escape(client_name)}", styles["Right"]),
     ]
 

--- a/portal/src/app/portal/[popupSlug]/passes/components/Payments/PaymentHistory.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/Payments/PaymentHistory.tsx
@@ -24,7 +24,7 @@ const PaymentHistory = ({ payments }: { payments: PaymentsProps[] }) => {
   const approvedPayments = payments?.filter(
     (payment) => payment.status === "approved",
   )
-  const [downloadingId, setDownloadingId] = useState<number | null>(null)
+  const [downloadingId, setDownloadingId] = useState<string | null>(null)
 
   if (!approvedPayments || approvedPayments.length === 0) {
     return (

--- a/portal/src/hooks/useGetPaymentsData.ts
+++ b/portal/src/hooks/useGetPaymentsData.ts
@@ -7,8 +7,8 @@ import type { PaymentsProps } from "@/types/passes"
 
 function mapPayment(p: PaymentPublic): PaymentsProps {
   return {
-    id: Number(p.id),
-    application_id: Number(p.application_id),
+    id: p.id,
+    application_id: p.application_id,
     external_id: p.external_id ?? null,
     status: (p.status ?? "pending") as PaymentsProps["status"],
     amount: Number(p.amount ?? 0),
@@ -18,8 +18,8 @@ function mapPayment(p: PaymentPublic): PaymentsProps {
     checkout_url: p.checkout_url ?? null,
     products_snapshot: (p.products_snapshot ?? []).map(
       (ps: PaymentProductResponse) => ({
-        product_id: Number(ps.product_id),
-        attendee_id: Number(ps.attendee_id),
+        product_id: ps.product_id,
+        attendee_id: ps.attendee_id,
         quantity: ps.quantity ?? 1,
         product_name: ps.product_name ?? "",
         product_description: ps.product_description ?? null,

--- a/portal/src/types/passes.ts
+++ b/portal/src/types/passes.ts
@@ -13,8 +13,8 @@ export interface AttendeePassesProps {
 }
 
 export interface ProductsSnapshotProps {
-  product_id: number
-  attendee_id: number
+  product_id: string
+  attendee_id: string
   quantity: number
   product_name: string
   product_description: string | null
@@ -24,7 +24,8 @@ export interface ProductsSnapshotProps {
 }
 
 export interface PaymentsProps {
-  application_id: number
+  id: string
+  application_id: string
   external_id: string | null
   status: "approved" | "pending" | "rejected"
   amount: number
@@ -35,5 +36,4 @@ export interface PaymentsProps {
   products_snapshot: ProductsSnapshotProps[]
   created_at: string
   updated_at: string
-  id: number
 }


### PR DESCRIPTION
## Summary
- Remove redundant "Invoice" title below header image in generated PDF
- Use SimpleFi `external_id` instead of UUID for invoice number (with UUID fallback)
- Fix portal invoice download hitting `/payments/my/NaN/invoice` by correcting UUID fields from `number` to `string` in `PaymentsProps` types and payment mapper