### PR TITLE
fix(backoffice): add payments status filter and sorting

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -188,6 +188,8 @@ def _calculate_price(
 class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
     """CRUD operations for Payments."""
 
+    SORT_FIELDS = {"amount", "status", "created_at"}
+
     def __init__(self) -> None:
         super().__init__(Payments)
 
@@ -474,6 +476,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         limit: int = 100,
         status_filter: PaymentStatus | None = None,
         search: str | None = None,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
     ) -> tuple[list[Payments], int]:
         """Find payments by popup_id via the denormalized popup_id column.
 
@@ -511,7 +515,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.order_by(desc(Payments.created_at))  # type: ignore[arg-type]
+        validated_sort = sort_by if sort_by in self.SORT_FIELDS else "created_at"
+        statement = self._apply_sorting(statement, validated_sort, sort_order)
         statement = statement.offset(skip).limit(limit)
         statement = statement.options(
             selectinload(Payments.products_snapshot).selectinload(  # ty: ignore[invalid-argument-type]
@@ -528,6 +533,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         filters: PaymentFilter,
         skip: int = 0,
         limit: int = 100,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
     ) -> tuple[list[Payments], int]:
         """Find payments with filters."""
         statement = select(Payments)
@@ -544,7 +551,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.order_by(desc(Payments.created_at))  # type: ignore[arg-type]
+        validated_sort = sort_by if sort_by in self.SORT_FIELDS else "created_at"
+        statement = self._apply_sorting(statement, validated_sort, sort_order)
         statement = statement.offset(skip).limit(limit)
         statement = statement.options(
             selectinload(Payments.products_snapshot).selectinload(  # ty: ignore[invalid-argument-type]

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -1,6 +1,6 @@
 import uuid
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from sqlmodel import Session
@@ -335,6 +335,8 @@ async def list_payments(
     external_id: str | None = None,
     payment_status: PaymentStatus | None = None,
     search: str | None = None,
+    sort_by: str | None = None,
+    sort_order: Literal["asc", "desc"] = "desc",
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[PaymentPublic]:
@@ -347,6 +349,8 @@ async def list_payments(
             limit=limit,
             status_filter=payment_status,
             search=search,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
     else:
         filters = PaymentFilter(
@@ -355,7 +359,12 @@ async def list_payments(
             status=payment_status,
         )
         payments, total = payments_crud.find_by_filter(
-            db, filters=filters, skip=skip, limit=limit
+            db,
+            filters=filters,
+            skip=skip,
+            limit=limit,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
 
     return ListModel[PaymentPublic](

--- a/backend/tests/api/payment/test_payment_list_search.py
+++ b/backend/tests/api/payment/test_payment_list_search.py
@@ -1,6 +1,6 @@
+import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-import uuid
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session
@@ -91,13 +91,15 @@ def _create_payment(
     external_id: str,
     created_at: datetime,
     attendee_specs: list[dict[str, str]],
+    amount: Decimal = Decimal("100.00"),
+    status: PaymentStatus = PaymentStatus.APPROVED,
 ) -> Payments:
     payment = Payments(
         tenant_id=tenant.id,
         popup_id=popup.id,
         external_id=external_id,
-        status=PaymentStatus.APPROVED.value,
-        amount=Decimal("100.00"),
+        status=status.value,
+        amount=amount,
         currency="USD",
         source="SimpleFI",
         created_at=created_at,
@@ -143,6 +145,99 @@ def _create_payment(
 
 
 class TestPaymentListSearch:
+    def test_status_filter_limits_results_across_full_popup_dataset(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="status-filter")
+        approved_payment = _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="STATUS-APPROVED",
+            created_at=datetime.now(UTC),
+            attendee_specs=[{"name": "Approved", "email": "approved@test.com"}],
+            status=PaymentStatus.APPROVED,
+        )
+        _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="STATUS-PENDING",
+            created_at=datetime.now(UTC) + timedelta(minutes=1),
+            attendee_specs=[{"name": "Pending", "email": "pending@test.com"}],
+            status=PaymentStatus.PENDING,
+        )
+
+        response = client.get(
+            "/api/v1/payments",
+            params={"popup_id": str(popup.id), "payment_status": "approved"},
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["paging"]["total"] == 1
+        assert [item["id"] for item in payload["results"]] == [str(approved_payment.id)]
+
+    def test_sorting_by_amount_uses_full_dataset_not_current_page_only(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _create_popup(db, tenant_a, suffix="sort-amount")
+        base_time = datetime.now(UTC)
+
+        low_payment = _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="SORT-AMOUNT-LOW",
+            created_at=base_time,
+            attendee_specs=[{"name": "Low", "email": "low@test.com"}],
+            amount=Decimal("50.00"),
+        )
+        _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="SORT-AMOUNT-MID",
+            created_at=base_time + timedelta(minutes=1),
+            attendee_specs=[{"name": "Mid", "email": "mid@test.com"}],
+            amount=Decimal("75.00"),
+        )
+        _create_payment(
+            db,
+            tenant_a,
+            popup,
+            external_id="SORT-AMOUNT-HIGH",
+            created_at=base_time + timedelta(minutes=2),
+            attendee_specs=[{"name": "High", "email": "high@test.com"}],
+            amount=Decimal("150.00"),
+        )
+
+        response = client.get(
+            "/api/v1/payments",
+            params={
+                "popup_id": str(popup.id),
+                "skip": 0,
+                "limit": 1,
+                "sort_by": "amount",
+                "sort_order": "asc",
+            },
+            headers=_admin_headers(admin_token_tenant_a),
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["paging"] == {"offset": 0, "limit": 1, "total": 3}
+        assert [item["id"] for item in payload["results"]] == [str(low_payment.id)]
+
     def test_search_matches_external_id_across_full_popup_dataset(
         self,
         client: TestClient,

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2326,6 +2326,8 @@ export class PaymentsService {
      * @param data.externalId
      * @param data.paymentStatus
      * @param data.search
+     * @param data.sortBy
+     * @param data.sortOrder
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -2345,6 +2347,8 @@ export class PaymentsService {
                 external_id: data.externalId,
                 payment_status: data.paymentStatus,
                 search: data.search,
+                sort_by: data.sortBy,
+                sort_order: data.sortOrder,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2910,6 +2910,8 @@ export type PaymentsListPaymentsData = {
      * Number of items to skip
      */
     skip?: number;
+    sortBy?: (string | null);
+    sortOrder?: 'asc' | 'desc';
     xTenantId?: (string | null);
 };
 

--- a/backoffice/src/routes/_layout/payments.helpers.test.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.test.ts
@@ -12,6 +12,9 @@ describe("payments.helpers", () => {
       page: 2,
       pageSize: 25,
       search: "Lucia",
+      statusFilter: "expired",
+      sortBy: "amount",
+      sortOrder: "asc",
     })
 
     expect(config.params).toEqual({
@@ -19,11 +22,21 @@ describe("payments.helpers", () => {
       limit: 25,
       popupId: "popup-123",
       search: "Lucia",
+      paymentStatus: "expired",
+      sortBy: "amount",
+      sortOrder: "asc",
     })
     expect(config.queryKey).toEqual([
       "payments",
       "popup-123",
-      { page: 2, pageSize: 25, search: "Lucia" },
+      {
+        page: 2,
+        pageSize: 25,
+        search: "Lucia",
+        statusFilter: "expired",
+        sortBy: "amount",
+        sortOrder: "asc",
+      },
     ])
   })
 

--- a/backoffice/src/routes/_layout/payments.helpers.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.ts
@@ -3,6 +3,9 @@ interface PaymentsQueryInput {
   page: number
   pageSize: number
   search: string
+  statusFilter?: string
+  sortBy?: string
+  sortOrder?: "asc" | "desc"
 }
 
 interface PaymentsPaging {
@@ -29,6 +32,9 @@ export function buildPaymentsQueryConfig({
   page,
   pageSize,
   search,
+  statusFilter,
+  sortBy,
+  sortOrder,
 }: PaymentsQueryInput) {
   const normalizedSearch = search.trim()
 
@@ -38,11 +44,21 @@ export function buildPaymentsQueryConfig({
       limit: pageSize,
       popupId: popupId || undefined,
       search: normalizedSearch || undefined,
+      paymentStatus: statusFilter || undefined,
+      sortBy: sortBy || undefined,
+      sortOrder: sortBy ? (sortOrder ?? "desc") : undefined,
     },
     queryKey: [
       "payments",
       popupId,
-      { page, pageSize, search: normalizedSearch },
+      {
+        page,
+        pageSize,
+        search: normalizedSearch,
+        statusFilter,
+        sortBy,
+        sortOrder,
+      },
     ],
   }
 }

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import type { ColumnDef, Row } from "@tanstack/react-table"
 import {
   ChevronDown,
@@ -13,8 +13,10 @@ import { Fragment, Suspense, useCallback, useState } from "react"
 import { toast } from "sonner"
 
 import {
+  DashboardService,
   OpenAPI,
   type PaymentPublic,
+  type PaymentStatus,
   PaymentsService,
   PopupsService,
 } from "@/client"
@@ -25,9 +27,17 @@ import { StatusBadge } from "@/components/Common/StatusBadge"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import {
+  type TableSearchParams,
   useTableSearchParams,
   validateTableSearch,
 } from "@/hooks/useTableSearchParams"
@@ -43,12 +53,18 @@ function getPaymentsQueryOptions(
   page: number,
   pageSize: number,
   search: string,
+  statusFilter?: PaymentStatus,
+  sortBy?: string,
+  sortOrder?: "asc" | "desc",
 ) {
   const queryConfig = buildPaymentsQueryConfig({
     popupId,
     page,
     pageSize,
     search,
+    statusFilter,
+    sortBy,
+    sortOrder,
   })
 
   return {
@@ -57,9 +73,113 @@ function getPaymentsQueryOptions(
   }
 }
 
+const PAYMENT_STATUS_OPTIONS: { value: PaymentStatus; label: string }[] = [
+  { value: "pending", label: "Pending" },
+  { value: "approved", label: "Approved" },
+  { value: "rejected", label: "Rejected" },
+  { value: "expired", label: "Expired" },
+  { value: "cancelled", label: "Cancelled" },
+]
+
+function usePaymentStatusCounts(popupId: string | null) {
+  const { data: stats } = useQuery({
+    queryKey: ["dashboard", "stats", popupId],
+    queryFn: () => DashboardService.getDashboardStats({ popupId: popupId! }),
+    enabled: !!popupId,
+  })
+
+  const counts: Partial<Record<PaymentStatus, number>> = {}
+  if (stats?.payments) {
+    const payments = stats.payments
+    counts.pending = payments.pending ?? 0
+    counts.approved = payments.approved ?? 0
+    counts.rejected = payments.rejected ?? 0
+    counts.expired = payments.expired ?? 0
+    counts.cancelled = payments.cancelled ?? 0
+  }
+
+  return { counts, total: stats?.payments?.total ?? 0 }
+}
+
+function StatusDropdownFilter({
+  popupId,
+  selected,
+  onSelect,
+}: {
+  popupId: string | null
+  selected: PaymentStatus | undefined
+  onSelect: (value: PaymentStatus | undefined) => void
+}) {
+  const { counts, total } = usePaymentStatusCounts(popupId)
+  const selectedOption = selected
+    ? PAYMENT_STATUS_OPTIONS.find((option) => option.value === selected)
+    : undefined
+
+  const options = [
+    { value: "all" as const, label: "All", count: total },
+    ...PAYMENT_STATUS_OPTIONS.map((option) => ({
+      value: option.value,
+      label: option.label,
+      count: counts[option.value] ?? 0,
+    })),
+  ]
+
+  const currentLabel = selectedOption?.label ?? "All"
+  const currentCount = selectedOption
+    ? (counts[selectedOption.value] ?? 0)
+    : total
+
+  return (
+    <Select
+      value={selectedOption?.value ?? "all"}
+      onValueChange={(value) =>
+        onSelect(value === "all" ? undefined : (value as PaymentStatus))
+      }
+    >
+      <SelectTrigger className="h-9 w-[180px]">
+        <SelectValue>
+          {currentLabel} ({currentCount})
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem
+            key={option.value === "all" ? "all" : option.value}
+            value={option.value === "all" ? "all" : option.value}
+          >
+            <span className="flex w-full items-center justify-between gap-4">
+              <span>{option.label}</span>
+              <span className="text-muted-foreground tabular-nums">
+                {option.count}
+              </span>
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+const VALID_PAYMENT_STATUSES: Set<string> = new Set([
+  "pending",
+  "approved",
+  "rejected",
+  "expired",
+  "cancelled",
+])
+
+type PaymentsSearchParams = TableSearchParams & {
+  status?: PaymentStatus
+}
+
 export const Route = createFileRoute("/_layout/payments")({
   component: Payments,
-  validateSearch: validateTableSearch,
+  validateSearch: (raw: Record<string, unknown>): PaymentsSearchParams => ({
+    ...validateTableSearch(raw),
+    ...(typeof raw.status === "string" && VALID_PAYMENT_STATUSES.has(raw.status)
+      ? { status: raw.status as PaymentStatus }
+      : {}),
+  }),
   head: () => ({
     meta: [{ title: "Payments - EdgeOS" }],
   }),
@@ -380,11 +500,11 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
 
 function PaymentsTableContent() {
   const { selectedPopupId } = useWorkspace()
+  const navigate = useNavigate()
   const searchParams = Route.useSearch()
-  const { search, pagination, setSearch, setPagination } = useTableSearchParams(
-    searchParams,
-    "/payments",
-  )
+  const { search, pagination, sorting, setSearch, setPagination, setSorting } =
+    useTableSearchParams(searchParams, "/payments")
+  const statusFilter = searchParams.status
 
   const { data: payments } = useQuery({
     ...getPaymentsQueryOptions(
@@ -392,6 +512,9 @@ function PaymentsTableContent() {
       pagination.pageIndex,
       pagination.pageSize,
       search,
+      statusFilter,
+      sorting[0]?.id,
+      sorting[0]?.desc ? "desc" : "asc",
     ),
     placeholderData: keepPreviousData,
   })
@@ -430,10 +553,27 @@ function PaymentsTableContent() {
       ]}
       searchValue={search}
       onSearchChange={setSearch}
+      serverSorting={{
+        sorting,
+        onSortingChange: setSorting,
+      }}
       serverPagination={{
         ...tableState.serverPagination,
         onPaginationChange: setPagination,
       }}
+      filterBar={
+        <StatusDropdownFilter
+          popupId={selectedPopupId}
+          selected={statusFilter}
+          onSelect={(value) => {
+            navigate({
+              to: "/payments",
+              search: (prev) => ({ ...prev, status: value, page: 0 }),
+              replace: true,
+            })
+          }}
+        />
+      }
       renderSubComponent={PaymentSubRow}
       emptyState={
         !search ? (

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2326,6 +2326,8 @@ export class PaymentsService {
      * @param data.externalId
      * @param data.paymentStatus
      * @param data.search
+     * @param data.sortBy
+     * @param data.sortOrder
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -2345,6 +2347,8 @@ export class PaymentsService {
                 external_id: data.externalId,
                 payment_status: data.paymentStatus,
                 search: data.search,
+                sort_by: data.sortBy,
+                sort_order: data.sortOrder,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2910,6 +2910,8 @@ export type PaymentsListPaymentsData = {
      * Number of items to skip
      */
     skip?: number;
+    sortBy?: (string | null);
+    sortOrder?: 'asc' | 'desc';
     xTenantId?: (string | null);
 };
 


### PR DESCRIPTION
## Summary

- Moves payments table sorting to the backend so Amount, Status, and Date sort across the full dataset instead of only within the current page.
- Adds a status dropdown filter to the backoffice payments table using the same operator pattern as applications.
- Regenerates frontend API clients and adds backend coverage for payment list status filtering and server-side sorting.

## Related Issue

Fixes #61

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Added `sort_by` / `sort_order` handling to the backend payments listing endpoint and payment CRUD query methods.
- Added backoffice payments status filter state/query wiring and server-side sorting integration.
- Updated generated clients for backoffice and portal to include the new payments list query params.

## Testing

- [x] Targeted backend linting passes: `uv run ruff check app/api/payment/router.py app/api/payment/crud.py tests/api/payment/test_payment_list_search.py scripts/sync_simplefi_pending_payments.py`
- [x] Targeted backoffice linting passes: `pnpm exec biome check "src/routes/_layout/payments.tsx" "src/routes/_layout/payments.helpers.ts" "src/routes/_layout/payments.helpers.test.ts"`
- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed
- [ ] Additional automated tests fully executed in this environment

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed (not needed)
- [x] I have added tests for new functionality
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [x] Database migrations are included if schema changed — not needed