### PR TITLE
feat(events): custom location + Meeting option for venue-less events

### DIFF
--- a/backend/app/alembic/versions/0044_event_custom_location.py
+++ b/backend/app/alembic/versions/0044_event_custom_location.py
@@ -1,0 +1,35 @@
+"""Add custom_location_name + custom_location_url to events.
+
+Lets users attach an ad-hoc location (place name + maps URL) to an event
+without needing an admin to provision an EventVenues row first. The pair
+is XOR with ``venue_id`` and is enforced at the schema layer.
+
+Revision ID: 0044_event_custom_location
+Revises: 0043_tenant_scoped_popup_slug
+Create Date: 2026-05-06
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0044_event_custom_location"
+down_revision: str | None = "0043_tenant_scoped_popup_slug"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("custom_location_name", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "events",
+        sa.Column("custom_location_url", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "custom_location_url")
+    op.drop_column("events", "custom_location_name")

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -225,6 +225,8 @@ def _to_public(
     ``venue_map``/``track_map`` let callers pre-fetch venues/tracks in a
     single query and avoid N+1 when serializing a list.
     """
+    # ``custom_location_name``/``custom_location_url`` live on EventBase and
+    # are picked up automatically by ``model_validate`` — no extra plumbing.
     data = EventPublic.model_validate(event)
     occ = event.__dict__.get("_occurrence_id") if hasattr(event, "__dict__") else None
     updates: dict = {}
@@ -525,6 +527,14 @@ async def create_event(
 
     event_data = event_in.model_dump()
     event_data.pop("recurrence", None)
+    # Defense-in-depth: the schema validator already rejects venue+custom
+    # collisions, but if either side is set we still null out the other so
+    # downstream code never sees both populated.
+    if event_data.get("custom_location_name"):
+        event_data["venue_id"] = None
+    elif event_data.get("venue_id") is not None:
+        event_data["custom_location_name"] = None
+        event_data["custom_location_url"] = None
     event_data["rrule"] = rrule_str
     event_data["tenant_id"] = tenant_id
     event_data["owner_id"] = current_user.id
@@ -533,6 +543,9 @@ async def create_event(
     # but if the venue requires approval OR the requested capacity exceeds
     # the venue's, we force the event into pending_approval and notify so
     # the decision stays auditable even for admin-created events.
+    # Custom-location events skip this venue-based gate entirely (no venue,
+    # no booking_mode rule); the popup-level events_require_approval flag
+    # still applies further below for portal events.
     requires_approval = False
     approval_reason = ""
     if event_in.venue_id is not None:
@@ -610,12 +623,26 @@ async def update_event(
             exclude_event_id=event.id,
         )
 
+    # Transition: switching to a venue clears any prior custom location, and
+    # switching to a custom location clears the prior venue. Rebuild via the
+    # dump dict so the cleared fields are tracked as set (CRUD.update relies
+    # on ``exclude_unset=True``).
+    patch_dict = event_in.model_dump(exclude_unset=True)
+    if patch_dict.get("venue_id") is not None:
+        patch_dict["custom_location_name"] = None
+        patch_dict["custom_location_url"] = None
+    elif patch_dict.get("custom_location_name") is not None:
+        patch_dict["venue_id"] = None
+    event_in = EventUpdate(**patch_dict)
+
     before = {
         "title": event.title,
         "start_time": event.start_time,
         "end_time": event.end_time,
         "venue_id": event.venue_id,
         "content": event.content,
+        "custom_location_name": event.custom_location_name,
+        "custom_location_url": event.custom_location_url,
     }
     updated = crud.events_crud.update(db, event, event_in)
 
@@ -1149,9 +1176,7 @@ async def _send_event_approval_email(
         from app.api.tenant.utils import get_portal_url
 
         portal_base = get_portal_url(popup.tenant)
-        event_url = (
-            f"{portal_base.rstrip('/')}/portal/{popup_slug}/events/{event.id}"
-        )
+        event_url = f"{portal_base.rstrip('/')}/portal/{popup_slug}/events/{event.id}"
 
     when = event.start_time.strftime("%b %d, %Y at %H:%M") if event.start_time else ""
 
@@ -1701,6 +1726,14 @@ async def create_portal_event(
 
     event_data = event_in.model_dump()
     event_data.pop("recurrence", None)
+    # Defense-in-depth: the schema validator already rejects venue+custom
+    # collisions, but if either side is set we still null out the other so
+    # downstream code never sees both populated.
+    if event_data.get("custom_location_name"):
+        event_data["venue_id"] = None
+    elif event_data.get("venue_id") is not None:
+        event_data["custom_location_name"] = None
+        event_data["custom_location_url"] = None
     event_data["rrule"] = rrule_str
     event_data["tenant_id"] = current_human.tenant_id
     event_data["owner_id"] = current_human.id
@@ -1709,6 +1742,8 @@ async def create_portal_event(
     #  1. Popup-level setting requires admin approval for human-created events.
     #  2. Venue is bookable only with admin approval (booking_mode).
     #  3. User requested ``max_participant`` larger than the venue capacity.
+    # Custom-location events skip (2) and (3) (no venue), but (1) still
+    # applies so admins keep moderation control over off-site portal events.
     requires_approval = False
     approval_reason = ""
     if settings and settings.events_require_approval:
@@ -1800,12 +1835,25 @@ async def update_portal_event(
             exclude_event_id=event.id,
         )
 
+    # Transition: switching to a venue clears any prior custom location, and
+    # switching to a custom location clears the prior venue. Rebuild via the
+    # dump dict so the cleared fields are tracked as set.
+    patch_dict = event_in.model_dump(exclude_unset=True)
+    if patch_dict.get("venue_id") is not None:
+        patch_dict["custom_location_name"] = None
+        patch_dict["custom_location_url"] = None
+    elif patch_dict.get("custom_location_name") is not None:
+        patch_dict["venue_id"] = None
+    event_in = EventUpdate(**patch_dict)
+
     before = {
         "title": event.title,
         "start_time": event.start_time,
         "end_time": event.end_time,
         "venue_id": event.venue_id,
         "content": event.content,
+        "custom_location_name": event.custom_location_name,
+        "custom_location_url": event.custom_location_url,
     }
     updated = crud.events_crud.update(db, event, event_in)
     if _event_calendar_fields_changed(before, updated):

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -77,6 +77,11 @@ class EventBase(SQLModel):
         sa_column=Column(JSONB, nullable=False, server_default="[]"),
     )
     venue_id: uuid.UUID | None = Field(default=None, foreign_key="event_venues.id")
+    # Custom location (used when no venue is selected). The pair is XOR with
+    # ``venue_id`` and is validated as all-or-nothing on the create/update
+    # schemas; either both fields are set or both must be null.
+    custom_location_name: str | None = Field(default=None, max_length=255)
+    custom_location_url: str | None = Field(default=None, sa_type=Text())
     track_id: uuid.UUID | None = Field(
         default=None, foreign_key="tracks.id", index=True
     )
@@ -113,6 +118,30 @@ class EventBase(SQLModel):
         default_factory=datetime.utcnow,
         sa_type=DateTime(timezone=True),
     )
+
+
+def _enforce_custom_location_xor(
+    *,
+    venue_id: uuid.UUID | None,
+    name: str | None,
+    url: str | None,
+) -> None:
+    """Validator helper for ``EventCreate``/``EventUpdate``.
+
+    Rules (all-or-nothing pairing, mutually exclusive with ``venue_id``):
+      - If either custom field is set, both must be set.
+      - If a venue is set, neither custom field may be set.
+    A venue-less, location-less event is allowed (online-only).
+    """
+    has_name = bool(name and name.strip())
+    has_url = bool(url and url.strip())
+    if has_name != has_url:
+        raise ValueError(
+            "custom_location_name and custom_location_url must both be "
+            "provided together, or both omitted."
+        )
+    if venue_id is not None and (has_name or has_url):
+        raise ValueError("venue_id and custom_location_* are mutually exclusive.")
 
 
 class EventPublic(EventBase):
@@ -159,6 +188,8 @@ class EventCreate(BaseModel):
     max_participant: int | None = None
     tags: list[str] = []
     venue_id: uuid.UUID | None = None
+    custom_location_name: str | None = None
+    custom_location_url: str | None = None
     track_id: uuid.UUID | None = None
     visibility: EventVisibility = EventVisibility.PUBLIC
     require_approval: bool = False
@@ -168,6 +199,15 @@ class EventCreate(BaseModel):
     recurrence: RecurrenceRule | None = None
 
     model_config = ConfigDict(str_strip_whitespace=True)
+
+    @model_validator(mode="after")
+    def _validate_custom_location(self) -> "EventCreate":
+        _enforce_custom_location_xor(
+            venue_id=self.venue_id,
+            name=self.custom_location_name,
+            url=self.custom_location_url,
+        )
+        return self
 
 
 class EventUpdate(BaseModel):
@@ -183,12 +223,32 @@ class EventUpdate(BaseModel):
     max_participant: int | None = None
     tags: list[str] | None = None
     venue_id: uuid.UUID | None = None
+    custom_location_name: str | None = None
+    custom_location_url: str | None = None
     track_id: uuid.UUID | None = None
     visibility: EventVisibility | None = None
     require_approval: bool | None = None
     kind: str | None = None
     status: EventStatus | None = None
     highlighted: bool | None = None
+
+    @model_validator(mode="after")
+    def _validate_custom_location(self) -> "EventUpdate":
+        # Only validate when at least one of the relevant fields is being
+        # touched in this patch — otherwise an unrelated PATCH (e.g.
+        # ``{"title": "..."}``) would reject the update.
+        if (
+            self.venue_id is None
+            and self.custom_location_name is None
+            and self.custom_location_url is None
+        ):
+            return self
+        _enforce_custom_location_xor(
+            venue_id=self.venue_id,
+            name=self.custom_location_name,
+            url=self.custom_location_url,
+        )
+        return self
 
 
 class RecurrenceUpdate(BaseModel):

--- a/backend/app/services/event_itip.py
+++ b/backend/app/services/event_itip.py
@@ -158,9 +158,7 @@ async def send_event_itip(
         from app.api.tenant.utils import get_portal_url
 
         portal_base = get_portal_url(popup.tenant)
-        event_url = (
-            f"{portal_base.rstrip('/')}/portal/{popup_slug}/events/{event.id}"
-        )
+        event_url = f"{portal_base.rstrip('/')}/portal/{popup_slug}/events/{event.id}"
 
     service = get_email_service()
     from_address = popup.tenant.sender_email if popup and popup.tenant else None
@@ -385,7 +383,14 @@ def calendar_fields_changed(before: dict, after) -> bool:
     ``before`` is a snapshot dict captured before the update; ``after`` is
     the refreshed Events row. We bump SEQUENCE when any of these differ.
     """
-    fields = ("title", "start_time", "end_time", "venue_id")
+    fields = (
+        "title",
+        "start_time",
+        "end_time",
+        "venue_id",
+        "custom_location_name",
+        "custom_location_url",
+    )
     for f in fields:
         if before.get(f) != getattr(after, f, None):
             return True

--- a/backend/app/services/ical.py
+++ b/backend/app/services/ical.py
@@ -113,6 +113,14 @@ def build_event_ics(
             location_bits.append(venue.title)
         if getattr(venue, "location", None):
             location_bits.append(venue.location)
+    elif getattr(event, "custom_location_name", None):
+        # No venue but the event has an ad-hoc custom location — use the
+        # name (and the maps URL when present, which the schema XOR
+        # guarantees) so calendar clients show something useful.
+        location_bits.append(event.custom_location_name)
+        custom_url = getattr(event, "custom_location_url", None)
+        if custom_url:
+            location_bits.append(custom_url)
     location = _escape(" — ".join(location_bits)) if location_bits else ""
 
     if occurrence_start is not None:

--- a/backend/tests/test_event_custom_location.py
+++ b/backend/tests/test_event_custom_location.py
@@ -1,0 +1,471 @@
+"""Tests for the custom-location feature on events.
+
+Covers:
+- Schema-level XOR validation (venue vs custom location, partial pairs).
+- Create flow: persistence, popup-level approval gate still fires, venue
+  approval gate skipped.
+- Update flow: switching directions clears the dropped side, custom-only
+  changes bump ``ical_sequence``.
+- ICS rendering for custom-location events.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.event.models import Events
+from app.api.event.schemas import (
+    EventCreate,
+    EventStatus,
+    EventUpdate,
+    EventVisibility,
+)
+from app.api.event_settings.models import EventSettings
+from app.api.event_venue.models import EventVenues
+from app.api.event_venue.schemas import VenueBookingMode, VenueStatus
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+from app.services.ical import build_event_ics
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _human_auth(human: Humans) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {create_access_token(subject=human.id, token_type='human')}"
+    }
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        name=f"CustomLoc {uuid.uuid4().hex[:6]}",
+        slug=f"customloc-{uuid.uuid4().hex[:10]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    h = Humans(
+        tenant_id=tenant.id,
+        email=f"customloc-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Test",
+        last_name="Human",
+    )
+    db.add(h)
+    db.commit()
+    db.refresh(h)
+    return h
+
+
+def _make_venue(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    booking_mode: VenueBookingMode = VenueBookingMode.FREE,
+) -> EventVenues:
+    v = EventVenues(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        owner_id=uuid.uuid4(),
+        title=f"Venue {uuid.uuid4().hex[:4]}",
+        status=VenueStatus.ACTIVE,
+        booking_mode=booking_mode,
+    )
+    db.add(v)
+    db.commit()
+    db.refresh(v)
+    return v
+
+
+def _set_settings(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    events_require_approval: bool = False,
+) -> EventSettings:
+    from sqlmodel import select
+
+    existing = db.exec(
+        select(EventSettings).where(EventSettings.popup_id == popup.id)
+    ).first()
+    if existing:
+        db.delete(existing)
+        db.commit()
+    row = EventSettings(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        events_require_approval=events_require_approval,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _payload(
+    popup: Popups,
+    *,
+    venue_id: uuid.UUID | None = None,
+    custom_location_name: str | None = None,
+    custom_location_url: str | None = None,
+    status: EventStatus = EventStatus.PUBLISHED,
+    visibility: EventVisibility = EventVisibility.PUBLIC,
+    max_participant: int | None = None,
+) -> dict:
+    body: dict = {
+        "popup_id": str(popup.id),
+        "title": "Custom Location Event",
+        "start_time": "2026-05-05T14:00:00+00:00",
+        "end_time": "2026-05-05T15:00:00+00:00",
+        "timezone": "UTC",
+        "visibility": visibility.value,
+        "status": status.value,
+    }
+    if venue_id is not None:
+        body["venue_id"] = str(venue_id)
+    if custom_location_name is not None:
+        body["custom_location_name"] = custom_location_name
+    if custom_location_url is not None:
+        body["custom_location_url"] = custom_location_url
+    if max_participant is not None:
+        body["max_participant"] = max_participant
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Schema-level validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaXOR:
+    def test_create_rejects_both_venue_and_custom(self) -> None:
+        with pytest.raises(ValueError):
+            EventCreate(
+                popup_id=uuid.uuid4(),
+                title="x",
+                start_time=datetime(2026, 5, 5, 14, tzinfo=UTC),
+                end_time=datetime(2026, 5, 5, 15, tzinfo=UTC),
+                venue_id=uuid.uuid4(),
+                custom_location_name="My place",
+                custom_location_url="https://maps.google.com/?q=x",
+            )
+
+    def test_create_rejects_partial_custom(self) -> None:
+        with pytest.raises(ValueError):
+            EventCreate(
+                popup_id=uuid.uuid4(),
+                title="x",
+                start_time=datetime(2026, 5, 5, 14, tzinfo=UTC),
+                end_time=datetime(2026, 5, 5, 15, tzinfo=UTC),
+                custom_location_name="My place",
+            )
+        with pytest.raises(ValueError):
+            EventCreate(
+                popup_id=uuid.uuid4(),
+                title="x",
+                start_time=datetime(2026, 5, 5, 14, tzinfo=UTC),
+                end_time=datetime(2026, 5, 5, 15, tzinfo=UTC),
+                custom_location_url="https://maps.google.com/?q=x",
+            )
+
+    def test_create_allows_neither(self) -> None:
+        EventCreate(
+            popup_id=uuid.uuid4(),
+            title="x",
+            start_time=datetime(2026, 5, 5, 14, tzinfo=UTC),
+            end_time=datetime(2026, 5, 5, 15, tzinfo=UTC),
+        )
+
+    def test_update_partial_unrelated_patch_ignored(self) -> None:
+        # A patch that doesn't touch venue/custom must not raise.
+        EventUpdate(title="renamed")
+
+    def test_update_rejects_partial_custom(self) -> None:
+        with pytest.raises(ValueError):
+            EventUpdate(custom_location_name="just the name")
+
+
+# ---------------------------------------------------------------------------
+# Create flow (HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCustomLocation:
+    def test_create_event_with_custom_location_persists_fields(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(
+                popup,
+                custom_location_name="Mi casa",
+                custom_location_url="https://maps.app.goo.gl/abc",
+                status=EventStatus.PUBLISHED,
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["custom_location_name"] == "Mi casa"
+        assert body["custom_location_url"] == "https://maps.app.goo.gl/abc"
+        assert body["venue_id"] is None
+        # Status not auto-forced (no popup approval flag, no venue approval).
+        assert body["status"] == EventStatus.PUBLISHED.value
+
+    def test_create_event_rejects_both_venue_and_custom_location(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        venue = _make_venue(db, tenant_a, popup)
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(
+                popup,
+                venue_id=venue.id,
+                custom_location_name="Mi casa",
+                custom_location_url="https://maps.app.goo.gl/abc",
+            ),
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_create_event_rejects_partial_custom_location(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        # Name-only.
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(popup, custom_location_name="Mi casa"),
+        )
+        assert resp.status_code == 422, resp.text
+        # URL-only.
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(popup, custom_location_url="https://maps.app.goo.gl/abc"),
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_create_portal_event_with_popup_approval_required(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _set_settings(db, tenant_a, popup, events_require_approval=True)
+        human = _make_human(db, tenant_a)
+        resp = client.post(
+            "/api/v1/events/portal/events",
+            headers=_human_auth(human),
+            json=_payload(
+                popup,
+                custom_location_name="Mi casa",
+                custom_location_url="https://maps.app.goo.gl/abc",
+                status=EventStatus.PUBLISHED,
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["status"] == EventStatus.PENDING_APPROVAL.value
+        assert body["visibility"] == EventVisibility.UNLISTED.value
+        assert body["custom_location_name"] == "Mi casa"
+
+    def test_create_portal_event_with_custom_location_skips_venue_approval_gate(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _set_settings(db, tenant_a, popup, events_require_approval=False)
+        # An approval-required venue exists in the popup, but this event uses
+        # a custom location and should bypass it.
+        _make_venue(
+            db, tenant_a, popup, booking_mode=VenueBookingMode.APPROVAL_REQUIRED
+        )
+        human = _make_human(db, tenant_a)
+        resp = client.post(
+            "/api/v1/events/portal/events",
+            headers=_human_auth(human),
+            json=_payload(
+                popup,
+                custom_location_name="Mi casa",
+                custom_location_url="https://maps.app.goo.gl/abc",
+                status=EventStatus.PUBLISHED,
+            ),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["status"] == EventStatus.PUBLISHED.value
+        assert body["visibility"] == EventVisibility.PUBLIC.value
+
+
+# ---------------------------------------------------------------------------
+# Update flow (HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateTransitions:
+    def test_switching_venue_to_custom_clears_venue_id(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        venue = _make_venue(db, tenant_a, popup)
+        create = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(popup, venue_id=venue.id, status=EventStatus.PUBLISHED),
+        )
+        assert create.status_code == 201, create.text
+        event_id = create.json()["id"]
+
+        patch = client.patch(
+            f"/api/v1/events/{event_id}",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "custom_location_name": "Mi casa",
+                "custom_location_url": "https://maps.app.goo.gl/abc",
+            },
+        )
+        assert patch.status_code == 200, patch.text
+        body = patch.json()
+        assert body["venue_id"] is None
+        assert body["custom_location_name"] == "Mi casa"
+        assert body["custom_location_url"] == "https://maps.app.goo.gl/abc"
+
+    def test_switching_custom_to_venue_clears_custom_fields(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        venue = _make_venue(db, tenant_a, popup)
+        create = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(
+                popup,
+                custom_location_name="Mi casa",
+                custom_location_url="https://maps.app.goo.gl/abc",
+                status=EventStatus.PUBLISHED,
+            ),
+        )
+        assert create.status_code == 201, create.text
+        event_id = create.json()["id"]
+
+        patch = client.patch(
+            f"/api/v1/events/{event_id}",
+            headers=_auth(admin_token_tenant_a),
+            json={"venue_id": str(venue.id)},
+        )
+        assert patch.status_code == 200, patch.text
+        body = patch.json()
+        assert body["venue_id"] == str(venue.id)
+        assert body["custom_location_name"] is None
+        assert body["custom_location_url"] is None
+
+    def test_changing_custom_location_bumps_ical_sequence(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        create = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json=_payload(
+                popup,
+                custom_location_name="Mi casa",
+                custom_location_url="https://maps.app.goo.gl/abc",
+                status=EventStatus.PUBLISHED,
+            ),
+        )
+        assert create.status_code == 201, create.text
+        event_id = create.json()["id"]
+        before_seq = create.json()["ical_sequence"]
+
+        # Patch only the custom location name; nothing else changes.
+        send_mock = AsyncMock()
+        with patch("app.services.event_itip.send_event_itip", new=send_mock):
+            patch_resp = client.patch(
+                f"/api/v1/events/{event_id}",
+                headers=_auth(admin_token_tenant_a),
+                json={
+                    "custom_location_name": "Mi nueva casa",
+                    "custom_location_url": "https://maps.app.goo.gl/xyz",
+                },
+            )
+        assert patch_resp.status_code == 200, patch_resp.text
+        body = patch_resp.json()
+        assert body["ical_sequence"] == before_seq + 1
+
+
+# ---------------------------------------------------------------------------
+# ICS rendering
+# ---------------------------------------------------------------------------
+
+
+class TestIcsRendering:
+    def test_ics_export_uses_custom_location_for_LOCATION_field(self) -> None:
+        start = datetime(2026, 5, 5, 14, tzinfo=UTC)
+        event = Events(
+            tenant_id=uuid.uuid4(),
+            popup_id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            title="My Off-site Event",
+            start_time=start,
+            end_time=start + timedelta(hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.PUBLIC,
+            status=EventStatus.PUBLISHED,
+            custom_location_name="Mi casa",
+            custom_location_url="https://maps.app.goo.gl/abc",
+        )
+
+        ics = build_event_ics(event, recipient_email="alice@example.com")
+
+        assert "LOCATION:Mi casa — https://maps.app.goo.gl/abc" in ics

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -4147,6 +4147,28 @@ export const EventCreateSchema = {
             ],
             title: 'Venue Id'
         },
+        custom_location_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Name'
+        },
+        custom_location_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Url'
+        },
         track_id: {
             anyOf: [
                 {
@@ -4600,6 +4622,29 @@ export const EventPublicSchema = {
                 }
             ],
             title: 'Venue Id'
+        },
+        custom_location_name: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Name'
+        },
+        custom_location_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Url'
         },
         track_id: {
             anyOf: [
@@ -5167,6 +5212,28 @@ export const EventUpdateSchema = {
                 }
             ],
             title: 'Venue Id'
+        },
+        custom_location_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Name'
+        },
+        custom_location_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Url'
         },
         track_id: {
             anyOf: [
@@ -9316,6 +9383,11 @@ export const PopupAdminSchema = {
             title: 'Tier Progression Enabled',
             default: false
         },
+        events_enabled: {
+            type: 'boolean',
+            title: 'Events Enabled',
+            default: true
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -9676,6 +9748,11 @@ export const PopupCreateSchema = {
             type: 'boolean',
             title: 'Tier Progression Enabled',
             default: false
+        },
+        events_enabled: {
+            type: 'boolean',
+            title: 'Events Enabled',
+            default: true
         }
     },
     type: 'object',
@@ -9957,6 +10034,11 @@ export const PopupPublicSchema = {
             type: 'boolean',
             title: 'Tier Progression Enabled',
             default: false
+        },
+        events_enabled: {
+            type: 'boolean',
+            title: 'Events Enabled',
+            default: true
         }
     },
     type: 'object',
@@ -10493,6 +10575,17 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Tier Progression Enabled'
+        },
+        events_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Events Enabled'
         }
     },
     type: 'object',

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -1253,6 +1253,7 @@ export class CheckoutService {
      * Rate-limited 120/min/IP.
      * @param data The data for the request.
      * @param data.slug
+     * @param data.xTenantId
      * @returns CheckoutRuntimeResponse Successful Response
      * @throws ApiError
      */
@@ -1262,6 +1263,9 @@ export class CheckoutService {
             url: '/api/v1/checkout/{slug}/runtime',
             path: {
                 slug: data.slug
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
             },
             errors: {
                 422: 'Validation Error'
@@ -1275,6 +1279,7 @@ export class CheckoutService {
      * @param data The data for the request.
      * @param data.slug
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns OpenTicketingPurchaseResponse Successful Response
      * @throws ApiError
      */
@@ -1284,6 +1289,9 @@ export class CheckoutService {
             url: '/api/v1/checkout/{slug}/purchase',
             path: {
                 slug: data.slug
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
             },
             body: data.requestBody,
             mediaType: 'application/json',
@@ -1304,6 +1312,7 @@ export class CouponsService {
      * Rate-limited 30/min/IP.
      * @param data The data for the request.
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns CouponValidatePublicResponse Successful Response
      * @throws ApiError
      */
@@ -1311,6 +1320,9 @@ export class CouponsService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/coupons/validate-public',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -923,6 +923,8 @@ export type EventCreate = {
     max_participant?: (number | null);
     tags?: Array<(string)>;
     venue_id?: (string | null);
+    custom_location_name?: (string | null);
+    custom_location_url?: (string | null);
     track_id?: (string | null);
     visibility?: EventVisibility;
     require_approval?: boolean;
@@ -1012,6 +1014,8 @@ export type EventPublic = {
     max_participant?: (number | null);
     tags?: Array<(string)>;
     venue_id?: (string | null);
+    custom_location_name?: (string | null);
+    custom_location_url?: (string | null);
     track_id?: (string | null);
     visibility?: EventVisibility;
     require_approval?: boolean;
@@ -1101,6 +1105,8 @@ export type EventUpdate = {
     max_participant?: (number | null);
     tags?: (Array<(string)> | null);
     venue_id?: (string | null);
+    custom_location_name?: (string | null);
+    custom_location_url?: (string | null);
     track_id?: (string | null);
     visibility?: (EventVisibility | null);
     require_approval?: (boolean | null);
@@ -3261,6 +3267,7 @@ export type CartsDeleteMyCartResponse = (void);
 
 export type CheckoutGetRuntimeData = {
     slug: string;
+    xTenantId?: (string | null);
 };
 
 export type CheckoutGetRuntimeResponse = (CheckoutRuntimeResponse);
@@ -3268,12 +3275,14 @@ export type CheckoutGetRuntimeResponse = (CheckoutRuntimeResponse);
 export type CheckoutPurchaseOpenTicketingData = {
     requestBody: OpenTicketingPurchaseCreate;
     slug: string;
+    xTenantId?: (string | null);
 };
 
 export type CheckoutPurchaseOpenTicketingResponse = (OpenTicketingPurchaseResponse);
 
 export type CouponsValidateCouponPublicData = {
     requestBody: CouponValidatePublicRequest;
+    xTenantId?: (string | null);
 };
 
 export type CouponsValidateCouponPublicResponse = (CouponValidatePublicResponse);

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -9,7 +9,7 @@ import {
 import { useForm, useStore } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
-import { Trash2 } from "lucide-react"
+import { Home, Trash2, Video } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import {
   type EventCreate,
@@ -36,7 +36,10 @@ import { LoadingButton } from "@/components/ui/loading-button"
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
@@ -220,6 +223,12 @@ export function EventForm({
   const [durationValue, setDurationValue] =
     useState<number>(initialDurationValue)
   const [venueDialogOpen, setVenueDialogOpen] = useState(false)
+  // True when the user picked the "Custom location" sentinel in the venue
+  // dropdown — the event has no Venue row, but stores an ad-hoc place name
+  // and Maps URL on the event itself.
+  const [customSelected, setCustomSelected] = useState<boolean>(
+    Boolean(defaultValues?.custom_location_name),
+  )
   const durationMinutes = Math.max(
     1,
     Math.round(durationUnit === "hours" ? durationValue * 60 : durationValue),
@@ -239,6 +248,8 @@ export function EventForm({
       meeting_url: defaultValues?.meeting_url ?? "",
       max_participant: defaultValues?.max_participant?.toString() ?? "",
       venue_id: defaultValues?.venue_id ?? initialVenueId ?? "",
+      custom_location_name: defaultValues?.custom_location_name ?? "",
+      custom_location_url: defaultValues?.custom_location_url ?? "",
       track_id: defaultValues?.track_id ?? "",
       visibility: (defaultValues?.visibility ?? "public") as
         | "public"
@@ -272,8 +283,29 @@ export function EventForm({
       const startDate = localTzNaiveToUtc(value.start_time, value.timezone)
       const endDate = new Date(startDate.getTime() + durationMinutes * 60_000)
 
-      // meeting_url only applies when there's no physical venue.
-      const meetingUrl = value.venue_id ? null : value.meeting_url || null
+      // meeting_url only applies for online-only Meeting events (no venue,
+      // no custom physical location). When the Meeting option is selected
+      // it is required — there's nowhere else for attendees to go.
+      const isMeeting = !value.venue_id && !customSelected
+      const meetingUrl = isMeeting ? value.meeting_url.trim() || null : null
+      if (isMeeting && !meetingUrl) {
+        showErrorToast("Meeting URL is required for Meeting events.")
+        return
+      }
+
+      const customName = customSelected
+        ? value.custom_location_name.trim() || null
+        : null
+      const customUrl = customSelected
+        ? value.custom_location_url.trim() || null
+        : null
+      if (customSelected && (!customName || !customUrl)) {
+        showErrorToast(
+          "Provide both a name and a Google Maps link for the custom location.",
+        )
+        return
+      }
+      const venueId = customSelected ? null : value.venue_id || null
 
       if (isEdit) {
         const payload: EventUpdate = {
@@ -288,7 +320,9 @@ export function EventForm({
           max_participant: value.max_participant
             ? parseInt(value.max_participant, 10)
             : null,
-          venue_id: value.venue_id || null,
+          venue_id: venueId,
+          custom_location_name: customName,
+          custom_location_url: customUrl,
           track_id: value.track_id || null,
           visibility: value.visibility,
           require_approval: value.require_approval,
@@ -311,7 +345,9 @@ export function EventForm({
           max_participant: value.max_participant
             ? parseInt(value.max_participant, 10)
             : null,
-          venue_id: value.venue_id || null,
+          venue_id: venueId,
+          custom_location_name: customName,
+          custom_location_url: customUrl,
           track_id: value.track_id || null,
           visibility: value.visibility,
           require_approval: value.require_approval,
@@ -904,28 +940,106 @@ export function EventForm({
           <form.Field name="venue_id">
             {(field) => (
               <Select
-                value={field.state.value || "__none__"}
-                onValueChange={(v) =>
-                  field.handleChange(v === "__none__" ? "" : v)
+                value={
+                  customSelected
+                    ? "__custom__"
+                    : field.state.value || "__none__"
                 }
+                onValueChange={(v) => {
+                  if (v === "__custom__") {
+                    setCustomSelected(true)
+                    field.handleChange("")
+                  } else if (v === "__none__") {
+                    setCustomSelected(false)
+                    field.handleChange("")
+                  } else {
+                    setCustomSelected(false)
+                    field.handleChange(v)
+                  }
+                }}
                 disabled={readOnly}
               >
                 <SelectTrigger className="w-[240px]">
-                  <SelectValue placeholder="No venue" />
+                  <SelectValue placeholder="Meeting" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="__none__">No venue</SelectItem>
-                  {venues?.results.map((v) => (
-                    <SelectItem key={v.id} value={v.id}>
-                      {v.title || "Untitled venue"}
-                      {v.capacity ? ` (cap. ${v.capacity})` : ""}
-                    </SelectItem>
-                  ))}
+                  <SelectItem
+                    value="__none__"
+                    className="bg-muted/40 text-foreground data-[highlighted]:bg-muted"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <Video className="h-3.5 w-3.5 text-muted-foreground" />
+                      Meeting
+                    </span>
+                  </SelectItem>
+                  <SelectItem
+                    value="__custom__"
+                    className="bg-muted/40 text-foreground data-[highlighted]:bg-muted"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <Home className="h-3.5 w-3.5 text-muted-foreground" />
+                      Custom location
+                    </span>
+                  </SelectItem>
+                  {venues?.results && venues.results.length > 0 && (
+                    <>
+                      <SelectSeparator />
+                      <SelectGroup>
+                        <SelectLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                          Venues
+                        </SelectLabel>
+                        {venues.results.map((v) => (
+                          <SelectItem key={v.id} value={v.id}>
+                            {v.title || "Untitled venue"}
+                            {v.capacity ? ` (cap. ${v.capacity})` : ""}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </>
+                  )}
                 </SelectContent>
               </Select>
             )}
           </form.Field>
         </InlineRow>
+
+        {customSelected && (
+          <>
+            <InlineRow
+              label="Place name"
+              description="Shown to attendees in place of a venue card."
+            >
+              <form.Field name="custom_location_name">
+                {(field) => (
+                  <Input
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    placeholder="My apartment"
+                    disabled={readOnly}
+                    className="w-[280px]"
+                  />
+                )}
+              </form.Field>
+            </InlineRow>
+            <InlineRow
+              label="Google Maps link"
+              description="Any well-formed http(s) URL — Google Maps, Apple Maps, OSM…"
+            >
+              <form.Field name="custom_location_url">
+                {(field) => (
+                  <Input
+                    type="url"
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    placeholder="https://maps.google.com/..."
+                    disabled={readOnly}
+                    className="w-[280px]"
+                  />
+                )}
+              </form.Field>
+            </InlineRow>
+          </>
+        )}
 
         {selectedVenue && (
           <InlineRow
@@ -951,14 +1065,16 @@ export function EventForm({
           </div>
         )}
 
-        {!venueIdValue && (
+        {!venueIdValue && !customSelected && (
           <InlineRow
             label="Meeting URL"
-            description="Virtual meeting link for this event"
+            description="Virtual meeting link — required for Meeting events."
           >
             <form.Field name="meeting_url">
               {(field) => (
                 <Input
+                  type="url"
+                  required
                   value={field.state.value}
                   onChange={(e) => field.handleChange(e.target.value)}
                   placeholder="https://meet.google.com/..."

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -497,11 +497,22 @@ function buildEventColumns(
       cell: ({ row }) => {
         const venueId = row.original.venue_id
         const label = venueId ? venueNameById.get(venueId) : null
-        return (
-          <span className="text-muted-foreground truncate max-w-[200px] block">
-            {label ?? "—"}
-          </span>
-        )
+        const customName = row.original.custom_location_name
+        if (label) {
+          return (
+            <span className="text-muted-foreground truncate max-w-[200px] block">
+              {label}
+            </span>
+          )
+        }
+        if (!venueId && customName) {
+          return (
+            <span className="text-muted-foreground/80 truncate max-w-[200px] block">
+              ⌂ {customName}
+            </span>
+          )
+        }
+        return <span className="text-muted-foreground">—</span>
       },
     },
     {

--- a/portal/next-env.d.ts
+++ b/portal/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
@@ -167,12 +167,20 @@ export function EditEventForm({
 
   const venueMaxCapacity = selectedVenue?.capacity ?? null
   const venueDisabled = selectedVenue?.booking_mode === "unbookable"
+  const isCustomLocation = form.venueId === "__custom__"
+  const isMeeting = !form.venueId && !isCustomLocation
+  const customLocationMissing =
+    isCustomLocation &&
+    (!form.customLocationName.trim() || !form.customLocationUrl.trim())
+  const meetingUrlMissing = isMeeting && !form.meetingUrl.trim()
 
   const canSubmit =
     !!form.title.trim() &&
     !!startIso &&
     !!endIso &&
-    (!form.venueId || withinOpenHours) &&
+    (!form.venueId || isCustomLocation || withinOpenHours) &&
+    !customLocationMissing &&
+    !meetingUrlMissing &&
     availability !== "conflict" &&
     availability !== "checking" &&
     !updateMutation.isPending
@@ -203,7 +211,16 @@ export function EditEventForm({
           selectedVenue={selectedVenue}
           selectedDateIsClosed={selectedDateIsClosed}
           selectedVenueLabel={event.venue_title ?? undefined}
+          customLocationName={form.customLocationName}
+          onCustomLocationNameChange={form.setCustomLocationName}
+          customLocationUrl={form.customLocationUrl}
+          onCustomLocationUrlChange={form.setCustomLocationUrl}
         />
+        {customLocationMissing && (
+          <p className="text-xs text-destructive">
+            {t("events.form.custom_location_validation_both_required")}
+          </p>
+        )}
 
         <div className="space-y-2">
           <Label htmlFor="title">{t("events.form.title_label")}</Label>
@@ -268,16 +285,27 @@ export function EditEventForm({
           onChange={form.setTags}
         />
 
-        <div className="space-y-2">
-          <Label htmlFor="meeting">{t("events.form.meeting_url_label")}</Label>
-          <Input
-            id="meeting"
-            type="url"
-            value={form.meetingUrl}
-            onChange={(e) => form.setMeetingUrl(e.target.value)}
-            placeholder={t("events.form.meeting_url_placeholder")}
-          />
-        </div>
+        {isMeeting && (
+          <div className="space-y-2">
+            <Label htmlFor="meeting">
+              {t("events.form.meeting_url_label")}
+              <span className="text-destructive ml-0.5">*</span>
+            </Label>
+            <Input
+              id="meeting"
+              type="url"
+              required
+              value={form.meetingUrl}
+              onChange={(e) => form.setMeetingUrl(e.target.value)}
+              placeholder={t("events.form.meeting_url_placeholder")}
+            />
+            {meetingUrlMissing && (
+              <p className="text-xs text-destructive">
+                {t("events.form.meeting_url_required")}
+              </p>
+            )}
+          </div>
+        )}
 
         <TrackField
           tracks={tracks}

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/VenueSection.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/VenueSection.tsx
@@ -12,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { VenueHoursSummary } from "@/components/VenueHoursSummary"
 import { VenueSelect } from "../../../components/VenueSelect"
@@ -27,6 +28,10 @@ interface VenueSectionProps {
    * (list query still resolving) or for soft-deleted venues.
    */
   selectedVenueLabel?: string
+  customLocationName: string
+  onCustomLocationNameChange: (next: string) => void
+  customLocationUrl: string
+  onCustomLocationUrlChange: (next: string) => void
 }
 
 export function VenueSection({
@@ -36,9 +41,14 @@ export function VenueSection({
   selectedVenue,
   selectedDateIsClosed,
   selectedVenueLabel,
+  customLocationName,
+  onCustomLocationNameChange,
+  customLocationUrl,
+  onCustomLocationUrlChange,
 }: VenueSectionProps) {
   const { t } = useTranslation()
   const [picturesOpen, setPicturesOpen] = useState(false)
+  const isCustom = venueId === "__custom__"
 
   const pictures = useMemo(() => {
     if (!selectedVenue) return [] as { id: string; url: string }[]
@@ -60,6 +70,33 @@ export function VenueSection({
         venues={venues}
         selectedVenueLabel={selectedVenueLabel}
       />
+      {isCustom && (
+        <div className="space-y-2 pt-1">
+          <div className="space-y-1">
+            <Label htmlFor="custom_location_name" className="text-xs">
+              {t("events.form.custom_location_name_label")}
+            </Label>
+            <Input
+              id="custom_location_name"
+              value={customLocationName}
+              onChange={(e) => onCustomLocationNameChange(e.target.value)}
+              placeholder={t("events.form.custom_location_name_placeholder")}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="custom_location_url" className="text-xs">
+              {t("events.form.custom_location_url_label")}
+            </Label>
+            <Input
+              id="custom_location_url"
+              type="url"
+              value={customLocationUrl}
+              onChange={(e) => onCustomLocationUrlChange(e.target.value)}
+              placeholder={t("events.form.custom_location_url_placeholder")}
+            />
+          </div>
+        </div>
+      )}
       {selectedVenue?.booking_mode === "approval_required" && (
         <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
           <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/useEditEventForm.ts
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/useEditEventForm.ts
@@ -13,6 +13,10 @@ export interface UseEditEventFormResult {
   setContent: (next: string) => void
   venueId: string
   setVenueId: (next: string) => void
+  customLocationName: string
+  setCustomLocationName: (next: string) => void
+  customLocationUrl: string
+  setCustomLocationUrl: (next: string) => void
   trackId: string
   setTrackId: (next: string) => void
   visibility: Visibility
@@ -35,7 +39,17 @@ export interface UseEditEventFormResult {
 export function useEditEventForm(event: EventPublic): UseEditEventFormResult {
   const [title, setTitle] = useState(() => event.title ?? "")
   const [content, setContent] = useState(() => event.content ?? "")
-  const [venueId, setVenueId] = useState(() => event.venue_id ?? "")
+  // Seed the dropdown with the custom-location sentinel when the event was
+  // created with one — keeps the inputs visible and editable on first paint.
+  const [venueId, setVenueId] = useState(() =>
+    event.custom_location_name ? "__custom__" : (event.venue_id ?? ""),
+  )
+  const [customLocationName, setCustomLocationName] = useState(
+    () => event.custom_location_name ?? "",
+  )
+  const [customLocationUrl, setCustomLocationUrl] = useState(
+    () => event.custom_location_url ?? "",
+  )
   const [trackId, setTrackId] = useState(() => event.track_id ?? "")
   const [visibility, setVisibility] = useState<Visibility>(
     () => (event.visibility as Visibility) ?? "public",
@@ -51,22 +65,27 @@ export function useEditEventForm(event: EventPublic): UseEditEventFormResult {
     timezone: string,
     startIso: string,
     endIso: string,
-  ): EventUpdate => ({
-    title: title.trim(),
-    content: content.trim() || null,
-    start_time: startIso,
-    end_time: endIso,
-    timezone: timezone || "UTC",
-    venue_id: venueId || null,
-    track_id: trackId || null,
-    visibility,
-    max_participant: maxParticipants
-      ? Math.max(0, Number.parseInt(maxParticipants, 10))
-      : null,
-    meeting_url: meetingUrl || null,
-    cover_url: coverUrl || null,
-    tags,
-  })
+  ): EventUpdate => {
+    const isCustom = venueId === "__custom__"
+    return {
+      title: title.trim(),
+      content: content.trim() || null,
+      start_time: startIso,
+      end_time: endIso,
+      timezone: timezone || "UTC",
+      venue_id: !isCustom && venueId ? venueId : null,
+      custom_location_name: isCustom ? customLocationName.trim() || null : null,
+      custom_location_url: isCustom ? customLocationUrl.trim() || null : null,
+      track_id: trackId || null,
+      visibility,
+      max_participant: maxParticipants
+        ? Math.max(0, Number.parseInt(maxParticipants, 10))
+        : null,
+      meeting_url: !isCustom && !venueId ? meetingUrl || null : null,
+      cover_url: coverUrl || null,
+      tags,
+    }
+  }
 
   return {
     title,
@@ -75,6 +94,10 @@ export function useEditEventForm(event: EventPublic): UseEditEventFormResult {
     setContent,
     venueId,
     setVenueId,
+    customLocationName,
+    setCustomLocationName,
+    customLocationUrl,
+    setCustomLocationUrl,
     trackId,
     setTrackId,
     visibility,

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -9,6 +9,7 @@ import {
   CalendarPlus,
   CheckCircle,
   Clock,
+  Home,
   Layers,
   Mail,
   MapPin,
@@ -488,6 +489,24 @@ export default function EventDetailPage() {
               <div className="flex items-center gap-2.5 pr-36">{inner}</div>
             )
           })()}
+        {!event.venue_title && event.custom_location_name && (
+          <a
+            href={event.custom_location_url ?? undefined}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={t("events.detail.open_in_maps")}
+            className="group flex items-center gap-2.5 pr-36 -mx-2 px-2 py-1.5 rounded-md hover:bg-muted/50 transition-colors"
+          >
+            <div className="h-8 w-8 rounded-lg bg-muted flex items-center justify-center shrink-0">
+              <Home className="h-4 w-4 text-muted-foreground" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium truncate group-hover:underline">
+                {event.custom_location_name}
+              </p>
+            </div>
+          </a>
+        )}
         {event.meeting_url && (
           <div className="flex items-center gap-2.5">
             <div className="h-8 w-8 rounded-lg bg-purple-500/10 flex items-center justify-center shrink-0">

--- a/portal/src/app/portal/[popupSlug]/events/components/EventVenueField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/EventVenueField.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { VenueHoursSummary } from "@/components/VenueHoursSummary"
 import { VenueSelect } from "./VenueSelect"
@@ -27,6 +28,10 @@ interface EventVenueFieldProps {
    * no SelectItem to read the trigger label from and shows the placeholder.
    */
   selectedVenueLabel?: string
+  customLocationName: string
+  onCustomLocationNameChange: (next: string) => void
+  customLocationUrl: string
+  onCustomLocationUrlChange: (next: string) => void
 }
 
 export function EventVenueField({
@@ -36,9 +41,14 @@ export function EventVenueField({
   selectedVenue,
   selectedDateIsClosed,
   selectedVenueLabel,
+  customLocationName,
+  onCustomLocationNameChange,
+  customLocationUrl,
+  onCustomLocationUrlChange,
 }: EventVenueFieldProps) {
   const { t } = useTranslation()
   const [picturesOpen, setPicturesOpen] = useState(false)
+  const isCustom = venueId === "__custom__"
 
   // Combine the venue's cover and gallery into a single ordered list. The
   // cover comes first (when present), followed by gallery photos sorted by
@@ -63,6 +73,33 @@ export function EventVenueField({
         venues={venues}
         selectedVenueLabel={selectedVenueLabel}
       />
+      {isCustom && (
+        <div className="space-y-2 pt-1">
+          <div className="space-y-1">
+            <Label htmlFor="custom_location_name" className="text-xs">
+              {t("events.form.custom_location_name_label")}
+            </Label>
+            <Input
+              id="custom_location_name"
+              value={customLocationName}
+              onChange={(e) => onCustomLocationNameChange(e.target.value)}
+              placeholder={t("events.form.custom_location_name_placeholder")}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="custom_location_url" className="text-xs">
+              {t("events.form.custom_location_url_label")}
+            </Label>
+            <Input
+              id="custom_location_url"
+              type="url"
+              value={customLocationUrl}
+              onChange={(e) => onCustomLocationUrlChange(e.target.value)}
+              placeholder={t("events.form.custom_location_url_placeholder")}
+            />
+          </div>
+        </div>
+      )}
       {selectedVenue?.booking_mode === "approval_required" && (
         <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
           <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />

--- a/portal/src/app/portal/[popupSlug]/events/components/VenueSelect.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/VenueSelect.tsx
@@ -1,14 +1,19 @@
 "use client"
 
+import { Home, Video } from "lucide-react"
 import { memo, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import type { EventVenuePublic } from "@/client"
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
+  SelectSeparator,
   SelectTrigger,
 } from "@/components/ui/select"
+import { cn } from "@/lib/utils"
 
 interface VenueSelectProps {
   venueId: string
@@ -23,6 +28,7 @@ interface VenueSelectProps {
 }
 
 const NONE_VALUE = "__none__"
+const CUSTOM_VALUE = "__custom__"
 
 function VenueSelectImpl({
   venueId,
@@ -32,15 +38,15 @@ function VenueSelectImpl({
 }: VenueSelectProps) {
   const { t } = useTranslation()
 
-  // Build the dropdown item list with one entry per unique value. The
-  // currently selected venue is included exactly once: from `venues` when
-  // present, or as a stub using `selectedVenueLabel` while the list query
-  // is still resolving.
-  const items = useMemo(() => {
-    const out: { value: string; label: string }[] = [
-      { value: NONE_VALUE, label: t("events.form.no_venue_option") },
-    ]
-    const seen = new Set<string>([NONE_VALUE])
+  // Build venue dropdown items separately from the two synthetic options
+  // (Meeting + Custom location), which always sit at the top of the list
+  // with a visual separator and an icon to distinguish them from real
+  // venues. The currently selected venue is included exactly once: from
+  // `venues` when present, or as a stub using `selectedVenueLabel` while
+  // the list query is still resolving.
+  const venueItems = useMemo(() => {
+    const out: { value: string; label: string }[] = []
+    const seen = new Set<string>([NONE_VALUE, CUSTOM_VALUE])
 
     const formatVenueLabel = (v: EventVenuePublic) => {
       const title = v.title || t("events.venues.list.untitled_venue")
@@ -51,7 +57,11 @@ function VenueSelectImpl({
         : title
     }
 
-    if (venueId && !venues.some((v) => v.id === venueId)) {
+    if (
+      venueId &&
+      venueId !== CUSTOM_VALUE &&
+      !venues.some((v) => v.id === venueId)
+    ) {
       out.push({
         value: venueId,
         label: selectedVenueLabel || t("events.venues.list.untitled_venue"),
@@ -77,8 +87,12 @@ function VenueSelectImpl({
   // ourselves and dropping it straight into the trigger sidesteps that
   // entire mechanism.
   const triggerLabel =
-    items.find((i) => i.value === (venueId || NONE_VALUE))?.label ??
-    t("events.form.venue_placeholder")
+    venueId === CUSTOM_VALUE
+      ? t("events.form.custom_location_option")
+      : !venueId
+        ? t("events.form.no_venue_option")
+        : (venueItems.find((i) => i.value === venueId)?.label ??
+          t("events.form.venue_placeholder"))
 
   return (
     <Select
@@ -89,11 +103,45 @@ function VenueSelectImpl({
         <span className="truncate text-left">{triggerLabel}</span>
       </SelectTrigger>
       <SelectContent>
-        {items.map((item) => (
-          <SelectItem key={item.value} value={item.value}>
-            {item.label}
-          </SelectItem>
-        ))}
+        <SelectItem
+          value={NONE_VALUE}
+          className={cn(
+            "data-[highlighted]:bg-muted",
+            "bg-muted/40 text-foreground",
+          )}
+        >
+          <span className="inline-flex items-center gap-2">
+            <Video className="h-3.5 w-3.5 text-muted-foreground" />
+            {t("events.form.no_venue_option")}
+          </span>
+        </SelectItem>
+        <SelectItem
+          value={CUSTOM_VALUE}
+          className={cn(
+            "data-[highlighted]:bg-muted",
+            "bg-muted/40 text-foreground",
+          )}
+        >
+          <span className="inline-flex items-center gap-2">
+            <Home className="h-3.5 w-3.5 text-muted-foreground" />
+            {t("events.form.custom_location_option")}
+          </span>
+        </SelectItem>
+        {venueItems.length > 0 && (
+          <>
+            <SelectSeparator />
+            <SelectGroup>
+              <SelectLabel className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {t("events.form.venues_group_label")}
+              </SelectLabel>
+              {venueItems.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </>
+        )}
       </SelectContent>
     </Select>
   )

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   Clock,
   Crown,
+  Home,
   Layers,
   Repeat,
   Tag,
@@ -258,15 +259,22 @@ export function DayBody({
   // Build the column list. Always show every venue we know about, even
   // those without events on this day, so the calendar layout is stable
   // as the user pages through days. Append a synthetic "no venue" column
-  // only when at least one event lacks a venue.
+  // only when at least one event lacks a venue, and a separate "off-site"
+  // column at the very end for events that have a custom location.
   const columns: VenueColumn[] = useMemo(() => {
     const venues = venuesData?.results ?? []
     const cols: VenueColumn[] = venues.map((v) => ({
       id: v.id,
       title: v.title,
     }))
-    if (dayEvents.some((e) => !e.venue_id)) {
+    if (dayEvents.some((e) => !e.venue_id && !e.custom_location_name)) {
       cols.push({ id: "__no_venue__", title: t("events.day.no_venue_column") })
+    }
+    if (dayEvents.some((e) => !e.venue_id && !!e.custom_location_name)) {
+      cols.push({
+        id: "__custom_location__",
+        title: t("events.day.offsite_column"),
+      })
     }
     return cols
   }, [venuesData, dayEvents, t])
@@ -279,7 +287,9 @@ export function DayBody({
     for (const col of columns) map.set(col.id, [])
 
     for (const event of dayEvents) {
-      const colId = event.venue_id ?? "__no_venue__"
+      const colId =
+        event.venue_id ??
+        (event.custom_location_name ? "__custom_location__" : "__no_venue__")
       if (!map.has(colId)) continue
       const startMin = minutesInTz(event.start_time)
       const endsOnDay = formatDayKey(event.end_time) === dayKey
@@ -597,6 +607,13 @@ export function DayBody({
                                   aria-label={t("events.list.owned_title")}
                                 />
                               )}
+                              {!event.venue_id &&
+                                event.custom_location_name && (
+                                  <Home
+                                    className="h-3 w-3 shrink-0 text-muted-foreground"
+                                    aria-hidden="true"
+                                  />
+                                )}
                               <span
                                 className={cn(
                                   isShort ? "truncate" : "line-clamp-2",
@@ -605,6 +622,13 @@ export function DayBody({
                                 {event.title}
                               </span>
                             </div>
+                            {!isShort &&
+                              !event.venue_id &&
+                              event.custom_location_name && (
+                                <div className="text-[10px] text-muted-foreground/80 truncate">
+                                  {event.custom_location_name}
+                                </div>
+                              )}
                             <div className="flex items-center gap-1 text-[10px] text-muted-foreground mt-0.5">
                               <Clock className="h-2.5 w-2.5" />
                               <span className="truncate">
@@ -808,6 +832,13 @@ export function DayBody({
                                   aria-hidden="true"
                                 />
                               )}
+                              {!event.venue_id &&
+                                event.custom_location_name && (
+                                  <Home
+                                    className="h-2.5 w-2.5 shrink-0 text-muted-foreground"
+                                    aria-hidden="true"
+                                  />
+                                )}
                               <span className="truncate">{event.title}</span>
                             </div>
                             <div className="flex items-center gap-1 text-[9px] text-muted-foreground mt-0.5">

--- a/portal/src/app/portal/[popupSlug]/events/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/new/page.tsx
@@ -79,6 +79,8 @@ export default function NewPortalEventPage() {
   const [title, setTitle] = useState("")
   const [content, setContent] = useState("")
   const [venueId, setVenueId] = useState<string>("")
+  const [customLocationName, setCustomLocationName] = useState("")
+  const [customLocationUrl, setCustomLocationUrl] = useState("")
 
   const {
     dateStr,
@@ -155,6 +157,13 @@ export default function NewPortalEventPage() {
   })
   const tracks: TrackPublic[] = tracksData?.results ?? []
 
+  const isCustomLocation = venueId === "__custom__"
+  const isMeeting = !venueId && !isCustomLocation
+  const customLocationMissing =
+    isCustomLocation &&
+    (!customLocationName.trim() || !customLocationUrl.trim())
+  const meetingUrlMissing = isMeeting && !meetingUrl.trim()
+
   // ---- mutation -------------------------------------------------------
   const createMutation = useMutation({
     mutationFn: () => {
@@ -167,13 +176,19 @@ export default function NewPortalEventPage() {
           start_time: startIso,
           end_time: endIso,
           timezone: timezone || "UTC",
-          venue_id: venueId || null,
+          venue_id: !isCustomLocation && venueId ? venueId : null,
+          custom_location_name: isCustomLocation
+            ? customLocationName.trim() || null
+            : null,
+          custom_location_url: isCustomLocation
+            ? customLocationUrl.trim() || null
+            : null,
           track_id: trackId || null,
           visibility,
           max_participant: maxParticipants
             ? Math.max(0, parseInt(maxParticipants, 10))
             : null,
-          meeting_url: meetingUrl || null,
+          meeting_url: isMeeting ? meetingUrl.trim() || null : null,
           cover_url: coverUrl || null,
           tags,
           status: "published",
@@ -276,7 +291,9 @@ export default function NewPortalEventPage() {
     !!title.trim() &&
     !!startIso &&
     !!endIso &&
-    (!venueId || withinOpenHours) &&
+    (!venueId || isCustomLocation || withinOpenHours) &&
+    !customLocationMissing &&
+    !meetingUrlMissing &&
     availability !== "conflict" &&
     availability !== "checking" &&
     !createMutation.isPending
@@ -321,7 +338,16 @@ export default function NewPortalEventPage() {
           venues={venues}
           selectedVenue={selectedVenue}
           selectedDateIsClosed={selectedDateIsClosed}
+          customLocationName={customLocationName}
+          onCustomLocationNameChange={setCustomLocationName}
+          customLocationUrl={customLocationUrl}
+          onCustomLocationUrlChange={setCustomLocationUrl}
         />
+        {customLocationMissing && (
+          <p className="text-xs text-destructive">
+            {t("events.form.custom_location_validation_both_required")}
+          </p>
+        )}
 
         {/* Title */}
         <div className="space-y-2">
@@ -548,17 +574,28 @@ export default function NewPortalEventPage() {
           </div>
         )}
 
-        {/* Meeting URL */}
-        <div className="space-y-2">
-          <Label htmlFor="meeting">{t("events.form.meeting_url_label")}</Label>
-          <Input
-            id="meeting"
-            type="url"
-            value={meetingUrl}
-            onChange={(e) => setMeetingUrl(e.target.value)}
-            placeholder={t("events.form.meeting_url_placeholder")}
-          />
-        </div>
+        {/* Meeting URL — required when the Meeting option is selected. */}
+        {isMeeting && (
+          <div className="space-y-2">
+            <Label htmlFor="meeting">
+              {t("events.form.meeting_url_label")}
+              <span className="text-destructive ml-0.5">*</span>
+            </Label>
+            <Input
+              id="meeting"
+              type="url"
+              required
+              value={meetingUrl}
+              onChange={(e) => setMeetingUrl(e.target.value)}
+              placeholder={t("events.form.meeting_url_placeholder")}
+            />
+            {meetingUrlMissing && (
+              <p className="text-xs text-destructive">
+                {t("events.form.meeting_url_required")}
+              </p>
+            )}
+          </div>
+        )}
 
         <div className="flex justify-end gap-2 pt-2">
           <Button

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -4147,6 +4147,28 @@ export const EventCreateSchema = {
             ],
             title: 'Venue Id'
         },
+        custom_location_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Name'
+        },
+        custom_location_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Url'
+        },
         track_id: {
             anyOf: [
                 {
@@ -4600,6 +4622,29 @@ export const EventPublicSchema = {
                 }
             ],
             title: 'Venue Id'
+        },
+        custom_location_name: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Name'
+        },
+        custom_location_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Url'
         },
         track_id: {
             anyOf: [
@@ -5167,6 +5212,28 @@ export const EventUpdateSchema = {
                 }
             ],
             title: 'Venue Id'
+        },
+        custom_location_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Name'
+        },
+        custom_location_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Custom Location Url'
         },
         track_id: {
             anyOf: [
@@ -9316,6 +9383,11 @@ export const PopupAdminSchema = {
             title: 'Tier Progression Enabled',
             default: false
         },
+        events_enabled: {
+            type: 'boolean',
+            title: 'Events Enabled',
+            default: true
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -9676,6 +9748,11 @@ export const PopupCreateSchema = {
             type: 'boolean',
             title: 'Tier Progression Enabled',
             default: false
+        },
+        events_enabled: {
+            type: 'boolean',
+            title: 'Events Enabled',
+            default: true
         }
     },
     type: 'object',
@@ -9957,6 +10034,11 @@ export const PopupPublicSchema = {
             type: 'boolean',
             title: 'Tier Progression Enabled',
             default: false
+        },
+        events_enabled: {
+            type: 'boolean',
+            title: 'Events Enabled',
+            default: true
         }
     },
     type: 'object',
@@ -10493,6 +10575,17 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Tier Progression Enabled'
+        },
+        events_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Events Enabled'
         }
     },
     type: 'object',

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -1253,6 +1253,7 @@ export class CheckoutService {
      * Rate-limited 120/min/IP.
      * @param data The data for the request.
      * @param data.slug
+     * @param data.xTenantId
      * @returns CheckoutRuntimeResponse Successful Response
      * @throws ApiError
      */
@@ -1262,6 +1263,9 @@ export class CheckoutService {
             url: '/api/v1/checkout/{slug}/runtime',
             path: {
                 slug: data.slug
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
             },
             errors: {
                 422: 'Validation Error'
@@ -1275,6 +1279,7 @@ export class CheckoutService {
      * @param data The data for the request.
      * @param data.slug
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns OpenTicketingPurchaseResponse Successful Response
      * @throws ApiError
      */
@@ -1284,6 +1289,9 @@ export class CheckoutService {
             url: '/api/v1/checkout/{slug}/purchase',
             path: {
                 slug: data.slug
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
             },
             body: data.requestBody,
             mediaType: 'application/json',
@@ -1304,6 +1312,7 @@ export class CouponsService {
      * Rate-limited 30/min/IP.
      * @param data The data for the request.
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns CouponValidatePublicResponse Successful Response
      * @throws ApiError
      */
@@ -1311,6 +1320,9 @@ export class CouponsService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/coupons/validate-public',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -923,6 +923,8 @@ export type EventCreate = {
     max_participant?: (number | null);
     tags?: Array<(string)>;
     venue_id?: (string | null);
+    custom_location_name?: (string | null);
+    custom_location_url?: (string | null);
     track_id?: (string | null);
     visibility?: EventVisibility;
     require_approval?: boolean;
@@ -1012,6 +1014,8 @@ export type EventPublic = {
     max_participant?: (number | null);
     tags?: Array<(string)>;
     venue_id?: (string | null);
+    custom_location_name?: (string | null);
+    custom_location_url?: (string | null);
     track_id?: (string | null);
     visibility?: EventVisibility;
     require_approval?: boolean;
@@ -1101,6 +1105,8 @@ export type EventUpdate = {
     max_participant?: (number | null);
     tags?: (Array<(string)> | null);
     venue_id?: (string | null);
+    custom_location_name?: (string | null);
+    custom_location_url?: (string | null);
     track_id?: (string | null);
     visibility?: (EventVisibility | null);
     require_approval?: (boolean | null);
@@ -3261,6 +3267,7 @@ export type CartsDeleteMyCartResponse = (void);
 
 export type CheckoutGetRuntimeData = {
     slug: string;
+    xTenantId?: (string | null);
 };
 
 export type CheckoutGetRuntimeResponse = (CheckoutRuntimeResponse);
@@ -3268,12 +3275,14 @@ export type CheckoutGetRuntimeResponse = (CheckoutRuntimeResponse);
 export type CheckoutPurchaseOpenTicketingData = {
     requestBody: OpenTicketingPurchaseCreate;
     slug: string;
+    xTenantId?: (string | null);
 };
 
 export type CheckoutPurchaseOpenTicketingResponse = (OpenTicketingPurchaseResponse);
 
 export type CouponsValidateCouponPublicData = {
     requestBody: CouponValidatePublicRequest;
+    xTenantId?: (string | null);
 };
 
 export type CouponsValidateCouponPublicResponse = (CouponValidatePublicResponse);

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -500,7 +500,8 @@
       "event_count_one": "{{count}} event",
       "event_count_other": "{{count}} events",
       "no_venues": "No venues configured for this pop-up yet.",
-      "no_venue_column": "No venue",
+      "no_venue_column": "Meeting",
+      "offsite_column": "Off-site",
       "untitled_venue": "Untitled venue"
     },
     "add_to_calendar": {
@@ -549,7 +550,8 @@
       "remove_invitation_aria": "Remove invitation for {{email}}",
       "edit_event_button": "Edit event",
       "pending_approval_banner_title": "Pending approval",
-      "pending_approval_banner_message": "Your event is pending approval and not yet visible to others."
+      "pending_approval_banner_message": "Your event is pending approval and not yet visible to others.",
+      "open_in_maps": "Open in Google Maps"
     },
     "form": {
       "create_heading": "Create event",
@@ -603,8 +605,9 @@
       "no_tags_configured": "Tags for this pop-up are not configured. Ask an admin to set them in Event Settings.",
       "track_label": "Track (optional)",
       "track_placeholder": "No track",
-      "meeting_url_label": "Meeting URL (optional)",
+      "meeting_url_label": "Meeting URL",
       "meeting_url_placeholder": "https://…",
+      "meeting_url_required": "Meeting URL is required when no venue is selected.",
       "cancel_button": "Cancel",
       "create_button": "Create event",
       "save_button": "Save changes",
@@ -619,7 +622,14 @@
       "creation_restricted_heading": "Event creation is restricted",
       "creation_restricted_message": "Only admins can create events for this pop-up.",
       "no_popup_error": "No popup",
-      "no_venue_option": "No venue",
+      "no_venue_option": "Meeting",
+      "custom_location_option": "Custom location",
+      "venues_group_label": "Venues",
+      "custom_location_name_label": "Place name",
+      "custom_location_name_placeholder": "My apartment",
+      "custom_location_url_label": "Google Maps link",
+      "custom_location_url_placeholder": "https://maps.google.com/...",
+      "custom_location_validation_both_required": "Provide both a name and a Google Maps link.",
       "no_track_option": "No track",
       "venue_capacity_suffix": " (cap. {{capacity}})",
       "event_cover_alt": "Event cover",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -500,7 +500,8 @@
       "event_count_one": "{{count}} evento",
       "event_count_other": "{{count}} eventos",
       "no_venues": "Este pop-up todavía no tiene venues configurados.",
-      "no_venue_column": "Sin venue",
+      "no_venue_column": "Reunión",
+      "offsite_column": "Fuera de sede",
       "untitled_venue": "Venue sin título"
     },
     "add_to_calendar": {
@@ -549,7 +550,8 @@
       "remove_invitation_aria": "Quitar invitación para {{email}}",
       "edit_event_button": "Editar evento",
       "pending_approval_banner_title": "Pendiente de aprobación",
-      "pending_approval_banner_message": "Tu evento está pendiente de aprobación y aún no es visible para otros."
+      "pending_approval_banner_message": "Tu evento está pendiente de aprobación y aún no es visible para otros.",
+      "open_in_maps": "Abrir en Google Maps"
     },
     "form": {
       "create_heading": "Crear evento",
@@ -603,8 +605,9 @@
       "no_tags_configured": "Las etiquetas para este pop-up no están configuradas. Pedile a un admin que las defina en Event Settings.",
       "track_label": "Track (opcional)",
       "track_placeholder": "Sin track",
-      "meeting_url_label": "URL de la reunión (opcional)",
+      "meeting_url_label": "URL de la reunión",
       "meeting_url_placeholder": "https://…",
+      "meeting_url_required": "La URL de la reunión es obligatoria si no elegís un venue.",
       "cancel_button": "Cancelar",
       "create_button": "Crear evento",
       "save_button": "Guardar cambios",
@@ -619,7 +622,14 @@
       "creation_restricted_heading": "La creación de eventos está restringida",
       "creation_restricted_message": "Solo los admins pueden crear eventos para este pop-up.",
       "no_popup_error": "Sin popup",
-      "no_venue_option": "Sin lugar",
+      "no_venue_option": "Reunión",
+      "custom_location_option": "Ubicación personalizada",
+      "venues_group_label": "Venues",
+      "custom_location_name_label": "Nombre del lugar",
+      "custom_location_name_placeholder": "Mi casa",
+      "custom_location_url_label": "Link de Google Maps",
+      "custom_location_url_placeholder": "https://maps.google.com/...",
+      "custom_location_validation_both_required": "Indicá un nombre y un link de Google Maps.",
       "no_track_option": "Sin track",
       "venue_capacity_suffix": " (cap. {{capacity}})",
       "event_cover_alt": "Portada del evento",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -500,7 +500,8 @@
       "event_count_one": "{{count}} 个活动",
       "event_count_other": "{{count}} 个活动",
       "no_venues": "此 pop-up 暂未配置场地。",
-      "no_venue_column": "无场地",
+      "no_venue_column": "会议",
+      "offsite_column": "外部地点",
       "untitled_venue": "未命名场地"
     },
     "add_to_calendar": {
@@ -549,7 +550,8 @@
       "remove_invitation_aria": "移除 {{email}} 的邀请",
       "edit_event_button": "编辑活动",
       "pending_approval_banner_title": "等待审批",
-      "pending_approval_banner_message": "你的活动正在等待审批,其他人暂时无法查看。"
+      "pending_approval_banner_message": "你的活动正在等待审批,其他人暂时无法查看。",
+      "open_in_maps": "在 Google 地图中打开"
     },
     "form": {
       "create_heading": "创建活动",
@@ -603,8 +605,9 @@
       "no_tags_configured": "此 pop-up 尚未配置标签。请让管理员在 Event Settings 中设置。",
       "track_label": "Track(可选)",
       "track_placeholder": "无 track",
-      "meeting_url_label": "会议链接(可选)",
+      "meeting_url_label": "会议链接",
       "meeting_url_placeholder": "https://…",
+      "meeting_url_required": "未选择场地时必须填写会议链接。",
       "cancel_button": "取消",
       "create_button": "创建活动",
       "save_button": "保存更改",
@@ -619,7 +622,14 @@
       "creation_restricted_heading": "创建活动受限",
       "creation_restricted_message": "仅管理员可为此 pop-up 创建活动。",
       "no_popup_error": "无 popup",
-      "no_venue_option": "无场地",
+      "no_venue_option": "会议",
+      "custom_location_option": "自定义地点",
+      "venues_group_label": "场地",
+      "custom_location_name_label": "地点名称",
+      "custom_location_name_placeholder": "我家",
+      "custom_location_url_label": "Google 地图链接",
+      "custom_location_url_placeholder": "https://maps.google.com/...",
+      "custom_location_validation_both_required": "请同时填写名称与 Google 地图链接。",
       "no_track_option": "无 track",
       "venue_capacity_suffix": "(容量 {{capacity}})",
       "event_cover_alt": "活动封面",


### PR DESCRIPTION
## Summary

- Adds `custom_location_name` + `custom_location_url` to events: a venue-less but locatable event (e.g. "Mi casa" + Google Maps link), enforced as XOR with `venue_id` at the schema layer. iCal `LOCATION` falls back to the custom name+URL, and changes to either field bump `ical_sequence` so iTIP updates correlate.
- Renames the venue dropdown "No venue" → **Meeting** (online-only), highlights both Meeting and Custom location with icons and a `Venues` group below them. The Meeting URL field is now **required** when Meeting is selected (UI-only validation).
- Day view gains a dedicated **Off-site** column at the end for custom-location events; the event detail page renders them with a Home glyph + neutral muted styling.

Backend, backoffice, and portal all updated. Generated clients regenerated. 14 new backend tests cover schema XOR, both approval gates, update transitions, iCal sequence bump, and ICS rendering — all 66 related event tests still pass.

## Test plan

- [ ] Run `cd backend && uv run alembic upgrade head` against a dev DB.
- [ ] `cd backend && uv run pytest tests/test_event_custom_location.py -v` — expect 14 pass.
- [ ] Backoffice `/events/new`: dropdown shows Meeting (with Video icon) + Custom location (with Home icon) above a "VENUES" header. Selecting Meeting → URL field required. Selecting Custom location → name + Maps URL inputs render and are required.
- [ ] Portal `/portal/<slug>/events/new`: same dropdown treatment + required Meeting URL.
- [ ] Edit a venue event → switch to Custom location → venue clears, custom inputs editable. Switch back → custom fields clear.
- [ ] Day view: custom-location event lands in the new Off-site column; event detail shows Home icon + opens Maps in new tab.
- [ ] Trigger an iTIP update by changing a custom-location event's start time → check `LOCATION:` line in the outgoing `.ics` (Mailpit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)