### PR TITLE
fix(backoffice): restrict email templates for viewer role

### DIFF
--- a/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
+++ b/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { ArrowLeft } from "lucide-react"
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 
 import { EmailTemplatesService, type EmailTemplateType } from "@/client"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
@@ -10,6 +10,7 @@ import { EmailTemplateEditor } from "@/components/EmailTemplateEditor"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
+import useAuth from "@/hooks/useAuth"
 
 export const Route = createFileRoute("/_layout/email-templates/$type/edit")({
   component: EditEmailTemplate,
@@ -74,6 +75,18 @@ function EditorContent({ templateType }: { templateType: string }) {
 function EditEmailTemplate() {
   const { type } = Route.useParams()
   const { isContextReady } = useWorkspace()
+  const { isAdmin, isUserLoading } = useAuth()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!isUserLoading && !isAdmin) {
+      navigate({ to: "/email-templates" })
+    }
+  }, [isAdmin, isUserLoading, navigate])
+
+  if (isUserLoading || !isAdmin) {
+    return null
+  }
 
   if (!isContextReady) {
     return (

--- a/backoffice/src/routes/_layout/email-templates/index.tsx
+++ b/backoffice/src/routes/_layout/email-templates/index.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
+import useAuth from "@/hooks/useAuth"
 
 export const Route = createFileRoute("/_layout/email-templates/")({
   component: EmailTemplatesPage,
@@ -95,6 +96,18 @@ function TemplateList() {
 
 function EmailTemplatesPage() {
   const { isContextReady } = useWorkspace()
+  const { isAdmin } = useAuth()
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <h1 className="text-2xl font-bold tracking-tight">Email Templates</h1>
+        <p className="text-muted-foreground">
+          You need admin permissions to manage email templates.
+        </p>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- Viewers could navigate to email template pages and interact with the editor UI (writes would fail with 403 but the UI was fully accessible)
- Added admin role guards to email template pages following the same pattern as form-builder
- Main page shows permission message for viewers; edit page redirects to list

## Test plan
- [x] Log in as VIEWER → navigate to Email Templates → should see "You need admin permissions" message
- [x] Log in as VIEWER → go directly to `/email-templates/{type}/edit` → should redirect to `/email-templates`
- [x] Log in as ADMIN → email templates work as before (list, edit, save)