### PR TITLE
fix(theme): decouple housing date toggles and apply navbar color over…

### DIFF
--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewCheckoutBottomBar.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewCheckoutBottomBar.tsx
@@ -30,7 +30,7 @@ export function PreviewCheckoutBottomBar() {
         style={{ color: "var(--checkout-bottom-bar-text)" }}
       >
         <ArrowLeft className="size-3.5" />
-        Volver
+        Back
       </button>
       <div className="flex min-w-0 flex-1 flex-col">
         <span
@@ -65,7 +65,7 @@ export function PreviewCheckoutBottomBar() {
           borderRadius: "var(--radius)",
         }}
       >
-        Continuar
+        Continue
       </button>
     </div>
   )

--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewCheckoutTopBar.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewCheckoutTopBar.tsx
@@ -18,11 +18,11 @@ interface Step {
 }
 
 const STEPS: Step[] = [
-  { id: "pases", label: "Pases", icon: Ticket, active: true },
-  { id: "alojamiento", label: "Alojamiento", icon: BedDouble },
-  { id: "experiencias", label: "Experiencias", icon: Sparkles },
-  { id: "galeria", label: "Galería", icon: ImageIcon },
-  { id: "continuar", label: "Continuar", icon: Check },
+  { id: "pases", label: "Passes", icon: Ticket, active: true },
+  { id: "alojamiento", label: "Housing", icon: BedDouble },
+  { id: "experiencias", label: "Experiences", icon: Sparkles },
+  { id: "galeria", label: "Gallery", icon: ImageIcon },
+  { id: "continuar", label: "Continue", icon: Check },
 ]
 
 // Replica del navbar sticky del checkout real: strip de pills con icono + label

--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewContext.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewContext.tsx
@@ -33,9 +33,9 @@ export function usePreview() {
 // Resolves a PreviewEvent field to its display value, falling back to a mock
 // when the popup form hasn't been filled in yet.
 const DISPLAY_FALLBACKS = {
-  name: "Mi Evento",
-  tagline: "Una descripción breve del evento",
-  location: "Ubicación",
+  name: "My Event",
+  tagline: "A brief event description",
+  location: "Location",
 }
 
 export function useDisplayEvent() {

--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewEventCard.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewEventCard.tsx
@@ -107,7 +107,7 @@ export function PreviewEventCard() {
                 borderRadius: "var(--radius)",
               }}
             >
-              Ver pases
+              View passes
             </button>
           </div>
         </div>

--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewHeaderBar.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewHeaderBar.tsx
@@ -34,14 +34,14 @@ export function PreviewHeaderBar() {
           className="h-3.5 w-3.5 shrink-0"
           style={{ color: "var(--nav-text-secondary)" }}
         />
-        <span style={{ color: "var(--nav-text-secondary)" }}>Aplicación</span>
+        <span style={{ color: "var(--nav-text-secondary)" }}>Application</span>
       </nav>
       <div className="ml-auto flex items-center gap-1 text-sm">
         <Globe
           className="h-3.5 w-3.5"
           style={{ color: "var(--nav-text-secondary)" }}
         />
-        <span style={{ color: "var(--nav-text)" }}>Español</span>
+        <span style={{ color: "var(--nav-text)" }}>English</span>
       </div>
     </header>
   )

--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewProgressBar.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewProgressBar.tsx
@@ -3,9 +3,9 @@
 // finished state visually. Labels kept short to avoid overlap at preview scale.
 
 const STAGES: { key: string; label: string }[] = [
-  { key: "draft", label: "Borrador" },
-  { key: "in_review", label: "Enviada" },
-  { key: "accepted", label: "Aceptada" },
+  { key: "draft", label: "Draft" },
+  { key: "in_review", label: "Submitted" },
+  { key: "accepted", label: "Accepted" },
 ]
 
 export function PreviewProgressBar() {

--- a/backoffice/src/components/forms/ThemePreview/parts/PreviewSidebar.tsx
+++ b/backoffice/src/components/forms/ThemePreview/parts/PreviewSidebar.tsx
@@ -70,7 +70,7 @@ export function PreviewSidebar() {
         </div>
       </div>
 
-      {/* Resources — "Tu Participación" */}
+      {/* Resources — "Your Participation" */}
       <div className="flex-1 overflow-hidden p-2">
         <div
           className="px-2 py-1.5 text-[10px] font-medium uppercase tracking-wider"
@@ -79,10 +79,10 @@ export function PreviewSidebar() {
               "color-mix(in oklab, var(--sidebar-foreground) 55%, transparent)",
           }}
         >
-          Tu Participación
+          Your Participation
         </div>
 
-        {/* Active item: Aplicación with "accepted" badge */}
+        {/* Active item: Application with "accepted" badge */}
         <div
           className={cn(
             "mb-0.5 flex items-center justify-between rounded-md px-2 py-1.5 text-sm",
@@ -96,15 +96,15 @@ export function PreviewSidebar() {
         >
           <div className="flex items-center gap-2">
             <FileText className="h-4 w-4" />
-            <span>Aplicación</span>
+            <span>Application</span>
           </div>
           <span className="rounded-full bg-green-100 px-1.5 py-0.5 text-[9px] font-medium text-green-800">
             accepted
           </span>
         </div>
 
-        <SidebarItem icon={Ticket} label="Pases" />
-        <SidebarItem icon={Users} label="Directorio de Asistentes" />
+        <SidebarItem icon={Ticket} label="Passes" />
+        <SidebarItem icon={Users} label="Attendee Directory" />
       </div>
 
       {/* Footer: EdgeOS + profile */}
@@ -122,7 +122,7 @@ export function PreviewSidebar() {
             49
           </span>
         </div>
-        <SidebarItem icon={User} label="Mi Perfil" />
+        <SidebarItem icon={User} label="My Profile" />
       </div>
 
       {/* Focus ring sample (only visible when sidebar_ring hovered) */}
@@ -134,7 +134,7 @@ export function PreviewSidebar() {
             color: "var(--sidebar-foreground)",
           }}
         >
-          Item con foco
+          Focused item
         </div>
       )}
     </aside>

--- a/backoffice/src/components/forms/ThemePreview/parts/dateFormat.ts
+++ b/backoffice/src/components/forms/ThemePreview/parts/dateFormat.ts
@@ -1,4 +1,4 @@
-const DATE_FORMATTER = new Intl.DateTimeFormat("es-AR", {
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
   month: "long",
   year: "numeric",
@@ -19,11 +19,11 @@ export function formatDateRange(
   if (s && e) return `${DATE_FORMATTER.format(s)} - ${DATE_FORMATTER.format(e)}`
   if (s) return DATE_FORMATTER.format(s)
   if (e) return DATE_FORMATTER.format(e)
-  return "Fechas por definir"
+  return "Dates TBD"
 }
 
 export function formatShortDate(iso: string | null): string {
   const d = parseDate(iso)
-  if (!d) return "Próximamente"
+  if (!d) return "Coming soon"
   return DATE_FORMATTER.format(d)
 }

--- a/backoffice/src/components/forms/ThemePreview/tabs/CheckoutView.tsx
+++ b/backoffice/src/components/forms/ThemePreview/tabs/CheckoutView.tsx
@@ -86,7 +86,7 @@ export function CheckoutView() {
             )}
             style={{ color: "var(--checkout-subtitle)" }}
           >
-            Experiencias
+            Experiences
           </div>
 
           <div className="flex items-start justify-between gap-4 px-4 pb-4">
@@ -103,7 +103,7 @@ export function CheckoutView() {
                   )}
                   style={{ color: "var(--checkout-title)" }}
                 >
-                  Ticket 4 Días
+                  4-Day Ticket
                 </span>
               </div>
               <span
@@ -113,7 +113,7 @@ export function CheckoutView() {
                 )}
                 style={{ color: "var(--checkout-subtitle)" }}
               >
-                20 nov → 24 nov
+                Nov 20 → Nov 24
               </span>
               <span
                 className={cn(
@@ -122,9 +122,9 @@ export function CheckoutView() {
                 )}
                 style={{ color: "var(--checkout-subtitle)" }}
               >
-                La entrada te brinda acceso a todas las actividades, talleres y
-                shows durante los cuatro días del festival. Podés participar de
-                Amanita Festival: 20 al 24 de Noviembre,...
+                This ticket gives you access to all activities, workshops and
+                shows during the four days of the festival. Join Amanita
+                Festival: November 20–24,...
               </span>
               <span
                 className={cn(
@@ -133,7 +133,7 @@ export function CheckoutView() {
                 )}
                 style={{ color: "var(--checkout-badge-bg)" }}
               >
-                Ver más
+                See more
               </span>
             </div>
             <span

--- a/backoffice/src/components/ticketing-step-builder/template-configs/HousingDateConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/HousingDateConfig.tsx
@@ -152,8 +152,8 @@ export function HousingDateConfig({
   productCategory,
 }: TemplateConfigProps) {
   const variant = (config?.variant as string) || "default"
-  const showDates =
-    config?.show_dates !== false && config?.price_per_day !== false
+  const showDates = config?.show_dates !== false
+  const pricePerDay = showDates && config?.price_per_day !== false
   const parsed = parseConfigSections(config)
 
   const { data: productsData } = useQuery({
@@ -220,10 +220,17 @@ export function HousingDateConfig({
     updateSections([...parsed.sections, newSection])
   }
 
-  const updateHousingDateMode = (enabled: boolean) => {
+  const updateShowDates = (enabled: boolean) => {
     onChange({
       ...config,
       show_dates: enabled,
+      ...(enabled ? {} : { price_per_day: false }),
+    })
+  }
+
+  const updatePricePerDay = (enabled: boolean) => {
+    onChange({
+      ...config,
       price_per_day: enabled,
     })
   }
@@ -292,12 +299,11 @@ export function HousingDateConfig({
         <div>
           <Label className="text-sm font-medium">Show date picker</Label>
           <p className="text-xs text-muted-foreground">
-            This is tied to Price per night. If customers can choose dates, the
-            housing product is sold per night. If not, it behaves like a flat
-            price ticket with no stay selection.
+            Let customers pick check-in and check-out dates. When disabled,
+            housing behaves like a flat-price ticket with no stay selection.
           </p>
         </div>
-        <Switch checked={showDates} onCheckedChange={updateHousingDateMode} />
+        <Switch checked={showDates} onCheckedChange={updateShowDates} />
       </div>
 
       <Separator />
@@ -312,12 +318,15 @@ export function HousingDateConfig({
         <div>
           <Label className="text-sm font-medium">Price per night</Label>
           <p className="text-xs text-muted-foreground">
-            This setting is tied to Show date picker. Disabling it also removes
-            date selection, since customers can no longer choose multiple
-            nights.
+            Multiply the product price by the number of nights. Requires the
+            date picker to be enabled.
           </p>
         </div>
-        <Switch checked={showDates} onCheckedChange={updateHousingDateMode} />
+        <Switch
+          checked={pricePerDay}
+          disabled={!showDates}
+          onCheckedChange={updatePricePerDay}
+        />
       </div>
 
       <Separator />

--- a/portal/src/app/checkout/components/PopupCheckoutContent.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.tsx
@@ -134,9 +134,9 @@ export const PopupCheckoutContent = ({
             <button
               type="button"
               aria-label={`Signed in as ${user.email}`}
-              className="flex size-9 shrink-0 items-center justify-center rounded-full bg-checkout-badge-bg text-checkout-badge-title shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="flex size-7 shrink-0 items-center justify-center rounded-full bg-checkout-badge-bg text-checkout-badge-title shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <UserRound className="size-4" />
+              <UserRound className="size-3.5" />
             </button>
           </PopoverTrigger>
           <PopoverContent align="end" className="w-auto max-w-[280px] p-3">

--- a/portal/src/app/globals.css
+++ b/portal/src/app/globals.css
@@ -111,7 +111,7 @@
 :root {
   --radius: 0.5rem;
   --border-radius: 0.5rem;
-  --background: oklch(1 0 0);
+  --background: #f5f5f5;
   --foreground: oklch(0.145 0 0);
   --heading: oklch(0.145 0 0);
   --heading-secondary: oklch(0.556 0.01 260);

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -86,7 +86,6 @@ function ScrollyCheckoutFlowInner({
   const scrollToIndexRef = useRef<((index: number) => void) | null>(null)
 
   const footerDesign = "pill" as const
-  const navDesign = "pills" as const
   const watermarkStyle: WatermarkStyle = "bold"
 
   const allSections = useMemo(() => {
@@ -182,11 +181,32 @@ function ScrollyCheckoutFlowInner({
       el.style.scrollSnapStop = "always"
     }
 
+    // While a programmatic scroll is in flight we lock the active section to
+    // the destination so the IntersectionObserver doesn't flip through every
+    // intermediate section as they pass under the viewport.
+    let scrollTargetId: string | null = null
+    let scrollTargetTimeout: number | null = null
+    const releaseScrollTarget = () => {
+      scrollTargetId = null
+      if (scrollTargetTimeout !== null) {
+        window.clearTimeout(scrollTargetTimeout)
+        scrollTargetTimeout = null
+      }
+    }
+
     const observer = new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting && entry.intersectionRatio >= 0.3) {
-            setActiveSection(entry.target.id)
+            const id = entry.target.id
+            if (scrollTargetId !== null) {
+              if (id === scrollTargetId) {
+                releaseScrollTarget()
+                setActiveSection(id)
+              }
+              continue
+            }
+            setActiveSection(id)
           }
         }
       },
@@ -196,16 +216,24 @@ function ScrollyCheckoutFlowInner({
 
     scrollToIndexRef.current = (index: number) => {
       const clamped = Math.max(0, Math.min(index, sectionsSnapshot.length - 1))
-      const el = document.getElementById(sectionsSnapshot[clamped].id)
+      const targetId = sectionsSnapshot[clamped].id
+      const el = document.getElementById(targetId)
       if (!el) return
       const reduceMotion = window.matchMedia(
         "(prefers-reduced-motion: reduce)",
       ).matches
+      scrollTargetId = targetId
+      if (scrollTargetTimeout !== null) {
+        window.clearTimeout(scrollTargetTimeout)
+      }
+      // Safety net in case the target never reaches the threshold (e.g. user
+      // interrupts the scroll). 1500ms covers smooth scroll across many steps.
+      scrollTargetTimeout = window.setTimeout(releaseScrollTarget, 1500)
       mainEl.scrollTo({
         top: getScrollTop(el),
         behavior: reduceMotion ? "auto" : "smooth",
       })
-      setActiveSection(sectionsSnapshot[clamped].id)
+      setActiveSection(targetId)
     }
 
     return () => {
@@ -220,6 +248,7 @@ function ScrollyCheckoutFlowInner({
       observer.disconnect()
       ro.disconnect()
       navRo.disconnect()
+      releaseScrollTarget()
       scrollToIndexRef.current = null
     }
   }, [allSections])
@@ -274,7 +303,6 @@ function ScrollyCheckoutFlowInner({
           const idx = allSections.findIndex((s) => s.id === sectionId)
           if (idx >= 0) scrollToIndexRef.current?.(idx)
         }}
-        variant={navDesign}
         extraContent={navExtraContent}
       />
       {allSections.map((section) => {

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  Check,
   Heart,
   HelpCircle,
   Home,
@@ -10,12 +11,11 @@ import {
   ShoppingBag,
   Ticket,
 } from "lucide-react"
-import { Fragment, type ReactNode } from "react"
+import type { ReactNode } from "react"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import type { CheckoutStep } from "@/types/checkout"
 
-export type NavDesign = "pills" | "progress" | "underline"
 export type FooterDesign = "pill" | "stripe" | "dock"
 export type WatermarkStyle = "none" | "ghost" | "stroke" | "bold"
 
@@ -44,11 +44,16 @@ function resolveIcon(section: { id: string; template?: string | null }) {
   return SECTION_ICONS[section.id] ?? Ticket
 }
 
+interface NavSection {
+  id: string
+  label: string
+  template?: string | null
+}
+
 interface ScrollySectionNavProps {
-  sections: { id: string; label: string; template?: string | null }[]
+  sections: NavSection[]
   activeSection: string
   onSectionClick: (sectionId: string) => void
-  variant?: NavDesign
   extraContent?: ReactNode
 }
 
@@ -56,180 +61,64 @@ export default function ScrollySectionNav({
   sections,
   activeSection,
   onSectionClick,
-  variant = "pills",
   extraContent,
 }: ScrollySectionNavProps) {
   const { isStepComplete } = useCheckout()
 
-  const getSectionState = (section: { id: string }) => {
-    const isActive = section.id === activeSection
-    const isComplete = !isActive && isStepComplete(section.id as CheckoutStep)
-    return { isActive, isComplete }
-  }
+  const activeIndex = Math.max(
+    0,
+    sections.findIndex((s) => s.id === activeSection),
+  )
+  const segmentWidthPct = sections.length > 0 ? 100 / sections.length : 100
 
   return (
-    <div
-      data-snap-nav
-      className="sticky top-0 z-20 bg-checkout-navbar-bg backdrop-blur-md"
-    >
-      <div className="max-w-4xl mx-auto px-4 py-2">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div className="min-w-0 flex-1">
-            {variant === "pills" && (
-              <PillsNav
-                sections={sections}
-                getSectionState={getSectionState}
-                onSectionClick={onSectionClick}
-              />
-            )}
-            {variant === "progress" && (
-              <ProgressNav
-                sections={sections}
-                getSectionState={getSectionState}
-                onSectionClick={onSectionClick}
-              />
-            )}
-            {variant === "underline" && (
-              <UnderlineNav
-                sections={sections}
-                getSectionState={getSectionState}
-                onSectionClick={onSectionClick}
-              />
-            )}
+    <div data-snap-nav className="sticky top-0 z-20">
+      <div className="bg-checkout-navbar-bg/85 px-2.5 py-1.5 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-4xl items-center gap-1.5">
+          <div className="relative flex-1 overflow-hidden rounded-xl border border-white/10 bg-checkout-badge-bg-disabled/60 p-0.5">
+            <div
+              aria-hidden
+              className="absolute inset-y-0.5 rounded-lg bg-checkout-badge-bg shadow-sm transition-[transform,width] duration-300 ease-out"
+              style={{
+                width: `calc(${segmentWidthPct}% - 0.125rem)`,
+                transform: `translateX(calc(${activeIndex * 100}% + ${activeIndex * 0.125}rem))`,
+                left: "0.125rem",
+              }}
+            />
+            <div className="relative grid auto-cols-fr grid-flow-col">
+              {sections.map((section) => {
+                const Icon = resolveIcon(section)
+                const isActive = section.id === activeSection
+                const isComplete =
+                  !isActive && isStepComplete(section.id as CheckoutStep)
+                return (
+                  <button
+                    key={section.id}
+                    type="button"
+                    onClick={() => onSectionClick(section.id)}
+                    aria-current={isActive ? "step" : undefined}
+                    className={cn(
+                      "relative z-10 flex h-7 min-w-0 items-center justify-center gap-1 px-1.5 text-xs font-semibold transition-colors duration-200",
+                      isActive
+                        ? "text-checkout-badge-title"
+                        : "text-checkout-badge-title-disabled hover:text-checkout-badge-title/80",
+                    )}
+                  >
+                    <Icon className="size-3.5 shrink-0" />
+                    <span className="hidden truncate sm:inline">
+                      {section.label}
+                    </span>
+                    {isComplete && (
+                      <Check className="size-2.5 text-emerald-400" />
+                    )}
+                  </button>
+                )
+              })}
+            </div>
           </div>
-
-          {extraContent ? (
-            <div className="md:max-w-[260px] md:shrink-0">{extraContent}</div>
-          ) : null}
+          {extraContent ? <div className="shrink-0">{extraContent}</div> : null}
         </div>
       </div>
-    </div>
-  )
-}
-
-interface InnerNavProps {
-  sections: { id: string; label: string; template?: string | null }[]
-  getSectionState: (section: { id: string }) => {
-    isActive: boolean
-    isComplete: boolean
-  }
-  onSectionClick: (sectionId: string) => void
-}
-
-function PillsNav({
-  sections,
-  getSectionState,
-  onSectionClick,
-}: InnerNavProps) {
-  return (
-    <div className="flex items-center gap-1.5 flex-wrap">
-      {sections.map((section) => {
-        const Icon = resolveIcon(section)
-        const { isActive, isComplete } = getSectionState(section)
-
-        return (
-          <button
-            key={section.id}
-            type="button"
-            onClick={() => onSectionClick(section.id)}
-            className={cn(
-              "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-all duration-200",
-              isActive &&
-                "bg-checkout-badge-bg text-checkout-badge-title shadow-sm",
-              !isActive &&
-                "bg-checkout-badge-bg-disabled text-checkout-badge-title-disabled hover:opacity-80",
-            )}
-          >
-            <Icon className="size-4 shrink-0" />
-            <span className="hidden sm:inline">{section.label}</span>
-          </button>
-        )
-      })}
-    </div>
-  )
-}
-
-function ProgressNav({
-  sections,
-  getSectionState,
-  onSectionClick,
-}: InnerNavProps) {
-  return (
-    <div className="flex items-center justify-between flex-wrap gap-y-2">
-      {sections.map((section, i) => {
-        const Icon = resolveIcon(section)
-        const { isActive } = getSectionState(section)
-        const _prevComplete =
-          i > 0 && getSectionState(sections[i - 1]).isComplete
-
-        return (
-          <Fragment key={section.id}>
-            {i > 0 && (
-              <div className={cn("flex-1 h-0.5 mx-1", "bg-gray-300")} />
-            )}
-            <button
-              type="button"
-              onClick={() => onSectionClick(section.id)}
-              className="flex flex-col items-center gap-1 shrink-0"
-            >
-              <div
-                className={cn(
-                  "flex items-center justify-center size-8 rounded-full border-2 transition-all duration-200",
-                  isActive &&
-                    "border-checkout-nav-text bg-checkout-nav-text text-checkout-nav-bg",
-                  !isActive && "border-gray-300 bg-white text-gray-400",
-                )}
-              >
-                <Icon className="size-4" />
-              </div>
-              <span
-                className={cn(
-                  "hidden sm:block text-[10px] font-medium whitespace-nowrap",
-                  isActive && "text-checkout-nav-text",
-                  !isActive && "text-checkout-nav-text/40",
-                )}
-              >
-                {section.label}
-              </span>
-            </button>
-          </Fragment>
-        )
-      })}
-    </div>
-  )
-}
-
-function UnderlineNav({
-  sections,
-  getSectionState,
-  onSectionClick,
-}: InnerNavProps) {
-  return (
-    <div className="flex items-center gap-4 flex-wrap relative">
-      {sections.map((section) => {
-        const { isActive, isComplete } = getSectionState(section)
-
-        return (
-          <button
-            key={section.id}
-            type="button"
-            onClick={() => onSectionClick(section.id)}
-            className={cn(
-              "relative pb-2 text-sm font-medium whitespace-nowrap transition-colors duration-200 flex items-center gap-1",
-              isActive && "text-checkout-nav-text",
-              isComplete && !isActive && "text-checkout-nav-text/60",
-              !isActive &&
-                !isComplete &&
-                "text-checkout-nav-text/40 hover:text-checkout-nav-text/60",
-            )}
-          >
-            {section.label}
-            {isActive && (
-              <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-checkout-nav-text rounded-full" />
-            )}
-          </button>
-        )
-      })}
     </div>
   )
 }

--- a/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
@@ -368,68 +368,104 @@ function MerchCompact({
         const hasDiscount =
           product.compare_price != null && product.compare_price > product.price
 
-        return (
-          <div
-            key={product.id}
-            className={cn(
-              "flex items-center gap-3 rounded-xl border px-3 py-3 transition-all",
-              hasQty
-                ? "border-primary/30 bg-primary/10"
-                : "border-border hover:border-muted-foreground/40",
+        const cardClassName = cn(
+          "group relative w-full flex items-center gap-3 rounded-2xl border bg-checkout-card-bg px-3 py-2.5 transition-all",
+          hasQty
+            ? "border-primary/30 shadow-sm"
+            : "border-border cursor-pointer hover:border-muted-foreground/40 hover:shadow-sm",
+        )
+
+        const cardBody = (
+          <>
+            {hasQty && (
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-0 rounded-2xl bg-primary/5"
+              />
             )}
-          >
-            <div className="relative w-14 h-14 shrink-0 rounded-lg overflow-hidden bg-muted flex items-center justify-center">
-              {product.image_url ? (
-                <Image
-                  src={product.image_url}
-                  alt={product.name}
-                  fill
-                  className="object-cover"
-                />
-              ) : (
-                <ShoppingBag className="w-5 h-5 text-muted-foreground" />
+
+            <div className="relative shrink-0">
+              <div className="relative w-11 h-11 rounded-xl overflow-hidden bg-muted flex items-center justify-center">
+                {product.image_url ? (
+                  <Image
+                    src={product.image_url}
+                    alt={product.name}
+                    fill
+                    className="object-cover"
+                  />
+                ) : (
+                  <ShoppingBag className="w-4 h-4 text-muted-foreground" />
+                )}
+              </div>
+              {hasQty && qty > 1 && (
+                <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-full bg-primary text-primary-foreground text-[10px] font-bold shadow-sm tabular-nums">
+                  {qty}
+                </span>
               )}
             </div>
 
-            <div className="flex-1 min-w-0">
-              <p className="font-medium text-sm text-foreground truncate">
+            <div className="relative flex-1 min-w-0 text-left">
+              <p className="font-semibold text-sm text-pass-title truncate leading-tight">
                 {product.name}
               </p>
-              <div>
-                {hasDiscount && product.compare_price != null && (
-                  <span className="text-xs text-muted-foreground line-through mr-1">
+              <div className="mt-0.5 flex items-center gap-1.5">
+                {hasDiscount && product.compare_price != null && !hasQty && (
+                  <span className="text-[11px] text-pass-text line-through">
                     {formatCurrency(product.compare_price)}
                   </span>
                 )}
                 <span
                   className={cn(
                     "text-xs font-medium",
-                    hasDiscount ? "text-green-600" : "text-muted-foreground",
+                    hasQty
+                      ? "text-primary"
+                      : hasDiscount
+                        ? "text-green-600"
+                        : "text-pass-text",
                   )}
                 >
-                  {formatCurrency(product.price)} each
+                  {hasQty
+                    ? formatCurrency(product.price * qty)
+                    : `${formatCurrency(product.price)} each`}
                 </span>
               </div>
             </div>
 
-            <div className="flex items-center gap-3 shrink-0">
-              <MerchQtyControl
-                product={product}
-                quantity={qty}
-                onQuantityChange={(nextQty) =>
-                  onQuantityChange(product.id, nextQty)
-                }
-              />
-              <span
-                className={cn(
-                  "font-bold text-sm w-16 text-right",
-                  hasQty ? "text-primary" : "text-muted-foreground",
-                )}
-              >
-                {formatCurrency(hasQty ? product.price * qty : product.price)}
-              </span>
+            <div className="relative shrink-0">
+              {hasQty ? (
+                <MerchQtyControl
+                  product={product}
+                  quantity={qty}
+                  onQuantityChange={(nextQty) =>
+                    onQuantityChange(product.id, nextQty)
+                  }
+                />
+              ) : (
+                <span
+                  aria-hidden
+                  className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary transition-colors group-hover:bg-primary/20"
+                >
+                  <Plus className="size-4" strokeWidth={2.5} />
+                </span>
+              )}
             </div>
+          </>
+        )
+
+        return hasQty ? (
+          <div key={product.id} className={cardClassName}>
+            {cardBody}
           </div>
+        ) : (
+          <button
+            key={product.id}
+            type="button"
+            onClick={() => onQuantityChange(product.id, 1)}
+            aria-label={`Add ${product.name} to cart`}
+            className={cn(cardClassName, "text-left")}
+          >
+            {cardBody}
+          </button>
         )
       })}
     </div>

--- a/portal/src/providers/themeProvider.tsx
+++ b/portal/src/providers/themeProvider.tsx
@@ -81,16 +81,27 @@ function computeThemeVars(
 ): Record<string, string> {
   if (!colors) return {}
 
-  // If nothing is set (no mode, no primary), skip the theme entirely so the
-  // portal defaults from globals.css stay intact.
-  if (!colors.mode && !colors.primary_color) return {}
+  const hasTheme = Boolean(colors.mode || colors.primary_color)
+  const vars: Record<string, string> = {}
+
+  // Per-surface overrides (like checkout_navbar_bg) apply independently of
+  // mode/primary so the admin can tweak a single color without committing to
+  // the full design-token theme.
+  if (colors.checkout_navbar_bg) {
+    vars["--checkout-navbar-bg"] = colors.checkout_navbar_bg
+    vars["--checkout-nav-bg"] = colors.checkout_navbar_bg
+  }
+
+  // If no mode/primary is set, stop here — rest of the palette stays on the
+  // globals.css defaults.
+  if (!hasTheme) return vars
 
   const mode: ThemeMode = colors.mode === "dark" ? "dark" : "light"
   const palette = mode === "dark" ? DARK : LIGHT
   const primary = colors.primary_color
   const primaryFg = colors.primary_foreground_color || "oklch(1 0 0)"
 
-  const vars: Record<string, string> = {
+  Object.assign(vars, {
     // ─ Surface neutrals (always applied when a mode is chosen so the admin
     // can preview dark/light without committing to a primary).
     "--background": palette.background,
@@ -132,7 +143,7 @@ function computeThemeVars(
     "--checkout-card-bg": palette.card,
     "--checkout-bottom-bar-bg": palette.sidebar,
     "--checkout-bottom-bar-text": palette.foreground,
-  }
+  })
 
   // Brand-dependent tokens only fill in once the admin picked a primary —
   // otherwise we'd overwrite the nice shadcn default with nothing usable.


### PR DESCRIPTION
…ride independently

- Backoffice HousingDateConfig: split show_dates and price_per_day switches so admins can keep the date picker while disabling per-night pricing; disabling the picker still auto-clears per-night pricing.
- Portal themeProvider: emit checkout_navbar_bg as a standalone override so changing the navbar color applies even without mode/primary set.
- Backoffice ThemePreview: translate remaining Spanish copy in preview mocks (navbar labels, sidebar items, checkout card, bottom bar) to English; switch date formatter locale to en-US.

Includes pre-staged checkout UI work on the pill nav variant, merch image variant, checkout bottom bar layout, and the light-mode default background.

## Summary

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality
- [ ] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [ ] Database migrations are included if schema changed
