### PR TITLE
fix: /attendees/my/popup 422 + portal infinite loader on /passes (dev)

### DIFF
--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -41,10 +41,11 @@ def _build_attendee_with_origin(attendee) -> AttendeeWithOriginPublic:
         for ap in attendee.attendee_products
     ]
     origin = "application" if attendee.application_id is not None else "direct_sale"
-    result = AttendeeWithOriginPublic.model_validate(attendee)
-    result.products = products  # type: ignore[assignment]
-    result.origin = origin
-    return result
+    # Exclude `products` from the base validation: Attendees.products is a
+    # property returning Products ORM rows, which would fail to coerce into
+    # AttendeeProductPublic (link-table shape). Override afterwards.
+    base = AttendeePublic.model_validate(attendee).model_dump(exclude={"products"})
+    return AttendeeWithOriginPublic(**base, products=products, origin=origin)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/attendee/test_http_my_attendees_by_popup.py
+++ b/backend/tests/api/attendee/test_http_my_attendees_by_popup.py
@@ -358,6 +358,34 @@ class TestListMyAttendeesByPopupHttp:
         assert str(att_a.id) in ids
         assert body["paging"]["total"] == 1
 
+    def test_attendee_with_purchased_products_serializes(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        # Regression: Attendees.products is a property returning Products
+        # ORM rows. If model_validate reads from `attendee.products`, it tries
+        # to coerce Products into AttendeeProductPublic (link-table shape) and
+        # fails with 422. The builder must read attendee_products instead.
+        popup = _make_popup(db, tenant_a, suffix="b-prods")
+        human = _make_human(db, tenant_a, suffix="b-prods")
+        app = _make_application(db, tenant_a, popup, human)
+        attendee = _make_app_attendee(db, tenant_a, popup, human, app)
+        _add_product_to_attendee(db, attendee, tenant_a, popup)
+
+        response = client.get(
+            f"/api/v1/attendees/my/popup/{popup.id}", headers=_auth(human)
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["paging"]["total"] == 1
+        result = body["results"][0]
+        assert result["id"] == str(attendee.id)
+        assert len(result["products"]) == 1
+        ap = result["products"][0]
+        assert ap["attendee_id"] == str(attendee.id)
+        assert "product_id" in ap
+        assert ap["quantity"] == 1
+
 
 # ---------------------------------------------------------------------------
 # CAP-C: POST /attendees/my/popup/{popup_id}

--- a/portal/src/app/portal/[popupSlug]/passes/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/page.tsx
@@ -1,14 +1,15 @@
 "use client"
 
-import { Ticket } from "lucide-react"
+import { AlertCircle, RefreshCw, Ticket } from "lucide-react"
 import { useParams, useRouter } from "next/navigation"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { resolvePopupCheckoutPolicy } from "@/checkout/popupCheckoutPolicy"
 import type { CompanionParticipation } from "@/client"
 import { CompanionPasses } from "@/components/CompanionPasses"
-import { ButtonAnimated } from "@/components/ui/button"
+import { Button, ButtonAnimated } from "@/components/ui/button"
 import { Loader } from "@/components/ui/Loader"
+import useHumanAttendeesQuery from "@/hooks/useHumanAttendeesQuery"
 import { useHumanPopupAccess } from "@/hooks/useHumanPopupAccess"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCityProvider } from "@/providers/cityProvider"
@@ -31,6 +32,12 @@ export default function HomePasses() {
   const access = useHumanPopupAccess(city?.id ? String(city.id) : null)
   const isDirectSale = policy.saleType === "direct"
 
+  // Subscribe to the same attendees query that PassesProvider drives off so
+  // a backend failure shows an inline error UI instead of an infinite loader.
+  // Disabled for direct-sale popups (matches useResolvedAttendees behavior).
+  const popupId = city?.id ? String(city.id) : null
+  const attendeesQuery = useHumanAttendeesQuery(isDirectSale ? null : popupId)
+
   useEffect(() => {
     // For direct-sale popups we keep /passes accessible even when the human
     // hasn't bought yet — the page renders an empty state with a CTA back to
@@ -47,6 +54,39 @@ export default function HomePasses() {
   }
   if (!isDirectSale && access.state === "denied") {
     return <Loader />
+  }
+
+  // Surface attendees-query failures so the page does not get stuck in a
+  // loader. Direct-sale popups skip this branch (their query is disabled).
+  if (!isDirectSale && attendeesQuery.isError) {
+    return (
+      <div className="w-full md:mt-0 mx-auto items-center max-w-3xl p-6 bg-transparent">
+        <div className="flex flex-col items-center justify-center rounded-2xl border bg-card p-10 text-center shadow-sm">
+          <div className="size-12 rounded-full bg-destructive/15 flex items-center justify-center mb-4">
+            <AlertCircle className="size-6 text-destructive" />
+          </div>
+          <h2 className="text-xl font-semibold">
+            {t("passes.error_title", {
+              defaultValue: "Couldn't load your tickets",
+            })}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground max-w-sm">
+            {t("passes.error_description", {
+              defaultValue:
+                "Something went wrong while fetching your tickets. Please try again.",
+            })}
+          </p>
+          <Button
+            className="mt-6"
+            onClick={() => attendeesQuery.refetch()}
+            disabled={attendeesQuery.isFetching}
+          >
+            <RefreshCw className="size-4" />
+            {t("passes.error_retry", { defaultValue: "Try again" })}
+          </Button>
+        </div>
+      </div>
+    )
   }
 
   // Companions don't have an Application, so PassesProvider data will be empty.


### PR DESCRIPTION
Backport of #77 to `dev`.

Same two commits, cherry-picked cleanly from the main branch (no conflicts).

## Summary

- **Backend**: `_build_attendee_with_origin` no longer calls `model_validate(attendee)` directly; it dumps `AttendeePublic` excluding `products` and rebuilds with the link-table products explicitly. Avoids Pydantic coercing `Attendees.products` (Products ORM rows) into `AttendeeProductPublic`.
- **Portal**: `/passes` subscribes to `useHumanAttendeesQuery` and renders an inline error UI with a retry button when `isError` fires, instead of staying in `<Loader />` forever.

See #77 for full context, root cause walkthrough, and modeling note.

## Test plan

- [x] `uv run ruff check .` (backend) — clean
- [x] `uv run pytest -q` (backend) — 455 passed, 1 skipped (includes the new regression test)
- [x] `pnpm --filter portal exec biome ci .` — clean
- [x] `pnpm --filter backoffice exec biome ci .` — clean
- [x] `pnpm --filter portal exec tsc --noEmit` — clean
- [x] `pnpm --filter backoffice exec tsc -p tsconfig.build.json --noEmit` — clean