### PR TITLE
fix(portal): satisfy biome — wrap + suppress useExhaustiveDependencies

### DIFF
--- a/portal/src/components/EventsApiAccessGate.tsx
+++ b/portal/src/components/EventsApiAccessGate.tsx
@@ -24,8 +24,7 @@ export function useEventsApiAccess(): { allowed: boolean } {
   const canSeeAttendees = application?.status === "accepted"
 
   return {
-    allowed:
-      !isDirectSale && !isCompanion && eventsEnabled && canSeeAttendees,
+    allowed: !isDirectSale && !isCompanion && eventsEnabled && canSeeAttendees,
   }
 }
 

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -126,6 +126,7 @@ function ScrollyCheckoutFlowInner({
     }
   }, [allSections, activeSection])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: isInitialLoading must trigger a re-run when sections mount in the DOM, even though it's not read inside.
   useEffect(() => {
     const findScrollContainer = (): HTMLElement | null => {
       const anchor = document.getElementById(allSections[0]?.id ?? "passes")
@@ -252,10 +253,6 @@ function ScrollyCheckoutFlowInner({
       releaseScrollTarget()
       scrollToIndexRef.current = null
     }
-    // isInitialLoading gates whether sections are mounted in the DOM. Without
-    // it, the effect runs once during the spinner phase, finds no section
-    // anchor, aborts, and never re-runs after sections appear — leaving
-    // scrollToIndexRef.current null forever.
   }, [allSections, isInitialLoading])
 
   const renderSectionContent = (stepId: string) => {


### PR DESCRIPTION
## Summary
CI hotfix on top of v1.3.1. The Frontend (biome) job failed on the v1.3.1 merge:

- **`EventsApiAccessGate.tsx`**: line wrap difference flagged by biome format.
- **`ScrollyCheckoutFlow.tsx`**: `useExhaustiveDependencies` flagged `isInitialLoading` as an unnecessary dep. The dep is intentional — the effect's body looks up section anchors via the DOM and only finds them after loading flips, so the effect MUST re-run when `isInitialLoading` changes even though it isn't read inside. Suppressed the rule with an inline reason instead of restructuring the effect.

## Test plan
- [ ] CI: `Frontend (biome + tsc)` job goes green.