### PR TITLE
fix(backoffice): correct payments status typing

### DIFF
--- a/backoffice/src/routes/_layout/payments.helpers.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.ts
@@ -1,9 +1,11 @@
+import type { PaymentStatus } from "@/client"
+
 interface PaymentsQueryInput {
   popupId: string | null
   page: number
   pageSize: number
   search: string
-  statusFilter?: string
+  statusFilter?: PaymentStatus
   sortBy?: string
   sortOrder?: "asc" | "desc"
 }


### PR DESCRIPTION
## Summary

- Fixes the payments query helper typing so `paymentStatus` matches the generated `PaymentStatus` union.
- Resolves the backoffice TypeScript build failure introduced by the payments status-filter change.

## Related Issue

Fixes #63

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Changed `statusFilter` in `payments.helpers.ts` from `string` to `PaymentStatus`.
- Kept the helper output aligned with `PaymentsListPaymentsData` from the generated client.

## Testing

- [x] Targeted formatting/lint passes: `pnpm exec biome format --write "src/routes/_layout/payments.helpers.ts" && pnpm exec biome check "src/routes/_layout/payments.helpers.ts"`
- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed (not needed)
- [x] I have added tests for new functionality (not needed for a type-only fix)
- [x] All new and existing tests pass where runnable in this environment
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`) — not needed
- [x] Database migrations are included if schema changed — not needed