### PR TITLE
fix(checkout): enhance CartFooter and SnapFooter with isLastSection prop

### DIFF
--- a/portal/src/components/checkout-flow/CartFooter.tsx
+++ b/portal/src/components/checkout-flow/CartFooter.tsx
@@ -20,6 +20,7 @@ interface CartFooterProps {
   onBack?: () => void
   nextSectionLabel?: string
   onContinue?: () => void
+  isLastSection?: boolean
 }
 
 export default function CartFooter({
@@ -27,6 +28,7 @@ export default function CartFooter({
   onBack,
   nextSectionLabel,
   onContinue,
+  isLastSection = false,
 }: CartFooterProps) {
   const { t } = useTranslation()
   const {
@@ -48,7 +50,7 @@ export default function CartFooter({
 
   const [isExpanded, setIsExpanded] = useState(false)
 
-  const isConfirmStep = currentStep === "confirm"
+  const isConfirmStep = currentStep === "confirm" || isLastSection
   const isFirstStep = currentStep === "passes"
   const currentIndex = availableSteps.indexOf(currentStep)
   const nextStepId =

--- a/portal/src/components/checkout-flow/SnapFooter.tsx
+++ b/portal/src/components/checkout-flow/SnapFooter.tsx
@@ -256,6 +256,7 @@ export default function SnapFooter({
         onBack={onBack}
         nextSectionLabel={nextSectionLabel}
         onContinue={onGoToNextSection}
+        isLastSection={isOnConfirm}
       />
     ),
     stripe: (


### PR DESCRIPTION
## Summary
- Added `isLastSection` prop to `CartFooter` and `SnapFooter` components to control behavior at the last checkout section

## Files changed
- `portal/src/components/checkout-flow/CartFooter.tsx`
- `portal/src/components/checkout-flow/SnapFooter.tsx`