### PR TITLE
feat(payments): add server-side search for popup payments

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -4,11 +4,12 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 from loguru import logger
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, func, select
 
 from app.api.application.models import Applications
+from app.api.human.models import Humans
 
 if TYPE_CHECKING:
     from app.api.group.models import Groups
@@ -446,6 +447,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         skip: int = 0,
         limit: int = 100,
         status_filter: PaymentStatus | None = None,
+        search: str | None = None,
     ) -> tuple[list[Payments], int]:
         """Find payments by popup_id via the denormalized popup_id column.
 
@@ -455,6 +457,30 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         statement = select(Payments).where(Payments.popup_id == popup_id)
         if status_filter:
             statement = statement.where(Payments.status == status_filter.value)
+
+        normalized_search = search.strip() if search else ""
+        if normalized_search:
+            pattern = f"%{normalized_search}%"
+            attendee_match = (
+                select(PaymentProducts.payment_id)
+                .join(Attendees, PaymentProducts.attendee_id == Attendees.id)
+                .outerjoin(Humans, Attendees.human_id == Humans.id)
+                .where(
+                    PaymentProducts.payment_id == Payments.id,
+                    or_(
+                        Attendees.name.ilike(pattern),
+                        Attendees.email.ilike(pattern),
+                        Humans.email.ilike(pattern),
+                    ),
+                )
+                .exists()
+            )
+            statement = statement.where(
+                or_(
+                    Payments.external_id.ilike(pattern),
+                    attendee_match,
+                )
+            )
 
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -334,13 +334,19 @@ async def list_payments(
     application_id: uuid.UUID | None = None,
     external_id: str | None = None,
     payment_status: PaymentStatus | None = None,
+    search: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[PaymentPublic]:
     """List payments with optional filters (BO only)."""
     if popup_id:
         payments, total = payments_crud.find_by_popup(
-            db, popup_id=popup_id, skip=skip, limit=limit, status_filter=payment_status
+            db,
+            popup_id=popup_id,
+            skip=skip,
+            limit=limit,
+            status_filter=payment_status,
+            search=search,
         )
     else:
         filters = PaymentFilter(

--- a/backend/tests/api/payment/test_payment_list_search.py
+++ b/backend/tests/api/payment/test_payment_list_search.py
@@ -1,0 +1,403 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.attendee.models import Attendees
+from app.api.human.models import Humans
+from app.api.payment.models import PaymentProducts, Payments
+from app.api.payment.schemas import PaymentStatus
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.tenant.models import Tenants
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_popup(db: Session, tenant: Tenants, *, suffix: str) -> Popups:
+    popup = Popups(
+        name=f"Payments Search {suffix}",
+        slug=f"payments-search-{suffix}-{uuid.uuid4().hex[:6]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _create_human(db: Session, tenant: Tenants, *, email: str) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=email,
+        first_name="Search",
+        last_name="Human",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _create_attendee(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    name: str,
+    email: str,
+    human: Humans | None = None,
+) -> Attendees:
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id if human else None,
+        name=name,
+        category="main",
+        email=email,
+        check_in_code=f"CHK{uuid.uuid4().hex[:8].upper()}",
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+    return attendee
+
+
+def _create_product(db: Session, tenant: Tenants, popup: Popups, *, suffix: str) -> Products:
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Search Product {suffix}",
+        slug=f"search-product-{suffix}-{uuid.uuid4().hex[:6]}",
+        price=Decimal("100.00"),
+        category="ticket",
+        is_active=True,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _create_payment(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    external_id: str,
+    created_at: datetime,
+    attendee_specs: list[dict[str, str]],
+) -> Payments:
+    payment = Payments(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        external_id=external_id,
+        status=PaymentStatus.APPROVED.value,
+        amount=Decimal("100.00"),
+        currency="USD",
+        source="SimpleFI",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+
+    for index, attendee_spec in enumerate(attendee_specs):
+        product = _create_product(db, tenant, popup, suffix=f"{external_id}-{index}")
+        human = None
+        human_email = attendee_spec.get("human_email")
+        if human_email:
+            human = _create_human(db, tenant, email=human_email)
+
+        attendee = _create_attendee(
+            db,
+            tenant,
+            popup,
+            name=attendee_spec["name"],
+            email=attendee_spec["email"],
+            human=human,
+        )
+        db.add(
+            PaymentProducts(
+                tenant_id=tenant.id,
+                payment_id=payment.id,
+                product_id=product.id,
+                attendee_id=attendee.id,
+                quantity=1,
+                product_name=f"Product {index + 1}",
+                product_description=None,
+                product_price=Decimal("100.00"),
+                product_category="ticket",
+                product_currency="USD",
+            )
+        )
+
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+class TestPaymentListSearch:
+    def test_search_matches_external_id_across_full_popup_dataset(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="external-id")
+        base_time = datetime.now(UTC)
+
+        expected_payment = _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="TARGET-EXT-9000",
+            created_at=base_time - timedelta(minutes=30),
+            attendee_specs=[
+                {"name": "Ana Search", "email": "ana.search@test.com"},
+            ],
+        )
+
+        for index in range(30):
+            _create_payment(
+                db,
+                tenant_a,
+                popup,
+                external_id=f"OTHER-{index:02d}",
+                created_at=base_time + timedelta(minutes=index),
+                attendee_specs=[
+                    {
+                        "name": f"Other Person {index}",
+                        "email": f"other-{index}@test.com",
+                    },
+                ],
+            )
+
+        response = client.get(
+            "/api/v1/payments",
+            params={
+                "popup_id": str(popup.id),
+                "skip": 0,
+                "limit": 25,
+                "search": "ext-9000",
+            },
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["paging"]["total"] == 1
+        assert [item["id"] for item in payload["results"]] == [str(expected_payment.id)]
+
+    def test_search_matches_attendee_name_and_email_once_per_payment(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="attendee")
+        payment = _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="ATTENDEE-MATCH",
+            created_at=datetime.now(UTC),
+            attendee_specs=[
+                {
+                    "name": "Lucia Multi Match",
+                    "email": "lucia.match@test.com",
+                },
+                {
+                    "name": "Lucia Backup",
+                    "email": "lucia.other@test.com",
+                },
+            ],
+        )
+        _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="ATTENDEE-DISTRACTOR",
+            created_at=datetime.now(UTC) + timedelta(minutes=1),
+            attendee_specs=[
+                {"name": "Other Person", "email": "other.person@test.com"},
+            ],
+        )
+
+        name_response = client.get(
+            "/api/v1/payments",
+            params={"popup_id": str(popup.id), "search": "multi match"},
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+        email_response = client.get(
+            "/api/v1/payments",
+            params={"popup_id": str(popup.id), "search": "lucia.match@test.com"},
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert name_response.status_code == 200
+        assert email_response.status_code == 200
+        assert name_response.json()["paging"]["total"] == 1
+        assert email_response.json()["paging"]["total"] == 1
+        assert name_response.json()["results"][0]["id"] == str(payment.id)
+        assert email_response.json()["results"][0]["id"] == str(payment.id)
+
+    def test_search_matches_linked_human_email_when_attendee_snapshot_differs(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="human-email")
+        payment = _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="HUMAN-EMAIL-MATCH",
+            created_at=datetime.now(UTC),
+            attendee_specs=[
+                {
+                    "name": "Human Linked",
+                    "email": "snapshot-email@test.com",
+                    "human_email": "real-human-email@test.com",
+                },
+            ],
+        )
+        _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="HUMAN-EMAIL-DISTRACTOR",
+            created_at=datetime.now(UTC) + timedelta(minutes=1),
+            attendee_specs=[
+                {
+                    "name": "Snapshot Only",
+                    "email": "snapshot-only@test.com",
+                    "human_email": "different-human@test.com",
+                },
+            ],
+        )
+
+        response = client.get(
+            "/api/v1/payments",
+            params={"popup_id": str(popup.id), "search": "real-human-email"},
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["paging"]["total"] == 1
+        assert payload["results"][0]["id"] == str(payment.id)
+
+    def test_no_search_preserves_popup_listing_pagination_and_order(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="baseline")
+        base_time = datetime.now(UTC)
+
+        newest_payment = _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="BASELINE-NEW",
+            created_at=base_time + timedelta(minutes=5),
+            attendee_specs=[{"name": "Newest", "email": "newest@test.com"}],
+        )
+        _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="BASELINE-OLD",
+            created_at=base_time,
+            attendee_specs=[{"name": "Older", "email": "older@test.com"}],
+        )
+
+        response = client.get(
+            "/api/v1/payments",
+            params={"popup_id": str(popup.id), "skip": 0, "limit": 1},
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["paging"] == {"offset": 0, "limit": 1, "total": 2}
+        assert [item["id"] for item in payload["results"]] == [str(newest_payment.id)]
+
+    def test_search_paginates_server_side_with_correct_total_and_no_duplicates(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="pagination")
+        base_time = datetime.now(UTC)
+
+        expected_page_ids: list[str] = []
+        for index in range(60):
+            payment = _create_payment(
+                db,
+                tenant_a,
+                popup,
+                external_id=f"BULK-MATCH-{index:02d}",
+                created_at=base_time + timedelta(minutes=index),
+                attendee_specs=[
+                    {
+                        "name": f"Bulk Search Person {index}",
+                        "email": f"bulk-search-{index}@test.com",
+                    },
+                    {
+                        "name": f"Bulk Search Companion {index}",
+                        "email": f"bulk-search-companion-{index}@test.com",
+                    },
+                ],
+            )
+            if 10 <= index <= 34:
+                expected_page_ids.append(str(payment.id))
+
+        for index in range(10):
+            _create_payment(
+                db,
+                tenant_a,
+                popup,
+                external_id=f"NO-MATCH-{index:02d}",
+                created_at=base_time + timedelta(minutes=100 + index),
+                attendee_specs=[
+                    {
+                        "name": f"Irrelevant Person {index}",
+                        "email": f"irrelevant-{index}@test.com",
+                    },
+                ],
+            )
+
+        response = client.get(
+            "/api/v1/payments",
+            params={
+                "popup_id": str(popup.id),
+                "search": "bulk-search",
+                "skip": 25,
+                "limit": 25,
+            },
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        result_ids = [item["id"] for item in payload["results"]]
+
+        assert payload["paging"] == {"offset": 25, "limit": 25, "total": 60}
+        assert len(result_ids) == 25
+        assert len(result_ids) == len(set(result_ids))
+        assert result_ids == list(reversed(expected_page_ids))

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2325,6 +2325,7 @@ export class PaymentsService {
      * @param data.applicationId
      * @param data.externalId
      * @param data.paymentStatus
+     * @param data.search
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -2343,6 +2344,7 @@ export class PaymentsService {
                 application_id: data.applicationId,
                 external_id: data.externalId,
                 payment_status: data.paymentStatus,
+                search: data.search,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2905,6 +2905,7 @@ export type PaymentsListPaymentsData = {
     limit?: number;
     paymentStatus?: (PaymentStatus | null);
     popupId?: (string | null);
+    search?: (string | null);
     /**
      * Number of items to skip
      */

--- a/backoffice/src/routes/_layout/payments.helpers.test.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildPaymentsQueryConfig,
+  buildPaymentsTableState,
+} from "./payments.helpers"
+
+describe("payments.helpers", () => {
+  it("forwards the server search term in query params and cache key", () => {
+    const config = buildPaymentsQueryConfig({
+      popupId: "popup-123",
+      page: 2,
+      pageSize: 25,
+      search: "Lucia",
+    })
+
+    expect(config.params).toEqual({
+      skip: 50,
+      limit: 25,
+      popupId: "popup-123",
+      search: "Lucia",
+    })
+    expect(config.queryKey).toEqual([
+      "payments",
+      "popup-123",
+      { page: 2, pageSize: 25, search: "Lucia" },
+    ])
+  })
+
+  it("uses server totals and preserves server rows without local filtering", () => {
+    const state = buildPaymentsTableState({
+      payments: {
+        results: [{ id: "payment-1" }, { id: "payment-2" }],
+        paging: { total: 60 },
+      },
+      pagination: { pageIndex: 1, pageSize: 25 },
+    })
+
+    expect(state.data).toEqual([{ id: "payment-1" }, { id: "payment-2" }])
+    expect(state.serverPagination).toEqual({
+      total: 60,
+      pagination: { pageIndex: 1, pageSize: 25 },
+    })
+  })
+})

--- a/backoffice/src/routes/_layout/payments.helpers.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.ts
@@ -1,0 +1,61 @@
+interface PaymentsQueryInput {
+  popupId: string | null
+  page: number
+  pageSize: number
+  search: string
+}
+
+interface PaymentsPaging {
+  total: number
+}
+
+interface PaymentsResponse<TPayment> {
+  results: TPayment[]
+  paging: PaymentsPaging
+}
+
+interface PaymentsPagination {
+  pageIndex: number
+  pageSize: number
+}
+
+interface PaymentsTableStateInput<TPayment> {
+  payments: PaymentsResponse<TPayment>
+  pagination: PaymentsPagination
+}
+
+export function buildPaymentsQueryConfig({
+  popupId,
+  page,
+  pageSize,
+  search,
+}: PaymentsQueryInput) {
+  const normalizedSearch = search.trim()
+
+  return {
+    params: {
+      skip: page * pageSize,
+      limit: pageSize,
+      popupId: popupId || undefined,
+      search: normalizedSearch || undefined,
+    },
+    queryKey: [
+      "payments",
+      popupId,
+      { page, pageSize, search: normalizedSearch },
+    ],
+  }
+}
+
+export function buildPaymentsTableState<TPayment>({
+  payments,
+  pagination,
+}: PaymentsTableStateInput<TPayment>) {
+  return {
+    data: payments.results,
+    serverPagination: {
+      total: payments.paging.total,
+      pagination,
+    },
+  }
+}

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -33,19 +33,27 @@ import {
 } from "@/hooks/useTableSearchParams"
 import { exportToCsv, fetchAllPages } from "@/lib/export"
 
+import {
+  buildPaymentsQueryConfig,
+  buildPaymentsTableState,
+} from "./payments.helpers"
+
 function getPaymentsQueryOptions(
   popupId: string | null,
   page: number,
   pageSize: number,
+  search: string,
 ) {
+  const queryConfig = buildPaymentsQueryConfig({
+    popupId,
+    page,
+    pageSize,
+    search,
+  })
+
   return {
-    queryFn: () =>
-      PaymentsService.listPayments({
-        skip: page * pageSize,
-        limit: pageSize,
-        popupId: popupId || undefined,
-      }),
-    queryKey: ["payments", popupId, { page, pageSize }],
+    queryFn: () => PaymentsService.listPayments(queryConfig.params),
+    queryKey: queryConfig.queryKey,
   }
 }
 
@@ -383,6 +391,7 @@ function PaymentsTableContent() {
       selectedPopupId,
       pagination.pageIndex,
       pagination.pageSize,
+      search,
     ),
     placeholderData: keepPreviousData,
   })
@@ -404,24 +413,13 @@ function PaymentsTableContent() {
 
   if (!payments) return <Skeleton className="h-64 w-full" />
 
-  const filtered = search
-    ? payments.results.filter((p) => {
-        const term = search.toLowerCase()
-        return (
-          p.id.toLowerCase().includes(term) ||
-          (p.status ?? "").toLowerCase().includes(term) ||
-          (p.source ?? "").toLowerCase().includes(term) ||
-          (p.coupon_code ?? "").toLowerCase().includes(term) ||
-          String(p.amount).includes(term)
-        )
-      })
-    : payments.results
+  const tableState = buildPaymentsTableState({ payments, pagination })
 
   return (
     <DataTable
       columns={columns}
-      data={filtered}
-      searchPlaceholder="Search by status, source, coupon, or amount..."
+      data={tableState.data}
+      searchPlaceholder="Search by external ID, attendee email, or attendee name..."
       hiddenOnMobile={[
         "source",
         "insurance_amount",
@@ -433,10 +431,7 @@ function PaymentsTableContent() {
       searchValue={search}
       onSearchChange={setSearch}
       serverPagination={{
-        total: search ? filtered.length : payments.paging.total,
-        pagination: search
-          ? { pageIndex: 0, pageSize: payments.paging.total }
-          : pagination,
+        ...tableState.serverPagination,
         onPaginationChange: setPagination,
       }}
       renderSubComponent={PaymentSubRow}

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2325,6 +2325,7 @@ export class PaymentsService {
      * @param data.applicationId
      * @param data.externalId
      * @param data.paymentStatus
+     * @param data.search
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -2343,6 +2344,7 @@ export class PaymentsService {
                 application_id: data.applicationId,
                 external_id: data.externalId,
                 payment_status: data.paymentStatus,
+                search: data.search,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2905,6 +2905,7 @@ export type PaymentsListPaymentsData = {
     limit?: number;
     paymentStatus?: (PaymentStatus | null);
     popupId?: (string | null);
+    search?: (string | null);
     /**
      * Number of items to skip
      */


### PR DESCRIPTION
## Summary

Add server-side payment search for popup payments and keep the backoffice table aligned with server pagination.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- add backend popup payment search by external ID, attendee name/email, and linked human email
- move backoffice payments search from local filtering to server-side query + pagination state
- add targeted backend/frontend tests and regenerate OpenAPI clients for backoffice and portal

## Testing

- [x] Backend targeted tests pass (`uv run pytest tests/api/payment/test_payment_list_search.py`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [ ] All new and existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [x] Database migrations are included if schema changed