### PR TITLE
fix(email): prevent duplicate template saves and missing application variables

### DIFF
--- a/backend/app/api/email_template/router.py
+++ b/backend/app/api/email_template/router.py
@@ -77,6 +77,43 @@ def _resolve_effective_tenant_id(current_user: CurrentUser, db: TenantSession) -
     return uuid.UUID(tenant_id)
 
 
+def _get_template_label(template_type: str) -> str | None:
+    from app.services.email.templates import TEMPLATE_TYPE_METADATA
+
+    metadata = next(
+        (
+            meta
+            for meta in TEMPLATE_TYPE_METADATA
+            if str(meta["type"]) == template_type
+        ),
+        None,
+    )
+    return metadata["label"] if metadata else None
+
+
+def _template_scope_required_message(template_type: str) -> str:
+    template_label = _get_template_label(template_type) or "email template"
+    return f"Select a popup before managing the {template_label} template"
+
+
+def _template_not_customizable_message(template_type: str) -> str:
+    template_label = _get_template_label(template_type)
+    if template_label:
+        return f"{template_label} can't be customized from backoffice"
+    return "This email template can't be customized from backoffice"
+
+
+def _duplicate_template_message(
+    template_type: str, template_scope: TemplateScope
+) -> str:
+    template_label = _get_template_label(template_type) or "email"
+    scope_label = "workspace" if template_scope == TemplateScope.TENANT else "popup"
+    return (
+        f"This {scope_label} already has a custom {template_label} template. "
+        "Open it from the list to edit it."
+    )
+
+
 @router.get("/types", response_model=list[TemplateTypeInfo])
 async def list_template_types(
     _: CurrentUser,
@@ -119,13 +156,13 @@ async def preview_template(
     if not is_customizable_template_type(body.template_type):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Template type is not customizable: {body.template_type}",
+            detail=_template_not_customizable_message(body.template_type),
         )
 
     if get_template_scope(body.template_type) == TemplateScope.POPUP and not body.popup_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="popup_id is required for popup-scoped templates",
+            detail=_template_scope_required_message(body.template_type),
         )
 
     # Start with enriched popup data as the base, then let preview_variables override
@@ -186,13 +223,13 @@ async def send_test_email(
     if not is_customizable_template_type(body.template_type):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Template type is not customizable: {body.template_type}",
+            detail=_template_not_customizable_message(body.template_type),
         )
 
     if get_template_scope(body.template_type) == TemplateScope.POPUP and not body.popup_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="popup_id is required for popup-scoped templates",
+            detail=_template_scope_required_message(body.template_type),
         )
 
     # Start with enriched popup data as the base, then let custom_variables override
@@ -307,7 +344,7 @@ async def create_email_template(
     if not is_customizable_template_type(template_in.template_type):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Template type is not customizable: {template_in.template_type}",
+            detail=_template_not_customizable_message(template_in.template_type),
         )
 
     template_scope = get_template_scope(template_in.template_type)
@@ -316,7 +353,7 @@ async def create_email_template(
         if not template_in.popup_id:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="popup_id is required for popup-scoped templates",
+                detail=_template_scope_required_message(template_in.template_type),
             )
 
         existing = crud.email_template_crud.get_by_popup_and_type(
@@ -325,7 +362,9 @@ async def create_email_template(
         if existing:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="A template for this type already exists in this popup",
+                detail=_duplicate_template_message(
+                    template_in.template_type, TemplateScope.POPUP
+                ),
             )
 
         if current_user.role == UserRole.SUPERADMIN:
@@ -348,7 +387,9 @@ async def create_email_template(
         if existing:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="A tenant-scoped template for this type already exists",
+                detail=_duplicate_template_message(
+                    template_in.template_type, TemplateScope.TENANT
+                ),
             )
 
     from app.api.email_template.models import EmailTemplates

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -33,8 +33,10 @@ from app.core.dependencies.users import (
 from app.core.redis import WebhookCache
 from app.services.email import (
     EmailAttachment,
+    PaymentAttendeeItem,
     PaymentConfirmedContext,
     PaymentProductItem,
+    compute_order_summary,
     get_email_service,
 )
 from app.services.email_helpers import send_application_status_email
@@ -86,6 +88,80 @@ def _extract_settlement_details(
     return settlement_currency, settlement_rate, source
 
 
+def _build_payment_email_products(payment: Payments) -> list[PaymentProductItem]:
+    return [
+        PaymentProductItem(
+            name=pp.product_name,
+            price=float(pp.product_price),
+            quantity=pp.quantity,
+        )
+        for pp in payment.products_snapshot
+    ]
+
+
+def _build_payment_email_attendees(
+    payment: Payments,
+) -> list[PaymentAttendeeItem] | None:
+    if not payment.products_snapshot:
+        return None
+
+    attendees_by_id: dict[uuid.UUID, PaymentAttendeeItem] = {}
+
+    for product_snapshot in payment.products_snapshot:
+        attendee = product_snapshot.attendee
+        attendee_id = product_snapshot.attendee_id
+
+        if attendee_id not in attendees_by_id:
+            attendees_by_id[attendee_id] = PaymentAttendeeItem(
+                name=(attendee.name if attendee else None)
+                or product_snapshot.attendee_name
+                or "Attendee",
+                category=(attendee.category if attendee else None) or "attendee",
+                products=[],
+            )
+
+        attendees_by_id[attendee_id].products = [
+            *(attendees_by_id[attendee_id].products or []),
+            PaymentProductItem(
+                name=product_snapshot.product_name,
+                price=float(product_snapshot.product_price),
+                quantity=product_snapshot.quantity,
+            ),
+        ]
+
+    return list(attendees_by_id.values())
+
+
+def _build_payment_confirmed_context(
+    payment: Payments,
+    popup_name: str,
+    first_name: str,
+    portal_url: str | None,
+) -> PaymentConfirmedContext:
+    products = _build_payment_email_products(payment)
+    attendees = _build_payment_email_attendees(payment)
+
+    original_amount = None
+    if payment.discount_value and payment.discount_value > 0:
+        original_amount = sum(
+            float(pp.product_price) * pp.quantity for pp in payment.products_snapshot
+        )
+
+    return PaymentConfirmedContext(
+        first_name=first_name,
+        popup_name=popup_name,
+        payment_id=str(payment.id),
+        amount=float(payment.amount),
+        currency=payment.currency,
+        products=products if products else None,
+        discount_value=int(payment.discount_value) if payment.discount_value else None,
+        original_amount=original_amount,
+        attendees=attendees,
+        order_summary=compute_order_summary(payment) if payment.products_snapshot else None,
+        portal_url=portal_url,
+    )
+
+
 async def _send_payment_confirmed_email(payment, db_session=None) -> None:
     """Send payment confirmation email.
 
@@ -130,25 +206,6 @@ async def _send_payment_confirmed_email(payment, db_session=None) -> None:
         )
         return
 
-    # Build products list from payment snapshot
-    products = [
-        PaymentProductItem(
-            name=pp.product_name,
-            price=float(pp.product_price),
-            quantity=pp.quantity,
-        )
-        for pp in payment_model.products_snapshot
-    ]
-
-    # Calculate original amount if discount was applied
-    original_amount = None
-    if payment_model.discount_value and payment_model.discount_value > 0:
-        # Sum of all products
-        original_amount = sum(
-            float(pp.product_price) * pp.quantity
-            for pp in payment_model.products_snapshot
-        )
-
     # Generate invoice PDF attachment if popup has invoice details configured
     attachments: list[EmailAttachment] | None = None
     popup_has_invoice = (
@@ -189,23 +246,17 @@ async def _send_payment_confirmed_email(payment, db_session=None) -> None:
     from app.api.tenant.utils import get_portal_url
 
     portal_url = get_portal_url(tenant)
+    context = _build_payment_confirmed_context(
+        payment_model,
+        popup_name=popup.name,
+        first_name=human.first_name or "",
+        portal_url=portal_url,
+    )
 
     await email_service.send_payment_confirmed(
         to=human.email,
         subject=f"Payment Confirmed for {popup.name}",
-        context=PaymentConfirmedContext(
-            first_name=human.first_name or "",
-            popup_name=popup.name,
-            payment_id=str(payment_model.id),
-            amount=float(payment_model.amount),
-            currency=payment_model.currency,
-            products=products if products else None,
-            discount_value=int(payment_model.discount_value)
-            if payment_model.discount_value
-            else None,
-            original_amount=original_amount,
-            portal_url=portal_url,
-        ),
+        context=context,
         from_address=tenant.sender_email,
         from_name=tenant.sender_name,
         popup_id=popup.id,

--- a/backend/app/services/email/templates.py
+++ b/backend/app/services/email/templates.py
@@ -56,8 +56,6 @@ class ApplicationAcceptedContext(BaseModel):
     first_name: str
     last_name: str
     popup_name: str
-    payment_deadline: str | None = None
-    discount_assigned: int | None = None
     portal_url: str | None = None
 
 
@@ -433,22 +431,6 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "description": "Applicant's last name",
                 "required": True,
                 "group": "Applicant",
-            },
-            {
-                "name": "payment_deadline",
-                "label": "Payment Deadline",
-                "type": "string",
-                "description": "Payment deadline date",
-                "required": False,
-                "group": "General",
-            },
-            {
-                "name": "discount_assigned",
-                "label": "Discount",
-                "type": "number",
-                "description": "Discount percentage if assigned",
-                "required": False,
-                "group": "General",
             },
             {
                 "name": "portal_url",

--- a/backend/app/services/email_helpers.py
+++ b/backend/app/services/email_helpers.py
@@ -1,6 +1,6 @@
 """Email dispatch helpers for application status transitions."""
 
-from typing import Union
+from datetime import UTC, datetime
 
 from sqlmodel import Session
 
@@ -15,12 +15,35 @@ from app.services.email import (
     get_email_service,
 )
 
-_AcceptedContext = Union[
-    ApplicationAcceptedContext,
-    ApplicationAcceptedWithDiscountContext,
-    ApplicationAcceptedWithIncentiveContext,
-    ApplicationAcceptedScholarshipRejectedContext,
-]
+_AcceptedContext = (
+    ApplicationAcceptedContext
+    | ApplicationAcceptedWithDiscountContext
+    | ApplicationAcceptedWithIncentiveContext
+    | ApplicationAcceptedScholarshipRejectedContext
+)
+
+
+def _resolve_application_human_details(
+    application, human
+) -> tuple[str, str, str]:
+    source_human = application.human or human
+
+    return (
+        getattr(source_human, "first_name", None) or "",
+        getattr(source_human, "last_name", None) or "",
+        getattr(source_human, "email", None) or "",
+    )
+
+
+def _format_email_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+
+    if value.tzinfo is not None:
+        value = value.astimezone(UTC)
+        return value.strftime("%B %d, %Y %H:%M UTC")
+
+    return value.strftime("%B %d, %Y %H:%M")
 
 
 def _get_scholarship_email_variant(
@@ -131,19 +154,23 @@ async def send_application_status_email(
     if not popup or not human:
         return
 
+    first_name, last_name, email = _resolve_application_human_details(application, human)
+    submitted_at = _format_email_datetime(getattr(application, "submitted_at", None))
+
     email_service = get_email_service()
     from_address = popup.tenant.sender_email if popup.tenant else None
     from_name = popup.tenant.sender_name if popup.tenant else None
 
     if current_status == ApplicationStatus.IN_REVIEW.value:
         await email_service.send_application_received(
-            to=human.email,
+            to=email,
             subject=f"Application Received for {popup.name}",
             context=ApplicationReceivedContext(
-                first_name=human.first_name or "",
-                last_name=human.last_name or "",
-                email=human.email,
+                first_name=first_name,
+                last_name=last_name,
+                email=email,
                 popup_name=popup.name,
+                submitted_at=submitted_at,
             ),
             from_address=from_address,
             from_name=from_name,
@@ -155,7 +182,7 @@ async def send_application_status_email(
 
         if template_type == EmailTemplateType.APPLICATION_ACCEPTED:
             await email_service.send_application_accepted(
-                to=human.email,
+                to=email,
                 subject=f"Application Accepted for {popup.name}",
                 context=context,
                 from_address=from_address,
@@ -165,7 +192,7 @@ async def send_application_status_email(
             )
         elif template_type == EmailTemplateType.APPLICATION_ACCEPTED_WITH_DISCOUNT:
             await email_service.send_application_accepted_with_discount(
-                to=human.email,
+                to=email,
                 subject=f"Your scholarship & application — {popup.name}",
                 context=context,
                 from_address=from_address,
@@ -175,7 +202,7 @@ async def send_application_status_email(
             )
         elif template_type == EmailTemplateType.APPLICATION_ACCEPTED_WITH_INCENTIVE:
             await email_service.send_application_accepted_with_incentive(
-                to=human.email,
+                to=email,
                 subject=f"Your scholarship award — {popup.name}",
                 context=context,
                 from_address=from_address,
@@ -187,7 +214,7 @@ async def send_application_status_email(
             template_type == EmailTemplateType.APPLICATION_ACCEPTED_SCHOLARSHIP_REJECTED
         ):
             await email_service.send_application_accepted_scholarship_rejected(
-                to=human.email,
+                to=email,
                 subject=f"Your application to {popup.name} — accepted",
                 context=context,
                 from_address=from_address,
@@ -197,11 +224,11 @@ async def send_application_status_email(
             )
     elif current_status == ApplicationStatus.REJECTED.value:
         await email_service.send_application_rejected(
-            to=human.email,
+            to=email,
             subject=f"Application Update for {popup.name}",
             context=ApplicationRejectedContext(
-                first_name=human.first_name or "",
-                last_name=human.last_name or "",
+                first_name=first_name,
+                last_name=last_name,
                 popup_name=popup.name,
             ),
             from_address=from_address,

--- a/backend/app/templates/emails/application/accepted.html
+++ b/backend/app/templates/emails/application/accepted.html
@@ -16,9 +16,6 @@
     <h2 style="margin-top: 0; color: #155724;">Next Steps</h2>
     <p style="color: #155724; margin-bottom: 0;">
         Please proceed to purchase your passes to confirm your participation.
-        {% if payment_deadline %}
-        Complete your payment by <strong>{{ payment_deadline }}</strong> to secure your spot.
-        {% endif %}
     </p>
 </div>
 
@@ -41,12 +38,6 @@
                 </span>
             </td>
         </tr>
-        {% if discount_assigned %}
-        <tr>
-            <td style="padding: 8px 0; color: #666;">Discount</td>
-            <td style="padding: 8px 0; color: #28a745; font-weight: 600;">{{ discount_assigned }}% off standard passes</td>
-        </tr>
-        {% endif %}
     </table>
 </div>
 

--- a/backend/tests/test_application_email_contexts.py
+++ b/backend/tests/test_application_email_contexts.py
@@ -1,0 +1,102 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from app.api.application.schemas import ApplicationStatus
+from app.services.email_helpers import send_application_status_email
+
+
+class _FakeEmailService:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def send_application_received(self, **kwargs):
+        self.calls.append({"method": "received", **kwargs})
+        return True
+
+    async def send_application_rejected(self, **kwargs):
+        self.calls.append({"method": "rejected", **kwargs})
+        return True
+
+
+def test_application_received_email_uses_application_human_and_submitted_at(
+    monkeypatch,
+):
+    fake_service = _FakeEmailService()
+    monkeypatch.setattr("app.services.email_helpers.get_email_service", lambda: fake_service)
+
+    application = SimpleNamespace(
+        status=ApplicationStatus.IN_REVIEW.value,
+        submitted_at=datetime(2026, 4, 24, 15, 30, tzinfo=UTC),
+        popup_id="popup-1",
+        popup=SimpleNamespace(
+            name="Edge Summit",
+            tenant=SimpleNamespace(
+                sender_email="hello@example.com",
+                sender_name="Edge Team",
+            ),
+        ),
+        human=SimpleNamespace(
+            first_name="Ada",
+            last_name="Lovelace",
+            email="ada@example.com",
+        ),
+    )
+    stale_human = SimpleNamespace(
+        first_name="",
+        last_name="",
+        email="stale@example.com",
+    )
+
+    import asyncio
+
+    asyncio.run(send_application_status_email(application, stale_human, db=None))
+
+    assert len(fake_service.calls) == 1
+    call = fake_service.calls[0]
+
+    assert call["method"] == "received"
+    assert call["to"] == "ada@example.com"
+    assert call["context"].first_name == "Ada"
+    assert call["context"].last_name == "Lovelace"
+    assert call["context"].email == "ada@example.com"
+    assert call["context"].submitted_at == "April 24, 2026 15:30 UTC"
+
+
+def test_application_rejected_email_uses_application_human_details(monkeypatch):
+    fake_service = _FakeEmailService()
+    monkeypatch.setattr("app.services.email_helpers.get_email_service", lambda: fake_service)
+
+    application = SimpleNamespace(
+        status=ApplicationStatus.REJECTED.value,
+        submitted_at=None,
+        popup_id="popup-1",
+        popup=SimpleNamespace(
+            name="Edge Summit",
+            tenant=SimpleNamespace(
+                sender_email="hello@example.com",
+                sender_name="Edge Team",
+            ),
+        ),
+        human=SimpleNamespace(
+            first_name="Grace",
+            last_name="Hopper",
+            email="grace@example.com",
+        ),
+    )
+    stale_human = SimpleNamespace(
+        first_name="",
+        last_name="",
+        email="stale@example.com",
+    )
+
+    import asyncio
+
+    asyncio.run(send_application_status_email(application, stale_human, db=None))
+
+    assert len(fake_service.calls) == 1
+    call = fake_service.calls[0]
+
+    assert call["method"] == "rejected"
+    assert call["to"] == "grace@example.com"
+    assert call["context"].first_name == "Grace"
+    assert call["context"].last_name == "Hopper"

--- a/backend/tests/test_email_template_contracts.py
+++ b/backend/tests/test_email_template_contracts.py
@@ -1,0 +1,31 @@
+from app.api.email_template.schemas import EmailTemplateType
+from app.services.email.templates import (
+    TEMPLATE_TYPE_METADATA,
+    ApplicationAcceptedContext,
+    flatten_template,
+)
+
+
+def test_application_accepted_context_does_not_expose_unsupported_fields() -> None:
+    assert "payment_deadline" not in ApplicationAcceptedContext.model_fields
+    assert "discount_assigned" not in ApplicationAcceptedContext.model_fields
+
+
+def test_application_accepted_metadata_does_not_advertise_unsupported_variables() -> None:
+    accepted_meta = next(
+        meta
+        for meta in TEMPLATE_TYPE_METADATA
+        if meta["type"] == EmailTemplateType.APPLICATION_ACCEPTED
+    )
+
+    variable_names = {variable["name"] for variable in accepted_meta["variables"]}
+
+    assert "payment_deadline" not in variable_names
+    assert "discount_assigned" not in variable_names
+
+
+def test_flattened_application_accepted_template_does_not_reference_removed_variables() -> None:
+    html = flatten_template(EmailTemplateType.APPLICATION_ACCEPTED)
+
+    assert "payment_deadline" not in html
+    assert "discount_assigned" not in html

--- a/backend/tests/test_payment_settlement_metadata.py
+++ b/backend/tests/test_payment_settlement_metadata.py
@@ -1,7 +1,10 @@
 from decimal import Decimal
 from types import SimpleNamespace
 
-from app.api.payment.router import _extract_settlement_details
+from app.api.payment.router import (
+    _build_payment_confirmed_context,
+    _extract_settlement_details,
+)
 from app.api.payment.schemas import SimpleFIWebhookPayload
 from app.services.email.service import compute_order_summary
 
@@ -135,3 +138,55 @@ def test_compute_order_summary_uses_snapshot_currency() -> None:
 
     assert "€120.00" in summary
     assert "BTC" not in summary
+
+
+def test_build_payment_confirmed_context_populates_attendees_and_order_summary() -> None:
+    payment = SimpleNamespace(
+        id="payment-1",
+        amount=Decimal("230.00"),
+        currency="USD",
+        discount_value=Decimal("10"),
+        products_snapshot=[
+            SimpleNamespace(
+                attendee_id="attendee-1",
+                attendee=SimpleNamespace(name="Ana", category="main"),
+                attendee_name="Ana",
+                product_name="VIP Pass",
+                product_price=Decimal("120.00"),
+                quantity=1,
+                product_currency="USD",
+            ),
+            SimpleNamespace(
+                attendee_id="attendee-2",
+                attendee=SimpleNamespace(name="Beto", category="companion"),
+                attendee_name="Beto",
+                product_name="Camp Ticket",
+                product_price=Decimal("55.00"),
+                quantity=2,
+                product_currency="USD",
+            ),
+        ],
+    )
+
+    context = _build_payment_confirmed_context(
+        payment,
+        popup_name="Edge Summit",
+        first_name="Ana",
+        portal_url="https://portal.example.com",
+    )
+
+    assert context.first_name == "Ana"
+    assert context.popup_name == "Edge Summit"
+    assert context.discount_value == 10
+    assert context.original_amount == 230.0
+    assert context.order_summary is not None
+    assert "VIP Pass" in context.order_summary
+    assert "Camp Ticket" in context.order_summary
+    assert context.attendees is not None
+    assert len(context.attendees) == 2
+    assert context.attendees[0].name == "Ana"
+    assert context.attendees[0].products is not None
+    assert context.attendees[0].products[0].name == "VIP Pass"
+    assert context.attendees[1].name == "Beto"
+    assert context.attendees[1].products is not None
+    assert context.attendees[1].products[0].quantity == 2

--- a/backend/tests/test_tenant_login_email_templates.py
+++ b/backend/tests/test_tenant_login_email_templates.py
@@ -128,7 +128,7 @@ def test_portal_login_templates_can_be_managed_without_popup_and_are_unique_per_
 
     assert duplicate_response.status_code == 400
     assert duplicate_response.json()["detail"] == (
-        "A tenant-scoped template for this type already exists"
+        "This workspace already has a custom Portal Login Code template. Open it from the list to edit it."
     )
 
 
@@ -143,7 +143,7 @@ def test_backoffice_login_template_is_not_customizable(client, admin_token_tenan
 
     assert response.status_code == 400
     assert response.json()["detail"] == (
-        "Template type is not customizable: login_code_user"
+        "This email template can't be customized from backoffice"
     )
 
 
@@ -159,7 +159,9 @@ def test_popup_templates_still_require_popup_context(client, admin_token_tenant_
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "popup_id is required for popup-scoped templates"
+    assert response.json()["detail"] == (
+        "Select a popup before managing the Application Received template"
+    )
 
 
 def test_popup_communications_ignore_tenant_auth_templates(

--- a/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
+++ b/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_layout/email-templates/$type/edit")({
 })
 
 export function EditorContent({ templateType }: { templateType: string }) {
-  const { selectedPopupId } = useWorkspace()
+  const { selectedPopupId, effectiveTenantId } = useWorkspace()
   const navigate = useNavigate()
 
   const { data: types } = useQuery({
@@ -32,7 +32,9 @@ export function EditorContent({ templateType }: { templateType: string }) {
   const requiresPopup = typeInfo?.scope === "popup"
 
   const { data: customTemplates } = useQuery({
-    queryKey: ["email-templates", requiresPopup ? selectedPopupId : "tenant"],
+    queryKey: requiresPopup
+      ? ["email-templates", "popup", effectiveTenantId, selectedPopupId]
+      : ["email-templates", "tenant", effectiveTenantId],
     queryFn: () =>
       requiresPopup
         ? EmailTemplatesService.listEmailTemplates({

--- a/backoffice/src/routes/_layout/email-templates/email-templates-routing.test.tsx
+++ b/backoffice/src/routes/_layout/email-templates/email-templates-routing.test.tsx
@@ -49,10 +49,14 @@ vi.mock("@/components/EmailTemplateEditor", () => ({
   EmailTemplateEditor: ({
     popupId,
     templateType,
+    existingTemplate,
   }: {
     popupId?: string
     templateType: string
-  }) => <div>{`editor:${templateType}:${popupId ?? "tenant"}`}</div>,
+    existingTemplate?: { id?: string }
+  }) => (
+    <div>{`editor:${templateType}:${popupId ?? "tenant"}:${existingTemplate?.id ?? "new"}`}</div>
+  ),
 }))
 
 import { EmailTemplatesService } from "@/client"
@@ -69,13 +73,23 @@ const mockListEmailTemplates = vi.mocked(
 function renderWithQueryClient(ui: ReactNode) {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: { retry: false },
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
     },
   })
 
-  return render(
+  const renderResult = render(
     <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
   )
+
+  return {
+    ...renderResult,
+    rerender: (nextUi: ReactNode) =>
+      renderResult.rerender(
+        <QueryClientProvider client={queryClient}>
+          {nextUi}
+        </QueryClientProvider>,
+      ),
+  }
 }
 
 describe("email template routing behavior", () => {
@@ -148,7 +162,57 @@ describe("email template routing behavior", () => {
     renderWithQueryClient(<EditorContent templateType="login_code_human" />)
 
     expect(
-      await screen.findByText("editor:login_code_human:tenant"),
+      await screen.findByText("editor:login_code_human:tenant:template-1"),
     ).toBeInTheDocument()
+  })
+
+  it("refreshes tenant-scoped template state when tenant changes", async () => {
+    let tenantId = "tenant-1"
+
+    mockUseWorkspace.mockImplementation(() => ({
+      selectedPopupId: null,
+      selectedTenantId: tenantId,
+      effectiveTenantId: tenantId,
+      isContextReady: false,
+      needsTenantSelection: false,
+      needsPopupSelection: true,
+      setSelectedPopupId: vi.fn(),
+      setSelectedTenantId: vi.fn(),
+    }))
+
+    mockListEmailTemplates.mockImplementation(async ({ popupId } = {}) => ({
+      results: popupId
+        ? []
+        : tenantId === "tenant-2"
+          ? [
+              {
+                id: "template-2",
+                tenant_id: tenantId,
+                popup_id: null,
+                template_type: "login_code_human",
+                subject: "Tenant 2 subject",
+                html_content: "<html></html>",
+                is_active: true,
+              },
+            ]
+          : [],
+      paging: { offset: 0, limit: 100, total: tenantId === "tenant-2" ? 1 : 0 },
+    }))
+
+    const { rerender } = renderWithQueryClient(
+      <EditorContent templateType="login_code_human" />,
+    )
+
+    expect(
+      await screen.findByText("editor:login_code_human:tenant:new"),
+    ).toBeInTheDocument()
+
+    tenantId = "tenant-2"
+    rerender(<EditorContent templateType="login_code_human" />)
+
+    expect(
+      await screen.findByText("editor:login_code_human:tenant:template-2"),
+    ).toBeInTheDocument()
+    expect(mockListEmailTemplates).toHaveBeenCalledTimes(2)
   })
 })

--- a/backoffice/src/routes/_layout/email-templates/index.tsx
+++ b/backoffice/src/routes/_layout/email-templates/index.tsx
@@ -27,7 +27,7 @@ const CATEGORY_COLORS: Record<string, string> = {
 }
 
 export function TemplateList() {
-  const { selectedPopupId } = useWorkspace()
+  const { selectedPopupId, effectiveTenantId } = useWorkspace()
 
   const { data: types } = useQuery({
     queryKey: ["email-template-types"],
@@ -35,12 +35,12 @@ export function TemplateList() {
   })
 
   const { data: tenantTemplates } = useQuery({
-    queryKey: ["email-templates", "tenant"],
+    queryKey: ["email-templates", "tenant", effectiveTenantId],
     queryFn: () => EmailTemplatesService.listEmailTemplates(),
   })
 
   const { data: popupTemplates } = useQuery({
-    queryKey: ["email-templates", "popup", selectedPopupId],
+    queryKey: ["email-templates", "popup", effectiveTenantId, selectedPopupId],
     queryFn: () =>
       EmailTemplatesService.listEmailTemplates({ popupId: selectedPopupId! }),
     enabled: !!selectedPopupId,


### PR DESCRIPTION
## Summary

- fix backoffice email-template cache scoping so tenant switches do not trigger duplicate create flows while editing
- replace technical email-template validation errors with backoffice-friendly messages
- restore application email context rendering by resolving applicant data from `application.human` and including formatted `submitted_at`

## Related Issue

Fixes #54

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- keyed email-template queries by tenant context in backoffice to avoid stale cached template state across tenant switches
- improved backend email-template validation messages for duplicate templates, unsupported customization, and missing popup context
- fixed application email helper context generation for `application_received` and `application_rejected`, with regression tests for applicant data and `submitted_at`

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [x] Focused automated checks performed
  - `uv run pytest tests/test_tenant_login_email_templates.py tests/test_application_email_contexts.py tests/test_scholarship_workflow.py`
  - `uv run ruff check app/api/email_template/router.py app/services/email_helpers.py tests/test_tenant_login_email_templates.py tests/test_application_email_contexts.py`
  - `pnpm exec vitest run src/routes/_layout/email-templates/email-templates-routing.test.tsx src/components/email-template-scope.test.ts`
  - `pnpm exec biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true src/routes/_layout/email-templates/index.tsx src/routes/_layout/email-templates/$type.edit.tsx src/routes/_layout/email-templates/email-templates-routing.test.tsx`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [ ] All new and existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [x] Database migrations are included if schema changed
