### PR TITLE
fix(payments): handle expired SimpleFI requests

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -403,6 +403,16 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         }
 
         try:
+            logger.info(
+                "Creating SimpleFI application fee payment: application_id={} popup_id={} tenant_id={} amount={} currency={} success_path={} cancel_path={}",
+                application.id,
+                popup.id,
+                application.tenant_id,
+                fee_amount,
+                popup.currency,
+                success_path,
+                cancel_path,
+            )
             simplefi_response = simplefi_client.create_payment(
                 amount=fee_amount,
                 popup_slug=popup.slug,
@@ -413,6 +423,13 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 portal_base_override=portal_base,
                 success_path=success_path,
                 cancel_path=cancel_path,
+            )
+            logger.info(
+                "SimpleFI application fee payment created: application_id={} external_id={} provider_status={} checkout_url={}",
+                application.id,
+                simplefi_response.id,
+                simplefi_response.status,
+                simplefi_response.checkout_url,
             )
         except Exception as e:
             logger.error(f"Failed to create SimpleFI fee payment: {e}")
@@ -437,6 +454,15 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         session.add(payment)
         session.commit()
         session.refresh(payment)
+
+        logger.info(
+            "Application fee payment persisted: payment_id={} application_id={} external_id={} status={} amount={}",
+            payment.id,
+            payment.application_id,
+            payment.external_id,
+            payment.status,
+            payment.amount,
+        )
 
         return payment
 
@@ -1096,6 +1122,18 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         try:
             from app.api.tenant.utils import get_portal_url
 
+            logger.info(
+                "Creating SimpleFI pass payment: application_id={} popup_id={} tenant_id={} amount={} currency={} product_count={} coupon_code={} edit_passes={} insurance={}",
+                application.id,
+                application.popup_id,
+                application.tenant_id,
+                preview.amount,
+                preview.currency,
+                len(obj.products),
+                obj.coupon_code,
+                obj.edit_passes,
+                obj.insurance,
+            )
             simplefi_response = simplefi_client.create_payment(
                 amount=preview.amount,
                 popup_slug=application.popup.slug,
@@ -1104,6 +1142,13 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 reference=reference,
                 memo=application.popup.tenant.name,
                 portal_base_override=get_portal_url(application.popup.tenant),
+            )
+            logger.info(
+                "SimpleFI pass payment created: application_id={} external_id={} provider_status={} checkout_url={}",
+                application.id,
+                simplefi_response.id,
+                simplefi_response.status,
+                simplefi_response.checkout_url,
             )
         except Exception as e:
             logger.error(f"Failed to create SimpleFI payment: {e}")
@@ -1158,6 +1203,16 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
 
         session.commit()
         session.refresh(payment)
+
+        logger.info(
+            "Pass payment persisted: payment_id={} application_id={} external_id={} status={} amount={} product_count={}",
+            payment.id,
+            payment.application_id,
+            payment.external_id,
+            payment.status,
+            payment.amount,
+            len(obj.products),
+        )
 
         # Update preview with SimpleFI response data
         preview.status = simplefi_response.status
@@ -1346,6 +1401,15 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         portal_base = get_portal_url(tenant)
 
         try:
+            logger.info(
+                "Creating SimpleFI direct payment: human_id={} popup_id={} tenant_id={} amount={} currency={} product_count={}",
+                human.id,
+                popup.id,
+                tenant.id,
+                amount,
+                popup.currency,
+                len(obj.products),
+            )
             simplefi_response = simplefi_client.create_payment(
                 amount=amount,
                 popup_slug=popup.slug,
@@ -1354,6 +1418,14 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 reference=reference,
                 memo=f"{popup.name} — direct purchase",
                 portal_base_override=portal_base,
+            )
+            logger.info(
+                "SimpleFI direct payment created: human_id={} popup_id={} external_id={} provider_status={} checkout_url={}",
+                human.id,
+                popup.id,
+                simplefi_response.id,
+                simplefi_response.status,
+                simplefi_response.checkout_url,
             )
         except Exception as e:
             logger.error(f"Failed to create SimpleFI direct payment: {e}")
@@ -1394,6 +1466,16 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
 
         session.commit()
         session.refresh(payment)
+        logger.info(
+            "Direct payment persisted: payment_id={} human_id={} popup_id={} external_id={} status={} amount={} product_count={}",
+            payment.id,
+            human.id,
+            payment.popup_id,
+            payment.external_id,
+            payment.status,
+            payment.amount,
+            len(obj.products),
+        )
         return payment
 
     def approve_payment(

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -755,7 +755,12 @@ async def simplefi_webhook(
 
     raw_body = await request.json()
     event_type = raw_body.get("event_type")
-    logger.info("SimpleFI webhook received, event_type: {}", event_type)
+    logger.info(
+        "SimpleFI webhook received: event_type={} entity_type={} entity_id={}",
+        event_type,
+        raw_body.get("entity_type"),
+        raw_body.get("entity_id"),
+    )
 
     if event_type == "installment_plan_completed":
         return await _handle_installment_plan_completed(raw_body, db, webhook_cache)
@@ -765,6 +770,10 @@ async def simplefi_webhook(
 
     if event_type == "installment_plan_cancelled":
         return await _handle_installment_plan_cancelled(raw_body, db, webhook_cache)
+
+    if event_type == "payment_request_expired":
+        payload = SimpleFIWebhookPayload(**raw_body)
+        return await _handle_payment_request_expired(payload, db, webhook_cache)
 
     if event_type not in ("new_payment", "new_card_payment"):
         logger.info("Unhandled event type: {}. Ignoring.", event_type)
@@ -800,9 +809,10 @@ async def _handle_regular_payment(
         return {"message": "Webhook already processed"}
 
     logger.info(
-        "Regular payment - payment_request_id: %s, event_type: %s",
+        "SimpleFI regular payment webhook processing: payment_request_id=%s event_type=%s provider_status=%s",
         payment_request_id,
         event_type,
+        payload.data.payment_request.status,
     )
 
     payment = payments_crud.get_by_external_id(db, payment_request_id)
@@ -814,6 +824,15 @@ async def _handle_regular_payment(
         )
 
     payment_request_status = payload.data.payment_request.status
+
+    logger.info(
+        "SimpleFI payment matched local payment: payment_id={} external_id={} current_status={} provider_status={} payment_type={}",
+        payment.id,
+        payment.external_id,
+        payment.status,
+        payment_request_status,
+        payment.payment_type,
+    )
 
     if payment.status == payment_request_status:
         logger.info(
@@ -853,6 +872,58 @@ async def _handle_regular_payment(
         )
 
     return {"message": "Payment status updated successfully"}
+
+
+async def _handle_payment_request_expired(
+    payload: SimpleFIWebhookPayload,
+    db: Session,
+    webhook_cache: WebhookCache,
+) -> dict:
+    """Handle SimpleFI payment request expiration webhooks."""
+    from loguru import logger
+
+    payment_request_id = payload.data.payment_request.id
+    fingerprint = f"simplefi:{payment_request_id}:{payload.event_type}"
+    if not webhook_cache.add(fingerprint):
+        logger.info(
+            "Webhook already processed (fingerprint: %s). Skipping...", fingerprint
+        )
+        return {"message": "Webhook already processed"}
+
+    payment = payments_crud.get_by_external_id(db, payment_request_id)
+    if not payment:
+        logger.warning("Payment not found for expired external_id: {}", payment_request_id)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Payment not found",
+        )
+
+    if payment.status == PaymentStatus.APPROVED.value:
+        logger.warning(
+            "Ignoring expiration webhook for already-approved payment {}",
+            payment.id,
+        )
+        return {"message": "Payment already approved"}
+
+    if payment.status == PaymentStatus.EXPIRED.value:
+        logger.info("Payment {} already expired. Skipping...", payment.id)
+        return {"message": "Payment status unchanged"}
+
+    logger.info(
+        "SimpleFI expiration webhook matched local payment: payment_id={} external_id={} current_status={} provider_status={}",
+        payment.id,
+        payment.external_id,
+        payment.status,
+        payload.data.payment_request.status,
+    )
+
+    payments_crud.update(db, payment, PaymentUpdate(status=PaymentStatus.EXPIRED))
+    logger.info(
+        "Payment {} marked as expired via SimpleFI webhook (external_id: {})",
+        payment.id,
+        payment_request_id,
+    )
+    return {"message": "Payment marked as expired"}
 
 
 async def _handle_fee_payment_approved(

--- a/backend/app/services/simplefi/client.py
+++ b/backend/app/services/simplefi/client.py
@@ -145,8 +145,25 @@ class SimpleFIClient:
             },
         }
 
-        logger.info("Creating SimpleFI payment for amount: {}", amount)
+        logger.info(
+            "SimpleFI create payment request: amount={} currency={} popup_slug={} tenant_slug={} memo={} reference_keys={} success_url={} cancel_url={}",
+            amount,
+            currency,
+            popup_slug,
+            tenant_slug,
+            memo,
+            sorted(body["reference"].keys()),
+            success_url,
+            cancel_url,
+        )
         data = self._make_request("POST", "/payment_requests", json=body)
+
+        logger.info(
+            "SimpleFI create payment parsed response: external_id={} status={} checkout_url={}",
+            data.get("id"),
+            data.get("status"),
+            data.get("checkout_v2_url"),
+        )
 
         return SimpleFIPaymentResponse(
             id=data["id"],

--- a/backend/tests/test_simplefi_expired_webhook.py
+++ b/backend/tests/test_simplefi_expired_webhook.py
@@ -1,0 +1,114 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+from app.api.payment.router import _handle_payment_request_expired
+from app.api.payment.schemas import PaymentStatus, SimpleFIWebhookPayload
+
+payment_router_module = importlib.import_module("app.api.payment.router")
+
+
+class FakeWebhookCache:
+    def __init__(self) -> None:
+        self.fingerprints: set[str] = set()
+
+    def add(self, fingerprint: str) -> bool:
+        if fingerprint in self.fingerprints:
+            return False
+        self.fingerprints.add(fingerprint)
+        return True
+
+
+def _make_expired_payload(payment_request_id: str) -> SimpleFIWebhookPayload:
+    return SimpleFIWebhookPayload.model_validate(
+        {
+            "id": "evt-expired-1",
+            "event_type": "payment_request_expired",
+            "entity_type": "payment_request",
+            "entity_id": payment_request_id,
+            "data": {
+                "payment_request": {
+                    "id": payment_request_id,
+                    "order_id": 323,
+                    "amount": 119.2,
+                    "amount_paid": 0,
+                    "currency": "USD",
+                    "reference": {},
+                    "status": "expired",
+                    "status_detail": "expired",
+                    "transactions": [],
+                    "card_payment": None,
+                    "payments": [],
+                    "installment_plan_id": None,
+                },
+                "new_payment": None,
+            },
+        }
+    )
+
+
+def test_payment_request_expired_webhook_marks_pending_payment_expired(
+    monkeypatch,
+) -> None:
+    external_id = "simplefi-expired-pr-1"
+    payment = SimpleNamespace(
+        id="payment-1",
+        external_id=external_id,
+        status=PaymentStatus.PENDING.value,
+    )
+
+    class FakePaymentsCRUD:
+        def get_by_external_id(self, _db, requested_external_id: str):
+            assert requested_external_id == external_id
+            return payment
+
+        def update(self, _db, db_obj, obj_in):
+            update_data = obj_in.model_dump(exclude_unset=True)
+            for field, value in update_data.items():
+                setattr(db_obj, field, value.value if hasattr(value, "value") else value)
+            return db_obj
+
+    monkeypatch.setattr(payment_router_module, "payments_crud", FakePaymentsCRUD())
+
+    result = asyncio.run(
+        _handle_payment_request_expired(
+            _make_expired_payload(external_id),
+            object(),
+            FakeWebhookCache(),
+        )
+    )
+
+    assert result == {"message": "Payment marked as expired"}
+    assert payment.status == PaymentStatus.EXPIRED.value
+
+
+def test_payment_request_expired_webhook_does_not_expire_approved_payment(
+    monkeypatch,
+) -> None:
+    external_id = "simplefi-approved-pr-1"
+    payment = SimpleNamespace(
+        id="payment-1",
+        external_id=external_id,
+        status=PaymentStatus.APPROVED.value,
+    )
+
+    class FakePaymentsCRUD:
+        def get_by_external_id(self, _db, requested_external_id: str):
+            assert requested_external_id == external_id
+            return payment
+
+        def update(self, _db, db_obj, obj_in):
+            raise AssertionError("Approved payments must not be expired")
+
+    monkeypatch.setattr(payment_router_module, "payments_crud", FakePaymentsCRUD())
+
+    result = asyncio.run(
+        _handle_payment_request_expired(
+            _make_expired_payload(external_id),
+            object(),
+            FakeWebhookCache(),
+        )
+    )
+
+    assert result == {"message": "Payment already approved"}
+    assert payment.status == PaymentStatus.APPROVED.value


### PR DESCRIPTION
## Summary

- Handles SimpleFI `payment_request_expired` webhooks so unresolved local payments are marked `expired`.
- Preserves already-approved payments from late expiration webhooks.
- Adds payment-flow observability logs around SimpleFI creation, local persistence, and webhook matching.

## Related Issue

Fixes #59

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added `payment_request_expired` routing and idempotent expiration handling in the SimpleFI webhook endpoint.
- Added targeted tests for pending payments expiring and approved payments remaining unchanged.
- Added structured logs to correlate SimpleFI create requests, parsed responses, local payments, and webhook status transitions.

## Testing

- [x] Targeted backend tests pass: `uv run pytest tests/test_simplefi_expired_webhook.py tests/test_payment_settlement_metadata.py`
- [x] Targeted backend linting passes: `uv run ruff check app/api/payment/router.py app/api/payment/crud.py app/services/simplefi/client.py tests/test_simplefi_expired_webhook.py`
- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed (not needed)
- [x] I have added tests for new functionality
- [x] All new and targeted existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`) — not needed, no schema change
- [x] Database migrations are included if schema changed — not needed