### PR TITLE
feat: tenant-scoped email templates

### DIFF
--- a/backend/app/alembic/versions/4f2b3c1d9e8a_tenant_login_email_templates_scope.py
+++ b/backend/app/alembic/versions/4f2b3c1d9e8a_tenant_login_email_templates_scope.py
@@ -1,0 +1,64 @@
+"""Add tenant scope support to email templates
+
+Revision ID: 4f2b3c1d9e8a
+Revises: 499dd4b24f32
+Create Date: 2026-04-23
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4f2b3c1d9e8a"
+down_revision = "499dd4b24f32"
+branch_labels = None
+depends_on = None
+
+
+TENANT_SCOPED_TEMPLATE_TYPES = ("login_code_human",)
+
+
+def upgrade():
+    op.drop_constraint(
+        "uq_email_template_popup_type", "email_templates", type_="unique"
+    )
+    op.alter_column("email_templates", "popup_id", existing_type=sa.UUID(), nullable=True)
+    op.create_check_constraint(
+        "ck_email_templates_scope",
+        "email_templates",
+        "(template_type IN ('login_code_human') AND popup_id IS NULL) "
+        "OR (template_type NOT IN ('login_code_human') AND popup_id IS NOT NULL)",
+    )
+    op.create_index(
+        "uq_email_template_popup_scope_type",
+        "email_templates",
+        ["popup_id", "template_type"],
+        unique=True,
+        postgresql_where=sa.text("popup_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_email_template_tenant_scope_type",
+        "email_templates",
+        ["tenant_id", "template_type"],
+        unique=True,
+        postgresql_where=sa.text("popup_id IS NULL"),
+    )
+
+
+def downgrade():
+    op.execute(
+        "DELETE FROM email_templates WHERE popup_id IS NULL AND template_type IN ('login_code_human')"
+    )
+    op.drop_index("uq_email_template_tenant_scope_type", table_name="email_templates")
+    op.drop_index("uq_email_template_popup_scope_type", table_name="email_templates")
+    op.drop_constraint("ck_email_templates_scope", "email_templates", type_="check")
+    op.alter_column(
+        "email_templates", "popup_id", existing_type=sa.UUID(), nullable=False
+    )
+    op.create_unique_constraint(
+        "uq_email_template_popup_type",
+        "email_templates",
+        ["popup_id", "template_type"],
+    )

--- a/backend/app/api/auth/crud.py
+++ b/backend/app/api/auth/crud.py
@@ -100,11 +100,14 @@ async def login_user(
         subject=f"Your Login Code - {tenant_name}",
         context=LoginCodeUserContext(
             user_name=user.full_name,
+            tenant_name=tenant_name,
             auth_code=auth_code,
             expiration_minutes=CODE_EXPIRATION_MINUTES,
         ),
+        tenant_id=user.tenant_id,
         from_address=from_address,
         from_name=from_name,
+        db_session=session,
     )
 
     if not success:
@@ -234,11 +237,14 @@ async def login_human(
             subject=f"Your Login Code - {tenant.name if tenant else settings.PROJECT_NAME}",
             context=LoginCodeHumanContext(
                 first_name=display_name,
+                tenant_name=tenant.name if tenant else settings.PROJECT_NAME,
                 auth_code=auth_code,
                 expiration_minutes=CODE_EXPIRATION_MINUTES,
             ),
+            tenant_id=data.tenant_id,
             from_address=tenant.sender_email if tenant else settings.SENDER_EMAIL,
             from_name=tenant.sender_name if tenant else settings.SENDER_NAME,
+            db_session=session,
         )
 
         if not success:
@@ -303,11 +309,14 @@ async def login_human(
         subject=f"Your Verification Code - {tenant.name if tenant else settings.PROJECT_NAME}",
         context=LoginCodeHumanContext(
             first_name=data.email.split("@")[0],  # Use email prefix as fallback
+            tenant_name=tenant.name if tenant else settings.PROJECT_NAME,
             auth_code=auth_code,
             expiration_minutes=CODE_EXPIRATION_MINUTES,
         ),
+        tenant_id=data.tenant_id,
         from_address=tenant.sender_email if tenant else settings.SENDER_EMAIL,
         from_name=tenant.sender_name if tenant else settings.SENDER_NAME,
+        db_session=session,
     )
 
     if not success:

--- a/backend/app/api/email_template/crud.py
+++ b/backend/app/api/email_template/crud.py
@@ -22,6 +22,16 @@ class EmailTemplateCRUD(
         )
         return session.exec(statement).first()
 
+    def get_by_tenant_and_type(
+        self, session: Session, tenant_id: uuid.UUID, template_type: str
+    ) -> EmailTemplates | None:
+        statement = select(EmailTemplates).where(
+            EmailTemplates.tenant_id == tenant_id,
+            EmailTemplates.popup_id == None,  # noqa: E711
+            EmailTemplates.template_type == template_type,
+        )
+        return session.exec(statement).first()
+
     def find_by_popup(
         self,
         session: Session,
@@ -39,11 +49,42 @@ class EmailTemplateCRUD(
 
         return results, total
 
-    def get_active_template(
+    def find_by_tenant_scope(
+        self,
+        session: Session,
+        tenant_id: uuid.UUID,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> tuple[list[EmailTemplates], int]:
+        statement = select(EmailTemplates).where(
+            EmailTemplates.tenant_id == tenant_id,
+            EmailTemplates.popup_id == None,  # noqa: E711
+        )
+
+        count_statement = select(func.count()).select_from(statement.subquery())
+        total = session.exec(count_statement).one()
+
+        statement = statement.offset(skip).limit(limit)
+        results = list(session.exec(statement).all())
+
+        return results, total
+
+    def get_active_popup_template(
         self, session: Session, popup_id: uuid.UUID, template_type: str
     ) -> EmailTemplates | None:
         statement = select(EmailTemplates).where(
             EmailTemplates.popup_id == popup_id,
+            EmailTemplates.template_type == template_type,
+            EmailTemplates.is_active == True,  # noqa: E712
+        )
+        return session.exec(statement).first()
+
+    def get_active_tenant_template(
+        self, session: Session, tenant_id: uuid.UUID, template_type: str
+    ) -> EmailTemplates | None:
+        statement = select(EmailTemplates).where(
+            EmailTemplates.tenant_id == tenant_id,
+            EmailTemplates.popup_id == None,  # noqa: E711
             EmailTemplates.template_type == template_type,
             EmailTemplates.is_active == True,  # noqa: E712
         )

--- a/backend/app/api/email_template/models.py
+++ b/backend/app/api/email_template/models.py
@@ -1,12 +1,13 @@
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import UniqueConstraint, func
+from sqlalchemy import CheckConstraint, Index, func, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Column, DateTime, Field, Relationship
 
-from app.api.email_template.schemas import EmailTemplateBase
+from app.api.email_template.schemas import EmailTemplateBase, TemplateScope
+from app.services.email.templates import get_template_scope
 
 if TYPE_CHECKING:
     from app.api.popup.models import Popups
@@ -16,8 +17,24 @@ if TYPE_CHECKING:
 class EmailTemplates(EmailTemplateBase, table=True):
     __tablename__ = "email_templates"
     __table_args__ = (
-        UniqueConstraint(
-            "popup_id", "template_type", name="uq_email_template_popup_type"
+        Index(
+            "uq_email_template_popup_scope_type",
+            "popup_id",
+            "template_type",
+            unique=True,
+            postgresql_where=text("popup_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_email_template_tenant_scope_type",
+            "tenant_id",
+            "template_type",
+            unique=True,
+            postgresql_where=text("popup_id IS NULL"),
+        ),
+        CheckConstraint(
+            "(template_type IN ('login_code_human') AND popup_id IS NULL) "
+            "OR (template_type NOT IN ('login_code_human') AND popup_id IS NOT NULL)",
+            name="ck_email_templates_scope",
         ),
     )
 
@@ -40,4 +57,8 @@ class EmailTemplates(EmailTemplateBase, table=True):
     )
 
     tenant: "Tenants" = Relationship(back_populates="email_templates")
-    popup: "Popups" = Relationship(back_populates="email_templates")
+    popup: Optional["Popups"] = Relationship(back_populates="email_templates")
+
+    @property
+    def scope(self) -> TemplateScope:
+        return get_template_scope(self.template_type)

--- a/backend/app/api/email_template/router.py
+++ b/backend/app/api/email_template/router.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, EmailStr
+from sqlalchemy import text
 
 from app.api.email_template import crud
 from app.api.email_template.schemas import (
@@ -10,6 +11,7 @@ from app.api.email_template.schemas import (
     EmailTemplatePublic,
     EmailTemplateType,
     EmailTemplateUpdate,
+    TemplateScope,
 )
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
@@ -32,6 +34,7 @@ class TemplateTypeInfo(BaseModel):
     label: str
     description: str
     category: str
+    scope: TemplateScope
     default_subject: str
     variables: list[TemplateVariable]
 
@@ -56,6 +59,22 @@ class SendTestRequest(BaseModel):
     to_email: EmailStr
     custom_variables: dict[str, Any] | None = None
     popup_id: uuid.UUID | None = None
+
+
+def _resolve_effective_tenant_id(current_user: CurrentUser, db: TenantSession) -> uuid.UUID:
+    if current_user.tenant_id:
+        return current_user.tenant_id
+
+    tenant_id = db.connection().execute(
+        text("SELECT current_setting('app.tenant_id', true)")
+    ).scalar_one_or_none()
+    if not tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unable to resolve tenant context",
+        )
+
+    return uuid.UUID(tenant_id)
 
 
 @router.get("/types", response_model=list[TemplateTypeInfo])
@@ -84,12 +103,29 @@ async def preview_template(
     _: CurrentUser,
     db: TenantSession,
 ) -> PreviewResponse:
+    from app.services.email.templates import (
+        get_template_scope,
+        is_customizable_template_type,
+    )
+
     try:
         EmailTemplateType(body.template_type)
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid template type: {body.template_type}",
+        )
+
+    if not is_customizable_template_type(body.template_type):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Template type is not customizable: {body.template_type}",
+        )
+
+    if get_template_scope(body.template_type) == TemplateScope.POPUP and not body.popup_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="popup_id is required for popup-scoped templates",
         )
 
     # Start with enriched popup data as the base, then let preview_variables override
@@ -134,12 +170,29 @@ async def send_test_email(
     _: CurrentWriter,
     db: TenantSession,
 ) -> dict[str, str]:
+    from app.services.email.templates import (
+        get_template_scope,
+        is_customizable_template_type,
+    )
+
     try:
         EmailTemplateType(body.template_type)
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid template type: {body.template_type}",
+        )
+
+    if not is_customizable_template_type(body.template_type):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Template type is not customizable: {body.template_type}",
+        )
+
+    if get_template_scope(body.template_type) == TemplateScope.POPUP and not body.popup_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="popup_id is required for popup-scoped templates",
         )
 
     # Start with enriched popup data as the base, then let custom_variables override
@@ -191,7 +244,7 @@ async def send_test_email(
 @router.get("", response_model=ListModel[EmailTemplatePublic])
 async def list_email_templates(
     db: TenantSession,
-    _: CurrentUser,
+    current_user: CurrentUser,
     popup_id: uuid.UUID | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
@@ -201,7 +254,10 @@ async def list_email_templates(
             db, popup_id=popup_id, skip=skip, limit=limit
         )
     else:
-        templates, total = crud.email_template_crud.find(db, skip=skip, limit=limit)
+        tenant_id = _resolve_effective_tenant_id(current_user, db)
+        templates, total = crud.email_template_crud.find_by_tenant_scope(
+            db, tenant_id=tenant_id, skip=skip, limit=limit
+        )
 
     return ListModel[EmailTemplatePublic](
         results=[EmailTemplatePublic.model_validate(t) for t in templates],
@@ -234,6 +290,11 @@ async def create_email_template(
     db: TenantSession,
     current_user: CurrentWriter,
 ) -> EmailTemplatePublic:
+    from app.services.email.templates import (
+        get_template_scope,
+        is_customizable_template_type,
+    )
+
     # Validate template_type
     try:
         EmailTemplateType(template_in.template_type)
@@ -243,33 +304,59 @@ async def create_email_template(
             detail=f"Invalid template type: {template_in.template_type}",
         )
 
-    # Check uniqueness
-    existing = crud.email_template_crud.get_by_popup_and_type(
-        db, template_in.popup_id, template_in.template_type
-    )
-    if existing:
+    if not is_customizable_template_type(template_in.template_type):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="A template for this type already exists in this popup",
+            detail=f"Template type is not customizable: {template_in.template_type}",
         )
 
-    if current_user.role == UserRole.SUPERADMIN:
-        from app.api.popup.crud import popups_crud
+    template_scope = get_template_scope(template_in.template_type)
 
-        popup = popups_crud.get(db, template_in.popup_id)
-        if not popup:
+    if template_scope == TemplateScope.POPUP:
+        if not template_in.popup_id:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Popup not found",
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="popup_id is required for popup-scoped templates",
             )
-        tenant_id = popup.tenant_id
+
+        existing = crud.email_template_crud.get_by_popup_and_type(
+            db, template_in.popup_id, template_in.template_type
+        )
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A template for this type already exists in this popup",
+            )
+
+        if current_user.role == UserRole.SUPERADMIN:
+            from app.api.popup.crud import popups_crud
+
+            popup = popups_crud.get(db, template_in.popup_id)
+            if not popup:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Popup not found",
+                )
+            tenant_id = popup.tenant_id
+        else:
+            tenant_id = current_user.tenant_id
     else:
-        tenant_id = current_user.tenant_id
+        tenant_id = _resolve_effective_tenant_id(current_user, db)
+        existing = crud.email_template_crud.get_by_tenant_and_type(
+            db, tenant_id, template_in.template_type
+        )
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A tenant-scoped template for this type already exists",
+            )
 
     from app.api.email_template.models import EmailTemplates
 
     template_data = template_in.model_dump()
     template_data["tenant_id"] = tenant_id
+    if template_scope == TemplateScope.TENANT:
+        template_data["popup_id"] = None
     template = EmailTemplates(**template_data)
 
     db.add(template)

--- a/backend/app/api/email_template/schemas.py
+++ b/backend/app/api/email_template/schemas.py
@@ -23,9 +23,16 @@ class EmailTemplateType(StrEnum):
     EDIT_PASSES_CONFIRMED = "edit_passes_confirmed"
 
 
+class TemplateScope(StrEnum):
+    TENANT = "tenant"
+    POPUP = "popup"
+
+
 class EmailTemplateBase(SQLModel):
     tenant_id: uuid.UUID = Field(foreign_key="tenants.id", index=True)
-    popup_id: uuid.UUID = Field(foreign_key="popups.id", index=True)
+    popup_id: uuid.UUID | None = Field(
+        default=None, foreign_key="popups.id", index=True
+    )
     template_type: str = Field(index=True)
     subject: str | None = Field(default=None, nullable=True)
     html_content: str = Field(sa_type=Text())
@@ -35,8 +42,9 @@ class EmailTemplateBase(SQLModel):
 class EmailTemplatePublic(BaseModel):
     id: uuid.UUID
     tenant_id: uuid.UUID
-    popup_id: uuid.UUID
+    popup_id: uuid.UUID | None
     template_type: str
+    scope: TemplateScope
     subject: str | None = None
     html_content: str
     is_active: bool = True
@@ -47,7 +55,7 @@ class EmailTemplatePublic(BaseModel):
 
 
 class EmailTemplateCreate(BaseModel):
-    popup_id: uuid.UUID
+    popup_id: uuid.UUID | None = None
     template_type: str
     subject: str | None = None
     html_content: str

--- a/backend/app/services/email/service.py
+++ b/backend/app/services/email/service.py
@@ -33,6 +33,8 @@ from app.services.email.templates import (
     LoginCodeUserContext,
     PaymentConfirmedContext,
     SilentUndefined,
+    coerce_email_template_type,
+    get_template_scope,
     log_missing_template_variables,
 )
 
@@ -178,9 +180,10 @@ class EmailService:
 
     def render_with_fallback(
         self,
-        template_type: EmailTemplateType,
+        template_type: EmailTemplateType | str,
         context: Mapping[str, Any],
         popup_id: uuid.UUID | None = None,
+        tenant_id: uuid.UUID | None = None,
         db_session: Session | None = None,
     ) -> tuple[str, str | None]:
         """Render email using DB-stored custom template or file-based fallback.
@@ -188,11 +191,14 @@ class EmailService:
         Returns:
             Tuple of (rendered_html, custom_subject_or_none)
         """
-        if popup_id and db_session:
+        template_type_enum = coerce_email_template_type(template_type)
+        template_scope = get_template_scope(template_type_enum)
+
+        if db_session and template_scope == "tenant" and tenant_id:
             from app.api.email_template.crud import email_template_crud
 
-            custom = email_template_crud.get_active_template(
-                db_session, popup_id, template_type.value
+            custom = email_template_crud.get_active_tenant_template(
+                db_session, tenant_id, template_type_enum.value
             )
             if custom:
                 rendered_html = self.render_custom_template(
@@ -200,14 +206,30 @@ class EmailService:
                 )
                 rendered_subject = None
                 if custom.subject:
-                    env = SandboxedEnvironment()
+                    env = SandboxedEnvironment(undefined=SilentUndefined)
+                    rendered_subject = env.from_string(custom.subject).render(**context)
+                return rendered_html, rendered_subject
+
+        if db_session and template_scope == "popup" and popup_id:
+            from app.api.email_template.crud import email_template_crud
+
+            custom = email_template_crud.get_active_popup_template(
+                db_session, popup_id, template_type_enum.value
+            )
+            if custom:
+                rendered_html = self.render_custom_template(
+                    custom.html_content, context
+                )
+                rendered_subject = None
+                if custom.subject:
+                    env = SandboxedEnvironment(undefined=SilentUndefined)
                     rendered_subject = env.from_string(custom.subject).render(**context)
                 return rendered_html, rendered_subject
 
         # Fallback to file-based template
-        file_path = TEMPLATE_TYPE_TO_FILE.get(template_type)
+        file_path = TEMPLATE_TYPE_TO_FILE.get(template_type_enum)
         if not file_path:
-            raise ValueError(f"No file mapping for template type: {template_type}")
+            raise ValueError(f"No file mapping for template type: {template_type_enum}")
 
         rendered_html = self.render_template(file_path, context)
         return rendered_html, None
@@ -248,6 +270,8 @@ class EmailService:
         from_address: str | None = None,
         from_name: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        ical_body: str | None = None,
+        ical_method: str = "REQUEST",
     ) -> bool:
         """
         Send an email via SMTP.
@@ -260,6 +284,10 @@ class EmailService:
             from_address: Override default from address (tenant-specific)
             from_name: Override default from name (tenant-specific)
             attachments: Optional list of file attachments
+            ical_body: Optional iTIP calendar body. When provided, embedded
+                as an inline ``text/calendar; method=...`` MIME part so Gmail
+                and other clients treat the email as a calendar invitation.
+            ical_method: iTIP method for the calendar part (REQUEST / CANCEL).
 
         Returns:
             True if email was sent successfully, False otherwise
@@ -275,11 +303,28 @@ class EmailService:
                 logger.error("No from address configured (neither tenant nor global)")
                 return False
 
-            # Build the text/html alternative part
+            # Build the text/html alternative part. When we have an iTIP body
+            # we also embed it as a peer alternative; Gmail/Apple Mail pick it
+            # up and render the invitation card inline.
             alt_part = MIMEMultipart("alternative")
             if text_content:
                 alt_part.attach(MIMEText(text_content, "plain"))
             alt_part.attach(MIMEText(html_content, "html"))
+            if ical_body:
+                method = ical_method.upper()
+                ical_part = MIMEText(ical_body, "calendar", "utf-8")
+                # MIMEText forces Content-Type = text/calendar; charset=utf-8.
+                # Replace it with the RFC 5546 flavour that iTIP requires so
+                # Gmail/Apple Mail parse the REQUEST vs. treating it as an
+                # .ics attachment.
+                del ical_part["Content-Type"]
+                ical_part.add_header(
+                    "Content-Type",
+                    "text/calendar",
+                    charset="utf-8",
+                    method=method,
+                )
+                alt_part.attach(ical_part)
 
             # If there are attachments, wrap in a mixed container
             if attachments:
@@ -343,28 +388,12 @@ class EmailService:
         from_address: str | None = None,
         from_name: str | None = None,
         attachments: list[EmailAttachment] | None = None,
+        ical_body: str | None = None,
+        ical_method: str = "REQUEST",
     ) -> bool:
-        """
-        Render and send a templated email.
-
-        Args:
-            to: Recipient email address(es)
-            subject: Email subject line
-            template_name: Name of the template file
-            context: Variables to pass to the template
-            text_content: Optional plain text version
-            from_address: Override default from address (tenant-specific)
-            from_name: Override default from name (tenant-specific)
-            attachments: Optional list of file attachments
-
-        Returns:
-            True if email was sent successfully, False otherwise
-        """
+        """Render and send a templated email. See ``send_email`` for args."""
         try:
-            # Render template
             html_content = self.render_template(template_name, context)
-
-            # Send email
             return await self.send_email(
                 to=to,
                 subject=subject,
@@ -373,6 +402,8 @@ class EmailService:
                 from_address=from_address,
                 from_name=from_name,
                 attachments=attachments,
+                ical_body=ical_body,
+                ical_method=ical_method,
             )
 
         except Exception as e:
@@ -384,8 +415,10 @@ class EmailService:
         to: str,
         subject: str,
         context: LoginCodeUserContext,
+        tenant_id: uuid.UUID | None = None,
         from_address: str | None = None,
         from_name: str | None = None,
+        db_session: Session | None = None,
     ) -> bool:
         """Send login code email to backoffice user."""
         return await self.send_template_email(
@@ -402,17 +435,22 @@ class EmailService:
         to: str,
         subject: str,
         context: LoginCodeHumanContext,
+        tenant_id: uuid.UUID | None = None,
         from_address: str | None = None,
         from_name: str | None = None,
+        db_session: Session | None = None,
     ) -> bool:
         """Send login code email to portal user (human)."""
-        return await self.send_template_email(
+        return await self._send_with_fallback(
             to=to,
             subject=subject,
+            template_type=EmailTemplateType.LOGIN_CODE_HUMAN,
             template_name=EmailTemplates.LOGIN_CODE_HUMAN,
             context=context.model_dump(exclude_none=True),
+            tenant_id=tenant_id,
             from_address=from_address,
             from_name=from_name,
+            db_session=db_session,
         )
 
     async def send_application_received(
@@ -423,6 +461,7 @@ class EmailService:
         from_address: str | None = None,
         from_name: str | None = None,
         popup_id: uuid.UUID | None = None,
+        tenant_id: uuid.UUID | None = None,
         db_session: Session | None = None,
     ) -> bool:
         """Send application received confirmation email."""
@@ -634,39 +673,41 @@ class EmailService:
         from_address: str | None = None,
         from_name: str | None = None,
         popup_id: uuid.UUID | None = None,
+        tenant_id: uuid.UUID | None = None,
         db_session: Session | None = None,
         attachments: list[EmailAttachment] | None = None,
+        ical_body: str | None = None,
+        ical_method: str = "REQUEST",
     ) -> bool:
         """Send email using DB custom template if available, else file-based fallback."""
         try:
             enriched_context: Mapping[str, Any] = context
-            if popup_id and db_session:
+            template_scope = get_template_scope(template_type)
+
+            if template_scope == "popup" and popup_id and db_session:
                 enriched_context = _enrich_with_popup_data(
                     dict(context), popup_id, db_session
                 )
-                log_missing_template_variables(template_type, dict(enriched_context))
-                rendered_html, custom_subject = self.render_with_fallback(
-                    template_type, enriched_context, popup_id, db_session
-                )
-                final_subject = custom_subject or subject
-                return await self.send_email(
-                    to=to,
-                    subject=final_subject,
-                    html_content=rendered_html,
-                    from_address=from_address,
-                    from_name=from_name,
-                    attachments=attachments,
-                )
-
-            return await self.send_template_email(
+            log_missing_template_variables(template_type, dict(enriched_context))
+            rendered_html, custom_subject = self.render_with_fallback(
+                template_type,
+                enriched_context,
+                popup_id=popup_id,
+                tenant_id=tenant_id,
+                db_session=db_session,
+            )
+            final_subject = custom_subject or subject
+            return await self.send_email(
                 to=to,
-                subject=subject,
-                template_name=template_name,
-                context=enriched_context,
+                subject=final_subject,
+                html_content=rendered_html,
                 from_address=from_address,
                 from_name=from_name,
                 attachments=attachments,
+                ical_body=ical_body,
+                ical_method=ical_method,
             )
+
         except Exception as e:
             logger.error(f"Error sending email with fallback to {to}: {e}")
             return False

--- a/backend/app/services/email/templates.py
+++ b/backend/app/services/email/templates.py
@@ -6,7 +6,7 @@ from jinja2 import Environment, FileSystemLoader, Undefined
 from loguru import logger
 from pydantic import BaseModel
 
-from app.api.email_template.schemas import EmailTemplateType
+from app.api.email_template.schemas import EmailTemplateType, TemplateScope
 
 
 class LoginCodeUserContext(BaseModel):
@@ -16,6 +16,7 @@ class LoginCodeUserContext(BaseModel):
     """
 
     user_name: str | None = None
+    tenant_name: str | None = None
     auth_code: str
     expiration_minutes: int = 15
 
@@ -27,6 +28,7 @@ class LoginCodeHumanContext(BaseModel):
     """
 
     first_name: str | None = None
+    tenant_name: str | None = None
     auth_code: str
     expiration_minutes: int = 15
 
@@ -287,7 +289,76 @@ _POPUP_EVENT_VARIABLES: list[dict[str, Any]] = [
     },
 ]
 
-TEMPLATE_TYPE_METADATA: list[dict[str, Any]] = [
+TENANT_SCOPED_TEMPLATE_TYPES = {
+    EmailTemplateType.LOGIN_CODE_HUMAN,
+}
+
+
+def coerce_email_template_type(
+    template_type: EmailTemplateType | str,
+) -> EmailTemplateType:
+    return (
+        template_type
+        if isinstance(template_type, EmailTemplateType)
+        else EmailTemplateType(template_type)
+    )
+
+
+def get_template_scope(template_type: EmailTemplateType | str) -> TemplateScope:
+    return (
+        TemplateScope.TENANT
+        if coerce_email_template_type(template_type) in TENANT_SCOPED_TEMPLATE_TYPES
+        else TemplateScope.POPUP
+    )
+
+
+AUTH_TEMPLATE_METADATA: list[dict[str, Any]] = [
+    {
+        "type": EmailTemplateType.LOGIN_CODE_HUMAN,
+        "label": "Portal Login Code",
+        "description": "Verification email sent to portal users during sign in.",
+        "category": "Auth",
+        "scope": TemplateScope.TENANT,
+        "default_subject": "Your Verification Code - {{ tenant_name or project_name }}",
+        "variables": [
+            {
+                "name": "first_name",
+                "label": "First Name",
+                "type": "string",
+                "description": "Portal user's first name",
+                "required": False,
+                "group": "Recipient",
+            },
+            {
+                "name": "tenant_name",
+                "label": "Tenant Name",
+                "type": "string",
+                "description": "Tenant or organization name",
+                "required": False,
+                "group": "General",
+            },
+            {
+                "name": "auth_code",
+                "label": "Authentication Code",
+                "type": "string",
+                "description": "One-time login code",
+                "required": True,
+                "group": "General",
+            },
+            {
+                "name": "expiration_minutes",
+                "label": "Expiration Minutes",
+                "type": "number",
+                "description": "How long the code remains valid",
+                "required": True,
+                "group": "General",
+            },
+        ],
+    },
+]
+
+
+POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
     # NOTE: Login code templates (LOGIN_CODE_USER, LOGIN_CODE_HUMAN) are excluded
     # because they have no popup context during auth flow and always use file-based defaults.
     {
@@ -969,3 +1040,15 @@ def flatten_template(template_type: EmailTemplateType) -> str:
 
     template = env.get_template(file_path)
     return template.render()
+
+
+TEMPLATE_TYPE_METADATA: list[dict[str, Any]] = [
+    *AUTH_TEMPLATE_METADATA,
+    *[{**meta, "scope": TemplateScope.POPUP} for meta in POPUP_TEMPLATE_METADATA],
+]
+
+CUSTOMIZABLE_TEMPLATE_TYPES = {meta["type"] for meta in TEMPLATE_TYPE_METADATA}
+
+
+def is_customizable_template_type(template_type: EmailTemplateType | str) -> bool:
+    return coerce_email_template_type(template_type) in CUSTOMIZABLE_TEMPLATE_TYPES

--- a/backend/tests/test_tenant_login_email_templates.py
+++ b/backend/tests/test_tenant_login_email_templates.py
@@ -1,0 +1,291 @@
+import uuid
+
+import pytest
+from sqlmodel import Session, select
+
+from app.api.email_template.models import EmailTemplates
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+from app.services.email.service import EmailService
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _delete_tenant_template(
+    db: Session,
+    tenant_id: uuid.UUID,
+    template_type: str,
+) -> None:
+    statement = select(EmailTemplates).where(
+        EmailTemplates.tenant_id == tenant_id,
+        EmailTemplates.popup_id == None,  # noqa: E711
+        EmailTemplates.template_type == template_type,
+    )
+    for template in db.exec(statement):
+        db.delete(template)
+    db.commit()
+
+
+def _create_auth_template(
+    client,
+    token: str,
+    *,
+    template_type: str,
+    subject: str,
+    html_content: str,
+    is_active: bool = True,
+):
+    return client.post(
+        "/api/v1/email-templates",
+        headers=_admin_headers(token),
+        json={
+            "template_type": template_type,
+            "subject": subject,
+            "html_content": html_content,
+            "is_active": is_active,
+        },
+    )
+
+
+def _create_popup_template(
+    client,
+    token: str,
+    popup_id: uuid.UUID,
+    *,
+    template_type: str,
+    subject: str,
+    html_content: str,
+    is_active: bool = True,
+):
+    return client.post(
+        "/api/v1/email-templates",
+        headers=_admin_headers(token),
+        json={
+            "popup_id": str(popup_id),
+            "template_type": template_type,
+            "subject": subject,
+            "html_content": html_content,
+            "is_active": is_active,
+        },
+    )
+
+
+@pytest.mark.usefixtures("tenant_a", "popup_tenant_a")
+def test_template_types_expose_scope_metadata(client, admin_token_tenant_a: str):
+    response = client.get(
+        "/api/v1/email-templates/types",
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+
+    assert response.status_code == 200
+
+    by_type = {item["type"]: item for item in response.json()}
+
+    assert by_type["login_code_human"]["scope"] == "tenant"
+    assert by_type["application_received"]["scope"] == "popup"
+    assert any(
+        variable["name"] == "auth_code"
+        for variable in by_type["login_code_human"]["variables"]
+    )
+    assert "login_code_user" not in by_type
+
+
+def test_portal_login_templates_can_be_managed_without_popup_and_are_unique_per_tenant(
+    client,
+    admin_token_tenant_a: str,
+):
+    create_response = _create_auth_template(
+        client,
+        admin_token_tenant_a,
+        template_type="login_code_human",
+        subject="Portal login {{ auth_code }}",
+        html_content="<html><body>Portal user code {{ auth_code }}</body></html>",
+    )
+
+    assert create_response.status_code == 201
+    assert create_response.json()["popup_id"] is None
+
+    list_response = client.get(
+        "/api/v1/email-templates",
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+
+    assert list_response.status_code == 200
+    assert [item["template_type"] for item in list_response.json()["results"]] == [
+        "login_code_human"
+    ]
+
+    duplicate_response = _create_auth_template(
+        client,
+        admin_token_tenant_a,
+        template_type="login_code_human",
+        subject="Duplicate",
+        html_content="<html><body>Duplicate</body></html>",
+    )
+
+    assert duplicate_response.status_code == 400
+    assert duplicate_response.json()["detail"] == (
+        "A tenant-scoped template for this type already exists"
+    )
+
+
+def test_backoffice_login_template_is_not_customizable(client, admin_token_tenant_a: str):
+    response = _create_auth_template(
+        client,
+        admin_token_tenant_a,
+        template_type="login_code_user",
+        subject="Should fail",
+        html_content="<html><body>Nope</body></html>",
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == (
+        "Template type is not customizable: login_code_user"
+    )
+
+
+def test_popup_templates_still_require_popup_context(client, admin_token_tenant_a: str):
+    response = client.post(
+        "/api/v1/email-templates",
+        headers=_admin_headers(admin_token_tenant_a),
+        json={
+            "template_type": "application_received",
+            "subject": "Popup required",
+            "html_content": "<html><body>Popup required</body></html>",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "popup_id is required for popup-scoped templates"
+
+
+def test_popup_communications_ignore_tenant_auth_templates(
+    client,
+    db: Session,
+    admin_token_tenant_a: str,
+    popup_tenant_a: Popups,
+):
+    _delete_tenant_template(db, popup_tenant_a.tenant_id, "login_code_human")
+
+    auth_response = _create_auth_template(
+        client,
+        admin_token_tenant_a,
+        template_type="login_code_human",
+        subject="Tenant auth",
+        html_content="<html><body>Tenant auth template {{ auth_code }}</body></html>",
+    )
+    assert auth_response.status_code == 201
+
+    popup_response = _create_popup_template(
+        client,
+        admin_token_tenant_a,
+        popup_tenant_a.id,
+        template_type="application_received",
+        subject="Popup subject",
+        html_content="<html><body>Popup communication for {{ popup_name }}</body></html>",
+    )
+    assert popup_response.status_code == 201
+
+    rendered_html, rendered_subject = EmailService().render_with_fallback(
+        template_type="application_received",
+        context={"popup_name": popup_tenant_a.name},
+        popup_id=popup_tenant_a.id,
+        db_session=db,
+    )
+
+    assert "Popup communication for" in rendered_html
+    assert "Tenant auth template" not in rendered_html
+    assert rendered_subject == "Popup subject"
+
+
+def test_inactive_tenant_auth_templates_fall_back_to_default_file(
+    client,
+    db: Session,
+    monkeypatch,
+    admin_user_tenant_a: Users,
+    admin_token_tenant_a: str,
+):
+    _delete_tenant_template(db, admin_user_tenant_a.tenant_id, "login_code_human")
+
+    create_response = _create_auth_template(
+        client,
+        admin_token_tenant_a,
+        template_type="login_code_human",
+        subject="Inactive custom subject",
+        html_content="<html><body>Inactive custom {{ auth_code }}</body></html>",
+        is_active=False,
+    )
+    assert create_response.status_code == 201
+
+    captured: dict[str, str] = {}
+
+    async def fake_send_email(_self, **kwargs):
+        captured["subject"] = kwargs["subject"]
+        captured["html_content"] = kwargs["html_content"]
+        return True
+
+    monkeypatch.setattr(EmailService, "send_email", fake_send_email)
+
+    human_email = f"pending-{uuid.uuid4().hex[:8]}@test.com"
+    response = client.post(
+        "/api/v1/auth/human/login",
+        json={
+            "tenant_id": str(admin_user_tenant_a.tenant_id),
+            "email": human_email,
+            "red_flag": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Inactive custom" not in captured["html_content"]
+    assert captured["subject"] == "Your Verification Code - Test Tenant A"
+
+
+def test_portal_login_route_uses_tenant_scoped_custom_template(
+    client,
+    db: Session,
+    monkeypatch,
+    admin_token_tenant_a: str,
+    tenant_a: Tenants,
+):
+    _delete_tenant_template(db, tenant_a.id, "login_code_human")
+
+    human_template_response = _create_auth_template(
+        client,
+        admin_token_tenant_a,
+        template_type="login_code_human",
+        subject="Human login for {{ tenant_name }}",
+        html_content="<html><body>Human custom code {{ auth_code }}</body></html>",
+    )
+    assert human_template_response.status_code == 201
+
+    captured_calls: list[dict[str, str]] = []
+
+    async def fake_send_email(_self, **kwargs):
+        captured_calls.append(
+            {
+                "subject": kwargs["subject"],
+                "html_content": kwargs["html_content"],
+                "to": kwargs["to"],
+            }
+        )
+        return True
+
+    monkeypatch.setattr(EmailService, "send_email", fake_send_email)
+
+    human_email = f"pending-{uuid.uuid4().hex[:8]}@test.com"
+    human_response = client.post(
+        "/api/v1/auth/human/login",
+        json={
+            "tenant_id": str(tenant_a.id),
+            "email": human_email,
+            "red_flag": False,
+        },
+    )
+
+    assert human_response.status_code == 200
+    assert captured_calls[0]["subject"] == "Human login for Test Tenant A"
+    assert "Human custom code" in captured_calls[0]["html_content"]

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -3049,8 +3049,15 @@ export const DistributionItemSchema = {
 export const EmailTemplateCreateSchema = {
     properties: {
         popup_id: {
-            type: 'string',
-            format: 'uuid',
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Popup Id'
         },
         template_type: {
@@ -3079,7 +3086,7 @@ export const EmailTemplateCreateSchema = {
         }
     },
     type: 'object',
-    required: ['popup_id', 'template_type', 'html_content'],
+    required: ['template_type', 'html_content'],
     title: 'EmailTemplateCreate'
 } as const;
 
@@ -3096,13 +3103,23 @@ export const EmailTemplatePublicSchema = {
             title: 'Tenant Id'
         },
         popup_id: {
-            type: 'string',
-            format: 'uuid',
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Popup Id'
         },
         template_type: {
             type: 'string',
             title: 'Template Type'
+        },
+        scope: {
+            '$ref': '#/components/schemas/TemplateScope'
         },
         subject: {
             anyOf: [
@@ -3150,7 +3167,7 @@ export const EmailTemplatePublicSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'tenant_id', 'popup_id', 'template_type', 'html_content'],
+    required: ['id', 'tenant_id', 'popup_id', 'template_type', 'scope', 'html_content'],
     title: 'EmailTemplatePublic'
 } as const;
 
@@ -9218,6 +9235,12 @@ export const SendTestRequestSchema = {
     title: 'SendTestRequest'
 } as const;
 
+export const TemplateScopeSchema = {
+    type: 'string',
+    enum: ['tenant', 'popup'],
+    title: 'TemplateScope'
+} as const;
+
 export const TemplateTypeInfoSchema = {
     properties: {
         type: {
@@ -9236,6 +9259,9 @@ export const TemplateTypeInfoSchema = {
             type: 'string',
             title: 'Category'
         },
+        scope: {
+            '$ref': '#/components/schemas/TemplateScope'
+        },
         default_subject: {
             type: 'string',
             title: 'Default Subject'
@@ -9249,7 +9275,7 @@ export const TemplateTypeInfoSchema = {
         }
     },
     type: 'object',
-    required: ['type', 'label', 'description', 'category', 'default_subject', 'variables'],
+    required: ['type', 'label', 'description', 'category', 'scope', 'default_subject', 'variables'],
     title: 'TemplateTypeInfo'
 } as const;
 

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -693,7 +693,7 @@ export type DistributionItem = {
 };
 
 export type EmailTemplateCreate = {
-    popup_id: string;
+    popup_id?: (string | null);
     template_type: string;
     subject?: (string | null);
     html_content: string;
@@ -703,8 +703,9 @@ export type EmailTemplateCreate = {
 export type EmailTemplatePublic = {
     id: string;
     tenant_id: string;
-    popup_id: string;
+    popup_id: (string | null);
     template_type: string;
+    scope: TemplateScope;
     subject?: (string | null);
     html_content: string;
     is_active?: boolean;
@@ -1824,11 +1825,14 @@ export type SendTestRequest = {
     popup_id?: (string | null);
 };
 
+export type TemplateScope = 'tenant' | 'popup';
+
 export type TemplateTypeInfo = {
     type: string;
     label: string;
     description: string;
     category: string;
+    scope: TemplateScope;
     default_subject: string;
     variables: Array<TemplateVariable>;
 };

--- a/backoffice/src/components/EmailTemplateEditor.tsx
+++ b/backoffice/src/components/EmailTemplateEditor.tsx
@@ -56,6 +56,12 @@ import {
   useDirtyBlocker,
 } from "@/hooks/useUnsavedChanges"
 import { createErrorHandler } from "@/utils"
+import {
+  buildEmailTemplateCreatePayload,
+  buildEmailTemplatePreviewPayload,
+  buildEmailTemplateSendTestPayload,
+  requirePopupForTemplateScope,
+} from "./email-template-scope"
 
 const HTML_SHELL_BEFORE_STYLE = `<!DOCTYPE html>
 <html lang="en">
@@ -114,7 +120,7 @@ function reconstructFullHtml(editableContent: string): string {
 
 interface EmailTemplateEditorProps {
   templateType: EmailTemplateType
-  popupId: string
+  popupId?: string
   existingTemplate?: EmailTemplatePublic
   typeInfo: TemplateTypeInfo
   onSave: () => void
@@ -151,6 +157,7 @@ export function EmailTemplateEditor({
   const [showPreview, setShowPreview] = useState(true)
 
   const isEdit = !!existingTemplate
+  const requiresPopup = requirePopupForTemplateScope(typeInfo.scope)
 
   const { data: defaultTemplate } = useQuery({
     queryKey: ["email-template-default", templateType],
@@ -162,7 +169,14 @@ export function EmailTemplateEditor({
 
   const { data: popupData } = useQuery({
     queryKey: ["popup", popupId],
-    queryFn: () => PopupsService.getPopup({ popupId }),
+    queryFn: () => {
+      if (!popupId) {
+        throw new Error("Popup id is required to load popup-scoped templates")
+      }
+
+      return PopupsService.getPopup({ popupId })
+    },
+    enabled: requiresPopup && !!popupId,
   })
 
   const initialHtmlRef = useRef(
@@ -214,12 +228,13 @@ export function EmailTemplateEditor({
         }
         try {
           const result = await EmailTemplatesService.previewTemplate({
-            requestBody: {
-              html_content: reconstructFullHtml(content),
-              template_type: templateType,
+            requestBody: buildEmailTemplatePreviewPayload({
+              scope: typeInfo.scope,
+              popupId,
+              templateType,
+              htmlContent: reconstructFullHtml(content),
               subject: subjectValue || undefined,
-              popup_id: popupId,
-            },
+            }),
           })
           setPreviewHtml(result.rendered_html)
         } catch {
@@ -227,7 +242,7 @@ export function EmailTemplateEditor({
         }
       }, 500)
     },
-    [templateType, popupId],
+    [templateType, popupId, typeInfo.scope],
   )
 
   useEffect(() => {
@@ -308,13 +323,14 @@ export function EmailTemplateEditor({
       is_active: boolean
     }) =>
       EmailTemplatesService.createEmailTemplate({
-        requestBody: {
-          popup_id: popupId,
-          template_type: templateType,
-          html_content: data.html_content,
+        requestBody: buildEmailTemplateCreatePayload({
+          scope: typeInfo.scope,
+          popupId,
+          templateType,
+          htmlContent: data.html_content,
           subject: data.subject,
-          is_active: data.is_active,
-        },
+          isActive: data.is_active,
+        }),
       }),
     onSuccess: () => {
       showSuccessToast("Template created")
@@ -362,13 +378,14 @@ export function EmailTemplateEditor({
   const sendTestMutation = useMutation({
     mutationFn: (email: string) =>
       EmailTemplatesService.sendTestEmail({
-        requestBody: {
-          html_content: reconstructFullHtml(htmlContent),
-          template_type: templateType,
+        requestBody: buildEmailTemplateSendTestPayload({
+          scope: typeInfo.scope,
+          popupId,
+          templateType,
+          htmlContent: reconstructFullHtml(htmlContent),
           subject: subject || undefined,
-          to_email: email,
-          popup_id: popupId,
-        },
+          toEmail: email,
+        }),
       }),
     onSuccess: () => {
       showSuccessToast("Test email sent!")
@@ -553,8 +570,8 @@ export function EmailTemplateEditor({
             <DialogTitle>Send Test Email</DialogTitle>
             <DialogDescription>
               Send a test email to verify layout and styling. Popup variables
-              will be filled with real data; other variables will show as
-              placeholders.
+              will be filled with real data when popup scope is required; other
+              variables will show as placeholders.
             </DialogDescription>
           </DialogHeader>
           <div>

--- a/backoffice/src/components/email-template-scope.test.ts
+++ b/backoffice/src/components/email-template-scope.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildEmailTemplateCreatePayload,
+  buildEmailTemplatePreviewPayload,
+  buildEmailTemplateSendTestPayload,
+  requirePopupForTemplateScope,
+} from "./email-template-scope"
+
+describe("email-template-scope helpers", () => {
+  it("omits popup context for tenant-scoped auth templates", () => {
+    expect(
+      buildEmailTemplateCreatePayload({
+        scope: "tenant",
+        popupId: "popup-1",
+        templateType: "login_code_human",
+        htmlContent: "<html></html>",
+        subject: "Tenant subject",
+        isActive: true,
+      }),
+    ).toEqual({
+      template_type: "login_code_human",
+      html_content: "<html></html>",
+      subject: "Tenant subject",
+      is_active: true,
+    })
+
+    expect(
+      buildEmailTemplatePreviewPayload({
+        scope: "tenant",
+        popupId: "popup-1",
+        templateType: "login_code_human",
+        htmlContent: "<html></html>",
+        subject: "Preview subject",
+      }),
+    ).toEqual({
+      template_type: "login_code_human",
+      html_content: "<html></html>",
+      subject: "Preview subject",
+    })
+
+    expect(
+      buildEmailTemplateSendTestPayload({
+        scope: "tenant",
+        popupId: "popup-1",
+        templateType: "login_code_human",
+        htmlContent: "<html></html>",
+        subject: "Send subject",
+        toEmail: "test@example.com",
+      }),
+    ).toEqual({
+      template_type: "login_code_human",
+      html_content: "<html></html>",
+      subject: "Send subject",
+      to_email: "test@example.com",
+    })
+  })
+
+  it("requires popup context for popup-scoped communications", () => {
+    expect(requirePopupForTemplateScope("popup")).toBe(true)
+    expect(requirePopupForTemplateScope("tenant")).toBe(false)
+
+    expect(
+      buildEmailTemplateCreatePayload({
+        scope: "popup",
+        popupId: "popup-123",
+        templateType: "application_received",
+        htmlContent: "<html></html>",
+        subject: "Popup subject",
+        isActive: false,
+      }),
+    ).toEqual({
+      popup_id: "popup-123",
+      template_type: "application_received",
+      html_content: "<html></html>",
+      subject: "Popup subject",
+      is_active: false,
+    })
+  })
+})

--- a/backoffice/src/components/email-template-scope.ts
+++ b/backoffice/src/components/email-template-scope.ts
@@ -1,0 +1,60 @@
+type TemplateScope = "tenant" | "popup"
+
+type ScopedTemplatePayloadArgs = {
+  scope: TemplateScope
+  popupId?: string
+  templateType: string
+  htmlContent: string
+  subject?: string
+}
+
+export function requirePopupForTemplateScope(scope: TemplateScope): boolean {
+  return scope === "popup"
+}
+
+function maybeAttachPopupId<T extends Record<string, unknown>>(
+  scope: TemplateScope,
+  popupId: string | undefined,
+  payload: T,
+): T & { popup_id?: string } {
+  if (!requirePopupForTemplateScope(scope)) {
+    return payload
+  }
+
+  return {
+    ...payload,
+    popup_id: popupId,
+  }
+}
+
+export function buildEmailTemplateCreatePayload(
+  args: ScopedTemplatePayloadArgs & { isActive: boolean },
+) {
+  return maybeAttachPopupId(args.scope, args.popupId, {
+    template_type: args.templateType,
+    html_content: args.htmlContent,
+    subject: args.subject,
+    is_active: args.isActive,
+  })
+}
+
+export function buildEmailTemplatePreviewPayload(
+  args: ScopedTemplatePayloadArgs,
+) {
+  return maybeAttachPopupId(args.scope, args.popupId, {
+    template_type: args.templateType,
+    html_content: args.htmlContent,
+    subject: args.subject,
+  })
+}
+
+export function buildEmailTemplateSendTestPayload(
+  args: ScopedTemplatePayloadArgs & { toEmail: string },
+) {
+  return maybeAttachPopupId(args.scope, args.popupId, {
+    template_type: args.templateType,
+    html_content: args.htmlContent,
+    subject: args.subject,
+    to_email: args.toEmail,
+  })
+}

--- a/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
+++ b/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/_layout/email-templates/$type/edit")({
   }),
 })
 
-function EditorContent({ templateType }: { templateType: string }) {
+export function EditorContent({ templateType }: { templateType: string }) {
   const { selectedPopupId } = useWorkspace()
   const navigate = useNavigate()
 
@@ -28,22 +28,30 @@ function EditorContent({ templateType }: { templateType: string }) {
     queryFn: () => EmailTemplatesService.listTemplateTypes(),
   })
 
+  const typeInfo = types?.find((t) => t.type === templateType)
+  const requiresPopup = typeInfo?.scope === "popup"
+
   const { data: customTemplates } = useQuery({
-    queryKey: ["email-templates", selectedPopupId],
+    queryKey: ["email-templates", requiresPopup ? selectedPopupId : "tenant"],
     queryFn: () =>
-      EmailTemplatesService.listEmailTemplates({
-        popupId: selectedPopupId!,
-      }),
-    enabled: !!selectedPopupId,
+      requiresPopup
+        ? EmailTemplatesService.listEmailTemplates({
+            popupId: selectedPopupId!,
+          })
+        : EmailTemplatesService.listEmailTemplates(),
+    enabled: !!typeInfo && (!requiresPopup || !!selectedPopupId),
   })
 
-  const typeInfo = types?.find((t) => t.type === templateType)
   const existingTemplate = customTemplates?.results?.find(
     (t) => t.template_type === templateType,
   )
 
-  if (!types || !customTemplates) return <Skeleton className="h-96 w-full" />
+  if (!types) return <Skeleton className="h-96 w-full" />
   if (!typeInfo) return <div>Unknown template type: {templateType}</div>
+  if (requiresPopup && !selectedPopupId) {
+    return <WorkspaceAlert resource="email templates" action="create" />
+  }
+  if (!customTemplates) return <Skeleton className="h-96 w-full" />
 
   return (
     <div className="flex flex-col gap-4">
@@ -63,7 +71,7 @@ function EditorContent({ templateType }: { templateType: string }) {
 
       <EmailTemplateEditor
         templateType={templateType as EmailTemplateType}
-        popupId={selectedPopupId!}
+        popupId={requiresPopup ? selectedPopupId! : undefined}
         existingTemplate={existingTemplate}
         typeInfo={typeInfo}
         onSave={() => navigate({ to: "/email-templates" })}
@@ -74,7 +82,7 @@ function EditorContent({ templateType }: { templateType: string }) {
 
 function EditEmailTemplate() {
   const { type } = Route.useParams()
-  const { isContextReady } = useWorkspace()
+  const { needsTenantSelection } = useWorkspace()
   const { isAdmin, isUserLoading } = useAuth()
   const navigate = useNavigate()
 
@@ -88,7 +96,7 @@ function EditEmailTemplate() {
     return null
   }
 
-  if (!isContextReady) {
+  if (needsTenantSelection) {
     return (
       <div className="flex flex-col gap-6">
         <WorkspaceAlert resource="email templates" action="create" />

--- a/backoffice/src/routes/_layout/email-templates/email-templates-routing.test.tsx
+++ b/backoffice/src/routes/_layout/email-templates/email-templates-routing.test.tsx
@@ -1,0 +1,154 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/client", () => ({
+  EmailTemplatesService: {
+    listTemplateTypes: vi.fn(),
+    listEmailTemplates: vi.fn(),
+  },
+}))
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<object>("@tanstack/react-router")
+  return {
+    ...actual,
+    createFileRoute: () => () => ({
+      useParams: () => ({ type: "login_code_human" }),
+    }),
+    Link: ({ children, to, params, ...props }: any) => (
+      <a href={typeof to === "string" ? to : "#"} {...props}>
+        {children}
+        {params?.type ? `:${params.type}` : null}
+      </a>
+    ),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: vi.fn(),
+}))
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ isAdmin: true, isUserLoading: false }),
+}))
+
+vi.mock("@/components/Common/QueryErrorBoundary", () => ({
+  QueryErrorBoundary: ({ children }: { children: ReactNode }) => children,
+}))
+
+vi.mock("@/components/Common/WorkspaceAlert", () => ({
+  WorkspaceAlert: ({ resource }: { resource: string }) => (
+    <div>{`workspace-alert:${resource}`}</div>
+  ),
+}))
+
+vi.mock("@/components/EmailTemplateEditor", () => ({
+  EmailTemplateEditor: ({
+    popupId,
+    templateType,
+  }: {
+    popupId?: string
+    templateType: string
+  }) => <div>{`editor:${templateType}:${popupId ?? "tenant"}`}</div>,
+}))
+
+import { EmailTemplatesService } from "@/client"
+import { useWorkspace } from "@/contexts/WorkspaceContext"
+import { EditorContent } from "./$type.edit"
+import { TemplateList } from "./index"
+
+const mockUseWorkspace = vi.mocked(useWorkspace)
+const mockListTemplateTypes = vi.mocked(EmailTemplatesService.listTemplateTypes)
+const mockListEmailTemplates = vi.mocked(
+  EmailTemplatesService.listEmailTemplates,
+)
+
+function renderWithQueryClient(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+}
+
+describe("email template routing behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseWorkspace.mockReturnValue({
+      selectedPopupId: null,
+      selectedTenantId: "tenant-1",
+      effectiveTenantId: "tenant-1",
+      isContextReady: false,
+      needsTenantSelection: false,
+      needsPopupSelection: true,
+      setSelectedPopupId: vi.fn(),
+      setSelectedTenantId: vi.fn(),
+    })
+
+    mockListTemplateTypes.mockResolvedValue([
+      {
+        type: "login_code_human",
+        label: "Portal Login Code",
+        description: "Tenant auth",
+        category: "Auth",
+        scope: "tenant",
+        default_subject: "Portal login",
+        variables: [],
+      },
+      {
+        type: "application_received",
+        label: "Application Received",
+        description: "Popup communication",
+        category: "Application",
+        scope: "popup",
+        default_subject: "Application received",
+        variables: [],
+      },
+    ] as Awaited<ReturnType<typeof EmailTemplatesService.listTemplateTypes>>)
+
+    mockListEmailTemplates.mockImplementation(async ({ popupId } = {}) => ({
+      results: popupId
+        ? []
+        : [
+            {
+              id: "template-1",
+              tenant_id: "tenant-1",
+              popup_id: null,
+              template_type: "login_code_human",
+              subject: "Tenant subject",
+              html_content: "<html></html>",
+              is_active: true,
+            },
+          ],
+      paging: { offset: 0, limit: 100, total: popupId ? 0 : 1 },
+    }))
+  })
+
+  it("shows auth templates without popup selection and gates popup templates", async () => {
+    renderWithQueryClient(<TemplateList />)
+
+    expect(await screen.findByText("Portal Login Code")).toBeInTheDocument()
+    expect(screen.getByText("Application Received")).toBeInTheDocument()
+    expect(screen.getByText("Custom")).toBeInTheDocument()
+    expect(screen.getByText("Select popup to edit")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(mockListEmailTemplates).toHaveBeenCalledWith()
+    })
+  })
+
+  it("opens auth template editor with tenant context only", async () => {
+    renderWithQueryClient(<EditorContent templateType="login_code_human" />)
+
+    expect(
+      await screen.findByText("editor:login_code_human:tenant"),
+    ).toBeInTheDocument()
+  })
+})

--- a/backoffice/src/routes/_layout/email-templates/index.tsx
+++ b/backoffice/src/routes/_layout/email-templates/index.tsx
@@ -26,7 +26,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   Payment: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
 }
 
-function TemplateList() {
+export function TemplateList() {
   const { selectedPopupId } = useWorkspace()
 
   const { data: types } = useQuery({
@@ -34,25 +34,34 @@ function TemplateList() {
     queryFn: () => EmailTemplatesService.listTemplateTypes(),
   })
 
-  const { data: customTemplates } = useQuery({
-    queryKey: ["email-templates", selectedPopupId],
+  const { data: tenantTemplates } = useQuery({
+    queryKey: ["email-templates", "tenant"],
+    queryFn: () => EmailTemplatesService.listEmailTemplates(),
+  })
+
+  const { data: popupTemplates } = useQuery({
+    queryKey: ["email-templates", "popup", selectedPopupId],
     queryFn: () =>
-      EmailTemplatesService.listEmailTemplates({
-        popupId: selectedPopupId!,
-      }),
+      EmailTemplatesService.listEmailTemplates({ popupId: selectedPopupId! }),
     enabled: !!selectedPopupId,
   })
 
   if (!types) return <Skeleton className="h-64 w-full" />
 
-  const customTypeSet = new Set(
-    customTemplates?.results?.map((t) => t.template_type) ?? [],
+  const tenantCustomTypeSet = new Set(
+    tenantTemplates?.results?.map((t) => t.template_type) ?? [],
+  )
+  const popupCustomTypeSet = new Set(
+    popupTemplates?.results?.map((t) => t.template_type) ?? [],
   )
 
   return (
     <div className="divide-y rounded-md border">
       {types.map((tmpl) => {
-        const hasCustom = customTypeSet.has(tmpl.type)
+        const requiresPopup = tmpl.scope === "popup"
+        const hasCustom = requiresPopup
+          ? popupCustomTypeSet.has(tmpl.type)
+          : tenantCustomTypeSet.has(tmpl.type)
         return (
           <div
             key={tmpl.type}
@@ -77,15 +86,22 @@ function TemplateList() {
               ) : (
                 <Badge variant="secondary">Default</Badge>
               )}
-              <Button variant="ghost" size="sm" asChild>
-                <Link
-                  to="/email-templates/$type/edit"
-                  params={{ type: tmpl.type }}
-                >
+              {requiresPopup && !selectedPopupId ? (
+                <Button variant="ghost" size="sm" disabled>
                   <Pencil className="mr-1.5 h-3.5 w-3.5" />
-                  Edit
-                </Link>
-              </Button>
+                  Select popup to edit
+                </Button>
+              ) : (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link
+                    to="/email-templates/$type/edit"
+                    params={{ type: tmpl.type }}
+                  >
+                    <Pencil className="mr-1.5 h-3.5 w-3.5" />
+                    Edit
+                  </Link>
+                </Button>
+              )}
             </div>
           </div>
         )
@@ -94,8 +110,8 @@ function TemplateList() {
   )
 }
 
-function EmailTemplatesPage() {
-  const { isContextReady } = useWorkspace()
+export function EmailTemplatesPage() {
+  const { needsTenantSelection, needsPopupSelection } = useWorkspace()
   const { isAdmin } = useAuth()
 
   if (!isAdmin) {
@@ -111,7 +127,10 @@ function EmailTemplatesPage() {
 
   return (
     <div className="flex flex-col gap-6">
-      {!isContextReady && <WorkspaceAlert resource="email templates" />}
+      {needsTenantSelection && <WorkspaceAlert resource="email templates" />}
+      {needsPopupSelection && (
+        <WorkspaceAlert resource="popup-scoped email templates" />
+      )}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Email Templates</h1>
@@ -120,7 +139,7 @@ function EmailTemplatesPage() {
           </p>
         </div>
       </div>
-      {isContextReady && (
+      {!needsTenantSelection && (
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-64 w-full" />}>
             <TemplateList />

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -3049,8 +3049,15 @@ export const DistributionItemSchema = {
 export const EmailTemplateCreateSchema = {
     properties: {
         popup_id: {
-            type: 'string',
-            format: 'uuid',
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Popup Id'
         },
         template_type: {
@@ -3079,7 +3086,7 @@ export const EmailTemplateCreateSchema = {
         }
     },
     type: 'object',
-    required: ['popup_id', 'template_type', 'html_content'],
+    required: ['template_type', 'html_content'],
     title: 'EmailTemplateCreate'
 } as const;
 
@@ -3096,13 +3103,23 @@ export const EmailTemplatePublicSchema = {
             title: 'Tenant Id'
         },
         popup_id: {
-            type: 'string',
-            format: 'uuid',
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
             title: 'Popup Id'
         },
         template_type: {
             type: 'string',
             title: 'Template Type'
+        },
+        scope: {
+            '$ref': '#/components/schemas/TemplateScope'
         },
         subject: {
             anyOf: [
@@ -3150,7 +3167,7 @@ export const EmailTemplatePublicSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'tenant_id', 'popup_id', 'template_type', 'html_content'],
+    required: ['id', 'tenant_id', 'popup_id', 'template_type', 'scope', 'html_content'],
     title: 'EmailTemplatePublic'
 } as const;
 
@@ -9218,6 +9235,12 @@ export const SendTestRequestSchema = {
     title: 'SendTestRequest'
 } as const;
 
+export const TemplateScopeSchema = {
+    type: 'string',
+    enum: ['tenant', 'popup'],
+    title: 'TemplateScope'
+} as const;
+
 export const TemplateTypeInfoSchema = {
     properties: {
         type: {
@@ -9236,6 +9259,9 @@ export const TemplateTypeInfoSchema = {
             type: 'string',
             title: 'Category'
         },
+        scope: {
+            '$ref': '#/components/schemas/TemplateScope'
+        },
         default_subject: {
             type: 'string',
             title: 'Default Subject'
@@ -9249,7 +9275,7 @@ export const TemplateTypeInfoSchema = {
         }
     },
     type: 'object',
-    required: ['type', 'label', 'description', 'category', 'default_subject', 'variables'],
+    required: ['type', 'label', 'description', 'category', 'scope', 'default_subject', 'variables'],
     title: 'TemplateTypeInfo'
 } as const;
 

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -693,7 +693,7 @@ export type DistributionItem = {
 };
 
 export type EmailTemplateCreate = {
-    popup_id: string;
+    popup_id?: (string | null);
     template_type: string;
     subject?: (string | null);
     html_content: string;
@@ -703,8 +703,9 @@ export type EmailTemplateCreate = {
 export type EmailTemplatePublic = {
     id: string;
     tenant_id: string;
-    popup_id: string;
+    popup_id: (string | null);
     template_type: string;
+    scope: TemplateScope;
     subject?: (string | null);
     html_content: string;
     is_active?: boolean;
@@ -1824,11 +1825,14 @@ export type SendTestRequest = {
     popup_id?: (string | null);
 };
 
+export type TemplateScope = 'tenant' | 'popup';
+
 export type TemplateTypeInfo = {
     type: string;
     label: string;
     description: string;
     category: string;
+    scope: TemplateScope;
     default_subject: string;
     variables: Array<TemplateVariable>;
 };


### PR DESCRIPTION
## Summary
- Adds a TENANT scope dimension to email templates alongside the existing POPUP scope, letting tenant-level templates (e.g. portal login code) be customized once per tenant
- Backend: migration + scope enum + scope-aware CRUD/render pipeline + endpoint validation that rejects popup-scoped requests without a popup and tenant-scoped requests without a tenant context
- Backoffice: list and editor adapt to scope — tenant-scoped types load without requiring popup selection, popup-scoped types keep the existing flow
- Regenerates OpenAPI clients for backoffice and portal

## Test plan
- [ ] `alembic upgrade head` applies the new migration on a DB already at `499dd4b24f32` without error
- [ ] Create a tenant-scoped template (LOGIN_CODE_HUMAN) from the backoffice without selecting a popup — it saves and appears in the list
- [ ] Trigger a portal login for the tenant — the custom template renders with `tenant_name` interpolated
- [ ] Create a popup-scoped template — popup selection is still required and enforced server-side
- [ ] Switching popup context in the list view refreshes only popup-scoped entries, tenant-scoped entries stay stable