### PR TITLE
feat(backend): tenant-scope open-checkout + popup slug uniqueness

### DIFF
--- a/backend/app/alembic/versions/0043_tenant_scoped_popup_slug.py
+++ b/backend/app/alembic/versions/0043_tenant_scoped_popup_slug.py
@@ -1,0 +1,91 @@
+"""Tenant-scoped popup slug uniqueness.
+
+Drops the global UNIQUE on popups.slug and replaces it with a composite
+UNIQUE(tenant_id, slug) so two tenants can own the same slug.
+
+The composite index is built CONCURRENTLY to avoid write locks.
+
+Revision ID: 0043_tenant_scoped_popup_slug
+Revises: 0042_popup_events_enabled
+Create Date: 2026-05-04
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0043_tenant_scoped_popup_slug"
+down_revision: str = "0042_popup_events_enabled"
+branch_labels = None
+depends_on = None
+
+
+def _is_transactional_connection() -> bool:
+    """Return True when running inside an already-open transaction.
+
+    When alembic is invoked from tests, the caller passes an explicit
+    connection (already inside a BEGIN block) via
+    alembic_cfg.attributes["connection"]. autocommit_block() asserts
+    that the connection is NOT already in a transaction and raises
+    AssertionError if it is. We detect this so we can skip CONCURRENTLY
+    in that context (safe for tests; the table is empty).
+    """
+    bind = op.get_bind()
+    return bind.in_transaction()
+
+
+def upgrade() -> None:
+    # 1. Build new composite unique index.
+    #    Use CONCURRENTLY in production (no write lock).
+    #    Fall back to plain CREATE in test environments where the connection
+    #    is already inside a transaction (CONCURRENTLY requires autocommit).
+    if _is_transactional_connection():
+        op.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS "
+            "uq_popups_tenant_slug ON popups (tenant_id, slug)"
+        )
+    else:
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+                "uq_popups_tenant_slug ON popups (tenant_id, slug)"
+            )
+
+    # 2. Drop the legacy global unique constraint if it exists.
+    #    SQLAlchemy's Field(unique=True) generates popups_slug_key.
+    #    Guard with IF EXISTS because some DB states may not have it.
+    op.execute(
+        "ALTER TABLE popups DROP CONSTRAINT IF EXISTS popups_slug_key"
+    )
+
+    # 3. Drop the old unique index on slug alone (Field(unique=True, index=True)
+    #    generates both a constraint and a separate index).
+    op.execute("DROP INDEX IF EXISTS ix_popups_slug")
+
+    # 4. Re-create a non-unique index on slug for fast single-column lookups.
+    op.create_index("ix_popups_slug", "popups", ["slug"])
+
+
+def downgrade() -> None:
+    # SAFETY: refuse to downgrade if cross-tenant duplicates exist.
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            "SELECT slug FROM popups GROUP BY slug HAVING COUNT(*) > 1 LIMIT 1"
+        )
+    ).first()
+    if result is not None:
+        raise RuntimeError(
+            f"Cannot downgrade: cross-tenant duplicate slug detected ({result[0]!r}). "
+            "Resolve duplicates manually before re-creating the global UNIQUE constraint."
+        )
+
+    op.drop_index("ix_popups_slug", table_name="popups")
+
+    if _is_transactional_connection():
+        op.execute("DROP INDEX IF EXISTS uq_popups_tenant_slug")
+    else:
+        with op.get_context().autocommit_block():
+            op.execute("DROP INDEX CONCURRENTLY IF EXISTS uq_popups_tenant_slug")
+
+    op.create_index("ix_popups_slug", "popups", ["slug"], unique=True)
+    op.create_unique_constraint("popups_slug_key", "popups", ["slug"])

--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -1,5 +1,7 @@
 """CRUD aggregator for the open-ticketing checkout bootstrap endpoint (CAP-A)."""
 
+import uuid
+
 from fastapi import HTTPException, status
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
@@ -21,14 +23,16 @@ from app.api.ticketing_step.models import TicketingSteps
 from app.api.ticketing_step.schemas import TicketingStepPublic
 
 
-def get_open_ticketing_popup(session: Session, slug: str) -> Popups:
-    """Resolve an active direct-sale popup by slug for open ticketing.
+def get_open_ticketing_popup(session: Session, slug: str, tenant_id: uuid.UUID) -> Popups:
+    """Resolve an active direct-sale popup by slug and tenant for open ticketing.
 
     Raises:
-        404 — popup not found by slug
+        404 — popup not found by slug + tenant_id
         403 — popup is not sale_type=direct OR is not active
     """
-    popup = session.exec(select(Popups).where(Popups.slug == slug)).first()
+    popup = session.exec(
+        select(Popups).where(Popups.slug == slug, Popups.tenant_id == tenant_id)
+    ).first()
 
     if popup is None:
         raise HTTPException(
@@ -51,9 +55,9 @@ def get_open_ticketing_popup(session: Session, slug: str) -> Popups:
     return popup
 
 
-def runtime_for_slug(session: Session, slug: str) -> CheckoutRuntimeResponse:
+def runtime_for_slug(session: Session, slug: str, tenant_id: uuid.UUID) -> CheckoutRuntimeResponse:
     """Load the public runtime data for an open-ticketing checkout page."""
-    popup = get_open_ticketing_popup(session, slug)
+    popup = get_open_ticketing_popup(session, slug, tenant_id)
 
     # Load active products
     products = list(

--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -1,8 +1,8 @@
 """Router for the open-ticketing checkout API.
 
 Endpoints:
-- GET  /checkout/{slug}/bootstrap — public, anonymous, rate-limited 120/min/IP
-- POST /checkout/{slug}/purchase  — public, anonymous, rate-limited 10/min/IP
+- GET  /checkout/{slug}/runtime  — public, anonymous, rate-limited 120/min/IP
+- POST /checkout/{slug}/purchase — public, anonymous, rate-limited 10/min/IP
 """
 
 from fastapi import APIRouter, Depends
@@ -14,7 +14,7 @@ from app.api.checkout.schemas import (
     OpenTicketingPurchaseResponse,
 )
 from app.api.payment.crud import payments_crud
-from app.api.tenant.models import Tenants
+from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import SessionDep
 from app.core.rate_limit import RateLimit
 
@@ -33,13 +33,14 @@ router = APIRouter(prefix="/checkout", tags=["checkout"])
 async def get_runtime(
     slug: str,
     db: SessionDep,
+    tenant: PublicTenant,
 ) -> CheckoutRuntimeResponse:
     """Return popup metadata, products, buyer form, and ticketing steps for anonymous checkout.
 
     Fully public endpoint (no JWT). Only serves sale_type=direct active popups.
     Rate-limited 120/min/IP.
     """
-    return runtime_for_slug(db, slug)
+    return runtime_for_slug(db, slug, tenant.id)
 
 
 @router.post(
@@ -53,12 +54,10 @@ async def purchase_open_ticketing(
     slug: str,
     request_in: OpenTicketingPurchaseCreate,
     db: SessionDep,
+    tenant: PublicTenant,
 ) -> OpenTicketingPurchaseResponse:
     """Create an anonymous open-ticketing payment and return provider checkout data."""
-    popup = get_open_ticketing_popup(db, slug)
-    tenant = db.get(Tenants, popup.tenant_id)
-    if tenant is None:
-        raise ValueError(f"Tenant not found for popup {popup.id}")
+    popup = get_open_ticketing_popup(db, slug, tenant.id)
 
     payment, checkout_url = payments_crud.create_open_ticketing_payment(
         db,

--- a/backend/app/api/coupon/crud.py
+++ b/backend/app/api/coupon/crud.py
@@ -28,11 +28,12 @@ class CouponsCRUD(BaseCRUD[Coupons, CouponCreate, CouponUpdate]):
         session: Session,
         popup_slug: str,
         code: str,
+        tenant_id: uuid.UUID,
     ) -> "CouponValidatePublicResponse":
         """Validate a coupon code for an anonymous (public) checkout request.
 
         Rules:
-        - Resolves popup by slug; popup must have sale_type="direct" (else 403).
+        - Resolves popup by (slug, tenant_id); popup must have sale_type="direct" (else 403).
         - ANY failure state (not found, inactive, expired, maxed-out) raises 400
           with the UNIFORM message "Invalid or expired coupon" — never differentiates.
         - On success, returns CouponValidatePublicResponse.
@@ -41,7 +42,12 @@ class CouponsCRUD(BaseCRUD[Coupons, CouponCreate, CouponUpdate]):
         from app.api.popup.models import Popups
         from app.api.shared.enums import SaleType
 
-        popup = session.exec(select(Popups).where(Popups.slug == popup_slug)).first()
+        popup = session.exec(
+            select(Popups).where(
+                Popups.slug == popup_slug,
+                Popups.tenant_id == tenant_id,
+            )
+        ).first()
 
         if popup is None:
             # Unknown popup — return uniform coupon error (don't reveal popup existence)

--- a/backend/app/api/coupon/router.py
+++ b/backend/app/api/coupon/router.py
@@ -13,6 +13,7 @@ from app.api.coupon.schemas import (
 )
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
+from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
     CurrentHuman,
     CurrentUser,
@@ -36,6 +37,7 @@ router = APIRouter(prefix="/coupons", tags=["coupons"])
 async def validate_coupon_public(
     request_in: CouponValidatePublicRequest,
     db: SessionDep,
+    tenant: PublicTenant,
 ) -> CouponValidatePublicResponse:
     """Validate a coupon code for an anonymous open-ticketing checkout (no JWT required).
 
@@ -47,6 +49,7 @@ async def validate_coupon_public(
         db,
         popup_slug=request_in.popup_slug,
         code=request_in.code,
+        tenant_id=tenant.id,
     )
 
 

--- a/backend/app/api/popup/models.py
+++ b/backend/app/api/popup/models.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import TYPE_CHECKING, Optional
 
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Column, Field, Relationship
 
@@ -25,6 +26,10 @@ if TYPE_CHECKING:
 
 
 class Popups(PopupBase, table=True):
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "slug", name="uq_popups_tenant_slug"),
+    )
+
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
         sa_column=Column(

--- a/backend/app/api/popup/router.py
+++ b/backend/app/api/popup/router.py
@@ -33,6 +33,8 @@ from app.api.translation.service import (
     get_translations_bulk,
     get_translations_for_entity,
 )
+from sqlalchemy.exc import IntegrityError
+
 from app.core.dependencies.users import (
     CurrentHuman,
     CurrentUser,
@@ -189,11 +191,26 @@ async def create_popup(
     existing = crud.get_by_slug(db, popup_in.slug)
     if existing:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="A popup with this slug already exists",
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "popup_slug_conflict",
+                "message": "A popup with this slug already exists in this tenant.",
+            },
         )
 
-    popup = crud.create(db, popup_in)
+    try:
+        popup = crud.create(db, popup_in)
+    except IntegrityError as exc:
+        db.rollback()
+        if "uq_popups_tenant_slug" in str(getattr(exc, "orig", exc)):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "popup_slug_conflict",
+                    "message": "A popup with this slug already exists in this tenant.",
+                },
+            )
+        raise
 
     # Direct-sale popups skip the application-centric bootstrap (no approval
     # strategy, no form sections, no base field configs). Only ticketing steps
@@ -225,8 +242,11 @@ async def update_popup(
         existing = crud.get_by_slug(db, popup_in.slug)
         if existing:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="A popup with this slug already exists",
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "popup_slug_conflict",
+                    "message": "A popup with this slug already exists in this tenant.",
+                },
             )
 
     sale_type_change_requested = (
@@ -255,7 +275,19 @@ async def update_popup(
         and (popup_in.allows_spouse is True or popup_in.allows_children is True)
     )
 
-    updated = crud.update(db, popup, popup_in)
+    try:
+        updated = crud.update(db, popup, popup_in)
+    except IntegrityError as exc:
+        db.rollback()
+        if "uq_popups_tenant_slug" in str(getattr(exc, "orig", exc)):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "popup_slug_conflict",
+                    "message": "A popup with this slug already exists in this tenant.",
+                },
+            )
+        raise
 
     if updated.sale_type == SaleType.application.value:
         _seed_application_defaults(db, updated)

--- a/backend/app/api/popup/router.py
+++ b/backend/app/api/popup/router.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Header, HTTPException, status
+from sqlalchemy.exc import IntegrityError
 
 from app.api.approval_strategy.crud import approval_strategies_crud
 from app.api.approval_strategy.schemas import (
@@ -33,8 +34,6 @@ from app.api.translation.service import (
     get_translations_bulk,
     get_translations_for_entity,
 )
-from sqlalchemy.exc import IntegrityError
-
 from app.core.dependencies.users import (
     CurrentHuman,
     CurrentUser,

--- a/backend/app/api/popup/router.py
+++ b/backend/app/api/popup/router.py
@@ -192,10 +192,7 @@ async def create_popup(
     if existing:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "code": "popup_slug_conflict",
-                "message": "A popup with this slug already exists in this tenant.",
-            },
+            detail="A popup with this slug already exists in this tenant",
         )
 
     try:
@@ -205,10 +202,7 @@ async def create_popup(
         if "uq_popups_tenant_slug" in str(getattr(exc, "orig", exc)):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "popup_slug_conflict",
-                    "message": "A popup with this slug already exists in this tenant.",
-                },
+                detail="A popup with this slug already exists in this tenant",
             )
         raise
 
@@ -243,10 +237,7 @@ async def update_popup(
         if existing:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "popup_slug_conflict",
-                    "message": "A popup with this slug already exists in this tenant.",
-                },
+                detail="A popup with this slug already exists in this tenant",
             )
 
     sale_type_change_requested = (
@@ -282,10 +273,7 @@ async def update_popup(
         if "uq_popups_tenant_slug" in str(getattr(exc, "orig", exc)):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "popup_slug_conflict",
-                    "message": "A popup with this slug already exists in this tenant.",
-                },
+                detail="A popup with this slug already exists in this tenant",
             )
         raise
 

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -67,7 +67,7 @@ class PopupBase(SQLModel):
     name: str = Field(index=True)
     tagline: str | None = None
     location: str | None = None
-    slug: str = Field(unique=True, index=True)
+    slug: str = Field(index=True)
     tenant_id: uuid.UUID = Field(foreign_key="tenants.id", index=True)
     start_date: datetime | None = None
     end_date: datetime | None = None

--- a/backend/app/core/dependencies/tenants.py
+++ b/backend/app/core/dependencies/tenants.py
@@ -1,0 +1,127 @@
+"""Public tenant resolver dependency for anonymous endpoints.
+
+Resolves the tenant from request signals in priority order:
+  1. Origin header
+  2. Referer header (fallback when Origin is absent or opaque)
+  3. X-Tenant-Id header
+  4. 404 — opaque, no tenant-existence information leaked
+
+This is NOT an auth dependency. There is no JWT, no trust boundary on the
+headers. The security boundary is the tenant_id filter in every downstream
+CRUD WHERE clause.
+"""
+
+import uuid as _uuid
+from typing import Annotated
+from urllib.parse import urlparse
+
+from fastapi import Depends, Header, HTTPException, Request, status
+from loguru import logger
+
+from app.api.tenant.crud import tenants_crud
+from app.api.tenant.models import Tenants
+from app.api.tenant.schemas import TenantPublic
+from app.core.config import settings
+from app.core.dependencies.users import SessionDep
+from app.core.redis import domain_cache
+
+
+def _extract_host(header_value: str | None) -> str | None:
+    """Parse an Origin or Referer header into a bare hostname (lowercased, port-stripped).
+
+    Returns None for:
+    - None / empty string
+    - The literal "null" (sandboxed iframes, file://, opaque origins)
+    - Values that urlparse cannot reduce to a hostname
+    """
+    if not header_value or header_value == "null":
+        return None
+    try:
+        parsed = urlparse(header_value)
+    except (ValueError, TypeError):
+        return None
+    host = parsed.hostname  # urlparse strips port and lowercases automatically
+    return host if host else None
+
+
+def _resolve_host_with_cache(db: SessionDep, host: str, portal_domain: str) -> Tenants | None:
+    """DomainCache-first tenant lookup.
+
+    Cache stores serialized TenantPublic JSON or the sentinel string "null".
+
+    On cache hit with valid JSON: re-fetches the live ORM Tenants instance by
+    id (required because downstream callers need the real SQLAlchemy object).
+    On stale cache (cached id no longer in DB): falls through to live resolution.
+    On sentinel "null": returns None immediately (domain known unresolvable).
+    On cache miss: calls resolve_by_host, stores result or sentinel.
+    """
+    cached = domain_cache.get(host)
+    if cached == "null":
+        return None
+    if cached is not None:
+        try:
+            tp = TenantPublic.model_validate_json(cached)
+        except (ValueError, TypeError):
+            tp = None
+        if tp is not None:
+            tenant = tenants_crud.get(db, tp.id)
+            if tenant is not None and not tenant.deleted:
+                return tenant
+            # Stale cache entry — fall through to live resolution
+
+    tenant = tenants_crud.resolve_by_host(db, host, portal_domain)
+    if tenant is None:
+        domain_cache.set(host, "null")
+        return None
+    domain_cache.set(host, TenantPublic.model_validate(tenant).model_dump_json())
+    return tenant
+
+
+def resolve_public_tenant(
+    request: Request,
+    db: SessionDep,
+    x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+) -> Tenants:
+    """Resolve the tenant for an anonymous public request.
+
+    Header resolution order:
+      1. Origin — extract host, strip port, resolve via DomainCache + resolve_by_host.
+      2. Referer — fallback when Origin is absent or opaque (sandboxed iframe,
+         privacy proxies stripping Origin).
+      3. X-Tenant-Id — last resort; treated as a UUID.
+      4. 404 (opaque) + structured DEBUG log.
+
+    Returns the live ORM Tenants instance so callers can access .id and other fields.
+    """
+    portal_domain = settings.PORTAL_DOMAIN
+
+    for header_name in ("origin", "referer"):
+        host = _extract_host(request.headers.get(header_name))
+        if host is None:
+            continue
+        tenant = _resolve_host_with_cache(db, host, portal_domain)
+        if tenant is not None:
+            return tenant
+
+    if x_tenant_id:
+        try:
+            tenant_id = _uuid.UUID(x_tenant_id)
+        except ValueError:
+            # Malformed UUID — treat as missing, fall through to 404
+            tenant_id = None
+        if tenant_id is not None:
+            tenant = tenants_crud.get(db, tenant_id)
+            if tenant is not None and not tenant.deleted:
+                return tenant
+
+    logger.debug(
+        "resolve_public_tenant: no tenant resolved",
+        origin=request.headers.get("origin"),
+        referer=request.headers.get("referer"),
+        x_tenant_id_present=x_tenant_id is not None,
+        path=request.url.path,
+    )
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+
+PublicTenant = Annotated[Tenants, Depends(resolve_public_tenant)]

--- a/backend/tests/api/checkout/test_bootstrap.py
+++ b/backend/tests/api/checkout/test_bootstrap.py
@@ -14,6 +14,7 @@ Scenarios:
 import uuid
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
@@ -24,7 +25,6 @@ from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 from app.api.ticketing_step.models import TicketingSteps
-
 from tests.conftest import with_origin
 
 # ---------------------------------------------------------------------------
@@ -298,10 +298,10 @@ def test_runtime_rate_limit_triggers_429(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("popup_tenant_b_summer_fest")
 def test_runtime_resolves_per_tenant_slug_collision(
     client: TestClient,
     popup_tenant_a_summer_fest: Popups,
-    popup_tenant_b_summer_fest: Popups,
 ) -> None:
     """Slug collision: origin resolves to tenant A → tenant A's popup returned."""
     response = client.get(
@@ -314,11 +314,11 @@ def test_runtime_resolves_per_tenant_slug_collision(
     assert body["popup"]["id"] == str(popup_tenant_a_summer_fest.id)
 
 
+@pytest.mark.usefixtures("tenant_a")
 def test_runtime_cross_tenant_slug_returns_404(
     client: TestClient,
     db: Session,
     popup_tenant_b_summer_fest: Popups,
-    tenant_a: Tenants,
 ) -> None:
     """Slug exists under tenant B but not A; origin resolves to A → 404."""
     # This test relies on a slug that tenant_a does NOT have.

--- a/backend/tests/api/checkout/test_bootstrap.py
+++ b/backend/tests/api/checkout/test_bootstrap.py
@@ -25,6 +25,8 @@ from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 from app.api.ticketing_step.models import TicketingSteps
 
+from tests.conftest import with_origin
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -153,7 +155,10 @@ def test_runtime_valid_direct_popup(
     _make_ticketing_step(db, popup, step_type="tickets", title="Choose Tickets")
     db.commit()
 
-    response = client.get(f"/api/v1/checkout/{popup.slug}/runtime")
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
 
     assert response.status_code == 200, response.text
     body = response.json()
@@ -190,16 +195,22 @@ def test_runtime_only_enabled_ticketing_steps(
     )
     db.commit()
 
-    response = client.get(f"/api/v1/checkout/{popup.slug}/runtime")
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
 
     assert response.status_code == 200, response.text
     body = response.json()
     assert [step["title"] for step in body["ticketing_steps"]] == ["Visible Step"]
 
 
-def test_runtime_unknown_slug_returns_404(client: TestClient) -> None:
+def test_runtime_unknown_slug_returns_404(client: TestClient, tenant_a: Tenants) -> None:
     """Unknown popup slug returns 404."""
-    response = client.get("/api/v1/checkout/does-not-exist-xyz/runtime")
+    response = client.get(
+        "/api/v1/checkout/does-not-exist-xyz/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
     assert response.status_code == 404, response.text
 
 
@@ -219,7 +230,10 @@ def test_runtime_application_popup_returns_403(
     db.add(popup)
     db.commit()
 
-    response = client.get(f"/api/v1/checkout/{popup.slug}/runtime")
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
     assert response.status_code == 403, response.text
 
 
@@ -230,7 +244,10 @@ def test_runtime_inactive_direct_popup_returns_403(
     popup = _make_direct_popup(db, tenant_a, status="draft")
     db.commit()
 
-    response = client.get(f"/api/v1/checkout/{popup.slug}/runtime")
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
     assert response.status_code == 403, response.text
 
 
@@ -243,7 +260,10 @@ def test_runtime_only_active_products(
     _make_product(db, popup, name="Inactive VIP", is_active=False)
     db.commit()
 
-    response = client.get(f"/api/v1/checkout/{popup.slug}/runtime")
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
 
     assert response.status_code == 200, response.text
     body = response.json()
@@ -266,8 +286,85 @@ def test_runtime_rate_limit_triggers_429(
     with patch("app.core.rate_limit.get_redis", return_value=mock_redis):
         response = client.get(
             f"/api/v1/checkout/{popup.slug}/runtime",
-            headers={"X-Forwarded-For": "8.8.8.8"},
+            headers={"X-Forwarded-For": "8.8.8.8", "X-Tenant-Id": str(tenant_a.id)},
         )
 
     assert response.status_code == 429, response.text
     assert "Retry-After" in response.headers
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Tenant-scoped runtime tests (T-3.1)
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_resolves_per_tenant_slug_collision(
+    client: TestClient,
+    popup_tenant_a_summer_fest: Popups,
+    popup_tenant_b_summer_fest: Popups,
+) -> None:
+    """Slug collision: origin resolves to tenant A → tenant A's popup returned."""
+    response = client.get(
+        "/api/v1/checkout/summer-fest/runtime",
+        headers=with_origin("test-tenant-a.localhost"),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["popup"]["id"] == str(popup_tenant_a_summer_fest.id)
+
+
+def test_runtime_cross_tenant_slug_returns_404(
+    client: TestClient,
+    db: Session,
+    popup_tenant_b_summer_fest: Popups,
+    tenant_a: Tenants,
+) -> None:
+    """Slug exists under tenant B but not A; origin resolves to A → 404."""
+    # This test relies on a slug that tenant_a does NOT have.
+    # We use a unique slug so it only exists under tenant_b.
+    import uuid as _uuid
+    unique_slug = f"only-b-{_uuid.uuid4().hex[:8]}"
+    from app.api.popup.models import Popups as _Popups
+    from app.api.shared.enums import SaleType as _SaleType
+    tenant_b_only = _Popups(
+        id=_uuid.uuid4(),
+        tenant_id=popup_tenant_b_summer_fest.tenant_id,
+        name="Only B Popup",
+        slug=unique_slug,
+        sale_type=_SaleType.direct.value,
+        status="active",
+    )
+    db.add(tenant_b_only)
+    db.commit()
+
+    response = client.get(
+        f"/api/v1/checkout/{unique_slug}/runtime",
+        headers=with_origin("test-tenant-a.localhost"),
+    )
+
+    assert response.status_code == 404, response.text
+
+
+def test_runtime_unknown_origin_returns_404(
+    client: TestClient,
+) -> None:
+    """No Origin header and no X-Tenant-Id → 404 from resolver."""
+    response = client.get("/api/v1/checkout/summer-fest/runtime")
+    assert response.status_code == 404, response.text
+
+
+def test_runtime_x_tenant_id_fallback(
+    client: TestClient,
+    popup_tenant_a_summer_fest: Popups,
+    tenant_a: Tenants,
+) -> None:
+    """No Origin header, X-Tenant-Id present → returns correct popup."""
+    response = client.get(
+        "/api/v1/checkout/summer-fest/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["popup"]["id"] == str(popup_tenant_a_summer_fest.id)

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -16,6 +16,8 @@ from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 
+from tests.conftest import with_origin
+
 
 def _make_popup(
     db: Session,
@@ -122,6 +124,7 @@ def test_purchase_happy_path_creates_payment_and_attendees(
                     "form_data": {field.name: "Matias"},
                 },
             },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
         )
 
     assert response.status_code == 200, response.text
@@ -139,7 +142,7 @@ def test_purchase_happy_path_creates_payment_and_attendees(
     assert len(attendees) == 2
 
 
-def test_purchase_unknown_slug_returns_404(client: TestClient) -> None:
+def test_purchase_unknown_slug_returns_404(client: TestClient, tenant_a: Tenants) -> None:
     response = client.post(
         "/api/v1/checkout/does-not-exist/purchase",
         json={
@@ -151,6 +154,7 @@ def test_purchase_unknown_slug_returns_404(client: TestClient) -> None:
                 "form_data": {},
             },
         },
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
     assert response.status_code == 404, response.text
 
@@ -177,6 +181,7 @@ def test_purchase_application_popup_returns_403(
                 "form_data": {},
             },
         },
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
     assert response.status_code == 403, response.text
 
@@ -203,6 +208,7 @@ def test_purchase_missing_required_field_returns_422(
                 "form_data": {},
             },
         },
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
     assert response.status_code == 422, response.text
 
@@ -232,6 +238,7 @@ def test_purchase_provider_failure_returns_502(
                     "form_data": {field.name: "Matias"},
                 },
             },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
         )
 
     assert response.status_code == 502, response.text
@@ -264,8 +271,77 @@ def test_purchase_rate_limit_returns_429(
                     "form_data": {field.name: "Matias"},
                 },
             },
-            headers={"X-Forwarded-For": "7.7.7.7"},
+            headers={"X-Forwarded-For": "7.7.7.7", "X-Tenant-Id": str(tenant_a.id)},
         )
 
     assert response.status_code == 429, response.text
     assert "Retry-After" in response.headers
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Tenant-scoped purchase tests (T-3.1)
+# ---------------------------------------------------------------------------
+
+
+def test_purchase_resolves_per_tenant(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Purchase with origin resolving to tenant A hits tenant A's popup."""
+    popup = _make_popup(db, tenant_a, slug_prefix="per-tenant")
+    product = _make_product(db, popup, price="50.00")
+    section = _make_section(db, popup)
+    field = _make_field(db, popup, section)
+    db.commit()
+
+    mock_redis = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+    mock_redis.get.return_value = None  # no prior requests — bypass rate limit
+    mock_redis.ttl.return_value = -1
+
+    with (
+        patch("app.services.simplefi.get_simplefi_client") as mock_client,
+        patch("app.core.rate_limit.get_redis", return_value=mock_redis),
+    ):
+        mock_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_per_tenant_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/per-tenant",
+        )
+
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Test",
+                    "last_name": "User",
+                    "form_data": {field.name: "Test"},
+                },
+            },
+            headers=with_origin("test-tenant-a.localhost"),
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "pending"
+
+
+def test_purchase_unknown_origin_returns_404(
+    client: TestClient,
+) -> None:
+    """No Origin and no X-Tenant-Id → 404 from resolver, no payment created."""
+    response = client.post(
+        "/api/v1/checkout/summer-fest/purchase",
+        json={
+            "products": [{"product_id": str(uuid.uuid4()), "quantity": 1}],
+            "buyer": {
+                "email": "buyer@test.com",
+                "first_name": "Test",
+                "last_name": "User",
+                "form_data": {},
+            },
+        },
+    )
+    assert response.status_code == 404, response.text

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -15,7 +15,6 @@ from app.api.popup.models import Popups
 from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
-
 from tests.conftest import with_origin
 
 

--- a/backend/tests/api/coupon/test_validate_public.py
+++ b/backend/tests/api/coupon/test_validate_public.py
@@ -14,6 +14,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
@@ -21,7 +22,6 @@ from app.api.coupon.models import Coupons
 from app.api.popup.models import Popups
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
-
 from tests.conftest import with_origin
 
 # ---------------------------------------------------------------------------
@@ -196,10 +196,10 @@ def test_validate_public_rate_limit_triggers_429(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("tenant_a")
 def test_coupon_validate_resolves_per_tenant(
     client: TestClient,
     db: Session,
-    tenant_a: Tenants,
     popup_tenant_a_summer_fest: Popups,
 ) -> None:
     """Coupon on tenant A's popup, origin=tenant A → 200 with discount."""
@@ -218,10 +218,9 @@ def test_coupon_validate_resolves_per_tenant(
     assert body["valid"] is True
 
 
+@pytest.mark.usefixtures("popup_tenant_a_summer_fest", "popup_tenant_b_summer_fest")
 def test_coupon_validate_cross_tenant_returns_invalid(
     client: TestClient,
-    popup_tenant_a_summer_fest: Popups,
-    popup_tenant_b_summer_fest: Popups,
 ) -> None:
     """Coupon exists on tenant A's popup; request from tenant B → uniform 400 (not found)."""
     response = client.post(

--- a/backend/tests/api/coupon/test_validate_public.py
+++ b/backend/tests/api/coupon/test_validate_public.py
@@ -22,6 +22,8 @@ from app.api.popup.models import Popups
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 
+from tests.conftest import with_origin
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -101,6 +103,7 @@ def test_validate_public_valid_coupon(
     response = client.post(
         "/api/v1/coupons/validate-public",
         json={"popup_slug": popup.slug, "code": "FEST10"},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
 
     assert response.status_code == 200, response.text
@@ -121,6 +124,7 @@ def test_validate_public_unknown_code_returns_400(
     response = client.post(
         "/api/v1/coupons/validate-public",
         json={"popup_slug": popup.slug, "code": "DOESNOTEXIST"},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
 
     assert response.status_code == 400, response.text
@@ -139,6 +143,7 @@ def test_validate_public_expired_coupon_same_shape(
     response = client.post(
         "/api/v1/coupons/validate-public",
         json={"popup_slug": popup.slug, "code": "EXPIRED99"},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
 
     assert response.status_code == 400, response.text
@@ -156,6 +161,7 @@ def test_validate_public_application_popup_returns_403(
     response = client.post(
         "/api/v1/coupons/validate-public",
         json={"popup_slug": popup.slug, "code": "ANY"},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
     )
 
     assert response.status_code == 403, response.text
@@ -178,8 +184,63 @@ def test_validate_public_rate_limit_triggers_429(
         response = client.post(
             "/api/v1/coupons/validate-public",
             json={"popup_slug": popup.slug, "code": "VALID1"},
-            headers={"X-Forwarded-For": "9.9.9.9"},
+            headers={"X-Forwarded-For": "9.9.9.9", "X-Tenant-Id": str(tenant_a.id)},
         )
 
     assert response.status_code == 429, response.text
     assert "Retry-After" in response.headers
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Tenant-scoped coupon validation tests (T-4.1)
+# ---------------------------------------------------------------------------
+
+
+def test_coupon_validate_resolves_per_tenant(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a_summer_fest: Popups,
+) -> None:
+    """Coupon on tenant A's popup, origin=tenant A → 200 with discount."""
+    _make_coupon(db, popup_tenant_a_summer_fest, code="SUMMERFEST10")
+    db.commit()
+
+    response = client.post(
+        "/api/v1/coupons/validate-public",
+        json={"popup_slug": "summer-fest", "code": "SUMMERFEST10"},
+        headers=with_origin("test-tenant-a.localhost"),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["code"] == "SUMMERFEST10"
+    assert body["valid"] is True
+
+
+def test_coupon_validate_cross_tenant_returns_invalid(
+    client: TestClient,
+    popup_tenant_a_summer_fest: Popups,
+    popup_tenant_b_summer_fest: Popups,
+) -> None:
+    """Coupon exists on tenant A's popup; request from tenant B → uniform 400 (not found)."""
+    response = client.post(
+        "/api/v1/coupons/validate-public",
+        json={"popup_slug": "summer-fest", "code": "SUMMERFEST10"},
+        headers=with_origin("test-tenant-b.localhost"),
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "Invalid or expired coupon"
+
+
+def test_coupon_validate_unknown_origin_returns_404(
+    client: TestClient,
+) -> None:
+    """No Origin and no X-Tenant-Id → 404 from resolver before coupon logic."""
+    response = client.post(
+        "/api/v1/coupons/validate-public",
+        json={"popup_slug": "summer-fest", "code": "ANY"},
+    )
+
+    assert response.status_code == 404, response.text

--- a/backend/tests/api/popup/test_migration.py
+++ b/backend/tests/api/popup/test_migration.py
@@ -185,11 +185,14 @@ class TestTenantScopedPopupSlugDowngradeSafety:
             with pytest.raises(RuntimeError, match="cross-tenant duplicate slug"):
                 module.downgrade()
 
-    def test_downgrade_proceeds_when_no_duplicates_exist(self) -> None:
-        """downgrade must NOT raise when no cross-tenant slug duplicates exist."""
+    def test_downgrade_uses_concurrently_in_production_path(self) -> None:
+        """Production path (non-transactional bind) must wrap DROP INDEX in autocommit_block."""
         module = _load_migration_module()
 
         mock_bind = MagicMock()
+        # Force the production branch: _is_transactional_connection() reads
+        # bind.in_transaction(), so mock that explicitly to False.
+        mock_bind.in_transaction.return_value = False
         mock_result = MagicMock()
         mock_result.first.return_value = None
         mock_bind.execute.return_value = mock_result
@@ -198,18 +201,38 @@ class TestTenantScopedPopupSlugDowngradeSafety:
         mock_context.__enter__ = MagicMock(return_value=None)
         mock_context.__exit__ = MagicMock(return_value=False)
 
-        with (
-            patch.object(module, "op") as mock_op,
-        ):
+        with patch.object(module, "op") as mock_op:
             mock_op.get_bind.return_value = mock_bind
             mock_op.get_context.return_value.autocommit_block.return_value = (
                 mock_context
             )
-            mock_op.get_context.return_value.in_transaction.return_value = False
 
-            # Should not raise — just call DDL ops
             module.downgrade()
 
+            mock_op.get_context.return_value.autocommit_block.assert_called_once()
+            mock_op.drop_index.assert_called()
+            mock_op.create_index.assert_called()
+            mock_op.create_unique_constraint.assert_called_with(
+                "popups_slug_key", "popups", ["slug"]
+            )
+
+    def test_downgrade_skips_concurrently_in_test_path(self) -> None:
+        """Test-env path (transactional bind) must NOT call autocommit_block."""
+        module = _load_migration_module()
+
+        mock_bind = MagicMock()
+        # Test branch: connection is already inside a BEGIN block.
+        mock_bind.in_transaction.return_value = True
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_bind.execute.return_value = mock_result
+
+        with patch.object(module, "op") as mock_op:
+            mock_op.get_bind.return_value = mock_bind
+
+            module.downgrade()
+
+            mock_op.get_context.return_value.autocommit_block.assert_not_called()
             mock_op.drop_index.assert_called()
             mock_op.create_index.assert_called()
             mock_op.create_unique_constraint.assert_called_with(

--- a/backend/tests/api/popup/test_migration.py
+++ b/backend/tests/api/popup/test_migration.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-import sqlalchemy as sa
 from sqlmodel import Session
 
 

--- a/backend/tests/api/popup/test_migration.py
+++ b/backend/tests/api/popup/test_migration.py
@@ -1,0 +1,217 @@
+"""Tests for the tenant-scoped popup slug migration (0043_tenant_scoped_popup_slug).
+
+Scenarios (REQ-E.1, REQ-E.2):
+  1. uq_popups_tenant_slug unique index exists after upgrade
+  2. popups_slug_key constraint does NOT exist after upgrade
+  3. ix_popups_slug non-unique index exists after upgrade
+  4. Two rows with same slug but different tenant_id succeed after migration
+  5. downgrade refuses (raises RuntimeError) when cross-tenant duplicates exist
+  6. downgrade restores popups_slug_key when no duplicates exist (logic test)
+"""
+
+import importlib.util
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import sqlalchemy as sa
+from sqlmodel import Session
+
+
+def _load_migration_module():
+    migration_path = (
+        Path(__file__).resolve().parents[3]
+        / "app"
+        / "alembic"
+        / "versions"
+    )
+    matches = list(migration_path.glob("0043_tenant_scoped_popup_slug.py"))
+    assert matches, "0043_tenant_scoped_popup_slug migration file not found"
+
+    module_path = matches[0]
+    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestTenantScopedPopupSlugMigration:
+    """Schema-level assertions for the 0043 migration.
+
+    These tests run against the shared test DB which is already at `head`
+    (the session-scoped test_engine ran `upgrade head` at session start).
+    The new 0043 migration must be present for these to pass.
+    """
+
+    def test_composite_unique_index_exists(self, db: Session) -> None:
+        """uq_popups_tenant_slug unique index must exist after upgrade."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT indexname
+            FROM pg_indexes
+            WHERE tablename = 'popups'
+              AND indexname = 'uq_popups_tenant_slug'
+            """
+        ).fetchone()
+        assert row is not None, (
+            "Index 'uq_popups_tenant_slug' not found on popups table. "
+            "Run migration 0043 to create it."
+        )
+
+    def test_composite_unique_index_is_unique(self, db: Session) -> None:
+        """uq_popups_tenant_slug must be a UNIQUE index."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT ix.indisunique
+            FROM pg_indexes pi
+            JOIN pg_class c ON c.relname = pi.indexname
+            JOIN pg_index ix ON ix.indexrelid = c.oid
+            WHERE pi.tablename = 'popups'
+              AND pi.indexname = 'uq_popups_tenant_slug'
+            """
+        ).fetchone()
+        assert row is not None, "uq_popups_tenant_slug index not found in pg_index"
+        assert row[0] is True, "uq_popups_tenant_slug must be a unique index"
+
+    def test_old_global_unique_constraint_removed(self, db: Session) -> None:
+        """popups_slug_key constraint must NOT exist after migration 0043."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT conname
+            FROM pg_constraint
+            WHERE conrelid = 'popups'::regclass
+              AND conname = 'popups_slug_key'
+            """
+        ).fetchone()
+        assert row is None, (
+            "Constraint 'popups_slug_key' still exists. "
+            "Migration 0043 should have dropped it."
+        )
+
+    def test_non_unique_slug_index_exists(self, db: Session) -> None:
+        """ix_popups_slug must exist as a non-unique index after migration."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT ix.indisunique
+            FROM pg_indexes pi
+            JOIN pg_class c ON c.relname = pi.indexname
+            JOIN pg_index ix ON ix.indexrelid = c.oid
+            WHERE pi.tablename = 'popups'
+              AND pi.indexname = 'ix_popups_slug'
+            """
+        ).fetchone()
+        assert row is not None, (
+            "Index 'ix_popups_slug' not found on popups table after migration."
+        )
+        assert row[0] is False, "ix_popups_slug must be a non-unique index"
+
+    def test_same_slug_different_tenants_can_coexist(
+        self, db: Session, tenant_a, tenant_b
+    ) -> None:
+        """Two rows with same slug but different tenant_id must succeed post-migration."""
+        conn = db.connection()
+        slug = f"migration-test-{uuid.uuid4().hex[:8]}"
+
+        try:
+            conn.exec_driver_sql(
+                """
+                INSERT INTO popups (id, name, slug, tenant_id, sale_type, checkout_mode,
+                                    status, currency, default_language,
+                                    supported_languages, insurance_enabled,
+                                    allows_scholarship, allows_incentive,
+                                    requires_application_fee,
+                                    tier_progression_enabled, events_enabled,
+                                    application_layout)
+                VALUES (%s, %s, %s, %s, 'application', 'pass_system',
+                        'draft', 'USD', 'en', '{en}', false,
+                        false, false, false, false, true, 'single_page')
+                """,
+                (str(uuid.uuid4()), f"Migration Test A {slug}", slug, str(tenant_a.id)),
+            )
+            conn.exec_driver_sql(
+                """
+                INSERT INTO popups (id, name, slug, tenant_id, sale_type, checkout_mode,
+                                    status, currency, default_language,
+                                    supported_languages, insurance_enabled,
+                                    allows_scholarship, allows_incentive,
+                                    requires_application_fee,
+                                    tier_progression_enabled, events_enabled,
+                                    application_layout)
+                VALUES (%s, %s, %s, %s, 'application', 'pass_system',
+                        'draft', 'USD', 'en', '{en}', false,
+                        false, false, false, false, true, 'single_page')
+                """,
+                (str(uuid.uuid4()), f"Migration Test B {slug}", slug, str(tenant_b.id)),
+            )
+
+            rows = conn.exec_driver_sql(
+                "SELECT id FROM popups WHERE slug = %s", (slug,)
+            ).fetchall()
+            assert len(rows) == 2, (
+                f"Expected 2 rows with slug={slug!r}, found {len(rows)}"
+            )
+        finally:
+            conn.exec_driver_sql("DELETE FROM popups WHERE slug = %s", (slug,))
+
+
+class TestTenantScopedPopupSlugDowngradeSafety:
+    """Tests for the downgrade safety guard.
+
+    These tests call the migration module's downgrade() logic directly
+    using mocks to avoid actually running DDL against the shared test DB.
+    This isolates the guard logic without disrupting the shared DB state.
+    """
+
+    def test_downgrade_refuses_when_cross_tenant_duplicates_exist(self) -> None:
+        """downgrade must raise RuntimeError if cross-tenant slug duplicates exist."""
+        module = _load_migration_module()
+
+        mock_bind = MagicMock()
+        mock_result = MagicMock()
+        mock_result.first.return_value = ("summer-fest",)
+        mock_bind.execute.return_value = mock_result
+
+        with (
+            patch.object(module, "op") as mock_op,
+        ):
+            mock_op.get_bind.return_value = mock_bind
+
+            with pytest.raises(RuntimeError, match="cross-tenant duplicate slug"):
+                module.downgrade()
+
+    def test_downgrade_proceeds_when_no_duplicates_exist(self) -> None:
+        """downgrade must NOT raise when no cross-tenant slug duplicates exist."""
+        module = _load_migration_module()
+
+        mock_bind = MagicMock()
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        mock_bind.execute.return_value = mock_result
+
+        mock_context = MagicMock()
+        mock_context.__enter__ = MagicMock(return_value=None)
+        mock_context.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(module, "op") as mock_op,
+        ):
+            mock_op.get_bind.return_value = mock_bind
+            mock_op.get_context.return_value.autocommit_block.return_value = (
+                mock_context
+            )
+            mock_op.get_context.return_value.in_transaction.return_value = False
+
+            # Should not raise — just call DDL ops
+            module.downgrade()
+
+            mock_op.drop_index.assert_called()
+            mock_op.create_index.assert_called()
+            mock_op.create_unique_constraint.assert_called_with(
+                "popups_slug_key", "popups", ["slug"]
+            )

--- a/backend/tests/api/popup/test_popup.py
+++ b/backend/tests/api/popup/test_popup.py
@@ -59,7 +59,7 @@ def test_create_popup_409_on_same_tenant_slug_conflict(
 
     assert response2.status_code == 409, response2.text
     body = response2.json()
-    assert body["detail"]["code"] == "popup_slug_conflict"
+    assert "slug" in body["detail"].lower()
 
 
 def test_create_popup_201_on_cross_tenant_slug(
@@ -111,7 +111,7 @@ def test_create_popup_race_condition_returns_409_not_500(
 
     assert response.status_code == 409, response.text
     body = response.json()
-    assert body["detail"]["code"] == "popup_slug_conflict"
+    assert "slug" in body["detail"].lower()
 
 
 def test_update_popup_409_on_same_tenant_slug_conflict(
@@ -148,7 +148,7 @@ def test_update_popup_409_on_same_tenant_slug_conflict(
 
     assert response3.status_code == 409, response3.text
     body = response3.json()
-    assert body["detail"]["code"] == "popup_slug_conflict"
+    assert "slug" in body["detail"].lower()
 
 
 def test_update_popup_race_condition_returns_409_not_500(
@@ -185,4 +185,4 @@ def test_update_popup_race_condition_returns_409_not_500(
 
     assert response2.status_code == 409, response2.text
     body = response2.json()
-    assert body["detail"]["code"] == "popup_slug_conflict"
+    assert "slug" in body["detail"].lower()

--- a/backend/tests/api/popup/test_popup.py
+++ b/backend/tests/api/popup/test_popup.py
@@ -1,0 +1,188 @@
+"""Tests for popup create/update 409 error path — Phase 5 (T-5.1).
+
+TDD: RED → GREEN.
+
+Scenarios:
+1. test_create_popup_409_on_same_tenant_slug_conflict — same-tenant duplicate slug → 409
+2. test_create_popup_201_on_cross_tenant_slug — cross-tenant same slug → 201
+3. test_create_popup_race_condition_returns_409_not_500 — IntegrityError injected → 409
+4. test_update_popup_409_on_same_tenant_slug_conflict — update to existing same-tenant slug → 409
+5. test_update_popup_race_condition_returns_409_not_500 — IntegrityError on update → 409
+"""
+
+import uuid
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.api.shared.enums import SaleType
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_popup_payload(name: str) -> dict:
+    """PopupCreate always generates slug from name via slugify(name). Pass a unique name."""
+    return {
+        "name": name,
+        "sale_type": SaleType.direct.value,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Popup 409 tests (T-5.1)
+# ---------------------------------------------------------------------------
+
+
+def test_create_popup_409_on_same_tenant_slug_conflict(
+    client: TestClient,
+    admin_token_tenant_a: str,
+) -> None:
+    """Create popup with same name (→ same slug) in same tenant twice → 409."""
+    # slugify("Summer Slug Test A") → "summer-slug-test-a" (unique enough for test)
+    unique_suffix = uuid.uuid4().hex[:6]
+    name = f"Slug Conflict {unique_suffix}"
+
+    response1 = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_popup_payload(name),
+    )
+    assert response1.status_code == 201, response1.text
+
+    response2 = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_popup_payload(name),
+    )
+
+    assert response2.status_code == 409, response2.text
+    body = response2.json()
+    assert body["detail"]["code"] == "popup_slug_conflict"
+
+
+def test_create_popup_201_on_cross_tenant_slug(
+    client: TestClient,
+    admin_token_tenant_a: str,
+    admin_token_tenant_b: str,
+) -> None:
+    """Tenant A and tenant B both create popup with same name (→ same slug) → both 201."""
+    unique_suffix = uuid.uuid4().hex[:6]
+    shared_name = f"Cross Tenant Popup {unique_suffix}"
+
+    response_a = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_popup_payload(shared_name),
+    )
+    assert response_a.status_code == 201, response_a.text
+
+    response_b = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_b),
+        json=_create_popup_payload(shared_name),
+    )
+    assert response_b.status_code == 201, response_b.text
+
+
+def test_create_popup_race_condition_returns_409_not_500(
+    client: TestClient,
+    admin_token_tenant_a: str,
+) -> None:
+    """IntegrityError from crud.create is translated to 409, not 500."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.api.popup import crud as popup_crud
+
+    unique_suffix = uuid.uuid4().hex[:6]
+    integrity_error = IntegrityError(
+        statement="INSERT INTO popups",
+        params={},
+        orig=Exception('duplicate key value violates unique constraint "uq_popups_tenant_slug"'),
+    )
+
+    with patch.object(popup_crud, "create", side_effect=integrity_error):
+        response = client.post(
+            "/api/v1/popups",
+            headers=_admin_headers(admin_token_tenant_a),
+            json=_create_popup_payload(f"Race Condition Popup {unique_suffix}"),
+        )
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["detail"]["code"] == "popup_slug_conflict"
+
+
+def test_update_popup_409_on_same_tenant_slug_conflict(
+    client: TestClient,
+    admin_token_tenant_a: str,
+) -> None:
+    """Update popup slug to the slug of another existing popup in same tenant → 409."""
+    unique_suffix = uuid.uuid4().hex[:6]
+
+    # Create popup A — slug will be "existing-popup-<suffix>"
+    response1 = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_popup_payload(f"Existing Popup {unique_suffix}"),
+    )
+    assert response1.status_code == 201, response1.text
+    slug_a = response1.json()["slug"]  # the actual generated slug
+
+    # Create popup B — slug will be different
+    response2 = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_popup_payload(f"Target Popup {unique_suffix}"),
+    )
+    assert response2.status_code == 201, response2.text
+    popup_b_id = response2.json()["id"]
+
+    # Try to PATCH popup B's slug to popup A's slug → should 409
+    response3 = client.patch(
+        f"/api/v1/popups/{popup_b_id}",
+        headers=_admin_headers(admin_token_tenant_a),
+        json={"slug": slug_a},
+    )
+
+    assert response3.status_code == 409, response3.text
+    body = response3.json()
+    assert body["detail"]["code"] == "popup_slug_conflict"
+
+
+def test_update_popup_race_condition_returns_409_not_500(
+    client: TestClient,
+    admin_token_tenant_a: str,
+) -> None:
+    """IntegrityError from crud.update is translated to 409, not 500."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.api.popup import crud as popup_crud
+
+    unique_suffix = uuid.uuid4().hex[:6]
+
+    response1 = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_popup_payload(f"Update Race Popup {unique_suffix}"),
+    )
+    assert response1.status_code == 201, response1.text
+    popup_id = response1.json()["id"]
+
+    integrity_error = IntegrityError(
+        statement="UPDATE popups",
+        params={},
+        orig=Exception('duplicate key value violates unique constraint "uq_popups_tenant_slug"'),
+    )
+
+    with patch.object(popup_crud, "update", side_effect=integrity_error):
+        response2 = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"slug": f"new-race-slug-{unique_suffix}"},
+        )
+
+    assert response2.status_code == 409, response2.text
+    body = response2.json()
+    assert body["detail"]["code"] == "popup_slug_conflict"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,7 +10,8 @@ from sqlmodel import Session, create_engine, select
 from testcontainers.postgres import PostgresContainer
 
 from app.api.popup.models import Popups
-from app.api.shared.enums import UserRole
+from app.api.popup.schemas import PopupStatus
+from app.api.shared.enums import SaleType, UserRole
 from app.api.tenant.models import Tenants
 from app.api.user.models import Users
 from app.core.dependencies.users import get_session
@@ -260,3 +261,52 @@ def popup_tenant_b(db: Session, tenant_b: Tenants) -> Popups:
         db.refresh(popup)
 
     return popup
+
+
+@pytest.fixture(scope="session")
+def popup_tenant_a_summer_fest(db: Session, tenant_a: Tenants) -> Popups:
+    popup = db.exec(
+        select(Popups).where(
+            Popups.slug == "summer-fest",
+            Popups.tenant_id == tenant_a.id,
+        )
+    ).first()
+    if popup is None:
+        popup = Popups(
+            name="Summer Fest A",
+            slug="summer-fest",
+            tenant_id=tenant_a.id,
+            sale_type=SaleType.direct,
+            status=PopupStatus.active,
+        )
+        db.add(popup)
+        db.commit()
+        db.refresh(popup)
+    return popup
+
+
+@pytest.fixture(scope="session")
+def popup_tenant_b_summer_fest(db: Session, tenant_b: Tenants) -> Popups:
+    popup = db.exec(
+        select(Popups).where(
+            Popups.slug == "summer-fest",
+            Popups.tenant_id == tenant_b.id,
+        )
+    ).first()
+    if popup is None:
+        popup = Popups(
+            name="Summer Fest B",
+            slug="summer-fest",
+            tenant_id=tenant_b.id,
+            sale_type=SaleType.direct,
+            status=PopupStatus.active,
+        )
+        db.add(popup)
+        db.commit()
+        db.refresh(popup)
+    return popup
+
+
+def with_origin(host: str) -> dict[str, str]:
+    """Return a headers dict with an Origin pointing at the given host."""
+    return {"Origin": f"https://{host}"}

--- a/backend/tests/core/dependencies/test_tenants.py
+++ b/backend/tests/core/dependencies/test_tenants.py
@@ -22,7 +22,6 @@ import uuid
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/backend/tests/core/dependencies/test_tenants.py
+++ b/backend/tests/core/dependencies/test_tenants.py
@@ -1,0 +1,433 @@
+"""Unit tests for resolve_public_tenant dependency — Phase 2 (T-2.1).
+
+All 11 test scenarios from the spec (REQ-A.1 to REQ-A.4, ADR-1, ADR-5).
+Tests use a minimal FastAPI TestClient + monkeypatch to keep them isolated
+from the real DB and Redis — matching the pattern in test_rate_limit.py.
+
+Scenarios:
+ 1. test_origin_resolves_known_tenant
+ 2. test_origin_unrecognized_raises_404
+ 3. test_referer_fallback_when_origin_absent
+ 4. test_x_tenant_id_fallback_when_origin_absent
+ 5. test_x_tenant_id_unknown_uuid_raises_404
+ 6. test_both_headers_absent_raises_404
+ 7. test_both_headers_absent_emits_debug_log
+ 8. test_null_origin_skipped
+ 9. test_origin_with_port_normalized
+10. test_cache_hit_returns_tenant
+11. test_cache_null_sentinel_skips_to_next_signal
+"""
+
+import uuid
+from typing import Any
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TENANT_A_ID = uuid.uuid4()
+
+
+def _make_tenant(tenant_id: uuid.UUID = _TENANT_A_ID) -> MagicMock:
+    """Return a mock Tenants ORM instance with enough fields for TenantPublic.model_validate."""
+    t = MagicMock()
+    t.id = tenant_id
+    t.deleted = False
+    t.name = "Test Tenant"
+    t.slug = "test-tenant"
+    t.sender_email = None
+    t.sender_name = None
+    t.image_url = None
+    t.icon_url = None
+    t.logo_url = None
+    t.custom_domain = None
+    t.custom_domain_active = False
+    return t
+
+
+def _make_tenant_public_json(tenant_id: uuid.UUID = _TENANT_A_ID) -> str:
+    """Return a minimal TenantPublic JSON string as stored in domain_cache."""
+    return (
+        f'{{"id":"{tenant_id}","name":"Test","slug":"test",'
+        f'"deleted":false,"sender_email":null,"sender_name":null,'
+        f'"image_url":null,"icon_url":null,"logo_url":null,'
+        f'"custom_domain":null,"custom_domain_active":false}}'
+    )
+
+
+def _make_app() -> FastAPI:
+    """Build a minimal FastAPI app that exposes the resolve_public_tenant dependency."""
+    from fastapi import Depends
+
+    from app.core.dependencies.tenants import resolve_public_tenant
+
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(tenant: Any = Depends(resolve_public_tenant)) -> dict:  # type: ignore[assignment]
+        return {"tenant_id": str(tenant.id)}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Shared patches helper
+# ---------------------------------------------------------------------------
+
+def _make_client(
+    *,
+    cache_return: str | None = None,
+    resolve_return: Any = None,
+    tenants_get_return: Any = None,
+    portal_domain: str = "dev.edgeos.world",
+) -> TestClient:
+    """Create a TestClient with domain_cache and tenants_crud patched."""
+    app = _make_app()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = cache_return
+    mock_cache.set.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = resolve_return
+    mock_crud.get.return_value = tenants_get_return
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = portal_domain
+        yield client, mock_cache, mock_crud
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_origin_resolves_known_tenant() -> None:
+    """Origin header resolves to a known tenant → dependency returns that tenant."""
+    tenant = _make_tenant()
+
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None  # cache miss
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = tenant
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe", headers={"Origin": "https://tenant-a.dev.edgeos.world"}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == str(_TENANT_A_ID)
+    mock_crud.resolve_by_host.assert_called_once()
+
+
+def test_origin_unrecognized_raises_404() -> None:
+    """Origin present but host resolves to no tenant AND no X-Tenant-Id → 404."""
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None  # unknown host
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe", headers={"Origin": "https://unknown.example.com"}
+        )
+
+    assert response.status_code == 404
+
+
+def test_referer_fallback_when_origin_absent() -> None:
+    """No Origin → Referer header used as fallback; resolves to known tenant."""
+    tenant = _make_tenant()
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = tenant
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe",
+            headers={"Referer": "https://tenant-a.dev.edgeos.world/some/path"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == str(_TENANT_A_ID)
+    # resolve_by_host was called with the host extracted from Referer
+    call_args = mock_crud.resolve_by_host.call_args
+    assert call_args[0][1] == "tenant-a.dev.edgeos.world"
+
+
+def test_x_tenant_id_fallback_when_origin_absent() -> None:
+    """No Origin, no Referer, valid X-Tenant-Id UUID → returns that tenant (REQ-A.2)."""
+    tenant = _make_tenant()
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None
+    mock_crud.get.return_value = tenant
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe", headers={"X-Tenant-Id": str(_TENANT_A_ID)}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == str(_TENANT_A_ID)
+
+
+def test_x_tenant_id_unknown_uuid_raises_404() -> None:
+    """No Origin, X-Tenant-Id present but UUID not in DB → 404 (REQ-A.2 Scenario 4)."""
+    app = _make_app()
+    unknown_id = uuid.uuid4()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None
+    mock_crud.get.return_value = None  # not found
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe", headers={"X-Tenant-Id": str(unknown_id)}
+        )
+
+    assert response.status_code == 404
+
+
+def test_both_headers_absent_raises_404() -> None:
+    """No Origin, no Referer, no X-Tenant-Id → HTTP 404 (REQ-A.3)."""
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/probe")
+
+    assert response.status_code == 404
+
+
+def test_both_headers_absent_emits_debug_log() -> None:
+    """No headers → 404 AND a DEBUG log entry is emitted (REQ-A.3).
+
+    loguru routes to its own sinks, not Python logging. We patch logger.debug
+    in the module under test to assert the call was made with the expected
+    keyword arguments.
+    """
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None
+
+    mock_logger_debug = MagicMock()
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+        patch("app.core.dependencies.tenants.logger") as mock_logger,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        mock_logger.debug = mock_logger_debug
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get("/probe")
+
+    assert response.status_code == 404
+    # The debug call must have been made
+    assert mock_logger_debug.called
+    # Verify the call included origin and x_tenant_id_present keyword args
+    call_kwargs = mock_logger_debug.call_args.kwargs
+    assert "origin" in call_kwargs
+    assert "x_tenant_id_present" in call_kwargs
+    assert call_kwargs["x_tenant_id_present"] is False
+
+
+def test_null_origin_skipped() -> None:
+    """Origin: null (sandboxed iframe) is treated as missing → falls through to X-Tenant-Id (ADR-5)."""
+    tenant = _make_tenant()
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None
+    mock_crud.get.return_value = tenant
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe",
+            headers={"Origin": "null", "X-Tenant-Id": str(_TENANT_A_ID)},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == str(_TENANT_A_ID)
+    # resolve_by_host must NOT have been called (Origin "null" was skipped)
+    mock_crud.resolve_by_host.assert_not_called()
+
+
+def test_origin_with_port_normalized() -> None:
+    """Origin with port (https://host:8443) → port stripped → hostname passed to resolver (ADR-5)."""
+    tenant = _make_tenant()
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = tenant
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe",
+            headers={"Origin": "https://tenant.dev.edgeos.world:8443"},
+        )
+
+    assert response.status_code == 200
+    call_args = mock_crud.resolve_by_host.call_args
+    # The host passed must NOT contain the port
+    resolved_host: str = call_args[0][1]
+    assert ":" not in resolved_host
+    assert resolved_host == "tenant.dev.edgeos.world"
+
+
+def test_cache_hit_returns_tenant() -> None:
+    """domain_cache returns valid TenantPublic JSON → DB fetched by id (ADR-1 cache strategy)."""
+    tenant = _make_tenant()
+    app = _make_app()
+
+    cached_json = _make_tenant_public_json(_TENANT_A_ID)
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = cached_json  # cache hit
+
+    mock_crud = MagicMock()
+    mock_crud.get.return_value = tenant  # re-fetch by id from DB
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe", headers={"Origin": "https://tenant-a.dev.edgeos.world"}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == str(_TENANT_A_ID)
+    # resolve_by_host must NOT have been called — we hit the cache
+    mock_crud.resolve_by_host.assert_not_called()
+    # But crud.get WAS called to get the live ORM instance
+    mock_crud.get.assert_called_once_with(ANY, _TENANT_A_ID)
+
+
+def test_cache_null_sentinel_skips_to_next_signal() -> None:
+    """domain_cache returns the sentinel "null" for Origin host → falls through to X-Tenant-Id (ADR-1)."""
+    tenant = _make_tenant()
+    app = _make_app()
+
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = "null"  # sentinel — domain known to be unresolvable
+
+    mock_crud = MagicMock()
+    mock_crud.resolve_by_host.return_value = None
+    mock_crud.get.return_value = tenant
+
+    with (
+        patch("app.core.dependencies.tenants.domain_cache", mock_cache),
+        patch("app.core.dependencies.tenants.tenants_crud", mock_crud),
+        patch("app.core.dependencies.tenants.settings") as mock_settings,
+    ):
+        mock_settings.PORTAL_DOMAIN = "dev.edgeos.world"
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/probe",
+            headers={
+                "Origin": "https://unknown.dev.edgeos.world",
+                "X-Tenant-Id": str(_TENANT_A_ID),
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tenant_id"] == str(_TENANT_A_ID)
+    # resolve_by_host must NOT have been called — sentinel said "not found"
+    mock_crud.resolve_by_host.assert_not_called()

--- a/backend/tests/test_fixtures.py
+++ b/backend/tests/test_fixtures.py
@@ -1,0 +1,29 @@
+"""Fixture coexistence test (REQ-G.1).
+
+Verifies that popup_tenant_a_summer_fest and popup_tenant_b_summer_fest
+can coexist in the same database — which only works after migration 0043
+replaces the global unique on popups.slug with the composite
+unique(tenant_id, slug).
+"""
+
+from sqlmodel import Session
+
+
+def test_shared_slug_fixtures_coexist(
+    db: Session,
+    popup_tenant_a_summer_fest,
+    popup_tenant_b_summer_fest,
+) -> None:
+    """Both same-slug popups must exist with distinct tenant_ids (REQ-G.1)."""
+    db.refresh(popup_tenant_a_summer_fest)
+    db.refresh(popup_tenant_b_summer_fest)
+
+    assert popup_tenant_a_summer_fest.id is not None
+    assert popup_tenant_b_summer_fest.id is not None
+
+    assert popup_tenant_a_summer_fest.slug == "summer-fest"
+    assert popup_tenant_b_summer_fest.slug == "summer-fest"
+
+    assert popup_tenant_a_summer_fest.tenant_id != popup_tenant_b_summer_fest.tenant_id, (
+        "Both popups have slug 'summer-fest' but must belong to different tenants"
+    )


### PR DESCRIPTION
## Summary

Closes the cross-tenant exposure on the public anonymous Open Ticketing surface and migrates `popups.slug` from globally unique to unique-per-tenant. The authenticated portal flow was always tenant-grounded via the human token; the open-checkout flow (`sale_type=direct`, post-festival decoupling) had no such grounding — it resolved popups by slug only.

Designed and implemented under SDD (`tenant-scoped-open-checkout`):
- Exploration: engram #1155
- Proposal: engram #1156 — Hybrid resolver (Origin → Referer → X-Tenant-Id) chosen over pure-Origin or pure-header
- Spec: engram #1157 (7 capabilities, 18 reqs, 21 G/W/T scenarios)
- Design: engram #1158 (6 ADRs, component map, sequence diagrams)
- Tasks: engram #1159 (27 tasks, Strict TDD)

## What changed by capability

| Capability | Description |
|---|---|
| **CAP-A** | New FastAPI dependency `resolve_public_tenant` in `app/core/dependencies/tenants.py`. Reads `Origin → Referer → X-Tenant-Id`, reuses existing `domain_cache` (Redis), 404 + structured DEBUG log on miss. 11 unit tests. |
| **CAP-B/C** | `GET /checkout/{slug}/runtime` and `POST /checkout/{slug}/purchase` now require the resolved tenant; lookups filter `(slug, tenant_id)`. The redundant `db.get(Tenants, popup.tenant_id)` in purchase removed. 6 cross-tenant tests. |
| **CAP-D** | `POST /coupons/validate-public` mirrors the same pattern. 3 cross-tenant tests. |
| **CAP-E** | Alembic `0043_tenant_scoped_popup_slug.py` — drops global `UNIQUE(slug)`, creates composite `UNIQUE(tenant_id, slug)` via `CREATE INDEX CONCURRENTLY` (production path) with a transactional fallback for the test container. Down-migration refuses on cross-tenant duplicates. 7 schema/safety tests. |
| **CAP-F** | Popup create/update — pre-check stays per-tenant via the existing `TenantSession` RLS; `IntegrityError` from `uq_popups_tenant_slug` translated to 409. **Detail body is a plain string** (matches the project-wide pattern at `tenant/router.py:206-209` — see fixup commit). 5 tests including race conditions. |
| **CAP-G** | New cross-tenant fixtures `popup_tenant_a_summer_fest` / `popup_tenant_b_summer_fest` (same slug, different tenants) and `with_origin(host)` helper in `conftest.py`. |

## Naming drift note

Spec REQ-G.1 references fixture names `popup_tenant_a_shared_slug` / `_b_shared_slug`. Implementation followed the tasks document which used `_summer_fest`. Functional contract is identical; consistent across all later tests. Flagged here so reviewers don't read it as a spec deviation.

## No portal product changes

The portal SDK interceptor (`portal/src/lib/api-client.ts:16-25`) already injects `X-Tenant-Id` from `localStorage.getItem(\"portal_tenant_id\")` (set by `TenantProvider`). The backend now consumes it as fallback when `Origin`/`Referer` don't resolve a tenant. Verified in T-7.3.

## Migration

- Composite unique index built `CONCURRENTLY` in production — no write lock.
- Test environments fall back to non-CONCURRENT inside the existing transactional connection; safe because the test table is small.
- Down: refuses if cross-tenant slug duplicates exist (would violate the restored global UNIQUE).

## Commits (work-unit structured)

\`\`\`
449f932 fix(backend): return 409 detail as string to match project pattern
c6660f9 feat(backend): translate popup slug collision to structured 409
c4c1724 feat(backend): scope coupon validate-public to resolved tenant
144e033 feat(backend): scope checkout runtime + purchase to resolved tenant
cd6f331 feat(backend): add resolve_public_tenant dependency for anonymous endpoints
fe9de79 test(backend): cover both branches of migration downgrade autocommit guard
2267e75 test(backend): add same-slug-different-tenant fixtures and with_origin helper
557c613 feat(backend): tenant-scoped popup slug — migration + SQLModel + schema tests
\`\`\`

## Test plan

- [x] `cd backend && uv run pytest -q` → 456 passed, 1 skipped (no regressions)
- [x] Migration up/down on test container (T-1.4)
- [x] Resolver dependency unit tests (11/11) — production CONCURRENTLY path covered explicitly
- [x] Cross-tenant runtime / purchase / coupon tests with `Origin` and `X-Tenant-Id` fallback
- [x] Popup 409 race-condition tests (mocked `IntegrityError`)
- [ ] Manual UI smoke: backoffice creates popup with duplicate slug in same tenant → friendly 409 toast (this PR fixes a React error #31 from the previous structured-detail body)
- [ ] CI green