### PR TITLE
feat(backend): remove API key rate limits on event endpoints

### DIFF
--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -331,24 +331,6 @@ login_rate_limiter = RateLimiter(
     window_seconds=15 * 60,  # 5 requests per 15 minutes
 )
 
-pat_event_write_rate_limiter = RateLimiter(
-    prefix="pat-event-write",
-    max_requests=20,
-    window_seconds=60 * 60,  # 20 mutating event requests per hour
-)
-
-pat_event_create_rate_limiter = RateLimiter(
-    prefix="pat-event-create",
-    max_requests=5,
-    window_seconds=60 * 60,  # 5 event creations per hour
-)
-
-pat_event_create_daily_rate_limiter = RateLimiter(
-    prefix="pat-event-create-daily",
-    max_requests=10,
-    window_seconds=24 * 60 * 60,  # 10 event creations per day
-)
-
 # Auth code store
 auth_code_store = AuthCodeStore(expiration_minutes=15, max_attempts=5)
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -10,11 +10,6 @@ from sqlmodel import Session
 
 from app.core.config import settings
 from app.core.db import engine
-from app.core.redis import (
-    pat_event_create_daily_rate_limiter,
-    pat_event_create_rate_limiter,
-    pat_event_write_rate_limiter,
-)
 
 # Defined here (not in app.api.api_key.schemas) to avoid an import cycle:
 # api_key.router imports from core.dependencies.users which imports from
@@ -91,42 +86,6 @@ def _enforce_api_key_policy(request: Request, payload: TokenPayload) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"API key lacks required scope: {required_scope}",
         )
-
-    identifier = payload.api_key_id or payload.sub
-    if method in {"POST", "PATCH", "PUT", "DELETE"}:
-        is_allowed, _remaining = pat_event_write_rate_limiter.is_allowed(identifier)
-        if not is_allowed:
-            ttl = pat_event_write_rate_limiter.get_ttl(identifier)
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="API key write limit exceeded for event automation.",
-                headers={"Retry-After": str(ttl)},
-            )
-
-    if method == "POST" and path == "/api/v1/events/portal/events":
-        create_identifier = f"create:{identifier}"
-        is_allowed, _remaining = pat_event_create_rate_limiter.is_allowed(
-            create_identifier
-        )
-        if not is_allowed:
-            ttl = pat_event_create_rate_limiter.get_ttl(create_identifier)
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="API key event creation limit exceeded.",
-                headers={"Retry-After": str(ttl)},
-            )
-
-        daily_identifier = f"create-daily:{identifier}"
-        is_allowed, _remaining = pat_event_create_daily_rate_limiter.is_allowed(
-            daily_identifier
-        )
-        if not is_allowed:
-            ttl = pat_event_create_daily_rate_limiter.get_ttl(daily_identifier)
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail="API key daily event creation limit exceeded.",
-                headers={"Retry-After": str(ttl)},
-            )
 
 
 def create_access_token(

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
@@ -172,75 +171,6 @@ class TestApiKeyPolicy:
         assert row is not None
         assert row.status == EventStatus.PENDING_APPROVAL
         assert row.visibility == EventVisibility.UNLISTED
-
-    def test_pat_event_create_rate_limit_returns_429(
-        self,
-        client: TestClient,
-        db: Session,
-        tenant_a: Tenants,
-    ) -> None:
-        popup = _make_popup(db, tenant_a)
-        _set_event_settings(db, tenant_a, popup)
-        human = _make_human(db, tenant_a)
-        raw_key = _make_pat(
-            db,
-            tenant_a,
-            human,
-            scopes=["events:read", "events:write"],
-        )
-
-        with patch(
-            "app.core.security.pat_event_create_rate_limiter.is_allowed",
-            return_value=(False, 0),
-        ), patch(
-            "app.core.security.pat_event_create_rate_limiter.get_ttl",
-            return_value=123,
-        ):
-            resp = client.post(
-                "/api/v1/events/portal/events",
-                headers=_pat_auth(raw_key),
-                json=_event_payload(popup),
-            )
-
-        assert resp.status_code == 429, resp.text
-        assert resp.json()["detail"] == "API key event creation limit exceeded."
-        assert resp.headers["Retry-After"] == "123"
-
-    def test_pat_event_daily_create_rate_limit_returns_429(
-        self,
-        client: TestClient,
-        db: Session,
-        tenant_a: Tenants,
-    ) -> None:
-        popup = _make_popup(db, tenant_a)
-        _set_event_settings(db, tenant_a, popup)
-        human = _make_human(db, tenant_a)
-        raw_key = _make_pat(
-            db,
-            tenant_a,
-            human,
-            scopes=["events:read", "events:write"],
-        )
-
-        with patch(
-            "app.core.security.pat_event_create_daily_rate_limiter.is_allowed",
-            return_value=(False, 0),
-        ), patch(
-            "app.core.security.pat_event_create_daily_rate_limiter.get_ttl",
-            return_value=456,
-        ):
-            resp = client.post(
-                "/api/v1/events/portal/events",
-                headers=_pat_auth(raw_key),
-                json=_event_payload(popup),
-            )
-
-        assert resp.status_code == 429, resp.text
-        assert (
-            resp.json()["detail"]
-            == "API key daily event creation limit exceeded."
-        )
-        assert resp.headers["Retry-After"] == "456"
 
     def test_pat_without_write_scope_cannot_create_event(
         self,


### PR DESCRIPTION
Drops the per-API-key write/create/daily-create rate limiters and their enforcement in _enforce_api_key_policy. API keys now rely on scope checks and human-level revocation/red_flag controls only.
