### PR TITLE
chore(release): events module gate + scrolly footer fix

### DIFF
--- a/portal/src/app/portal/api-keys/page.tsx
+++ b/portal/src/app/portal/api-keys/page.tsx
@@ -5,6 +5,10 @@ import { Check, Copy, Key, Loader2, Plus, Trash2 } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
+import {
+  EventsApiAccessUnavailable,
+  useEventsApiAccess,
+} from "@/components/EventsApiAccessGate"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -26,6 +30,9 @@ import type {
 } from "@/lib/apiKeysService"
 
 const DEFAULT_SCOPES: ApiKeyScope[] = ["events:read"]
+const WRITE_SCOPE_LIFETIME_DAYS = 30
+
+const scopeKey = (scope: ApiKeyScope) => scope.replace(":", "_")
 
 const SCOPE_OPTIONS: Array<{
   value: ApiKeyScope
@@ -39,6 +46,11 @@ const SCOPE_OPTIONS: Array<{
       "List events and read the context needed for event automation.",
   },
   {
+    value: "events:write",
+    label: "Create events",
+    description: "Create and edit events on your behalf.",
+  },
+  {
     value: "rsvp:write",
     label: "RSVP to events",
     description: "Register or cancel attendance for events.",
@@ -47,6 +59,7 @@ const SCOPE_OPTIONS: Array<{
 
 export default function ApiKeysPage() {
   const { t } = useTranslation()
+  const { allowed } = useEventsApiAccess()
   const {
     keys,
     isLoading,
@@ -80,11 +93,17 @@ export default function ApiKeysPage() {
   const onCreate = async () => {
     const name = newKeyName.trim()
     if (!name) return
+    const requiresExpiry = selectedScopes.includes("events:write")
+    const expiresAt = requiresExpiry
+      ? new Date(
+          Date.now() + WRITE_SCOPE_LIFETIME_DAYS * 24 * 60 * 60 * 1000,
+        ).toISOString()
+      : null
     try {
       const created = await createKey({
         name,
         scopes: selectedScopes,
-        expires_at: null,
+        expires_at: expiresAt,
       })
       setCreatedKey(created)
       setNewKeyName("")
@@ -124,6 +143,10 @@ export default function ApiKeysPage() {
 
   const isActive = (k: ApiKeyPublic) =>
     !k.revoked_at && (!k.expires_at || new Date(k.expires_at) > new Date())
+
+  if (!allowed) {
+    return <EventsApiAccessUnavailable />
+  }
 
   return (
     <div className="flex-1 p-6 bg-background">
@@ -307,14 +330,17 @@ export default function ApiKeysPage() {
                         htmlFor={checkboxId}
                         className="text-sm font-medium cursor-pointer"
                       >
-                        {t(`api_keys.scope.${scope.value}.label`, {
+                        {t(`api_keys.scope.${scopeKey(scope.value)}.label`, {
                           defaultValue: scope.label,
                         })}
                       </Label>
                       <p className="text-xs text-muted-foreground">
-                        {t(`api_keys.scope.${scope.value}.description`, {
-                          defaultValue: scope.description,
-                        })}
+                        {t(
+                          `api_keys.scope.${scopeKey(scope.value)}.description`,
+                          {
+                            defaultValue: scope.description,
+                          },
+                        )}
                       </p>
                     </div>
                   </div>

--- a/portal/src/app/portal/docs/page.tsx
+++ b/portal/src/app/portal/docs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
+import { EventsApiAccessGate } from "@/components/EventsApiAccessGate"
 
 export const metadata: Metadata = {
   title: "Events API",
@@ -112,6 +113,14 @@ const ERRORS: { code: string; meaning: string }[] = [
 ]
 
 export default function ApiDocsPage() {
+  return (
+    <EventsApiAccessGate>
+      <ApiDocsBody />
+    </EventsApiAccessGate>
+  )
+}
+
+function ApiDocsBody() {
   return (
     <div className="flex-1 p-6 bg-background">
       <div className="max-w-4xl mx-auto space-y-8">

--- a/portal/src/components/EventsApiAccessGate.tsx
+++ b/portal/src/components/EventsApiAccessGate.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { CalendarDays } from "lucide-react"
+import type * as React from "react"
+import { useTranslation } from "react-i18next"
+import { useApplication } from "@/providers/applicationProvider"
+import { useCityProvider } from "@/providers/cityProvider"
+
+// Mirrors the sidebar's exposure rule for API Keys / API Docs in
+// useResources.ts: shown only on the standard (application-based) flow,
+// for accepted attendees, when the events module is enabled at the popup
+// level. Direct-sale and companion flows never expose these subsections,
+// so navigating to /portal/api-keys or /portal/docs by URL must fall
+// through to the unavailable state instead of rendering the page.
+export function useEventsApiAccess(): { allowed: boolean } {
+  const { getCity } = useCityProvider()
+  const { getRelevantApplication, participation } = useApplication()
+  const city = getCity()
+  const application = getRelevantApplication()
+
+  const isDirectSale = city?.sale_type === "direct"
+  const isCompanion = participation?.type === "companion"
+  const eventsEnabled = city?.events_enabled ?? true
+  const canSeeAttendees = application?.status === "accepted"
+
+  return {
+    allowed:
+      !isDirectSale && !isCompanion && eventsEnabled && canSeeAttendees,
+  }
+}
+
+export function EventsApiAccessUnavailable() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col h-full max-w-4xl mx-auto p-4 sm:p-6">
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <CalendarDays className="h-10 w-10 text-muted-foreground/50 mb-3" />
+        <h1 className="text-xl font-semibold">
+          {t("events.api_access.unavailable_heading", {
+            defaultValue: "Not available for this popup",
+          })}
+        </h1>
+        <p className="text-sm text-muted-foreground mt-2">
+          {t("events.api_access.unavailable_message", {
+            defaultValue:
+              "API keys and the events API docs are part of the events module, which isn't enabled for this popup.",
+          })}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// Wrapper variant for callers that prefer a declarative gate over an
+// early-return — handy from server components, where the page can stay
+// server-rendered (and keep its `metadata` export) while delegating the
+// access check to this client island.
+export function EventsApiAccessGate({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { allowed } = useEventsApiAccess()
+  if (!allowed) return <EventsApiAccessUnavailable />
+  return <>{children}</>
+}

--- a/portal/src/components/checkout-flow/CartFooter.tsx
+++ b/portal/src/components/checkout-flow/CartFooter.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
+import type { CheckoutStep } from "@/types/checkout"
 import { formatCurrency } from "@/types/checkout"
 import CartItemList from "./CartItemList"
 
@@ -21,6 +22,7 @@ interface CartFooterProps {
   nextSectionLabel?: string
   onContinue?: () => void
   isLastSection?: boolean
+  activeSectionId?: string
 }
 
 export default function CartFooter({
@@ -29,6 +31,7 @@ export default function CartFooter({
   nextSectionLabel,
   onContinue,
   isLastSection = false,
+  activeSectionId,
 }: CartFooterProps) {
   const { t } = useTranslation()
   const {
@@ -52,9 +55,14 @@ export default function CartFooter({
 
   const [isExpanded, setIsExpanded] = useState(false)
 
-  const isConfirmStep = currentStep === "confirm" || isLastSection
-  const isFirstStep = currentStep === "passes"
-  const currentIndex = availableSteps.indexOf(currentStep)
+  // In scrolly mode `currentStep` stays at the initial value while the user
+  // scrolls. `activeSectionId` reflects the section actually in view, so
+  // position-based gating (next step, first step, etc.) must use it when
+  // provided to avoid letting users skip required steps like buyer info.
+  const positionStep = (activeSectionId ?? currentStep) as CheckoutStep
+  const isConfirmStep = positionStep === "confirm" || isLastSection
+  const isFirstStep = positionStep === "passes"
+  const currentIndex = availableSteps.indexOf(positionStep)
   const nextStepId =
     currentIndex < availableSteps.length - 1
       ? availableSteps[currentIndex + 1]

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -252,7 +252,11 @@ function ScrollyCheckoutFlowInner({
       releaseScrollTarget()
       scrollToIndexRef.current = null
     }
-  }, [allSections])
+    // isInitialLoading gates whether sections are mounted in the DOM. Without
+    // it, the effect runs once during the spinner phase, finds no section
+    // anchor, aborts, and never re-runs after sections appear — leaving
+    // scrollToIndexRef.current null forever.
+  }, [allSections, isInitialLoading])
 
   const renderSectionContent = (stepId: string) => {
     if (stepId === "passes" || stepId === "tickets") {

--- a/portal/src/components/checkout-flow/SnapFooter.tsx
+++ b/portal/src/components/checkout-flow/SnapFooter.tsx
@@ -257,6 +257,7 @@ export default function SnapFooter({
         nextSectionLabel={nextSectionLabel}
         onContinue={onGoToNextSection}
         isLastSection={isOnConfirm}
+        activeSectionId={activeSection}
       />
     ),
     stripe: (

--- a/portal/src/hooks/useResources.ts
+++ b/portal/src/hooks/useResources.ts
@@ -31,7 +31,8 @@ const useResources = () => {
 
   // Direct-sale popups have no application and no reviewer-controlled
   // attendees — just an event overview that links to checkout, plus a
-  // passes view for managing existing purchases.
+  // passes view for managing existing purchases. The events module
+  // (and its API Keys/Docs subsections) is not exposed in this flow.
   if (city?.sale_type === "direct" && user) {
     const resources: Resource[] = [
       {
@@ -39,22 +40,6 @@ const useResources = () => {
         icon: Ticket,
         status: "active",
         path: `/portal/${city?.slug}`,
-        children: eventsEnabled
-          ? [
-              {
-                name: t("sidebar.api_keys", { defaultValue: "API Keys" }),
-                icon: Key,
-                status: "active",
-                path: "/portal/api-keys",
-              },
-              {
-                name: t("sidebar.api_docs", { defaultValue: "API Docs" }),
-                icon: BookOpen,
-                status: "active",
-                path: "/portal/docs",
-              },
-            ]
-          : undefined,
       },
       {
         name: t("sidebar.passes"),

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -397,7 +397,23 @@
     "revoke_title": "Revoke API key",
     "revoke_description": "This action cannot be undone. Anything using this token will immediately stop working.",
     "revoked": "API key revoked",
-    "revoke_failed": "Failed to revoke API key"
+    "revoke_failed": "Failed to revoke API key",
+    "scopes_label": "Permissions",
+    "scopes_description": "New keys start with read-only access. Only enable broader permissions when you really need them.",
+    "scope": {
+      "events_read": {
+        "label": "Read events",
+        "description": "List events and read the context needed for event automation."
+      },
+      "events_write": {
+        "label": "Create events",
+        "description": "Create and edit events on your behalf."
+      },
+      "rsvp_write": {
+        "label": "RSVP to events",
+        "description": "Register or cancel attendance for events."
+      }
+    }
   },
   "breadcrumbs": {
     "application": "Application",
@@ -423,6 +439,10 @@
       "back_to_events": "Back to events",
       "no_open_hours": "No open hours",
       "in_timezone_time": "in {{timezone}} time"
+    },
+    "api_access": {
+      "unavailable_heading": "Not available for this popup",
+      "unavailable_message": "API keys and the events API docs are part of the events module, which isn't enabled for this popup."
     },
     "list": {
       "heading": "Events",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -397,7 +397,23 @@
     "revoke_title": "Revocar API key",
     "revoke_description": "Esta acción no se puede deshacer. Todo lo que use este token va a dejar de funcionar al instante.",
     "revoked": "API key revocada",
-    "revoke_failed": "Error al revocar la API key"
+    "revoke_failed": "Error al revocar la API key",
+    "scopes_label": "Permisos",
+    "scopes_description": "Las keys nuevas arrancan solo con acceso de lectura. Activá permisos más amplios solo cuando realmente los necesites.",
+    "scope": {
+      "events_read": {
+        "label": "Leer eventos",
+        "description": "Listar eventos y leer el contexto que necesita la automatización."
+      },
+      "events_write": {
+        "label": "Crear eventos",
+        "description": "Crear y editar eventos en tu nombre."
+      },
+      "rsvp_write": {
+        "label": "Registrarse a eventos",
+        "description": "Registrar o cancelar la asistencia a eventos."
+      }
+    }
   },
   "breadcrumbs": {
     "application": "Aplicación",
@@ -423,6 +439,10 @@
       "back_to_events": "Volver a eventos",
       "no_open_hours": "Sin horarios de apertura",
       "in_timezone_time": "en horario de {{timezone}}"
+    },
+    "api_access": {
+      "unavailable_heading": "No disponible para este popup",
+      "unavailable_message": "Las API keys y la documentación de la API de eventos forman parte del módulo de eventos, que no está habilitado para este popup."
     },
     "list": {
       "heading": "Eventos",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -397,7 +397,23 @@
     "revoke_title": "撤销 API 密钥",
     "revoke_description": "此操作无法撤销。任何使用此令牌的内容将立即停止工作。",
     "revoked": "API 密钥已撤销",
-    "revoke_failed": "撤销 API 密钥失败"
+    "revoke_failed": "撤销 API 密钥失败",
+    "scopes_label": "权限",
+    "scopes_description": "新密钥默认仅有只读权限。仅在确有需要时才开启更多权限。",
+    "scope": {
+      "events_read": {
+        "label": "读取活动",
+        "description": "列出活动并读取活动自动化所需的上下文。"
+      },
+      "events_write": {
+        "label": "创建活动",
+        "description": "代表你创建和编辑活动。"
+      },
+      "rsvp_write": {
+        "label": "报名活动",
+        "description": "为活动报名或取消报名。"
+      }
+    }
   },
   "breadcrumbs": {
     "application": "申请",
@@ -423,6 +439,10 @@
       "back_to_events": "返回活动列表",
       "no_open_hours": "无营业时间",
       "in_timezone_time": "{{timezone}} 时间"
+    },
+    "api_access": {
+      "unavailable_heading": "此 popup 不可用",
+      "unavailable_message": "API 密钥和活动 API 文档属于活动模块，此 popup 未启用该模块。"
     },
     "list": {
       "heading": "活动",


### PR DESCRIPTION
## Summary
- **feat(portal):** gate `/portal/api-keys` and `/portal/docs` behind the events module. Direct-sale, companion, and events-disabled popups now fall through to an unavailable state instead of rendering the page when the URL is hit directly. Also adds the `events:write` scope (with a 30-day expiry) and the related i18n strings.
- **fix(portal):** scrolly checkout footer now uses `activeSectionId` for position-based gating so the next-step label and first-step flag track what the user is actually viewing — previously `currentStep` stayed pinned to the initial value and let users skip required sections like buyer info. Also re-runs the scroll-target effect once `isInitialLoading` flips so the section anchor is found after sections mount.

## Test plan
- [ ] On a direct-sale popup, `/portal/api-keys` and `/portal/docs` show the unavailable state instead of the page body.
- [ ] On an events-enabled popup with an accepted application, both pages render normally; `events:write` scope appears with a 30-day expiry note.
- [ ] In scrolly checkout, scrolling past `passes` updates the footer next-step label and prevents skipping `buyer` info.
- [ ] Initial scrolly-checkout load still scrolls to the right anchor after the spinner disappears.