### PR TITLE
feat(payments): support popup sale currency and settlement metadata

### DIFF
--- a/backend/app/alembic/versions/7f8b4af4a2c1_add_currency_columns.py
+++ b/backend/app/alembic/versions/7f8b4af4a2c1_add_currency_columns.py
@@ -1,0 +1,46 @@
+"""Add currency columns to popups and payment_products.
+
+Adds popup-level currency selection (USD/ARS/EUR) and snapshots the product
+currency on payment_products so downstream documents keep the original sale
+currency even if payment settlement metadata changes.
+
+Revision ID: 7f8b4af4a2c1
+Revises: 3e11ce245531
+Create Date: 2026-04-17
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "7f8b4af4a2c1"
+down_revision = "3e11ce245531"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "popups",
+        sa.Column(
+            "currency",
+            sa.String(3),
+            nullable=False,
+            server_default="USD",
+        ),
+    )
+
+    op.add_column(
+        "payment_products",
+        sa.Column(
+            "product_currency",
+            sa.String(3),
+            nullable=False,
+            server_default="USD",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("payment_products", "product_currency")
+    op.drop_column("popups", "currency")

--- a/backend/app/alembic/versions/9b1f9c8e4d2a_add_settlement_currency_to_payments.py
+++ b/backend/app/alembic/versions/9b1f9c8e4d2a_add_settlement_currency_to_payments.py
@@ -1,0 +1,43 @@
+"""Add settlement currency to payments.
+
+Separates the commercial sale currency from the currency/coin used to settle the
+payment, so user-facing documents can stay aligned with popup pricing while
+still preserving minimal settlement details.
+
+Revision ID: 9b1f9c8e4d2a
+Revises: 7f8b4af4a2c1
+Create Date: 2026-04-17
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "9b1f9c8e4d2a"
+down_revision = "7f8b4af4a2c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "payments",
+        sa.Column("settlement_currency", sa.String(length=16), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE payments AS payment
+        SET
+            settlement_currency = payment.currency,
+            currency = popup.currency
+        FROM popups AS popup
+        WHERE payment.popup_id = popup.id
+          AND payment.source = 'SimpleFI'
+          AND payment.currency IS DISTINCT FROM popup.currency
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("payments", "settlement_currency")

--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -29,6 +29,7 @@ from app.api.dashboard.schemas import (
 )
 from app.api.payment.models import PaymentProducts, Payments
 from app.api.payment.schemas import PaymentStatus, PaymentType
+from app.api.popup.crud import popups_crud
 from app.api.product.models import Products
 from app.api.product.schemas import CATEGORY_HOUSING, CATEGORY_TICKET
 from app.core.dependencies.users import CurrentUser, TenantSession
@@ -219,21 +220,8 @@ def _get_key_metrics(
     # Accommodation percentage: attendees with housing product / total main attendees
     accommodation_pct = _get_accommodation_percentage(db, popup_id, people)
 
-    # Detect currency from latest approved payment
-    currency = "USD"
-    latest_currency = db.exec(
-        select(Payments.currency)
-        .join(Applications, Payments.application_id == Applications.id)
-        .where(
-            Applications.popup_id == popup_id,
-            Payments.status == PaymentStatus.APPROVED.value,
-            Payments.payment_type == PaymentType.PASS_PURCHASE.value,
-        )
-        .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
-        .limit(1)
-    ).first()
-    if latest_currency:
-        currency = latest_currency
+    popup = popups_crud.get(db, popup_id)
+    currency = popup.currency if popup else "USD"
 
     return KeyMetrics(
         people=people,

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -226,7 +226,11 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             )
 
         # 2. Validate popup is configured for fee
-        if not getattr(popup, "requires_application_fee", False) or not getattr(popup, "application_fee_amount", None) or popup.application_fee_amount <= 0:
+        if (
+            not getattr(popup, "requires_application_fee", False)
+            or not getattr(popup, "application_fee_amount", None)
+            or popup.application_fee_amount <= 0
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Popup is not configured to require an application fee",
@@ -314,6 +318,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 amount=fee_amount,
                 popup_slug=popup.slug,
                 tenant_slug=popup.tenant.slug,
+                currency=popup.currency,
                 reference=reference,
                 memo=f"Application fee – {popup.name}",
                 portal_base_override=portal_base,
@@ -334,7 +339,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             popup_id=application.popup_id,
             status=simplefi_response.status,
             amount=fee_amount,
-            currency="USD",
+            currency=popup.currency,
             external_id=simplefi_response.id,
             checkout_url=simplefi_response.checkout_url,
             source=PaymentSource.SIMPLEFI.value,
@@ -608,7 +613,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             products=obj.products,
             original_amount=Decimal("0"),
             amount=Decimal("0"),
-            currency="USD",
+            currency=application.popup.currency if application.popup else "USD",
             edit_passes=obj.edit_passes,
             discount_value=discount_assigned,
         )
@@ -829,6 +834,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         product_description=product.description,
                         product_price=product.price,
                         product_category=product.category or "",
+                        product_currency=preview.currency,
                     )
                     session.add(payment_product)
 
@@ -896,6 +902,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 amount=preview.amount,
                 popup_slug=application.popup.slug,
                 tenant_slug=application.popup.tenant.slug,
+                currency=preview.currency,
                 reference=reference,
                 memo=application.popup.tenant.name,
                 portal_base_override=get_portal_url(application.popup.tenant),
@@ -943,6 +950,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     product_description=product.description,
                     product_price=product.price,
                     product_category=product.category or "",
+                    product_currency=preview.currency,
                 )
                 session.add(payment_product)
 
@@ -1068,7 +1076,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 popup_id=popup.id,
                 status=PaymentStatus.APPROVED.value,
                 amount=Decimal("0"),
-                currency="USD",
+                currency=popup.currency,
                 source=None,
             )
             session.add(payment)
@@ -1086,6 +1094,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     product_description=product.description,
                     product_price=product.price,
                     product_category=product.category or "",
+                    product_currency=popup.currency,
                 )
                 session.add(pp)
 
@@ -1136,6 +1145,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 amount=amount,
                 popup_slug=popup.slug,
                 tenant_slug=tenant.slug,
+                currency=popup.currency,
                 reference=reference,
                 memo=f"{popup.name} — direct purchase",
                 portal_base_override=portal_base,
@@ -1153,7 +1163,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             popup_id=popup.id,
             status=simplefi_response.status,
             amount=amount,
-            currency="USD",
+            currency=popup.currency,
             external_id=simplefi_response.id,
             checkout_url=simplefi_response.checkout_url,
             source=PaymentSource.SIMPLEFI.value,
@@ -1173,6 +1183,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 product_description=product.description,
                 product_price=product.price,
                 product_category=product.category or "",
+                product_currency=popup.currency,
             )
             session.add(pp)
 
@@ -1185,8 +1196,9 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         session: Session,
         payment_id: uuid.UUID,
         *,
-        currency: str | None = None,
+        settlement_currency: str | None = None,
         rate: Decimal | None = None,
+        source: str | None = None,
     ) -> Payments:
         """
         Approve a payment and add products to attendees.
@@ -1205,20 +1217,17 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             return payment  # Already approved
 
         try:
-            # Use existing currency or default to USD for manual approvals
-            final_currency = currency or payment.currency or "USD"
-            source = (
-                PaymentSource.STRIPE
-                if final_currency == "USD"
-                else PaymentSource.SIMPLEFI
-            )
-
             # Set payment fields directly (no intermediate commit)
             payment.status = PaymentStatus.APPROVED.value
-            payment.currency = final_currency
+            if not payment.currency:
+                payment.currency = "USD"
+            payment.settlement_currency = (
+                settlement_currency or payment.settlement_currency
+            )
             if rate is not None:
                 payment.rate = rate
-            payment.source = source.value
+            if source is not None:
+                payment.source = source
             session.add(payment)
 
             # Clear existing products if editing passes

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -1,4 +1,5 @@
 import uuid
+from decimal import Decimal
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from sqlmodel import Session
@@ -38,6 +39,46 @@ from app.services.email import (
 from app.services.email_helpers import send_application_status_email
 
 router = APIRouter(prefix="/payments", tags=["payments"])
+
+
+def _normalize_payment_source(provider: str | None) -> str:
+    """Normalize provider labels from SimpleFI to local payment sources."""
+    if not provider:
+        return "SimpleFI"
+
+    normalized = provider.strip().lower()
+    if normalized == "stripe":
+        return "Stripe"
+    if normalized in {"mercadopago", "mercado pago", "mercado_pago"}:
+        return "MercadoPago"
+    return provider.strip()
+
+
+def _extract_settlement_details(
+    payload: SimpleFIWebhookPayload,
+) -> tuple[str | None, Decimal | None, str]:
+    """Extract settlement currency, rate, and visible source from a webhook."""
+    payment_request = payload.data.payment_request
+    settlement_currency = None
+    settlement_rate = None
+
+    if payload.data.new_payment is not None:
+        settlement_currency = payload.data.new_payment.coin
+
+    card_payment = payment_request.card_payment
+    if card_payment is not None:
+        settlement_currency = card_payment.coin or settlement_currency
+        source = _normalize_payment_source(card_payment.provider)
+    else:
+        source = "SimpleFI"
+
+    if settlement_currency:
+        for transaction in payment_request.transactions:
+            if transaction.coin == settlement_currency:
+                settlement_rate = Decimal(str(transaction.price_details.rate))
+                break
+
+    return settlement_currency, settlement_rate, source
 
 
 async def _send_payment_confirmed_email(payment, db_session=None) -> None:
@@ -318,7 +359,11 @@ async def update_payment(
     return PaymentPublic.model_validate(payment)
 
 
-@router.post("/my/application-fee", response_model=PaymentPublic, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/my/application-fee",
+    response_model=PaymentPublic,
+    status_code=status.HTTP_201_CREATED,
+)
 async def create_my_application_fee(
     fee_in: ApplicationFeeCreate,
     db: HumanTenantSession,
@@ -631,8 +676,6 @@ async def _handle_regular_payment(
     webhook_cache: WebhookCache,
 ) -> dict:
     """Handle new_payment/new_card_payment for regular (non-installment) payments."""
-    from decimal import Decimal
-
     from loguru import logger
 
     payment_request_id = payload.data.payment_request.id
@@ -667,24 +710,26 @@ async def _handle_regular_payment(
         )
         return {"message": "Payment status unchanged"}
 
-    # Extract currency and rate from transaction
-    currency = "USD"
-    rate = Decimal("1")
-    if payload.data.new_payment:
-        currency = payload.data.new_payment.coin
-        for t in payload.data.payment_request.transactions:
-            if t.coin == currency:
-                rate = Decimal(str(t.price_details.rate))
-                break
+    settlement_currency, settlement_rate, source = _extract_settlement_details(payload)
 
     if payment_request_status == "approved":
         from app.api.payment.schemas import PaymentType
 
         if payment.payment_type == PaymentType.APPLICATION_FEE.value:
-            await _handle_fee_payment_approved(db, payment, currency=currency, rate=rate)
+            await _handle_fee_payment_approved(
+                db,
+                payment,
+                settlement_currency=settlement_currency,
+                rate=settlement_rate,
+                source=source,
+            )
         else:
             payment = payments_crud.approve_payment(
-                db, payment.id, currency=currency, rate=rate
+                db,
+                payment.id,
+                settlement_currency=settlement_currency,
+                rate=settlement_rate,
+                source=source,
             )
             await _send_payment_confirmed_email(payment, db_session=db)
         logger.info("Payment {} approved via SimpleFI webhook", payment.id)
@@ -703,8 +748,9 @@ async def _handle_fee_payment_approved(
     db: Session,
     payment: Payments,
     *,
-    currency: str = "USD",
-    rate: object = None,
+    settlement_currency: str | None = None,
+    rate: Decimal | None = None,
+    source: str = "SimpleFI",
 ) -> None:
     """Handle approval of an application fee payment.
 
@@ -716,25 +762,23 @@ async def _handle_fee_payment_approved(
 
     from app.api.application.crud import applications_crud
     from app.api.application.schemas import ApplicationStatus
-    from app.api.payment.schemas import PaymentSource, PaymentStatus
+    from app.api.payment.schemas import PaymentStatus
 
     status_before = ApplicationStatus.PENDING_FEE.value
 
     # Approve the payment record first
     payment.status = PaymentStatus.APPROVED.value
-    payment.currency = currency
+    payment.settlement_currency = settlement_currency
     if rate is not None:
         payment.rate = rate
-    payment.source = PaymentSource.SIMPLEFI.value
+    payment.source = source
     db.add(payment)
     db.flush()
 
     # Load application
     application = applications_crud.get(db, payment.application_id)
     if not application:
-        logger.warning(
-            "Fee payment {} has no associated application", payment.id
-        )
+        logger.warning("Fee payment {} has no associated application", payment.id)
         db.commit()
         return
 
@@ -783,7 +827,6 @@ async def _handle_installment_payment(
 ) -> dict:
     """Handle new_payment/new_card_payment for installment plans."""
     from datetime import UTC, datetime
-    from decimal import Decimal
 
     from loguru import logger
 
@@ -815,6 +858,8 @@ async def _handle_installment_payment(
         )
 
     # Extract payment details
+    settlement_currency, settlement_rate, source = _extract_settlement_details(payload)
+
     if isinstance(new_payment, SimpleFIPaymentInfo):
         amount = Decimal(str(new_payment.amount))
         currency = new_payment.coin
@@ -840,7 +885,13 @@ async def _handle_installment_payment(
     # First installment: approve payment to assign products
     is_first_installment = (payment.installments_paid or 0) == 0
     if is_first_installment and payment.status != "approved":
-        payment = payments_crud.approve_payment(db, payment.id, currency=currency)
+        payment = payments_crud.approve_payment(
+            db,
+            payment.id,
+            settlement_currency=settlement_currency,
+            rate=settlement_rate,
+            source=source,
+        )
         logger.info("First installment received - payment {} approved", payment.id)
 
     # Increment installments_paid
@@ -909,7 +960,7 @@ async def _handle_installment_plan_completed(
         "Payment %s not approved when installment_plan_completed received", payment.id
     )
     payment.installments_paid = installment_plan.paid_installments_count
-    payment = payments_crud.approve_payment(db, payment.id, currency="USD")
+    payment = payments_crud.approve_payment(db, payment.id)
     await _send_payment_confirmed_email(payment, db_session=db)
 
     return {"message": "Installment plan payment approved successfully"}

--- a/backend/app/api/payment/schemas.py
+++ b/backend/app/api/payment/schemas.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
-from sqlalchemy import Integer, Numeric, Text
+from sqlalchemy import Integer, Numeric, String, Text
 from sqlmodel import Column, Field, SQLModel
 
 
@@ -16,10 +16,11 @@ class PaymentType(str, Enum):
 
 
 class PaymentSource(str, Enum):
-    """Payment source/provider."""
+    """Settlement rail/provider shown to users."""
 
     SIMPLEFI = "SimpleFI"
     STRIPE = "Stripe"
+    MERCADOPAGO = "MercadoPago"
 
 
 class PaymentStatus(str, Enum):
@@ -50,6 +51,10 @@ class PaymentProductBase(SQLModel):
     product_description: str | None = Field(default=None, sa_type=Text())
     product_price: Decimal = Field(sa_column=Column(Numeric(10, 2), nullable=False))
     product_category: str
+    product_currency: str = Field(
+        default="USD",
+        sa_column=Column(String(3), nullable=False, server_default="USD"),
+    )
 
 
 class PaymentBase(SQLModel):
@@ -70,6 +75,10 @@ class PaymentBase(SQLModel):
         sa_column=Column(Numeric(10, 2), nullable=False, server_default="0"),
     )
     currency: str = Field(default="USD")
+    settlement_currency: str | None = Field(
+        default=None,
+        sa_column=Column(String(16), nullable=True),
+    )
     rate: Decimal | None = Field(
         default=None, sa_column=Column(Numeric(18, 8), nullable=True)
     )
@@ -122,6 +131,7 @@ class PaymentProductResponse(BaseModel):
     product_description: str | None = None
     product_price: Decimal
     product_category: str
+    product_currency: str
     attendee_name: str | None = None
     created_at: datetime
 
@@ -232,6 +242,7 @@ class PaymentUpdate(BaseModel):
     source: PaymentSource | None = None
     rate: Decimal | None = None
     currency: str | None = None
+    settlement_currency: str | None = None
 
 
 class PaymentFilter(BaseModel):

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -4,13 +4,24 @@ from decimal import Decimal
 from enum import StrEnum
 from typing import Self
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from sqlalchemy import Boolean, Column, Numeric
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlmodel import Field, SQLModel, String
 
 from app.api.shared.enums import SaleType
 from app.utils.utils import slugify
+
+ALLOWED_CURRENCIES = ("USD", "ARS", "EUR")
+
+
+def validate_currency_value(value: str | None) -> str | None:
+    if value is None:
+        return value
+    normalized = value.upper()
+    if normalized not in ALLOWED_CURRENCIES:
+        raise ValueError(f"currency must be one of {ALLOWED_CURRENCIES}")
+    return normalized
 
 
 class PopupStatus(StrEnum):
@@ -55,6 +66,7 @@ class PopupBase(SQLModel):
     invoice_company_name: str | None = None
     invoice_company_address: str | None = None
     invoice_company_email: str | None = None
+    currency: str = Field(default="USD", max_length=3)
     requires_application_fee: bool = Field(
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
@@ -72,6 +84,11 @@ class PopupBase(SQLModel):
         default=["en"],
         sa_column=Column(ARRAY(String), nullable=False, server_default="{en}"),
     )
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency(cls, value: str) -> str:
+        return validate_currency_value(value) or "USD"
 
 
 class PopupCreate(SQLModel):
@@ -100,11 +117,17 @@ class PopupCreate(SQLModel):
     invoice_company_name: str | None = None
     invoice_company_address: str | None = None
     invoice_company_email: str | None = None
+    currency: str = Field(default="USD", max_length=3)
     requires_application_fee: bool = False
     application_fee_amount: Decimal | None = None
     theme_config: dict | None = None
     default_language: str = "en"
     supported_languages: list[str] = ["en"]
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency(cls, value: str) -> str:
+        return validate_currency_value(value) or "USD"
 
     @model_validator(mode="after")
     def generate_slug(self) -> Self:
@@ -142,11 +165,17 @@ class PopupUpdate(SQLModel):
     invoice_company_name: str | None = None
     invoice_company_address: str | None = None
     invoice_company_email: str | None = None
+    currency: str | None = Field(default=None, max_length=3)
     requires_application_fee: bool | None = None
     application_fee_amount: Decimal | None = None
     theme_config: dict | None = None
     default_language: str | None = None
     supported_languages: list[str] | None = None
+
+    @field_validator("currency")
+    @classmethod
+    def validate_currency(cls, value: str | None) -> str | None:
+        return validate_currency_value(value)
 
     @model_validator(mode="after")
     def validate_fee_config(self) -> Self:
@@ -181,6 +210,7 @@ class PopupPublic(SQLModel):
     allows_children: bool | None = False
     allows_coupons: bool | None = False
     allows_scholarship: bool = False
+    currency: str = "USD"
     terms_and_conditions_url: str | None = None
     invoice_company_name: str | None = None
     requires_application_fee: bool = False

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -721,6 +721,7 @@ def _seed_payments(
             status=payment_data.get("status", "pending"),
             amount=Decimal(payment_data.get("amount", "0")),
             currency=payment_data.get("currency", "USD"),
+            settlement_currency=payment_data.get("settlement_currency"),
             source=payment_data.get("source"),
             external_id=payment_data.get("external_id"),
             coupon_id=coupon_id,
@@ -778,6 +779,7 @@ def _seed_payments(
                 product_description=product.description,
                 product_price=product.price,
                 product_category=product.category,
+                product_currency="USD",
             )
             session.add(payment_product)
             session.commit()

--- a/backend/app/core/invoice.py
+++ b/backend/app/core/invoice.py
@@ -48,14 +48,21 @@ def _format_money(value: float, decimals: int = 2) -> str:
     return s.replace(",", "X").replace(".", ",").replace("X", ".")
 
 
-def _is_crypto_currency(code: str) -> bool:
-    return code.upper() in ("BTC", "ETH")
+CURRENCY_SYMBOLS: dict[str, str] = {"USD": "$", "ARS": "$", "EUR": "€"}
 
 
-def _format_currency(value: float, currency: str) -> str:
-    """Format a value with appropriate decimal places for the currency."""
-    decimals = 8 if _is_crypto_currency(currency) else 2
-    return _format_money(value, decimals)
+def _get_sale_currency(payment: Payments) -> str:
+    for item in payment.products_snapshot:
+        if item.product_currency:
+            return item.product_currency
+    return payment.currency or "USD"
+
+
+def _format_fiat_amount(value: float, currency: str) -> str:
+    symbol = CURRENCY_SYMBOLS.get(currency)
+    if symbol:
+        return f"{symbol}{_format_money(value)}"
+    return f"{_format_money(value)} {currency}"
 
 
 # ---- Cropped Image Flowable -------------------------------------------------
@@ -206,41 +213,26 @@ def generate_invoice_pdf(
     flow.append(Spacer(1, 12))
 
     # ---- Products table ------------------------------------------------------
-    payment_rate = float(payment.rate) if payment.rate else 1.0
-    payment_currency = payment.currency or "USD"
-
     headers = ["Qty", "Description", "Unit Price", "Amount"]
-    show_rate = payment_rate > 1
-    if show_rate:
-        headers.insert(3, "Rate")
-
     table_data: list[list[str | Paragraph]] = [list(headers)]
+    sale_currency = _get_sale_currency(payment)
 
-    subtotal_usd = 0.0
+    subtotal_amount = 0.0
     for item in payment.products_snapshot:
-        unit_price_usd = float(item.product_price)
+        line_currency = item.product_currency or sale_currency
+        unit_price = float(item.product_price)
         qty = int(item.quantity)
-        line_total_usd = unit_price_usd * qty
-        subtotal_usd += line_total_usd
+        line_total = unit_price * qty
+        subtotal_amount += line_total
 
         desc_para = Paragraph(escape(item.product_name), styles["Body"])
 
-        if show_rate:
-            line_in_currency = line_total_usd / payment_rate
-            row: list[str | Paragraph] = [
-                str(qty),
-                desc_para,
-                f"{_format_money(unit_price_usd)} USD",
-                f"1 {payment_currency} = {_format_money(payment_rate)} USD",
-                f"{_format_currency(line_in_currency, payment_currency)} {payment_currency}",
-            ]
-        else:
-            row = [
-                str(qty),
-                desc_para,
-                f"{_format_money(unit_price_usd)} USD",
-                f"{_format_money(line_total_usd)} USD",
-            ]
+        row: list[str | Paragraph] = [
+            str(qty),
+            desc_para,
+            _format_fiat_amount(unit_price, line_currency),
+            _format_fiat_amount(line_total, line_currency),
+        ]
         table_data.append(row)
 
     # ---- Column widths (auto-size) -------------------------------------------
@@ -248,7 +240,6 @@ def generate_invoice_pdf(
     qty_min = 10 * mm
     unit_min = 24 * mm
     amount_min = 28 * mm
-    rate_min = 36 * mm
     desc_min = 30 * mm
 
     def _measure(text: str, bold: bool = False) -> float:
@@ -263,18 +254,15 @@ def generate_invoice_pdf(
             col_max[c_idx] = max(col_max[c_idx], w)
 
     pad = 10
-    # Assign widths: qty=0, desc=1, unit=2, [rate=3], amount=last
+    # Assign widths: qty=0, desc=1, unit=2, amount=3
     qty_w = max(qty_min, col_max[0] + pad)
     unit_w = max(unit_min, col_max[2] + pad)
     amount_w = max(amount_min, col_max[-1] + pad)
-    rate_w = max(rate_min, col_max[3] + pad) if show_rate else 0
 
-    other_sum = qty_w + unit_w + amount_w + rate_w
+    other_sum = qty_w + unit_w + amount_w
     desc_w = max(desc_min, doc.width - other_sum)
 
     col_widths = [qty_w, desc_w, unit_w]
-    if show_rate:
-        col_widths.append(rate_w)
     col_widths.append(amount_w)
 
     # ---- Table style ---------------------------------------------------------
@@ -303,7 +291,7 @@ def generate_invoice_pdf(
     # ---- Footer: Subtotal / Discount / Total ---------------------------------
     payment_amount = float(payment.amount)
     discount_value = float(payment.discount_value) if payment.discount_value else 0.0
-    has_discount = discount_value > 0 or payment_amount < subtotal_usd
+    has_discount = discount_value > 0 or payment_amount < subtotal_amount
 
     # Build discount label
     discount_label = "Discount"
@@ -314,21 +302,10 @@ def generate_invoice_pdf(
     elif discount_value > 0:
         discount_label = f"Discount ({discount_value:.0f}%)"
 
-    # Convert amounts for crypto
-    if show_rate:
-        subtotal_display = _format_currency(
-            subtotal_usd / payment_rate, payment_currency
-        )
-        total_display = _format_currency(
-            payment_amount / payment_rate, payment_currency
-        )
-        discount_amount = (subtotal_usd - payment_amount) / payment_rate
-        discount_display = _format_currency(discount_amount, payment_currency)
-    else:
-        subtotal_display = _format_money(subtotal_usd)
-        total_display = _format_money(payment_amount)
-        discount_amount = subtotal_usd - payment_amount
-        discount_display = _format_money(discount_amount)
+    subtotal_display = _format_fiat_amount(subtotal_amount, sale_currency)
+    total_display = _format_fiat_amount(payment_amount, sale_currency)
+    discount_amount = subtotal_amount - payment_amount
+    discount_display = _format_fiat_amount(discount_amount, sale_currency)
 
     footer_data: list[list[str | Paragraph]] = []
 
@@ -336,26 +313,20 @@ def generate_invoice_pdf(
         footer_data.append(
             [
                 Paragraph("Subtotal:", styles["Right"]),
-                Paragraph(f"{subtotal_display} {payment_currency}", styles["Right"]),
+                Paragraph(subtotal_display, styles["Right"]),
             ]
         )
         footer_data.append(
             [
                 Paragraph(f"{escape(discount_label)}:", styles["Right"]),
-                Paragraph(
-                    f"-{discount_display} {payment_currency}",
-                    styles["Right"],
-                ),
+                Paragraph(f"-{discount_display}", styles["Right"]),
             ]
         )
 
     footer_data.append(
         [
             Paragraph("<b>Total:</b>", styles["BoldRight"]),
-            Paragraph(
-                f"<b>{total_display} {payment_currency}</b>",
-                styles["BoldRight"],
-            ),
+            Paragraph(f"<b>{total_display}</b>", styles["BoldRight"]),
         ]
     )
 

--- a/backend/app/services/email/service.py
+++ b/backend/app/services/email/service.py
@@ -40,6 +40,9 @@ if TYPE_CHECKING:
     from app.api.payment.models import Payments
 
 
+CURRENCY_SYMBOLS: dict[str, str] = {"USD": "$", "ARS": "$", "EUR": "€"}
+
+
 @dataclass
 class EmailAttachment:
     """A file attachment for an email."""
@@ -58,9 +61,12 @@ def compute_order_summary(payment: "Payments") -> str:
     lines: list[str] = []
     for ps in payment.products_snapshot:
         attendee_name = ps.attendee.name if ps.attendee else "N/A"
+        currency = ps.product_currency or payment.currency or "USD"
+        symbol = CURRENCY_SYMBOLS.get(currency)
+        price = f"{float(ps.product_price):.2f}"
+        display_price = f"{symbol}{price}" if symbol else f"{price} {currency}"
         lines.append(
-            f"<strong>{ps.product_name}</strong> ({attendee_name})"
-            f" — ${float(ps.product_price):.2f}"
+            f"<strong>{ps.product_name}</strong> ({attendee_name}) — {display_price}"
         )
     return "<br>".join(lines)
 

--- a/backend/app/services/simplefi/client.py
+++ b/backend/app/services/simplefi/client.py
@@ -80,7 +80,11 @@ class SimpleFIClient:
 
         with httpx.Client(timeout=self.timeout) as client:
             response = client.request(method, url, json=json, headers=headers)
-            logger.info("SimpleFI API response status: {}, body: {}", response.status_code, response.text)
+            logger.info(
+                "SimpleFI API response status: {}, body: {}",
+                response.status_code,
+                response.text,
+            )
             response.raise_for_status()
             return response.json()
 
@@ -89,6 +93,7 @@ class SimpleFIClient:
         amount: Decimal,
         popup_slug: str,
         tenant_slug: str,
+        currency: str = "USD",
         reference: dict[str, Any] | None = None,
         memo: str = "EdgeOS Payment",
         portal_base_override: str | None = None,
@@ -99,10 +104,11 @@ class SimpleFIClient:
         Create a payment request in SimpleFI.
 
         Args:
-            amount: The payment amount in USD
+            amount: The payment amount
             popup_slug: The popup slug for building portal redirect URLs
             tenant_slug: The tenant slug for the portal subdomain (used as
                 fallback when ``portal_base_override`` is not provided)
+            currency: The payment currency code (e.g. USD, ARS, EUR)
             reference: Optional reference data (application_id, email, products)
             portal_base_override: If provided, used as the portal base URL
                 instead of the default subdomain derivation.  Pass
@@ -121,12 +127,15 @@ class SimpleFIClient:
         )
 
         portal_base = portal_base_override or self._build_tenant_portal_url(tenant_slug)
-        success_url = success_path or f"{portal_base}/portal/{popup_slug}/passes/buy?checkout=success"
+        success_url = (
+            success_path
+            or f"{portal_base}/portal/{popup_slug}/passes/buy?checkout=success"
+        )
         cancel_url = cancel_path or f"{portal_base}/portal/{popup_slug}/passes/buy"
 
         body = {
             "amount": float(amount),
-            "currency": "USD",
+            "currency": currency,
             "reference": reference or {},
             "memo": memo,
             "notification_url": notification_url,
@@ -145,7 +154,9 @@ class SimpleFIClient:
             checkout_url=data["checkout_v2_url"],
         )
 
-    def get_payment_request_status(self, payment_request_id: str) -> SimpleFIPaymentRequestStatus:
+    def get_payment_request_status(
+        self, payment_request_id: str
+    ) -> SimpleFIPaymentRequestStatus:
         """Fetch the latest status for an existing SimpleFI payment request."""
 
         data = self._make_request("GET", f"/payment_requests/{payment_request_id}")

--- a/backend/tests/test_payment_settlement_metadata.py
+++ b/backend/tests/test_payment_settlement_metadata.py
@@ -1,0 +1,137 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.api.payment.router import _extract_settlement_details
+from app.api.payment.schemas import SimpleFIWebhookPayload
+from app.services.email.service import compute_order_summary
+
+
+def test_extract_settlement_details_for_crypto_payment() -> None:
+    payload = SimpleFIWebhookPayload.model_validate(
+        {
+            "id": "evt-1",
+            "event_type": "new_payment",
+            "entity_type": "payment_request",
+            "entity_id": "pr-1",
+            "data": {
+                "payment_request": {
+                    "id": "pr-1",
+                    "order_id": 1,
+                    "amount": 120.0,
+                    "amount_paid": 0.0013,
+                    "currency": "USD",
+                    "reference": {},
+                    "status": "approved",
+                    "status_detail": "approved",
+                    "transactions": [
+                        {
+                            "id": "tx-1",
+                            "coin": "BTC",
+                            "chain_id": 1,
+                            "status": "approved",
+                            "price_details": {
+                                "currency": "USD",
+                                "final_amount": 120.0,
+                                "rate": 92000.0,
+                            },
+                        }
+                    ],
+                    "card_payment": None,
+                    "payments": [
+                        {
+                            "coin": "BTC",
+                            "hash": "hash-1",
+                            "amount": 0.0013,
+                            "paid_at": "2026-04-17T12:00:00Z",
+                        }
+                    ],
+                    "installment_plan_id": None,
+                },
+                "new_payment": {
+                    "coin": "BTC",
+                    "hash": "hash-1",
+                    "amount": 0.0013,
+                    "paid_at": "2026-04-17T12:00:00Z",
+                },
+            },
+        }
+    )
+
+    settlement_currency, settlement_rate, source = _extract_settlement_details(payload)
+
+    assert settlement_currency == "BTC"
+    assert settlement_rate == Decimal("92000.0")
+    assert source == "SimpleFI"
+
+
+def test_extract_settlement_details_for_card_provider() -> None:
+    payload = SimpleFIWebhookPayload.model_validate(
+        {
+            "id": "evt-2",
+            "event_type": "new_card_payment",
+            "entity_type": "payment_request",
+            "entity_id": "pr-2",
+            "data": {
+                "payment_request": {
+                    "id": "pr-2",
+                    "order_id": 2,
+                    "amount": 150000.0,
+                    "amount_paid": 150000.0,
+                    "currency": "ARS",
+                    "reference": {},
+                    "status": "approved",
+                    "status_detail": "approved",
+                    "transactions": [
+                        {
+                            "id": "tx-2",
+                            "coin": "ARS",
+                            "chain_id": 0,
+                            "status": "approved",
+                            "price_details": {
+                                "currency": "ARS",
+                                "final_amount": 150000.0,
+                                "rate": 1.0,
+                            },
+                        }
+                    ],
+                    "card_payment": {
+                        "provider": "mercado pago",
+                        "status": "approved",
+                        "coin": "ARS",
+                    },
+                    "payments": [],
+                    "installment_plan_id": None,
+                },
+                "new_payment": {
+                    "provider": "mercado pago",
+                    "status": "approved",
+                    "coin": "ARS",
+                },
+            },
+        }
+    )
+
+    settlement_currency, settlement_rate, source = _extract_settlement_details(payload)
+
+    assert settlement_currency == "ARS"
+    assert settlement_rate == Decimal("1.0")
+    assert source == "MercadoPago"
+
+
+def test_compute_order_summary_uses_snapshot_currency() -> None:
+    payment = SimpleNamespace(
+        currency="BTC",
+        products_snapshot=[
+            SimpleNamespace(
+                product_name="VIP Pass",
+                attendee=SimpleNamespace(name="Ana"),
+                product_price=Decimal("120.00"),
+                product_currency="EUR",
+            )
+        ],
+    )
+
+    summary = compute_order_summary(payment)
+
+    assert "€120.00" in summary
+    assert "BTC" not in summary

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -5585,6 +5585,10 @@ export const PaymentProductResponseSchema = {
             type: 'string',
             title: 'Product Category'
         },
+        product_currency: {
+            type: 'string',
+            title: 'Product Currency'
+        },
         attendee_name: {
             anyOf: [
                 {
@@ -5603,7 +5607,7 @@ export const PaymentProductResponseSchema = {
         }
     },
     type: 'object',
-    required: ['product_id', 'attendee_id', 'quantity', 'product_name', 'product_price', 'product_category', 'created_at'],
+    required: ['product_id', 'attendee_id', 'quantity', 'product_name', 'product_price', 'product_category', 'product_currency', 'created_at'],
     title: 'PaymentProductResponse',
     description: 'Payment product snapshot in response.'
 } as const;
@@ -5664,6 +5668,17 @@ export const PaymentPublicSchema = {
             type: 'string',
             title: 'Currency',
             default: 'USD'
+        },
+        settlement_currency: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Settlement Currency'
         },
         rate: {
             anyOf: [
@@ -5830,9 +5845,9 @@ export const PaymentPublicSchema = {
 
 export const PaymentSourceSchema = {
     type: 'string',
-    enum: ['SimpleFI', 'Stripe'],
+    enum: ['SimpleFI', 'Stripe', 'MercadoPago'],
     title: 'PaymentSource',
-    description: 'Payment source/provider.'
+    description: 'Settlement rail/provider shown to users.'
 } as const;
 
 export const PaymentStatsSchema = {
@@ -5979,6 +5994,17 @@ export const PaymentUpdateSchema = {
                 }
             ],
             title: 'Currency'
+        },
+        settlement_currency: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Settlement Currency'
         }
     },
     type: 'object',
@@ -6221,6 +6247,12 @@ export const PopupAdminSchema = {
                 }
             ],
             title: 'Invoice Company Email'
+        },
+        currency: {
+            type: 'string',
+            maxLength: 3,
+            title: 'Currency',
+            default: 'USD'
         },
         requires_application_fee: {
             type: 'boolean',
@@ -6535,6 +6567,12 @@ export const PopupCreateSchema = {
             ],
             title: 'Invoice Company Email'
         },
+        currency: {
+            type: 'string',
+            maxLength: 3,
+            title: 'Currency',
+            default: 'USD'
+        },
         requires_application_fee: {
             type: 'boolean',
             title: 'Requires Application Fee',
@@ -6761,6 +6799,11 @@ export const PopupPublicSchema = {
             type: 'boolean',
             title: 'Allows Scholarship',
             default: false
+        },
+        currency: {
+            type: 'string',
+            title: 'Currency',
+            default: 'USD'
         },
         terms_and_conditions_url: {
             anyOf: [
@@ -7206,6 +7249,18 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Invoice Company Email'
+        },
+        currency: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 3
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Currency'
         },
         requires_application_fee: {
             anyOf: [

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1191,6 +1191,7 @@ export type PaymentProductResponse = {
     product_description?: (string | null);
     product_price: string;
     product_category: string;
+    product_currency: string;
     attendee_name?: (string | null);
     created_at: string;
 };
@@ -1207,6 +1208,7 @@ export type PaymentPublic = {
     amount?: string;
     insurance_amount?: string;
     currency?: string;
+    settlement_currency?: (string | null);
     rate?: (string | null);
     source?: (string | null);
     checkout_url?: (string | null);
@@ -1226,9 +1228,9 @@ export type PaymentPublic = {
 };
 
 /**
- * Payment source/provider.
+ * Settlement rail/provider shown to users.
  */
-export type PaymentSource = 'SimpleFI' | 'Stripe';
+export type PaymentSource = 'SimpleFI' | 'Stripe' | 'MercadoPago';
 
 /**
  * Statistics for payments.
@@ -1268,6 +1270,7 @@ export type PaymentUpdate = {
     source?: (PaymentSource | null);
     rate?: (number | string | null);
     currency?: (string | null);
+    settlement_currency?: (string | null);
 };
 
 /**
@@ -1299,6 +1302,7 @@ export type PopupAdmin = {
     invoice_company_name?: (string | null);
     invoice_company_address?: (string | null);
     invoice_company_email?: (string | null);
+    currency?: string;
     requires_application_fee?: boolean;
     application_fee_amount?: (string | null);
     theme_config?: ({
@@ -1335,6 +1339,7 @@ export type PopupCreate = {
     invoice_company_name?: (string | null);
     invoice_company_address?: (string | null);
     invoice_company_email?: (string | null);
+    currency?: string;
     requires_application_fee?: boolean;
     application_fee_amount?: (number | string | null);
     theme_config?: ({
@@ -1367,6 +1372,7 @@ export type PopupPublic = {
     allows_children?: (boolean | null);
     allows_coupons?: (boolean | null);
     allows_scholarship?: boolean;
+    currency?: string;
     terms_and_conditions_url?: (string | null);
     invoice_company_name?: (string | null);
     requires_application_fee?: boolean;
@@ -1434,6 +1440,7 @@ export type PopupUpdate = {
     invoice_company_name?: (string | null);
     invoice_company_address?: (string | null);
     invoice_company_email?: (string | null);
+    currency?: (string | null);
     requires_application_fee?: (boolean | null);
     application_fee_amount?: (number | string | null);
     theme_config?: ({

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -82,6 +82,12 @@ const AVAILABLE_LANGUAGES = [
   { value: "zh", label: "中文" },
 ] as const
 
+const CURRENCIES = [
+  { value: "USD", label: "USD — US Dollar" },
+  { value: "ARS", label: "ARS — Argentine Peso" },
+  { value: "EUR", label: "EUR — Euro" },
+] as const
+
 const SALE_TYPE_COPY = {
   application: {
     label: "Popup / application flow",
@@ -188,6 +194,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
       icon_url: defaultValues?.icon_url ?? "",
       express_checkout_background:
         defaultValues?.express_checkout_background ?? "",
+      currency: defaultValues?.currency ?? "USD",
       web_url: defaultValues?.web_url ?? "",
       blog_url: defaultValues?.blog_url ?? "",
       twitter_url: defaultValues?.twitter_url ?? "",
@@ -224,6 +231,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
         image_url: value.image_url || null,
         icon_url: value.icon_url || null,
         express_checkout_background: value.express_checkout_background || null,
+        currency: value.currency,
         web_url: value.web_url || null,
         blog_url: value.blog_url || null,
         twitter_url: value.twitter_url || null,
@@ -427,6 +435,35 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                       <SelectItem value="direct">
                         {SALE_TYPE_COPY.direct.label}
                       </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </InlineRow>
+              )}
+            </form.Field>
+
+            <form.Field name="currency">
+              {(field) => (
+                <InlineRow
+                  icon={
+                    <DollarSign className="h-4 w-4 text-muted-foreground" />
+                  }
+                  label="Currency"
+                  description="Currency used for products, fees, invoices, and checkout totals"
+                >
+                  <Select
+                    value={field.state.value}
+                    onValueChange={(value) => field.handleChange(value)}
+                    disabled={readOnly}
+                  >
+                    <SelectTrigger className="w-[220px] text-sm" size="sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CURRENCIES.map((currency) => (
+                        <SelectItem key={currency.value} value={currency.value}>
+                          {currency.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </InlineRow>
@@ -673,9 +710,12 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
           </form.Field>
 
           <form.Subscribe
-            selector={(state) => state.values.requires_application_fee}
+            selector={(state) => ({
+              requiresFee: state.values.requires_application_fee,
+              currency: state.values.currency,
+            })}
           >
-            {(requiresFee) =>
+            {({ requiresFee, currency }) =>
               requiresFee ? (
                 <form.Field name="application_fee_amount">
                   {(field) => (
@@ -683,8 +723,8 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                       icon={
                         <DollarSign className="h-4 w-4 text-muted-foreground" />
                       }
-                      label="Fee Amount (USD)"
-                      description="Amount in USD that applicants must pay"
+                      label={`Fee Amount (${currency})`}
+                      description={`Amount in ${currency} that applicants must pay`}
                     >
                       <Input
                         id="application_fee_amount"

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -5585,6 +5585,10 @@ export const PaymentProductResponseSchema = {
             type: 'string',
             title: 'Product Category'
         },
+        product_currency: {
+            type: 'string',
+            title: 'Product Currency'
+        },
         attendee_name: {
             anyOf: [
                 {
@@ -5603,7 +5607,7 @@ export const PaymentProductResponseSchema = {
         }
     },
     type: 'object',
-    required: ['product_id', 'attendee_id', 'quantity', 'product_name', 'product_price', 'product_category', 'created_at'],
+    required: ['product_id', 'attendee_id', 'quantity', 'product_name', 'product_price', 'product_category', 'product_currency', 'created_at'],
     title: 'PaymentProductResponse',
     description: 'Payment product snapshot in response.'
 } as const;
@@ -5664,6 +5668,17 @@ export const PaymentPublicSchema = {
             type: 'string',
             title: 'Currency',
             default: 'USD'
+        },
+        settlement_currency: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Settlement Currency'
         },
         rate: {
             anyOf: [
@@ -5830,9 +5845,9 @@ export const PaymentPublicSchema = {
 
 export const PaymentSourceSchema = {
     type: 'string',
-    enum: ['SimpleFI', 'Stripe'],
+    enum: ['SimpleFI', 'Stripe', 'MercadoPago'],
     title: 'PaymentSource',
-    description: 'Payment source/provider.'
+    description: 'Settlement rail/provider shown to users.'
 } as const;
 
 export const PaymentStatsSchema = {
@@ -5979,6 +5994,17 @@ export const PaymentUpdateSchema = {
                 }
             ],
             title: 'Currency'
+        },
+        settlement_currency: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Settlement Currency'
         }
     },
     type: 'object',
@@ -6221,6 +6247,12 @@ export const PopupAdminSchema = {
                 }
             ],
             title: 'Invoice Company Email'
+        },
+        currency: {
+            type: 'string',
+            maxLength: 3,
+            title: 'Currency',
+            default: 'USD'
         },
         requires_application_fee: {
             type: 'boolean',
@@ -6535,6 +6567,12 @@ export const PopupCreateSchema = {
             ],
             title: 'Invoice Company Email'
         },
+        currency: {
+            type: 'string',
+            maxLength: 3,
+            title: 'Currency',
+            default: 'USD'
+        },
         requires_application_fee: {
             type: 'boolean',
             title: 'Requires Application Fee',
@@ -6761,6 +6799,11 @@ export const PopupPublicSchema = {
             type: 'boolean',
             title: 'Allows Scholarship',
             default: false
+        },
+        currency: {
+            type: 'string',
+            title: 'Currency',
+            default: 'USD'
         },
         terms_and_conditions_url: {
             anyOf: [
@@ -7206,6 +7249,18 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Invoice Company Email'
+        },
+        currency: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 3
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Currency'
         },
         requires_application_fee: {
             anyOf: [

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1191,6 +1191,7 @@ export type PaymentProductResponse = {
     product_description?: (string | null);
     product_price: string;
     product_category: string;
+    product_currency: string;
     attendee_name?: (string | null);
     created_at: string;
 };
@@ -1207,6 +1208,7 @@ export type PaymentPublic = {
     amount?: string;
     insurance_amount?: string;
     currency?: string;
+    settlement_currency?: (string | null);
     rate?: (string | null);
     source?: (string | null);
     checkout_url?: (string | null);
@@ -1226,9 +1228,9 @@ export type PaymentPublic = {
 };
 
 /**
- * Payment source/provider.
+ * Settlement rail/provider shown to users.
  */
-export type PaymentSource = 'SimpleFI' | 'Stripe';
+export type PaymentSource = 'SimpleFI' | 'Stripe' | 'MercadoPago';
 
 /**
  * Statistics for payments.
@@ -1268,6 +1270,7 @@ export type PaymentUpdate = {
     source?: (PaymentSource | null);
     rate?: (number | string | null);
     currency?: (string | null);
+    settlement_currency?: (string | null);
 };
 
 /**
@@ -1299,6 +1302,7 @@ export type PopupAdmin = {
     invoice_company_name?: (string | null);
     invoice_company_address?: (string | null);
     invoice_company_email?: (string | null);
+    currency?: string;
     requires_application_fee?: boolean;
     application_fee_amount?: (string | null);
     theme_config?: ({
@@ -1335,6 +1339,7 @@ export type PopupCreate = {
     invoice_company_name?: (string | null);
     invoice_company_address?: (string | null);
     invoice_company_email?: (string | null);
+    currency?: string;
     requires_application_fee?: boolean;
     application_fee_amount?: (number | string | null);
     theme_config?: ({
@@ -1367,6 +1372,7 @@ export type PopupPublic = {
     allows_children?: (boolean | null);
     allows_coupons?: (boolean | null);
     allows_scholarship?: boolean;
+    currency?: string;
     terms_and_conditions_url?: (string | null);
     invoice_company_name?: (string | null);
     requires_application_fee?: boolean;
@@ -1434,6 +1440,7 @@ export type PopupUpdate = {
     invoice_company_name?: (string | null);
     invoice_company_address?: (string | null);
     invoice_company_email?: (string | null);
+    currency?: (string | null);
     requires_application_fee?: (boolean | null);
     application_fee_amount?: (number | string | null);
     theme_config?: ({


### PR DESCRIPTION
## Summary

Add popup sale currencies (USD/ARS/EUR) and keep settlement metadata separate so user-facing payment documents remain consistent across Stripe, MercadoPago, and crypto flows.

## Related Issue

Fixes #25

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- add popup currency and payment product currency snapshots, plus migrations and regenerated API clients
- separate sale currency from settlement currency in payment approval/webhook flows while reusing `source` as the visible settlement rail
- update invoices, email summaries, dashboard metrics, and backoffice popup configuration to use the correct commercial currency

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [x] Backoffice linting passes (`pnpm run lint` via `bash scripts/generate-client.sh`)
- [x] Manual testing performed

Additional verification performed:
- `uv run ruff check` on touched backend files
- `uv run pytest tests/test_payment_settlement_metadata.py tests/test_participation.py tests/test_human_attendee_link.py`
- local docker DB populated with USD/ARS/EUR + crypto examples for UI review

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [x] Database migrations are included if schema changed