### PR TITLE
feat(checkout): support schema-backed personal info form

### DIFF
--- a/portal/src/app/checkout/components/CheckoutFlow.tsx
+++ b/portal/src/app/checkout/components/CheckoutFlow.tsx
@@ -168,7 +168,7 @@ export default function CheckoutFlow({
     stepConfig?.description ?? getDefaultStepSubtitle(currentStep, t)
 
   const renderStepContent = () => {
-    // Passes/tickets: dynamic step or fall-back legacy section
+    // Passes/tickets: dynamic step or fall-back default section
     if (currentStep === "passes" || currentStep === "tickets") {
       const ticketStepConfig = stepConfigs.find(
         (s) =>

--- a/portal/src/app/checkout/components/PopupCheckoutContent.test.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { PopupCheckoutContent } from "./PopupCheckoutContent"
+
+const mockReplace = vi.fn()
+const mockUseQueryClient = vi.fn()
+const mockUseApplicationSchema = vi.fn()
+const mockUseCheckoutState = vi.fn()
+const mockGetRelevantApplication = vi.fn()
+const mockGetCity = vi.fn()
+const mockSetCityPreselected = vi.fn()
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>()
+  return {
+    ...actual,
+    useQueryClient: () => mockUseQueryClient(),
+  }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}))
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => children,
+  motion: {
+    div: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  },
+}))
+
+vi.mock("@/hooks/useApplicationSchema", () => ({
+  useApplicationSchema: (popupId: string | undefined) =>
+    mockUseApplicationSchema(popupId),
+}))
+
+vi.mock("../hooks/useCheckoutState", () => ({
+  default: (args: unknown) => mockUseCheckoutState(args),
+}))
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ user: { email: "human@example.com" } }),
+}))
+
+vi.mock("@/hooks/useIsAuthenticated", () => ({
+  useIsAuthenticated: () => true,
+  dispatchAuthChange: vi.fn(),
+}))
+
+vi.mock("@/hooks/useResolvedAttendees", () => ({
+  default: () => [],
+}))
+
+vi.mock("@/providers/applicationProvider", () => ({
+  useApplication: () => ({
+    getRelevantApplication: mockGetRelevantApplication,
+  }),
+}))
+
+vi.mock("@/providers/cityProvider", () => ({
+  useCityProvider: () => ({
+    getCity: mockGetCity,
+    setCityPreselected: mockSetCityPreselected,
+  }),
+}))
+
+vi.mock("@/components/checkout-flow/ScrollyCheckoutFlow", () => ({
+  default: () => <div>passes-flow</div>,
+}))
+
+vi.mock("./UserInfoForm", () => ({
+  default: ({ schema }: { schema?: { sections?: unknown[] } }) => (
+    <div>{schema ? "schema-form" : "default-form"}</div>
+  ),
+}))
+
+vi.mock("./CheckoutLoginGate", () => ({
+  default: () => <div>login-gate</div>,
+}))
+
+vi.mock("./TransitionScreen", () => ({
+  default: () => <div>transition</div>,
+}))
+
+vi.mock("./providers/Providers", () => ({
+  Providers: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+const popup = {
+  id: "popup-1",
+  slug: "popup-slug",
+  name: "Popup",
+  sale_type: "application",
+  checkout_mode: "pass_system",
+} as const
+
+describe("PopupCheckoutContent application schema gating", () => {
+  beforeEach(() => {
+    mockReplace.mockReset()
+    mockSetCityPreselected.mockReset()
+    mockUseQueryClient.mockReturnValue({
+      removeQueries: vi.fn(),
+    })
+    mockGetCity.mockReturnValue({ slug: "popup-slug" })
+    mockGetRelevantApplication.mockReturnValue(null)
+    mockUseCheckoutState.mockReturnValue({
+      checkoutState: "form",
+      isSubmitting: false,
+      errorMessage: null,
+      handleSubmit: vi.fn(),
+      setCheckoutState: vi.fn(),
+    })
+  })
+
+  it("keeps checkout open when the schema has application-only special sections", async () => {
+    mockUseApplicationSchema.mockReturnValue({
+      data: {
+        base_fields: {
+          email: {
+            type: "email",
+            label: "Email",
+            required: true,
+            target: "human",
+          },
+        },
+        custom_fields: {},
+        sections: [
+          {
+            id: "companions",
+            label: "Companions",
+            description: null,
+            order: 1,
+            kind: "companions",
+          },
+        ],
+      },
+      isLoading: false,
+    })
+
+    render(
+      <PopupCheckoutContent
+        popup={popup as never}
+        background={{ className: "bg" }}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText("schema-form")).toBeTruthy())
+    expect(mockReplace).not.toHaveBeenCalledWith(
+      "/portal/popup-slug/application",
+    )
+  })
+
+  it("keeps checkout open when unsupported fields are outside the mini form scope", async () => {
+    mockUseApplicationSchema.mockReturnValue({
+      data: {
+        base_fields: {
+          email: {
+            type: "email",
+            label: "Email",
+            required: true,
+            target: "human",
+          },
+          weird_field: {
+            type: "markdown",
+            label: "Weird",
+            required: false,
+            target: "application",
+          },
+        },
+        custom_fields: {},
+        sections: [],
+      },
+      isLoading: false,
+    })
+
+    render(
+      <PopupCheckoutContent
+        popup={popup as never}
+        background={{ className: "bg" }}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText("schema-form")).toBeTruthy())
+    expect(mockReplace).not.toHaveBeenCalledWith(
+      "/portal/popup-slug/application",
+    )
+  })
+
+  it("renders the schema-backed checkout form when the schema is supported", () => {
+    mockUseApplicationSchema.mockReturnValue({
+      data: {
+        base_fields: {
+          email: {
+            type: "email",
+            label: "Email",
+            required: true,
+            target: "human",
+          },
+        },
+        custom_fields: {},
+        sections: [],
+      },
+      isLoading: false,
+    })
+
+    render(
+      <PopupCheckoutContent
+        popup={popup as never}
+        background={{ className: "bg" }}
+      />,
+    )
+
+    expect(screen.getByText("schema-form")).toBeTruthy()
+  })
+})

--- a/portal/src/app/checkout/components/PopupCheckoutContent.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { AnimatePresence, motion } from "framer-motion"
 import { UserRound } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { type CSSProperties, useEffect, useMemo, useRef } from "react"
+import { type CSSProperties, useEffect, useRef } from "react"
 import { resolvePopupCheckoutPolicy } from "@/checkout/popupCheckoutPolicy"
 import type { PopupPublic } from "@/client"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
@@ -16,6 +16,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { useApplicationSchema } from "@/hooks/useApplicationSchema"
 import useAuth from "@/hooks/useAuth"
 import {
   dispatchAuthChange,
@@ -28,7 +29,10 @@ import { CheckoutProvider } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 import PassesProvider from "@/providers/passesProvider"
 import useCheckoutState from "../hooks/useCheckoutState"
-import type { FormDataProps } from "../types"
+import type {
+  CheckoutApplicationValues,
+  DefaultCheckoutFormData,
+} from "../types"
 import CheckoutLoginGate from "./CheckoutLoginGate"
 import TransitionScreen from "./TransitionScreen"
 import UserInfoForm from "./UserInfoForm"
@@ -42,6 +46,14 @@ export const PopupCheckoutContent = ({
   background: { className: string; style?: CSSProperties }
   groupId?: string | null
 }) => {
+  const policy = resolvePopupCheckoutPolicy(popup)
+  const isAuthenticated = useIsAuthenticated()
+  const { data: applicationSchema, isLoading: isLoadingApplicationSchema } =
+    useApplicationSchema(
+      policy.saleType === "application" && isAuthenticated
+        ? popup.id
+        : undefined,
+    )
   const {
     checkoutState,
     isSubmitting,
@@ -52,16 +64,16 @@ export const PopupCheckoutContent = ({
     popupId: popup.id,
     saleType: resolvePopupCheckoutPolicy(popup).saleType,
     groupId,
+    schema: applicationSchema,
   })
   const queryClient = useQueryClient()
   const { user } = useAuth()
   const { getRelevantApplication } = useApplication()
   const { getCity, setCityPreselected } = useCityProvider()
   const router = useRouter()
-  const isAuthenticated = useIsAuthenticated()
   const hasSkippedForm = useRef(false)
-  const policy = useMemo(() => resolvePopupCheckoutPolicy(popup), [popup])
   const attendees = useResolvedAttendees()
+  const existingApplication = getRelevantApplication()
 
   useEffect(() => {
     setCityPreselected(popup.id)
@@ -85,12 +97,11 @@ export const PopupCheckoutContent = ({
   useEffect(() => {
     if (hasSkippedForm.current) return
     if (policy.saleType !== "application") return
-    const existingApp = getRelevantApplication()
-    if (!existingApp || checkoutState !== "form") return
+    if (!existingApplication || checkoutState !== "form") return
 
     hasSkippedForm.current = true
 
-    const hasPurchasedPasses = existingApp.attendees?.some(
+    const hasPurchasedPasses = existingApplication.attendees?.some(
       (a) => a.products && a.products.length > 0,
     )
     if (hasPurchasedPasses) {
@@ -102,14 +113,16 @@ export const PopupCheckoutContent = ({
     setCheckoutState("passes")
   }, [
     policy.saleType,
-    getRelevantApplication,
+    existingApplication,
     checkoutState,
     setCheckoutState,
     getCity,
     router,
   ])
 
-  const handleFormSubmit = async (formData: FormDataProps): Promise<void> => {
+  const handleFormSubmit = async (
+    formData: DefaultCheckoutFormData | CheckoutApplicationValues,
+  ): Promise<void> => {
     await handleSubmit(formData)
   }
 
@@ -134,9 +147,9 @@ export const PopupCheckoutContent = ({
             <button
               type="button"
               aria-label={`Signed in as ${user.email}`}
-              className="flex size-7 shrink-0 items-center justify-center rounded-full bg-checkout-badge-bg text-checkout-badge-title shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="flex size-9 shrink-0 items-center justify-center rounded-full bg-checkout-badge-bg text-checkout-badge-title shadow-sm transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
-              <UserRound className="size-3.5" />
+              <UserRound className="size-4" />
             </button>
           </PopoverTrigger>
           <PopoverContent align="end" className="w-auto max-w-[280px] p-3">
@@ -183,7 +196,16 @@ export const PopupCheckoutContent = ({
     return <Loader />
   }
 
-  // Passes state: full-page scrollable layout for ScrollyCheckoutFlow
+  if (
+    policy.saleType === "application" &&
+    isAuthenticated &&
+    checkoutState === "form" &&
+    !existingApplication &&
+    (isLoadingApplicationSchema || !applicationSchema)
+  ) {
+    return <Loader />
+  }
+
   if (checkoutState === "passes") {
     return (
       <SidebarProvider
@@ -214,7 +236,6 @@ export const PopupCheckoutContent = ({
     )
   }
 
-  // Form/processing states: centered card layout with background
   return (
     <div
       className={`min-h-screen w-full py-8 flex items-center justify-center ${background.className}`}
@@ -233,6 +254,7 @@ export const PopupCheckoutContent = ({
               <UserInfoForm
                 popupId={popup.id}
                 popupName={popup.name}
+                schema={applicationSchema}
                 onSubmit={handleFormSubmit}
                 isSubmitting={isSubmitting}
               />

--- a/portal/src/app/checkout/components/UserInfoForm/PersonalInfoForm.tsx
+++ b/portal/src/app/checkout/components/UserInfoForm/PersonalInfoForm.tsx
@@ -1,25 +1,67 @@
-import { useEffect, useState } from "react"
+import {
+  Input,
+  InputForm,
+  LabelRequired,
+  SelectForm,
+} from "@edgeos/shared-form-ui"
 import { useTranslation } from "react-i18next"
-import { Button } from "@/components/ui/button"
-import InputForm, { AddonInputForm } from "@/components/ui/Form/Input"
-import RadioGroupForm from "@/components/ui/Form/RadioGroup"
-import { Input } from "@/components/ui/input"
-import { LabelRequired } from "@/components/ui/label"
-import { GENDER_OPTIONS } from "@/constants/util"
-import { useCityProvider } from "@/providers/cityProvider"
+import { DynamicField } from "@/app/portal/[popupSlug]/application/components/fields/dynamic-field"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import {
+  type CheckoutApplicationValues,
+  type DefaultCheckoutFormData,
+  getCheckoutSchemaSections,
+  toDefaultCheckoutFormData,
+} from "../../types"
 
 interface PersonalInfoFormProps {
-  formData: {
-    first_name: string
-    last_name: string
-    telegram: string
-    gender: string
-    email: string
-    local_resident: string
-  }
-  handleInputChange: (field: string, value: string) => void
+  formData: CheckoutApplicationValues
+  handleInputChange: (field: string, value: unknown) => void
   handleChangeEmail?: () => void
   errors: Record<string, string>
+  schema?: ApplicationFormSchema
+}
+
+function getDisplayGender(
+  formData: CheckoutApplicationValues,
+  schema?: ApplicationFormSchema,
+) {
+  const gender = formData.gender
+  if (gender === "Specify") return "Specify"
+  if (typeof gender !== "string") return ""
+
+  const options = schema?.base_fields.gender?.options ?? []
+  if (gender && !options.includes(gender)) return "Specify"
+  return gender
+}
+
+function getGenderSpecifyValue(formData: CheckoutApplicationValues) {
+  const specifiedGender = formData.gender_specify
+  if (typeof specifiedGender === "string" && specifiedGender) {
+    return specifiedGender
+  }
+
+  const gender = formData.gender
+  if (typeof gender !== "string") return ""
+  if (gender.startsWith("SYO - ")) return gender.slice("SYO - ".length)
+  return ""
+}
+
+function shouldRenderSectionHeader(
+  sectionId: string,
+  title: string,
+  index: number,
+) {
+  const normalizedTitle = title.trim().toLowerCase()
+  if (sectionId === "_unsectioned_base" && index === 0) return false
+  if (
+    normalizedTitle === "personal information" ||
+    normalizedTitle === "personal info"
+  ) {
+    return false
+  }
+
+  return true
 }
 
 const PersonalInfoForm = ({
@@ -27,140 +69,201 @@ const PersonalInfoForm = ({
   handleInputChange,
   handleChangeEmail,
   errors,
+  schema,
 }: PersonalInfoFormProps) => {
   const { t } = useTranslation()
-  const { getCity } = useCityProvider()
-  const _city = getCity()
-  // Estado para almacenar el valor de género normalizado
-  const [customGender, setCustomGender] = useState<string>("")
-  const [genderValue, setGenderValue] = useState<string>("")
-  useEffect(() => {
-    if (formData.gender) {
-      const matchingOption = GENDER_OPTIONS.find(
-        (opt) => opt.value.toLowerCase() === formData.gender.toLowerCase(),
-      )
-      if (matchingOption) {
-        setGenderValue(matchingOption.value)
-      } else {
-        setGenderValue("Specify")
-        const gender = formData.gender.split(" - ")[1]
-        setCustomGender(gender)
-      }
-    } else {
-      setGenderValue("")
-    }
-  }, [formData.gender])
 
-  return (
-    <div className="space-y-4 animate-in fade-in duration-500">
-      {/* Email con botón para cambiar */}
-      <div className="w-full flex items-center justify-between">
-        <div className="w-full flex flex-col gap-2">
-          <div className="flex flex-col gap-2">
+  if (!schema) {
+    const defaultFormData: DefaultCheckoutFormData =
+      toDefaultCheckoutFormData(formData)
+
+    return (
+      <div className="space-y-4 animate-in fade-in duration-500">
+        <div className="w-full flex items-center justify-between gap-4">
+          <div className="w-full flex flex-col gap-2">
             <LabelRequired isRequired={false}>
               {t("common.email")}
             </LabelRequired>
+            <Input
+              id="email-verified"
+              type="email"
+              value={defaultFormData.email}
+              onChange={() => {}}
+              disabled
+              className="w-full"
+            />
           </div>
-          <Input
-            id="email-verified"
-            type="email"
-            value={formData.email}
-            onChange={() => {}} // No se puede cambiar
-            disabled={true}
-            className="w-full"
+
+          {handleChangeEmail && (
+            <button
+              type="button"
+              className="mt-[21px] text-sm underline"
+              onClick={handleChangeEmail}
+            >
+              {t("form.change_email")}
+            </button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <InputForm
+            label={t("form.first_name")}
+            id="first_name"
+            value={defaultFormData.first_name}
+            onChange={(value) => handleInputChange("first_name", value)}
+            error={errors.first_name}
+            isRequired
+            placeholder={t("form.first_name_placeholder")}
+          />
+
+          <InputForm
+            label={t("form.last_name")}
+            id="last_name"
+            value={defaultFormData.last_name}
+            onChange={(value) => handleInputChange("last_name", value)}
+            error={errors.last_name}
+            isRequired
+            placeholder={t("form.last_name_placeholder")}
           />
         </div>
 
-        {handleChangeEmail && (
-          <Button
-            type="button"
-            variant="link"
-            size="default"
-            className="mt-[21px]"
-            onClick={handleChangeEmail}
-          >
-            {t("form.change_email")}
-          </Button>
-        )}
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <InputForm
-          label={t("form.first_name")}
-          id="first_name"
-          value={formData.first_name}
-          onChange={(value) => handleInputChange("first_name", value)}
-          error={errors.first_name}
+          label={t("form.telegram")}
+          id="telegram"
+          value={defaultFormData.telegram}
+          onChange={(value) => handleInputChange("telegram", value)}
+          error={errors.telegram}
           isRequired
-          placeholder={t("form.first_name_placeholder")}
+          placeholder={t("form.telegram_placeholder")}
         />
 
         <InputForm
-          label={t("form.last_name")}
-          id="last_name"
-          value={formData.last_name}
-          onChange={(value) => handleInputChange("last_name", value)}
-          error={errors.last_name}
+          label={t("form.gender")}
+          id="gender"
+          value={defaultFormData.gender}
+          onChange={(value) => handleInputChange("gender", value)}
+          error={errors.gender}
           isRequired
-          placeholder={t("form.last_name_placeholder")}
+          placeholder={t("form.gender")}
         />
       </div>
+    )
+  }
 
-      <AddonInputForm
-        label={t("form.telegram")}
-        id="telegram"
-        addon="@"
-        value={formData.telegram}
-        onChange={(value) => handleInputChange("telegram", value)}
-        error={errors.telegram}
-        isRequired
-        placeholder={t("form.telegram_placeholder")}
-      />
+  const sections = getCheckoutSchemaSections(schema)
+  const genderField = schema.base_fields.gender
+  const displayGender = getDisplayGender(formData, schema)
+  const genderSpecifyValue = getGenderSpecifyValue(formData)
 
-      {/* <SelectForm
-        label={form?.personal_information?.local_resident_title || "Are you a LATAM citizen / San Martin resident?"}
-        id="local_resident"
-        value={formData.local_resident}
-        onChange={(value) => {
-          if (value === formData.local_resident) return;
-          handleInputChange("local_resident", value);
-        }}
-        error={errors.local_resident}
-        isRequired
-        placeholder="Select..."
-        options={[
-          { value: "yes", label: "Yes" },
-          { value: "no", label: "No" },
-        ]}
-      />   */}
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      {sections.map((section, index) => (
+        <section key={section.id} className="space-y-4">
+          {shouldRenderSectionHeader(section.id, section.title, index) && (
+            <div>
+              <h3 className="text-base font-semibold">{section.title}</h3>
+              {section.subtitle && (
+                <p className="text-sm text-muted-foreground">
+                  {section.subtitle}
+                </p>
+              )}
+            </div>
+          )}
 
-      <RadioGroupForm
-        label={t("form.gender")}
-        subtitle={t("form.gender_select")}
-        value={genderValue}
-        onChange={(value) => {
-          setGenderValue(value)
-          handleInputChange("gender", value)
-        }}
-        error={errors.gender}
-        isRequired
-        options={GENDER_OPTIONS}
-      />
+          <div className="grid gap-4 md:grid-cols-2">
+            {section.fields.map(({ name, field }) => {
+              if (name === "email") {
+                return (
+                  <div key={name} className="space-y-2 md:col-span-2">
+                    <div className="flex items-end justify-between gap-4">
+                      <div className="flex-1 space-y-2">
+                        <LabelRequired isRequired={field.required}>
+                          {field.label}
+                        </LabelRequired>
+                        {field.help_text && (
+                          <p className="text-sm text-muted-foreground">
+                            {field.help_text}
+                          </p>
+                        )}
+                        <Input
+                          id="checkout-email"
+                          type="email"
+                          value={String(formData.email ?? "")}
+                          onChange={() => {}}
+                          disabled
+                          className="w-full"
+                        />
+                      </div>
 
-      {genderValue === "Specify" && (
-        <InputForm
-          label={t("form.gender_specify")}
-          id="gender_specify"
-          value={customGender}
-          onChange={(value) => {
-            setCustomGender(value)
-            handleInputChange("gender", `SYO - ${value}`)
-          }}
-          error={errors.gender_specify}
-          isRequired
-          placeholder={t("form.gender_specify_placeholder")}
-        />
-      )}
+                      {handleChangeEmail && (
+                        <button
+                          type="button"
+                          className="text-sm underline"
+                          onClick={handleChangeEmail}
+                        >
+                          {t("form.change_email")}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )
+              }
+
+              if (name === "gender" && genderField) {
+                return (
+                  <div key={name} className="space-y-4 md:col-span-2">
+                    <SelectForm
+                      label={genderField.label}
+                      id="gender"
+                      value={displayGender}
+                      onChange={(value) => handleInputChange("gender", value)}
+                      error={errors.gender}
+                      isRequired={genderField.required}
+                      options={(genderField.options ?? []).map((option) => ({
+                        value: option,
+                        label: option,
+                      }))}
+                    />
+
+                    {displayGender === "Specify" && (
+                      <InputForm
+                        label={t("form.gender_specify")}
+                        id="gender_specify"
+                        value={genderSpecifyValue}
+                        onChange={(value) =>
+                          handleInputChange("gender_specify", value)
+                        }
+                        error={errors.gender_specify}
+                        isRequired
+                        placeholder={t("form.gender_specify_placeholder")}
+                      />
+                    )}
+                  </div>
+                )
+              }
+
+              return (
+                <div
+                  key={name}
+                  className={
+                    field.type === "textarea" || field.type === "multiselect"
+                      ? "md:col-span-2"
+                      : ""
+                  }
+                >
+                  <DynamicField
+                    name={name}
+                    field={field}
+                    value={formData[name]}
+                    error={errors[name]}
+                    onChange={handleInputChange}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      ))}
     </div>
   )
 }

--- a/portal/src/app/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/portal/src/app/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import UserInfoForm from "."
+
+const mockUseApplicationData = vi.fn()
+const mockUseEmailVerification = vi.fn()
+
+vi.mock("react-i18next", async () => {
+  const actual =
+    await vi.importActual<typeof import("react-i18next")>("react-i18next")
+  return {
+    ...actual,
+    initReactI18next: {
+      type: "3rdParty",
+      init: () => {},
+    },
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock("@/hooks/useIsAuthenticated", () => ({
+  useIsAuthenticated: () => true,
+}))
+
+vi.mock("../../hooks/useApplicationData", () => ({
+  useApplicationData: (args: unknown) => mockUseApplicationData(args),
+}))
+
+vi.mock("../../hooks/useEmailVerification", () => ({
+  useEmailVerification: (args: unknown) => mockUseEmailVerification(args),
+}))
+
+const schema: ApplicationFormSchema = {
+  base_fields: {
+    email: {
+      type: "email",
+      label: "Email",
+      required: true,
+      target: "human",
+    },
+    first_name: {
+      type: "text",
+      label: "First name",
+      required: true,
+      target: "human",
+      section_id: "personal",
+      position: 1,
+    },
+    telegram: {
+      type: "text",
+      label: "Telegram",
+      required: true,
+      target: "human",
+      section_id: "personal",
+      position: 3,
+    },
+  },
+  custom_fields: {
+    document_id: {
+      type: "text",
+      label: "Document",
+      required: true,
+      section_id: "personal",
+      position: 2,
+    },
+    favorite_color: {
+      type: "text",
+      label: "Favorite color",
+      required: true,
+      section_id: "preferences",
+      position: 1,
+    },
+  },
+  sections: [
+    {
+      id: "personal",
+      label: "Personal info",
+      description: "About you",
+      order: 1,
+      kind: "standard",
+    },
+    {
+      id: "preferences",
+      label: "Preferences",
+      description: "Your choices",
+      order: 2,
+      kind: "standard",
+    },
+  ],
+}
+
+describe("UserInfoForm application checkout", () => {
+  beforeEach(() => {
+    mockUseApplicationData.mockReturnValue({
+      applicationData: {
+        email: "human@example.com",
+        email_verified: true,
+        first_name: "Matias",
+        telegram: "matias",
+        custom_document_id: "12345678",
+        custom_favorite_color: "",
+      },
+      isLoading: false,
+      refreshApplicationData: vi.fn(),
+    })
+    mockUseEmailVerification.mockReturnValue({
+      showVerificationInput: false,
+      verificationCode: "",
+      setVerificationCode: vi.fn(),
+      isSendingCode: false,
+      isVerifyingCode: false,
+      verificationError: null,
+      countdown: 0,
+      handleSendVerificationCode: vi.fn(),
+      handleVerifyCode: vi.fn(),
+      handleResendCode: vi.fn(),
+      handleChangeEmail: vi.fn(),
+    })
+  })
+
+  it("renders custom fields from the visible personal section only", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <UserInfoForm
+        popupId="popup-1"
+        popupName="Popup"
+        schema={schema}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />,
+    )
+
+    expect(screen.getByDisplayValue("human@example.com")).toHaveProperty(
+      "disabled",
+      true,
+    )
+    expect(screen.getByDisplayValue("Matias")).toBeTruthy()
+    expect(screen.getByDisplayValue("12345678")).toBeTruthy()
+    expect(screen.queryByLabelText(/Favorite color/)).toBeNull()
+    expect(screen.queryByText("Personal info")).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "common.continue" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: "human@example.com",
+          first_name: "Matias",
+          telegram: "matias",
+          custom_document_id: "12345678",
+        }),
+      )
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          custom_favorite_color: expect.anything(),
+        }),
+      )
+    })
+  })
+
+  it("does not render or require base fields omitted from the popup schema", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    const schemaWithoutTelegram: ApplicationFormSchema = {
+      ...schema,
+      base_fields: {
+        email: schema.base_fields.email,
+        first_name: schema.base_fields.first_name,
+      },
+      custom_fields: {},
+    }
+
+    mockUseApplicationData.mockReturnValue({
+      applicationData: {
+        email: "human@example.com",
+        email_verified: true,
+        first_name: "Matias",
+      },
+      isLoading: false,
+      refreshApplicationData: vi.fn(),
+    })
+
+    render(
+      <UserInfoForm
+        popupId="popup-1"
+        popupName="Popup"
+        schema={schemaWithoutTelegram}
+        onSubmit={onSubmit}
+        isSubmitting={false}
+      />,
+    )
+
+    expect(screen.queryByLabelText(/Telegram/)).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "common.continue" }))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: "human@example.com",
+          first_name: "Matias",
+        }),
+      )
+    })
+  })
+})

--- a/portal/src/app/checkout/components/UserInfoForm/index.tsx
+++ b/portal/src/app/checkout/components/UserInfoForm/index.tsx
@@ -11,23 +11,31 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import type { ApplicationFormSchema } from "@/types/form-schema"
 import { useApplicationData } from "../../hooks/useApplicationData"
 import { useEmailVerification } from "../../hooks/useEmailVerification"
 import { useUserForm } from "../../hooks/useUserForm"
-import type { FormDataProps } from "../../types"
+import type {
+  CheckoutApplicationValues,
+  DefaultCheckoutFormData,
+} from "../../types"
 import EmailVerification from "./EmailVerification"
 import PersonalInfoForm from "./PersonalInfoForm"
 
 interface UserInfoFormProps {
   popupId: string
   popupName: string
-  onSubmit: (data: FormDataProps) => Promise<void>
+  schema?: ApplicationFormSchema
+  onSubmit: (
+    data: DefaultCheckoutFormData | CheckoutApplicationValues,
+  ) => Promise<void>
   isSubmitting: boolean
 }
 
 const UserInfoForm = ({
   popupId,
   popupName,
+  schema,
   onSubmit,
   isSubmitting,
 }: UserInfoFormProps) => {
@@ -40,10 +48,12 @@ const UserInfoForm = ({
     refreshApplicationData,
   } = useApplicationData({
     groupPopupCityId: popupId,
+    schema,
   })
 
   const {
     formData,
+    emailVerified,
     errors,
     setErrors,
     handleInputChange,
@@ -52,9 +62,9 @@ const UserInfoForm = ({
     resetForm,
   } = useUserForm({
     applicationData,
+    schema,
   })
 
-  // Set autoFilled flag when applicationData has more than just email
   useEffect(() => {
     if (
       applicationData &&
@@ -79,9 +89,9 @@ const UserInfoForm = ({
     handleResendCode,
     handleChangeEmail,
   } = useEmailVerification({
-    email: formData.email,
+    email: String(formData.email ?? ""),
     onVerificationSuccess: (_token) => {
-      setEmailVerified(formData.email)
+      setEmailVerified(String(formData.email ?? ""))
       refreshApplicationData()
     },
   })
@@ -97,9 +107,9 @@ const UserInfoForm = ({
     e.preventDefault()
 
     if (
-      !formData.email_verified &&
+      !emailVerified &&
       formData.email &&
-      !/^\S+@\S+\.\S+$/.test(formData.email)
+      !/^\S+@\S+\.\S+$/.test(String(formData.email))
     ) {
       setErrors((prev) => ({
         ...prev,
@@ -108,7 +118,7 @@ const UserInfoForm = ({
       return
     }
 
-    if (!formData.email_verified) {
+    if (!emailVerified) {
       if (!showVerificationInput) {
         await handleSendVerificationCode()
       } else {
@@ -120,12 +130,26 @@ const UserInfoForm = ({
     if (validateForm()) {
       try {
         await onSubmit(formData)
-      } catch (error: any) {
+      } catch (error: unknown) {
         console.error("Error submitting form:", error)
-        if (error.response?.data?.message) {
+        const errorMessage =
+          typeof error === "object" &&
+          error !== null &&
+          "response" in error &&
+          typeof error.response === "object" &&
+          error.response !== null &&
+          "data" in error.response &&
+          typeof error.response.data === "object" &&
+          error.response.data !== null &&
+          "message" in error.response.data &&
+          typeof error.response.data.message === "string"
+            ? error.response.data.message
+            : null
+
+        if (errorMessage) {
           setErrors((prev) => ({
             ...prev,
-            general: error.response.data.message,
+            general: errorMessage,
           }))
         } else {
           setErrors((prev) => ({
@@ -179,9 +203,9 @@ const UserInfoForm = ({
       </CardHeader>
       <form noValidate onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
-          {!formData.email_verified && (
+          {!emailVerified && (
             <EmailVerification
-              email={formData.email}
+              email={String(formData.email ?? "")}
               showVerificationInput={showVerificationInput}
               verificationCode={verificationCode}
               setVerificationCode={setVerificationCode}
@@ -196,12 +220,13 @@ const UserInfoForm = ({
             />
           )}
 
-          {formData.email_verified && (
+          {emailVerified && (
             <PersonalInfoForm
               formData={formData}
               handleInputChange={handleInputChange}
               handleChangeEmail={handleEmailChange}
               errors={errors}
+              schema={schema}
             />
           )}
         </CardContent>
@@ -214,14 +239,14 @@ const UserInfoForm = ({
               isSubmitting ||
               (showVerificationInput &&
                 verificationCode.length !== 6 &&
-                !formData.email_verified) ||
+                !emailVerified) ||
               isSendingCode ||
               isVerifyingCode
             }
           >
             {isSubmitting
               ? t("common.processing")
-              : formData.email_verified
+              : emailVerified
                 ? t("common.continue")
                 : showVerificationInput
                   ? t("checkout.verify_code")

--- a/portal/src/app/checkout/hooks/useApplicationData.test.ts
+++ b/portal/src/app/checkout/hooks/useApplicationData.test.ts
@@ -1,0 +1,124 @@
+import type { ApplicationPublic, HumanPublic } from "@/client"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import { hydrateCheckoutApplicationValues } from "./useApplicationData"
+
+const schema: ApplicationFormSchema = {
+  base_fields: {
+    email: {
+      type: "email",
+      label: "Email",
+      required: true,
+      target: "human",
+    },
+    first_name: {
+      type: "text",
+      label: "First name",
+      required: true,
+      target: "human",
+    },
+    scholarship_request: {
+      type: "boolean",
+      label: "Scholarship",
+      required: false,
+      target: "application",
+    },
+    gender: {
+      type: "select",
+      label: "Gender",
+      required: true,
+      target: "human",
+      options: ["Female", "Male", "Specify"],
+    },
+  },
+  custom_fields: {
+    favorite_color: {
+      type: "text",
+      label: "Favorite color",
+      required: false,
+    },
+    document_id: {
+      type: "text",
+      label: "Document",
+      required: false,
+      section_id: "_unsectioned_base",
+    },
+  },
+  sections: [],
+}
+
+describe("hydrateCheckoutApplicationValues", () => {
+  it("hydrates checkout-visible base profile values for the current popup", () => {
+    const human = {
+      email: "human@example.com",
+      first_name: "Human",
+      gender: "Female",
+    } as HumanPublic
+
+    const application = {
+      popup_id: "popup-1",
+      human: {
+        first_name: "Applicant",
+        gender: "SYO - Non binary",
+      },
+      scholarship_request: true,
+      custom_fields: {
+        favorite_color: "Blue",
+        document_id: "A-123",
+      },
+    } as unknown as ApplicationPublic
+
+    expect(
+      hydrateCheckoutApplicationValues({
+        schema,
+        human,
+        application,
+        popupId: "popup-1",
+      }),
+    ).toEqual({
+      custom_document_id: "A-123",
+      custom_favorite_color: "Blue",
+      email: "human@example.com",
+      first_name: "Applicant",
+      gender: "SYO - Non binary",
+      gender_specify: "Non binary",
+      email_verified: true,
+    })
+  })
+
+  it("limits imported values to human-target fields when the application belongs to another popup", () => {
+    const human = {
+      email: "human@example.com",
+      first_name: "Human",
+      gender: "Male",
+    } as HumanPublic
+
+    const application = {
+      popup_id: "popup-2",
+      human: {
+        first_name: "Imported",
+        gender: "Male",
+      },
+      scholarship_request: true,
+      custom_fields: {
+        favorite_color: "Blue",
+      },
+    } as unknown as ApplicationPublic
+
+    expect(
+      hydrateCheckoutApplicationValues({
+        schema,
+        human,
+        application,
+        popupId: "popup-1",
+      }),
+    ).toEqual({
+      custom_document_id: "",
+      custom_favorite_color: "",
+      email: "human@example.com",
+      first_name: "Imported",
+      gender: "Male",
+      gender_specify: "",
+      email_verified: true,
+    })
+  })
+})

--- a/portal/src/app/checkout/hooks/useApplicationData.ts
+++ b/portal/src/app/checkout/hooks/useApplicationData.ts
@@ -1,19 +1,119 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import type { ApplicationPublic, HumanPublic } from "@/client"
 import { ApplicationsService, HumansService } from "@/client"
 import { useIsAuthenticated } from "@/hooks/useIsAuthenticated"
 import { queryKeys } from "@/lib/query-keys"
-import type { FormDataProps } from "../types"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import {
+  type CheckoutApplicationValues,
+  getCheckoutFieldDefaultValue,
+  getCheckoutMiniFormSchema,
+  HUMAN_FIELD_KEYS,
+} from "../types"
 
-interface ExtendedApplicationData extends Partial<FormDataProps> {
-  red_flag?: boolean
-}
+interface ExtendedApplicationData extends CheckoutApplicationValues {}
 
 interface UseApplicationDataProps {
   groupPopupCityId?: string
+  schema?: ApplicationFormSchema
+}
+
+function getSpecifiedGenderValue(value: unknown): string {
+  if (typeof value !== "string") return ""
+  if (value.startsWith("SYO - ")) return value.slice("SYO - ".length)
+  return value
+}
+
+interface HydrateCheckoutApplicationValuesArgs {
+  schema: ApplicationFormSchema
+  human?: HumanPublic | null
+  application?: ApplicationPublic | null
+  popupId?: string
+}
+
+export function hydrateCheckoutApplicationValues({
+  schema,
+  human,
+  application,
+  popupId,
+}: HydrateCheckoutApplicationValuesArgs): ExtendedApplicationData {
+  const values: ExtendedApplicationData = {}
+  const checkoutSchema = getCheckoutMiniFormSchema(schema)
+
+  for (const [name, field] of Object.entries(checkoutSchema.base_fields)) {
+    values[name] = getCheckoutFieldDefaultValue(field)
+  }
+  for (const [name, field] of Object.entries(checkoutSchema.custom_fields)) {
+    values[`custom_${name}`] = getCheckoutFieldDefaultValue(field)
+  }
+  values.gender_specify = ""
+  values.email_verified = Boolean(human?.email)
+
+  const isCurrentPopupApplication = application?.popup_id === popupId
+
+  for (const [name, field] of Object.entries(checkoutSchema.base_fields)) {
+    const readsHuman = field.target === "human" || HUMAN_FIELD_KEYS.has(name)
+
+    if (isCurrentPopupApplication && application) {
+      if (readsHuman && application.human) {
+        const value = (application.human as Record<string, unknown>)[name]
+        if (value !== undefined && value !== null) values[name] = value
+      } else {
+        const value = (application as Record<string, unknown>)[name]
+        if (value !== undefined && value !== null) values[name] = value
+      }
+      if (
+        readsHuman &&
+        human &&
+        (values[name] === "" ||
+          values[name] === undefined ||
+          values[name] === null)
+      ) {
+        const fallbackValue = (human as Record<string, unknown>)[name]
+        if (fallbackValue !== undefined && fallbackValue !== null) {
+          values[name] = fallbackValue
+        }
+      }
+      continue
+    }
+
+    if (application?.human && readsHuman) {
+      const importedValue = (application.human as Record<string, unknown>)[name]
+      if (importedValue !== undefined && importedValue !== null) {
+        values[name] = importedValue
+        continue
+      }
+    }
+
+    if (readsHuman && human) {
+      const value = (human as Record<string, unknown>)[name]
+      if (value !== undefined && value !== null) values[name] = value
+    }
+  }
+
+  if (isCurrentPopupApplication && application?.custom_fields) {
+    for (const [name] of Object.entries(checkoutSchema.custom_fields)) {
+      const customValue = application.custom_fields[name]
+      if (customValue !== undefined && customValue !== null) {
+        values[`custom_${name}`] = customValue
+      }
+    }
+  }
+
+  const normalizedGender = values.gender
+  if (typeof normalizedGender === "string") {
+    const genderOptions = checkoutSchema.base_fields.gender?.options ?? []
+    if (normalizedGender && !genderOptions.includes(normalizedGender)) {
+      values.gender_specify = getSpecifiedGenderValue(normalizedGender)
+    }
+  }
+
+  return values
 }
 
 export const useApplicationData = ({
   groupPopupCityId,
+  schema,
 }: UseApplicationDataProps) => {
   const queryClient = useQueryClient()
   const isAuthenticated = useIsAuthenticated()
@@ -25,55 +125,33 @@ export const useApplicationData = ({
   } = useQuery({
     queryKey: [...queryKeys.applications.mine(), "checkout", groupPopupCityId],
     queryFn: async (): Promise<ExtendedApplicationData | null> => {
+      if (!schema) return null
       const token = window?.localStorage?.getItem("token")
       if (!token) return null
 
-      // Get current human info from API (email, name, etc.)
       const human = await HumansService.getCurrentHumanInfo()
       if (!human?.email) return null
 
-      const baseData: ExtendedApplicationData = {
-        email: human.email,
-        first_name: human.first_name || "",
-        last_name: human.last_name || "",
-        telegram: human.telegram || "",
-        gender: human.gender?.toLowerCase() || "",
-        email_verified: true,
-        local_resident: "",
-        red_flag: human.red_flag || false,
-      }
-
-      // If we have a group, check for matching application to get app-specific data
+      let matchingApplication: ApplicationPublic | null = null
       if (groupPopupCityId) {
         try {
           const result = await ApplicationsService.listMyApplications()
-          const matchingApp = result.results.find(
-            (app) => app.popup_id === groupPopupCityId,
-          )
-
-          if (matchingApp) {
-            return {
-              ...baseData,
-              first_name:
-                matchingApp.human?.first_name || human.first_name || "",
-              last_name: matchingApp.human?.last_name || human.last_name || "",
-              telegram: matchingApp.human?.telegram || human.telegram || "",
-              gender: (
-                matchingApp.human?.gender ||
-                human.gender ||
-                ""
-              ).toLowerCase(),
-              red_flag: matchingApp.red_flag || false,
-            }
-          }
+          matchingApplication =
+            result.results.find((app) => app.popup_id === groupPopupCityId) ??
+            null
         } catch {
-          // If applications fetch fails, still return human data
+          matchingApplication = null
         }
       }
 
-      return baseData
+      return hydrateCheckoutApplicationValues({
+        schema,
+        human,
+        application: matchingApplication,
+        popupId: groupPopupCityId,
+      })
     },
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && Boolean(schema),
   })
 
   const refreshApplicationData = () => {

--- a/portal/src/app/checkout/hooks/useCheckoutState.test.ts
+++ b/portal/src/app/checkout/hooks/useCheckoutState.test.ts
@@ -1,0 +1,86 @@
+import type { ApplicationPublic } from "@/client"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import { buildCheckoutApplicationMutationPayload } from "./useCheckoutState"
+
+const schema: ApplicationFormSchema = {
+  base_fields: {
+    first_name: {
+      type: "text",
+      label: "First name",
+      required: true,
+      target: "human",
+    },
+    scholarship_request: {
+      type: "boolean",
+      label: "Scholarship",
+      required: false,
+      target: "application",
+    },
+  },
+  custom_fields: {
+    favorite_color: {
+      type: "text",
+      label: "Favorite color",
+      required: false,
+    },
+  },
+  sections: [],
+}
+
+describe("buildCheckoutApplicationMutationPayload", () => {
+  it("builds create payloads from checkout-visible base and custom fields", () => {
+    expect(
+      buildCheckoutApplicationMutationPayload({
+        popupId: "popup-1",
+        schema,
+        values: {
+          first_name: "Matias",
+          scholarship_request: true,
+          custom_favorite_color: "Blue",
+          gender_specify: "ignored",
+        },
+        existingApplication: null,
+      }),
+    ).toEqual({
+      kind: "create",
+      payload: {
+        popup_id: "popup-1",
+        first_name: "Matias",
+        last_name: "",
+        custom_fields: {
+          favorite_color: "Blue",
+        },
+        status: "in review",
+      },
+    })
+  })
+
+  it("builds update payloads from checkout-visible base and custom fields", () => {
+    const existingApplication = {
+      id: "app-1",
+      popup_id: "popup-1",
+    } as ApplicationPublic
+
+    expect(
+      buildCheckoutApplicationMutationPayload({
+        popupId: "popup-1",
+        schema,
+        values: {
+          first_name: "Matias",
+          scholarship_request: false,
+          custom_favorite_color: "Green",
+        },
+        existingApplication,
+      }),
+    ).toEqual({
+      kind: "update",
+      payload: {
+        first_name: "Matias",
+        custom_fields: {
+          favorite_color: "Green",
+        },
+        status: "in review",
+      },
+    })
+  })
+})

--- a/portal/src/app/checkout/hooks/useCheckoutState.ts
+++ b/portal/src/app/checkout/hooks/useCheckoutState.ts
@@ -4,24 +4,84 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import {
   ApiError,
+  type ApplicationCreate,
   type ApplicationPublic,
   ApplicationsService,
+  type ApplicationUpdate,
   HumansService,
 } from "@/client"
+import { splitForCreate, splitForUpdate } from "@/lib/form-data-splitter"
 import { queryKeys } from "@/lib/query-keys"
-import type { CheckoutState, FormDataProps } from "../types"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import {
+  type CheckoutApplicationValues,
+  type CheckoutState,
+  type DefaultCheckoutFormData,
+  filterCheckoutApplicationValues,
+  toDefaultCheckoutFormData,
+} from "../types"
 import useCookies from "./useCookies"
 
 interface UseCheckoutStateProps {
   popupId: string
   saleType: "application" | "direct"
   groupId?: string | null
+  schema?: ApplicationFormSchema
+}
+
+interface BuildCheckoutApplicationMutationPayloadArgs {
+  popupId: string
+  values: CheckoutApplicationValues
+  schema: ApplicationFormSchema
+  existingApplication: ApplicationPublic | null
+}
+
+type CheckoutApplicationMutationPayload =
+  | { kind: "create"; payload: ApplicationCreate }
+  | { kind: "update"; payload: ApplicationUpdate }
+
+function getApiErrorDetail(error: ApiError): string | null {
+  if (typeof error.body !== "object" || error.body === null) return null
+  const detail = (error.body as Record<string, unknown>).detail
+  return typeof detail === "string" ? detail : null
+}
+
+export function buildCheckoutApplicationMutationPayload({
+  popupId,
+  values,
+  schema,
+  existingApplication,
+}: BuildCheckoutApplicationMutationPayloadArgs): CheckoutApplicationMutationPayload {
+  const checkoutValues = filterCheckoutApplicationValues(schema, values)
+
+  if (existingApplication) {
+    return {
+      kind: "update",
+      payload: splitForUpdate({
+        values: checkoutValues,
+        status: "in review",
+        schema,
+      }),
+    }
+  }
+
+  return {
+    kind: "create",
+    payload: splitForCreate({
+      values: checkoutValues,
+      popupId,
+      companions: [],
+      status: "in review",
+      schema,
+    }),
+  }
 }
 
 const useCheckoutState = ({
   popupId,
   saleType,
   groupId,
+  schema,
 }: UseCheckoutStateProps) => {
   const queryClient = useQueryClient()
   const [checkoutState, setCheckoutState] = useState<CheckoutState>("form")
@@ -29,7 +89,11 @@ const useCheckoutState = ({
   const { setCookie } = useCookies()
 
   const submitMutation = useMutation({
-    mutationFn: async ({ formData }: { formData: FormDataProps }) => {
+    mutationFn: async ({
+      formData,
+    }: {
+      formData: DefaultCheckoutFormData | CheckoutApplicationValues
+    }) => {
       if (!popupId) throw new Error("No popup selected")
 
       setCookie(
@@ -41,44 +105,49 @@ const useCheckoutState = ({
       )
 
       if (saleType === "direct") {
+        const directFormData: DefaultCheckoutFormData =
+          toDefaultCheckoutFormData(formData)
         await HumansService.updateCurrentHuman({
           requestBody: {
-            first_name: formData.first_name,
-            last_name: formData.last_name,
-            telegram: formData.telegram,
-            gender: formData.gender || undefined,
+            first_name: directFormData.first_name,
+            last_name: directFormData.last_name,
+            telegram: directFormData.telegram,
+            gender: directFormData.gender || undefined,
           },
         })
 
         return { matchingApp: null }
       }
 
-      // Check if an application already exists (e.g. user navigated back)
+      if (!schema) {
+        throw new Error("Application checkout schema is required")
+      }
+
       const existingApps = queryClient.getQueryData<ApplicationPublic[]>(
         queryKeys.applications.mine(),
       )
       const existingApp = existingApps?.find((app) => app.popup_id === popupId)
 
+      const mutationPayload = buildCheckoutApplicationMutationPayload({
+        popupId,
+        values: filterCheckoutApplicationValues(
+          schema,
+          formData as CheckoutApplicationValues,
+        ),
+        schema,
+        existingApplication: existingApp ?? null,
+      })
+
       let application: ApplicationPublic
-      if (existingApp) {
+      if (mutationPayload.kind === "update") {
         application = await ApplicationsService.updateMyApplication({
           popupId,
-          requestBody: {
-            first_name: formData.first_name,
-            last_name: formData.last_name,
-            telegram: formData.telegram,
-            gender: formData.gender || undefined,
-          },
+          requestBody: mutationPayload.payload,
         })
       } else {
         application = await ApplicationsService.createMyApplication({
           requestBody: {
-            popup_id: popupId,
-            first_name: formData.first_name,
-            last_name: formData.last_name,
-            email: formData.email,
-            telegram: formData.telegram,
-            gender: formData.gender || undefined,
+            ...mutationPayload.payload,
             group_id: groupId ?? undefined,
           },
         })
@@ -105,13 +174,15 @@ const useCheckoutState = ({
       setCheckoutState("passes")
       setErrorMessage(null)
     },
-    onError: async (error: any) => {
+    onError: async (error: unknown) => {
+      const detail = error instanceof ApiError ? getApiErrorDetail(error) : null
+
       if (
         saleType === "application" &&
         error instanceof ApiError &&
         (error.status === 400 ||
           error.status === 409 ||
-          (error.body as any)?.detail?.includes("already have an application"))
+          detail?.includes("already have an application"))
       ) {
         try {
           const token = window?.localStorage?.getItem("token")
@@ -135,14 +206,14 @@ const useCheckoutState = ({
         }
 
         setErrorMessage(
-          "You already have a pending application for this event. Please check your email or contact support.",
+          "You already have a pending application for this pop-up. Please check your email or contact support.",
         )
       } else {
         const msg =
-          error instanceof ApiError
-            ? ((error.body as any)?.detail ??
-              "Something went wrong. Please try again.")
-            : "Something went wrong. Please try again."
+          detail ??
+          (error instanceof ApiError
+            ? "Something went wrong. Please try again."
+            : "Something went wrong. Please try again.")
         setErrorMessage(msg)
       }
 
@@ -150,7 +221,9 @@ const useCheckoutState = ({
     },
   })
 
-  const handleSubmit = async (formData: FormDataProps): Promise<void> => {
+  const handleSubmit = async (
+    formData: DefaultCheckoutFormData | CheckoutApplicationValues,
+  ): Promise<void> => {
     await submitMutation.mutateAsync({ formData })
   }
 

--- a/portal/src/app/checkout/hooks/useUserForm.ts
+++ b/portal/src/app/checkout/hooks/useUserForm.ts
@@ -1,13 +1,23 @@
 import { useEffect, useState } from "react"
 import { useIsAuthenticated } from "@/hooks/useIsAuthenticated"
-import type { FormDataProps } from "../types"
+import { buildFormZodSchema } from "@/lib/form-schema-builder"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import {
+  type CheckoutApplicationValues,
+  type DefaultCheckoutFormData,
+  filterCheckoutApplicationValues,
+  getCheckoutFieldDefaultValue,
+  getCheckoutMiniFormSchema,
+  toDefaultCheckoutFormData,
+} from "../types"
 
 interface UseUserFormProps {
-  initialData?: Partial<FormDataProps>
-  applicationData?: Partial<FormDataProps> | null
+  initialData?: Partial<DefaultCheckoutFormData>
+  applicationData?: CheckoutApplicationValues | null
+  schema?: ApplicationFormSchema
 }
 
-const defaultFormData: FormDataProps = {
+const defaultCheckoutFormData: DefaultCheckoutFormData = {
   first_name: "",
   last_name: "",
   email: "",
@@ -20,43 +30,98 @@ const defaultFormData: FormDataProps = {
 export const useUserForm = ({
   initialData = {},
   applicationData,
+  schema,
 }: UseUserFormProps = {}) => {
   const isAuthenticated = useIsAuthenticated()
+  const checkoutSchema = schema ? getCheckoutMiniFormSchema(schema) : undefined
 
-  const [formData, setFormData] = useState<FormDataProps>(() => ({
-    ...defaultFormData,
-    ...initialData,
-    ...(applicationData ?? {}),
-    email_verified: applicationData?.email_verified ?? isAuthenticated ?? false,
-  }))
+  const getCheckoutScopedValues = (
+    values?: CheckoutApplicationValues | null,
+  ): CheckoutApplicationValues => {
+    if (!schema || !values) return values ?? {}
+    return filterCheckoutApplicationValues(schema, values)
+  }
+
+  const getSchemaDefaultValues = (): CheckoutApplicationValues => {
+    if (!checkoutSchema) return {}
+
+    const values: CheckoutApplicationValues = {
+      gender_specify: "",
+    }
+
+    for (const [name, field] of Object.entries(checkoutSchema.base_fields)) {
+      values[name] = getCheckoutFieldDefaultValue(field)
+    }
+
+    return values
+  }
+
+  const [formData, setFormData] = useState<CheckoutApplicationValues>(() =>
+    checkoutSchema
+      ? {
+          ...getSchemaDefaultValues(),
+          ...getCheckoutScopedValues(applicationData),
+        }
+      : ({
+          ...defaultCheckoutFormData,
+          ...initialData,
+          ...(applicationData ?? {}),
+          email_verified:
+            (applicationData?.email_verified as boolean | undefined) ??
+            isAuthenticated ??
+            false,
+        } as CheckoutApplicationValues),
+  )
 
   const [errors, setErrors] = useState<Record<string, string>>({})
+  const [emailVerified, setEmailVerifiedState] = useState(
+    (applicationData?.email_verified as boolean | undefined) ??
+      isAuthenticated ??
+      false,
+  )
 
-  // Actualizar formData cuando llegan nuevos datos de aplicación
   useEffect(() => {
     if (applicationData) {
+      const scopedValues = !schema
+        ? applicationData
+        : filterCheckoutApplicationValues(schema, applicationData)
+
       setFormData((prev) => ({
         ...prev,
-        ...applicationData,
+        ...scopedValues,
       }))
+      setEmailVerifiedState(
+        (applicationData.email_verified as boolean | undefined) ??
+          isAuthenticated ??
+          false,
+      )
     }
-  }, [applicationData])
+  }, [applicationData, isAuthenticated, schema])
 
-  const handleInputChange = (field: string, value: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: value,
-    }))
-
-    // Si cambia el email, resetear la verificación
-    if (field === "email") {
-      setFormData((prev) => ({
+  const handleInputChange = (field: string, value: unknown) => {
+    setFormData((prev) => {
+      const nextValues: CheckoutApplicationValues = {
         ...prev,
-        email_verified: false,
-      }))
-    }
+        [field]: value,
+      }
 
-    // Eliminar error cuando el usuario empieza a escribir
+      if (field === "email") {
+        setEmailVerifiedState(false)
+      }
+
+      if (field === "gender") {
+        if (value !== "Specify") {
+          nextValues.gender_specify = ""
+        }
+      }
+
+      if (field === "gender_specify") {
+        nextValues.gender = value ? `SYO - ${value}` : "Specify"
+      }
+
+      return nextValues
+    })
+
     if (errors[field]) {
       setErrors((prev) => {
         const newErrors = { ...prev }
@@ -68,21 +133,57 @@ export const useUserForm = ({
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {}
-    if (!formData.first_name) newErrors.first_name = "First name is required"
-    if (!formData.last_name) newErrors.last_name = "Last name is required"
 
-    if (!formData.email && !formData.email_verified) {
-      newErrors.email = "Email is required"
-    } else if (!/^\S+@\S+\.\S+$/.test(formData.email)) {
-      newErrors.email = "Invalid email"
-    } else if (!formData.email_verified) {
-      newErrors.email =
-        "Email verification is required. Please verify your email before continuing."
+    if (checkoutSchema) {
+      const result = buildFormZodSchema(checkoutSchema, false).safeParse(
+        formData,
+      )
+      if (!result.success) {
+        for (const issue of result.error.issues) {
+          const path = issue.path.join(".")
+          if (!newErrors[path]) {
+            newErrors[path] = issue.message
+          }
+        }
+      }
+
+      const genderValue = formData.gender
+      const genderSpecify = formData.gender_specify
+      if (
+        (genderValue === "Specify" ||
+          (typeof genderValue === "string" &&
+            genderValue.startsWith("SYO - "))) &&
+        !String(genderSpecify ?? "").trim()
+      ) {
+        newErrors.gender_specify = "Please specify your gender"
+      }
+
+      if (!emailVerified) {
+        newErrors.email =
+          "Email verification is required. Please verify your email before continuing."
+      }
+    } else {
+      const defaultFormData: DefaultCheckoutFormData =
+        toDefaultCheckoutFormData(formData)
+      if (!defaultFormData.first_name)
+        newErrors.first_name = "First name is required"
+      if (!defaultFormData.last_name)
+        newErrors.last_name = "Last name is required"
+
+      if (!defaultFormData.email && !emailVerified) {
+        newErrors.email = "Email is required"
+      } else if (!/^\S+@\S+\.\S+$/.test(defaultFormData.email)) {
+        newErrors.email = "Invalid email"
+      } else if (!emailVerified) {
+        newErrors.email =
+          "Email verification is required. Please verify your email before continuing."
+      }
+      if (!defaultFormData.telegram) newErrors.telegram = "Telegram is required"
+      if (!defaultFormData.gender) newErrors.gender = "Gender is required"
+      if (defaultFormData.gender === "Specify") {
+        newErrors.gender_specify = "Please specify your gender"
+      }
     }
-    if (!formData.telegram) newErrors.telegram = "Telegram is required"
-    if (!formData.gender) newErrors.gender = "Gender is required"
-    if (formData.gender === "Specify")
-      newErrors.gender_specify = "Please specify your gender"
 
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
@@ -92,25 +193,23 @@ export const useUserForm = ({
     setFormData((prev) => ({
       ...prev,
       email,
-      email_verified: true,
     }))
+    setEmailVerifiedState(true)
   }
 
   const resetForm = () => {
-    setFormData({
-      first_name: "",
-      last_name: "",
-      email: "",
-      telegram: "",
-      gender: "",
-      email_verified: false,
-      local_resident: "",
-    })
+    setFormData(
+      checkoutSchema
+        ? getSchemaDefaultValues()
+        : ({ ...defaultCheckoutFormData } as CheckoutApplicationValues),
+    )
+    setEmailVerifiedState(false)
     setErrors({})
   }
 
   return {
     formData,
+    emailVerified,
     errors,
     setErrors,
     handleInputChange,

--- a/portal/src/app/checkout/types.test.ts
+++ b/portal/src/app/checkout/types.test.ts
@@ -1,0 +1,165 @@
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import { getCheckoutMiniFormSchema, getCheckoutSchemaSections } from "./types"
+
+function createSchema(
+  overrides: Partial<ApplicationFormSchema> = {},
+): ApplicationFormSchema {
+  return {
+    base_fields: {
+      email: {
+        type: "email",
+        label: "Email",
+        required: true,
+        target: "human",
+      },
+      first_name: {
+        type: "text",
+        label: "First name",
+        required: true,
+        section_id: "personal",
+        position: 2,
+        target: "human",
+      },
+      telegram: {
+        type: "text",
+        label: "Telegram",
+        required: true,
+        section_id: "personal",
+        position: 3,
+        target: "human",
+      },
+    },
+    custom_fields: {
+      tshirt_size: {
+        type: "select",
+        label: "T-Shirt size",
+        required: true,
+        section_id: "preferences",
+        position: 1,
+        options: ["S", "M"],
+      },
+    },
+    sections: [
+      {
+        id: "personal",
+        label: "Personal info",
+        description: "About you",
+        order: 1,
+        kind: "standard",
+      },
+      {
+        id: "preferences",
+        label: "Preferences",
+        description: "Your choices",
+        order: 2,
+        kind: "standard",
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe("checkout application schema helpers", () => {
+  it("keeps custom fields that belong to checkout-visible sections", () => {
+    const miniFormSchema = getCheckoutMiniFormSchema(
+      createSchema({
+        base_fields: {
+          email: {
+            type: "email",
+            label: "Email",
+            required: true,
+            target: "human",
+          },
+          referral: {
+            type: "text",
+            label: "Referral",
+            required: true,
+            target: "application",
+          },
+        },
+        custom_fields: {
+          favorite_color: {
+            type: "text",
+            label: "Favorite color",
+            required: true,
+            section_id: "preferences",
+          },
+          document_id: {
+            type: "text",
+            label: "Document",
+            required: true,
+            section_id: "_unsectioned_base",
+          },
+        },
+      }),
+    )
+
+    expect(Object.keys(miniFormSchema.base_fields)).toEqual(["email"])
+    expect(Object.keys(miniFormSchema.custom_fields)).toEqual(["document_id"])
+  })
+
+  it("keeps checkout on the mini-form subset when schema has special sections or unsupported application-only fields", () => {
+    const schemaWithOutOfScopeFields = createSchema({
+      base_fields: {
+        email: {
+          type: "email",
+          label: "Email",
+          required: true,
+          target: "human",
+        },
+        markdown_notes: {
+          type: "markdown",
+          label: "Notes",
+          required: false,
+          target: "application",
+        },
+      },
+      custom_fields: {},
+      sections: [
+        {
+          id: "companions",
+          label: "Companions",
+          description: null,
+          order: 1,
+          kind: "companions",
+        },
+      ],
+    })
+
+    expect(
+      Object.keys(
+        getCheckoutMiniFormSchema(schemaWithOutOfScopeFields).base_fields,
+      ),
+    ).toEqual(["email"])
+  })
+
+  it("orders base and custom fields by schema sections", () => {
+    const sections = getCheckoutSchemaSections(
+      createSchema({
+        custom_fields: {
+          document_id: {
+            type: "text",
+            label: "Document",
+            required: false,
+            section_id: "personal",
+            position: 1,
+          },
+        },
+      }),
+    )
+
+    expect(sections).toHaveLength(2)
+    expect(sections[0]).toMatchObject({
+      id: "_unsectioned_base",
+      fields: [{ name: "email", isCustom: false }],
+    })
+    expect(sections[1]).toMatchObject({
+      id: "personal",
+      fields: [
+        { name: "custom_document_id", isCustom: true },
+        { name: "first_name", isCustom: false },
+        { name: "telegram", isCustom: false },
+      ],
+    })
+  })
+})

--- a/portal/src/app/checkout/types.ts
+++ b/portal/src/app/checkout/types.ts
@@ -1,4 +1,57 @@
-export interface FormDataProps {
+import type {
+  ApplicationFormSchema,
+  FormFieldSchema,
+} from "@/types/form-schema"
+
+export type CheckoutApplicationValues = Record<string, unknown>
+
+export interface CheckoutSchemaSectionField {
+  name: string
+  field: FormFieldSchema
+  isCustom: boolean
+}
+
+export interface CheckoutSchemaSection {
+  id: string
+  title: string
+  subtitle?: string
+  fields: CheckoutSchemaSectionField[]
+}
+
+export const SUPPORTED_CHECKOUT_FIELD_TYPE = {
+  TEXT: "text",
+  TEXTAREA: "textarea",
+  NUMBER: "number",
+  BOOLEAN: "boolean",
+  SELECT: "select",
+  SELECT_CARDS: "select_cards",
+  MULTISELECT: "multiselect",
+  DATE: "date",
+  EMAIL: "email",
+  URL: "url",
+} as const
+
+export const HUMAN_FIELD_KEYS = new Set([
+  "email",
+  "first_name",
+  "last_name",
+  "telegram",
+  "gender",
+  "age",
+  "residence",
+])
+
+export const CHECKOUT_BASE_FIELD_KEYS = new Set([
+  "email",
+  "first_name",
+  "last_name",
+  "telegram",
+  "gender",
+  "age",
+  "residence",
+])
+
+export interface DefaultCheckoutFormData {
   first_name: string
   last_name: string
   email: string
@@ -8,9 +61,169 @@ export interface FormDataProps {
   local_resident: string
 }
 
-export type CheckoutState = "form" | "processing" | "success" | "passes"
-
 export interface GenderOption {
   value: string
   label: string
 }
+
+function getStringCheckoutValue(
+  values: CheckoutApplicationValues | DefaultCheckoutFormData,
+  key: keyof DefaultCheckoutFormData,
+): string {
+  const value = values[key]
+  return typeof value === "string" ? value : ""
+}
+
+function getBooleanCheckoutValue(
+  values: CheckoutApplicationValues | DefaultCheckoutFormData,
+  key: keyof DefaultCheckoutFormData,
+): boolean {
+  const value = values[key]
+  return typeof value === "boolean" ? value : false
+}
+
+export function toDefaultCheckoutFormData(
+  values: CheckoutApplicationValues | DefaultCheckoutFormData,
+): DefaultCheckoutFormData {
+  return {
+    first_name: getStringCheckoutValue(values, "first_name"),
+    last_name: getStringCheckoutValue(values, "last_name"),
+    email: getStringCheckoutValue(values, "email"),
+    telegram: getStringCheckoutValue(values, "telegram"),
+    gender: getStringCheckoutValue(values, "gender"),
+    email_verified: getBooleanCheckoutValue(values, "email_verified"),
+    local_resident: getStringCheckoutValue(values, "local_resident"),
+  }
+}
+
+export function getCheckoutFieldDefaultValue(field: FormFieldSchema): unknown {
+  if (field.type === SUPPORTED_CHECKOUT_FIELD_TYPE.BOOLEAN) return false
+  if (field.type === SUPPORTED_CHECKOUT_FIELD_TYPE.MULTISELECT) return []
+  return ""
+}
+
+export function isCheckoutBaseField(name: string, field: FormFieldSchema) {
+  return CHECKOUT_BASE_FIELD_KEYS.has(name) || field.target === "human"
+}
+
+function getCheckoutVisibleSectionIds(
+  baseFields: Record<string, FormFieldSchema>,
+): Set<string> {
+  const sectionIds = new Set<string>()
+
+  for (const [name, field] of Object.entries(baseFields)) {
+    if (!isCheckoutBaseField(name, field)) continue
+    sectionIds.add(field.section_id || "_unsectioned_base")
+  }
+
+  return sectionIds
+}
+
+export function getCheckoutMiniFormSchema(
+  schema: ApplicationFormSchema,
+): ApplicationFormSchema {
+  const visibleSectionIds = getCheckoutVisibleSectionIds(schema.base_fields)
+
+  return {
+    ...schema,
+    base_fields: Object.fromEntries(
+      Object.entries(schema.base_fields).filter(([name, field]) =>
+        isCheckoutBaseField(name, field),
+      ),
+    ),
+    custom_fields: Object.fromEntries(
+      Object.entries(schema.custom_fields).filter(([, field]) =>
+        visibleSectionIds.has(field.section_id || "_unsectioned_base"),
+      ),
+    ),
+  }
+}
+
+export function filterCheckoutApplicationValues(
+  schema: ApplicationFormSchema,
+  values: CheckoutApplicationValues,
+): CheckoutApplicationValues {
+  const miniFormSchema = getCheckoutMiniFormSchema(schema)
+  const allowedKeys = new Set([
+    ...Object.keys(miniFormSchema.base_fields),
+    ...Object.keys(miniFormSchema.custom_fields).map(
+      (name) => `custom_${name}`,
+    ),
+    "gender_specify",
+    "email_verified",
+  ])
+
+  return Object.fromEntries(
+    Object.entries(values).filter(([key]) => allowedKeys.has(key)),
+  )
+}
+
+export function getCheckoutSchemaSections(
+  schema: ApplicationFormSchema,
+): CheckoutSchemaSection[] {
+  const miniFormSchema = getCheckoutMiniFormSchema(schema)
+  const groupedFields: Record<string, CheckoutSchemaSectionField[]> = {}
+
+  for (const [name, field] of Object.entries(miniFormSchema.base_fields)) {
+    const sectionId = field.section_id || "_unsectioned_base"
+    if (!groupedFields[sectionId]) groupedFields[sectionId] = []
+    groupedFields[sectionId].push({ name, field, isCustom: false })
+  }
+
+  for (const [name, field] of Object.entries(miniFormSchema.custom_fields)) {
+    const sectionId = field.section_id || "_unsectioned_base"
+    if (!groupedFields[sectionId]) groupedFields[sectionId] = []
+    groupedFields[sectionId].push({
+      name: `custom_${name}`,
+      field,
+      isCustom: true,
+    })
+  }
+
+  for (const fields of Object.values(groupedFields)) {
+    fields.sort(
+      (left, right) => (left.field.position ?? 0) - (right.field.position ?? 0),
+    )
+  }
+
+  const sections: CheckoutSchemaSection[] = []
+  const orderedSchemaSections = [...(schema.sections ?? [])].sort(
+    (left, right) => (left.order ?? 0) - (right.order ?? 0),
+  )
+
+  if (groupedFields._unsectioned_base?.length) {
+    sections.push({
+      id: "_unsectioned_base",
+      title: "Personal information",
+      subtitle: undefined,
+      fields: groupedFields._unsectioned_base,
+    })
+    delete groupedFields._unsectioned_base
+  }
+
+  for (const section of orderedSchemaSections) {
+    const fields = groupedFields[section.id] ?? []
+    if (fields.length === 0) continue
+    sections.push({
+      id: section.id,
+      title: section.label,
+      subtitle: section.description ?? undefined,
+      fields,
+    })
+    delete groupedFields[section.id]
+  }
+
+  for (const [id, fields] of Object.entries(groupedFields)) {
+    if (fields.length === 0) continue
+    sections.push({
+      id,
+      title: "Other",
+      subtitle: undefined,
+      fields,
+    })
+  }
+
+  return sections
+}
+
+export type CheckoutState = "form" | "processing" | "success" | "passes"


### PR DESCRIPTION
## Summary

Support schema-backed personal information in checkout for application sales without forcing the full application form.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- add a checkout mini-schema that supports visible base fields plus custom fields from checkout-visible sections
- hydrate and submit schema-backed checkout values, including custom fields and current-popup application data
- hide the redundant personal information section header in checkout and add focused portal tests for schema gating, hydration, payload splitting, and UI rendering

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [x] Manual testing performed
- [x] Focused portal tests pass (`NODE_OPTIONS=\"--max-old-space-size=8192\" pnpm exec vitest run --maxWorkers=1 src/app/checkout/components/UserInfoForm/UserInfoForm.test.tsx src/app/checkout/hooks/useApplicationData.test.ts src/app/checkout/hooks/useCheckoutState.test.ts src/app/checkout/types.test.ts src/app/checkout/components/PopupCheckoutContent.test.tsx`)

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [x] I have added tests for new functionality
- [ ] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [x] Database migrations are included if schema changed