### PR TITLE
refactor(passes): deprecate attendee.check_in_code; use per-ticket codes

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -17,7 +17,7 @@ from app.api.application.schemas import (
     ScholarshipDecisionRequest,
 )
 from app.api.application_review.models import ApplicationReviews
-from app.api.attendee.crud import attendees_crud, generate_check_in_code
+from app.api.attendee.crud import attendees_crud
 from app.api.attendee.models import AttendeeProducts, Attendees
 from app.api.human.models import Humans
 from app.api.human.schemas import HumanCreate, HumanUpdate
@@ -389,9 +389,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         session.flush()
 
         # Create main attendee
-        prefix = popup.slug[:3].upper() if popup.slug else "ATT"
-        check_in_code = generate_check_in_code(prefix)
-
         # Get name from human (just updated)
         session.refresh(human)
         name = (
@@ -405,7 +402,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             popup_id=application.popup_id,
             name=name,
             category="main",
-            check_in_code=check_in_code,
             email=human.email,
             gender=human.gender,
             human_id=human.id,
@@ -418,7 +414,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 application=application,
                 companions=app_data.companions,
                 tenant_id=tenant_id,
-                check_in_prefix=prefix,
             )
 
         # Apply approval strategy for non-group applications still in review
@@ -452,7 +447,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         application: Applications,
         companions: list,
         tenant_id: uuid.UUID,
-        check_in_prefix: str,
     ) -> None:
         """Create companion attendees (spouse/kids) for an application.
 
@@ -470,7 +464,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                         detail="Only one spouse attendee allowed per application",
                     )
 
-            check_in_code = generate_check_in_code(check_in_prefix)
             attendees_crud.create_internal(
                 session,
                 tenant_id=tenant_id,
@@ -478,7 +471,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 popup_id=application.popup_id,
                 name=companion.name,
                 category=companion.category,
-                check_in_code=check_in_code,
                 email=companion.email,
                 gender=companion.gender,
             )
@@ -623,9 +615,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         session.flush()
 
         # Create main attendee
-        prefix = popup.slug[:3].upper() if popup.slug else "ATT"
-        check_in_code = generate_check_in_code(prefix)
-
         session.refresh(human)
         name = (
             f"{human.first_name or ''} {human.last_name or ''}".strip() or human.email
@@ -638,7 +627,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             popup_id=application.popup_id,
             name=name,
             category="main",
-            check_in_code=check_in_code,
             email=human.email,
             gender=human.gender,
             human_id=human.id,
@@ -651,7 +639,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 application=application,
                 companions=app_data.companions,
                 tenant_id=tenant_id,
-                check_in_prefix=prefix,
             )
 
         # Apply approval strategy if status is IN_REVIEW
@@ -846,10 +833,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                     detail="Attendee with this email already exists",
                 )
 
-        # Generate check-in code
-        prefix = application.popup.slug[:3].upper() if application.popup.slug else "ATT"
-        check_in_code = generate_check_in_code(prefix)
-
         attendee = attendees_crud.create_internal(
             session,
             tenant_id=application.tenant_id,
@@ -857,7 +840,6 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             popup_id=application.popup_id,
             name=name,
             category=category,
-            check_in_code=check_in_code,
             email=email.lower() if email else None,
             gender=gender,
         )

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -362,12 +362,18 @@ async def get_my_participation(
         db, human_id=current_human.id, popup_id=popup_id
     )
     if attendee:
+        from app.api.application.schemas import AttendeeTicketInfo
+
         return CompanionParticipation(
             attendee=AttendeeInfo(
                 id=attendee.id,
                 name=attendee.name,
                 category=attendee.category,
                 check_in_code=attendee.check_in_code,
+                tickets=[
+                    AttendeeTicketInfo(id=ap.id, check_in_code=ap.check_in_code)
+                    for ap in attendee.attendee_products
+                ],
             ),
             application_status=attendee.application.status,
         )

--- a/backend/app/api/application/schemas.py
+++ b/backend/app/api/application/schemas.py
@@ -349,13 +349,29 @@ class ApplicationSnapshotPublic(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AttendeeTicketInfo(BaseModel):
+    """Per-ticket info exposed on companion participation responses.
+
+    `check_in_code` is the per-ticket code from `attendee_products` — the
+    source of truth post-`ticket-as-first-class-entity`. New clients MUST read
+    from this list rather than the legacy `AttendeeInfo.check_in_code`.
+    """
+
+    id: uuid.UUID
+    check_in_code: str
+
+
 class AttendeeInfo(BaseModel):
     """Minimal attendee information for participation responses."""
 
     id: uuid.UUID
     name: str
     category: str
+    # Legacy attendee-level code. Kept for backwards compatibility with old
+    # clients that read it directly. New attendees no longer populate it —
+    # clients SHOULD prefer `tickets[].check_in_code`.
     check_in_code: str | None = None
+    tickets: list[AttendeeTicketInfo] = []
 
 
 class ApplicantParticipation(BaseModel):

--- a/backend/app/api/attendee/crud.py
+++ b/backend/app/api/attendee/crud.py
@@ -130,7 +130,6 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
         popup_id: uuid.UUID,
         name: str,
         category: str,
-        check_in_code: str,
         email: str | None = None,
         gender: str | None = None,
         human_id: uuid.UUID | None = None,
@@ -142,6 +141,9 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
 
         popup_id is REQUIRED — it's a NOT NULL column on attendees. Callers
         that work with an application should pass application.popup_id.
+
+        Attendees.check_in_code is no longer populated — per-ticket codes on
+        attendee_products are the source of truth post-`ticket-as-first-class-entity`.
         """
         # If email provided but no human_id, try to find matching Human
         if email and not human_id:
@@ -153,7 +155,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
             popup_id=popup_id,
             name=name,
             category=category,
-            check_in_code=check_in_code,
+            check_in_code=None,
             email=email,
             gender=gender,
             human_id=human_id,
@@ -199,16 +201,10 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
 
         Used for popups with sale_type="direct". The attendee is bound to a
         Human and a Popup directly — application_id remains NULL.
+
+        Attendees.check_in_code is no longer populated — per-ticket codes on
+        attendee_products are the source of truth post-`ticket-as-first-class-entity`.
         """
-        prefix = ""
-        # Short prefix from popup slug if available
-        from app.api.popup.models import Popups
-
-        popup = session.get(Popups, popup_id)
-        if popup and popup.slug:
-            prefix = popup.slug[:3].upper()
-        check_in_code = generate_check_in_code(prefix)
-
         attendee = Attendees(
             tenant_id=tenant_id,
             application_id=None,
@@ -216,7 +212,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
             human_id=human_id,
             name=name,
             category="main",
-            check_in_code=check_in_code,
+            check_in_code=None,
             email=email.lower() if email else None,
         )
         session.add(attendee)
@@ -369,7 +365,10 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                 Applications.popup_id == popup_id,
                 Applications.human_id != human_id,
             )
-            .options(selectinload(Attendees.application))  # type: ignore[arg-type]
+            .options(
+                selectinload(Attendees.application),  # type: ignore[arg-type]
+                selectinload(Attendees.attendee_products),  # type: ignore[arg-type]
+            )
             .limit(1)
         )
         return session.exec(statement).first()

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -164,7 +164,6 @@ async def create_my_attendee_for_popup(
     popup is not an application popup.
     """
     from app.api.application.crud import applications_crud
-    from app.api.attendee.crud import generate_check_in_code
     from app.api.popup.models import Popups
     from app.api.shared.enums import SaleType
 
@@ -194,9 +193,6 @@ async def create_my_attendee_for_popup(
             ],
         )
 
-    prefix = popup.slug[:3].upper() if popup.slug else ""
-    check_in_code = generate_check_in_code(prefix)
-
     attendee = crud.attendees_crud.create_internal(
         session=db,
         tenant_id=application.tenant_id,
@@ -204,7 +200,6 @@ async def create_my_attendee_for_popup(
         popup_id=popup_id,
         name=attendee_in.name,
         category=attendee_in.category,
-        check_in_code=check_in_code,
         email=attendee_in.email,
         gender=attendee_in.gender,
     )

--- a/backend/tests/test_human_attendee_link.py
+++ b/backend/tests/test_human_attendee_link.py
@@ -81,7 +81,6 @@ class TestHumanAttendeeLink:
             popup_id=popup.id,
             name="Spouse Name",
             category="spouse",
-            check_in_code=f"TEST{uuid.uuid4().hex[:4].upper()}",
             email="spouse@example.com",  # Same email as existing human
         )
 
@@ -138,7 +137,6 @@ class TestHumanAttendeeLink:
             popup_id=popup.id,
             name="Spouse Name",
             category="spouse",
-            check_in_code=f"TEST{uuid.uuid4().hex[:4].upper()}",
             email="nonexistent@example.com",
         )
 
@@ -195,7 +193,6 @@ class TestHumanAttendeeLink:
             popup_id=popup.id,
             name="Spouse Name",
             category="spouse",
-            check_in_code=f"TEST{uuid.uuid4().hex[:4].upper()}",
             email="future-spouse@example.com",
             human_id=None,  # Not linked yet
         )

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -1621,6 +1621,14 @@ export const AttendeeInfoSchema = {
                 }
             ],
             title: 'Check In Code'
+        },
+        tickets: {
+            items: {
+                '$ref': '#/components/schemas/AttendeeTicketInfo'
+            },
+            type: 'array',
+            title: 'Tickets',
+            default: []
         }
     },
     type: 'object',
@@ -2068,6 +2076,28 @@ export const AttendeeStatsSchema = {
     type: 'object',
     title: 'AttendeeStats',
     description: 'Statistics for attendees.'
+} as const;
+
+export const AttendeeTicketInfoSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        check_in_code: {
+            type: 'string',
+            title: 'Check In Code'
+        }
+    },
+    type: 'object',
+    required: ['id', 'check_in_code'],
+    title: 'AttendeeTicketInfo',
+    description: `Per-ticket info exposed on companion participation responses.
+
+\`check_in_code\` is the per-ticket code from \`attendee_products\` — the
+source of truth post-\`ticket-as-first-class-entity\`. New clients MUST read
+from this list rather than the legacy \`AttendeeInfo.check_in_code\`.`
 } as const;
 
 export const AttendeeUpdateSchema = {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -342,6 +342,7 @@ export type AttendeeInfo = {
     name: string;
     category: string;
     check_in_code?: (string | null);
+    tickets?: Array<AttendeeTicketInfo>;
 };
 
 /**
@@ -458,6 +459,18 @@ export type AttendeeStats = {
     main?: number;
     spouse?: number;
     kid?: number;
+};
+
+/**
+ * Per-ticket info exposed on companion participation responses.
+ *
+ * `check_in_code` is the per-ticket code from `attendee_products` — the
+ * source of truth post-`ticket-as-first-class-entity`. New clients MUST read
+ * from this list rather than the legacy `AttendeeInfo.check_in_code`.
+ */
+export type AttendeeTicketInfo = {
+    id: string;
+    check_in_code: string;
 };
 
 /**

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -1621,6 +1621,14 @@ export const AttendeeInfoSchema = {
                 }
             ],
             title: 'Check In Code'
+        },
+        tickets: {
+            items: {
+                '$ref': '#/components/schemas/AttendeeTicketInfo'
+            },
+            type: 'array',
+            title: 'Tickets',
+            default: []
         }
     },
     type: 'object',
@@ -2068,6 +2076,28 @@ export const AttendeeStatsSchema = {
     type: 'object',
     title: 'AttendeeStats',
     description: 'Statistics for attendees.'
+} as const;
+
+export const AttendeeTicketInfoSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        check_in_code: {
+            type: 'string',
+            title: 'Check In Code'
+        }
+    },
+    type: 'object',
+    required: ['id', 'check_in_code'],
+    title: 'AttendeeTicketInfo',
+    description: `Per-ticket info exposed on companion participation responses.
+
+\`check_in_code\` is the per-ticket code from \`attendee_products\` — the
+source of truth post-\`ticket-as-first-class-entity\`. New clients MUST read
+from this list rather than the legacy \`AttendeeInfo.check_in_code\`.`
 } as const;
 
 export const AttendeeUpdateSchema = {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -342,6 +342,7 @@ export type AttendeeInfo = {
     name: string;
     category: string;
     check_in_code?: (string | null);
+    tickets?: Array<AttendeeTicketInfo>;
 };
 
 /**
@@ -458,6 +459,18 @@ export type AttendeeStats = {
     main?: number;
     spouse?: number;
     kid?: number;
+};
+
+/**
+ * Per-ticket info exposed on companion participation responses.
+ *
+ * `check_in_code` is the per-ticket code from `attendee_products` — the
+ * source of truth post-`ticket-as-first-class-entity`. New clients MUST read
+ * from this list rather than the legacy `AttendeeInfo.check_in_code`.
+ */
+export type AttendeeTicketInfo = {
+    id: string;
+    check_in_code: string;
 };
 
 /**

--- a/portal/src/components/CompanionPasses.tsx
+++ b/portal/src/components/CompanionPasses.tsx
@@ -32,10 +32,14 @@ export function CompanionPasses({ participation }: CompanionPassesProps) {
   const myTicketEntry = allTickets.find((t) => t.id === attendee.id)
   const tickets = myTicketEntry?.products ?? []
 
+  // Prefer the per-ticket check-in code (source of truth post-`ticket-as-first-class-entity`).
+  // Fall back to the legacy attendee-level code for old data still carrying it.
+  const checkInCode =
+    attendee.tickets?.[0]?.check_in_code ?? attendee.check_in_code ?? null
+
   const isAccepted = application_status === "accepted"
   const hasTickets = tickets.length > 0
-  // check_in_code is nullable post-migration (direct-sale attendees may have null)
-  const canShowCheckIn = isAccepted && hasTickets && !!attendee.check_in_code
+  const canShowCheckIn = isAccepted && hasTickets && !!checkInCode
 
   return (
     <div className="space-y-6 pb-24 lg:pb-0">
@@ -134,9 +138,9 @@ export function CompanionPasses({ participation }: CompanionPassesProps) {
         </div>
       )}
 
-      {canShowCheckIn && attendee.check_in_code && (
+      {canShowCheckIn && checkInCode && (
         <QRcode
-          check_in_code={attendee.check_in_code}
+          check_in_code={checkInCode}
           isOpen={isQrModalOpen}
           onOpenChange={setIsQrModalOpen}
         />

--- a/portal/src/components/CompanionView.tsx
+++ b/portal/src/components/CompanionView.tsx
@@ -74,11 +74,15 @@ export function CompanionView({ participation }: CompanionViewProps) {
   const myTicketEntry = allTickets.find((t) => t.id === attendee.id)
   const tickets = myTicketEntry?.products ?? []
 
+  // Prefer the per-ticket check-in code (source of truth post-`ticket-as-first-class-entity`).
+  // Fall back to the legacy attendee-level code for old data still carrying it.
+  const checkInCode =
+    attendee.tickets?.[0]?.check_in_code ?? attendee.check_in_code ?? null
+
   const isAccepted = application_status === "accepted"
   const hasTickets = tickets.length > 0
   // QR code is only safe to show when application is accepted AND companion has passes
-  // check_in_code is nullable post-migration (direct-sale attendees may have null)
-  const canShowCheckIn = isAccepted && hasTickets && !!attendee.check_in_code
+  const canShowCheckIn = isAccepted && hasTickets && !!checkInCode
 
   const status = statusConfig[application_status]
 
@@ -194,9 +198,9 @@ export function CompanionView({ participation }: CompanionViewProps) {
         )}
       </CardContent>
 
-      {canShowCheckIn && attendee.check_in_code && (
+      {canShowCheckIn && checkInCode && (
         <QRcode
-          check_in_code={attendee.check_in_code}
+          check_in_code={checkInCode}
           isOpen={isQrModalOpen}
           onOpenChange={setIsQrModalOpen}
         />


### PR DESCRIPTION
## Summary

- New attendees no longer populate the legacy `Attendees.check_in_code` column. Per-ticket codes on `attendee_products` are the source of truth post-`ticket-as-first-class-entity`.
- `AttendeeInfo` (companion participation response) gains a `tickets[]` array exposing per-ticket `id` and `check_in_code`. The legacy attendee-level `check_in_code` field stays as a nullable fallback for old data.
- Companion-facing portal components (`CompanionPasses`, `CompanionView`) prefer `attendee.tickets[0].check_in_code`, falling back to the legacy field when it is missing.

## Why

Memory #1254 follow-up #4 (`backend-deprecate-attendee-check-in-code`). After the `ticket-as-first-class-entity` refactor, per-ticket codes on `attendee_products` became the source of truth. The legacy attendee-level `check_in_code` column was still being populated for new rows and the companion portal components were still reading from it. This PR finishes the migration:

- Backend stops populating the legacy column.
- Response surface exposes per-ticket codes.
- Frontend reads per-ticket first, with a backwards-compatible fallback so the rollout order (frontend then backend, or the reverse) doesn't break existing companions.

The legacy column itself stays in the schema; an optional NULL-out migration of post-refactor rows is deferred per memory #1254.

## Backend changes

- `backend/app/api/attendee/crud.py`: `create_internal` drops the `check_in_code` parameter and writes `None`. `create_direct_attendee` writes `None` (drops the slug-prefixed code generation). `find_companion_for_popup` eager-loads `attendee_products`.
- `backend/app/api/attendee/router.py`: portal companion creation no longer generates a prefix code.
- `backend/app/api/application/crud.py`: 4 attendee creation sites stop generating prefix codes; `_create_companions` drops the `check_in_prefix` argument; `generate_check_in_code` import removed.
- `backend/app/api/application/schemas.py`: new `AttendeeTicketInfo`; `AttendeeInfo` adds `tickets: list[AttendeeTicketInfo]`.
- `backend/app/api/application/router.py`: `CompanionParticipation` response populates the new `tickets` field from `attendee.attendee_products`.
- `generate_check_in_code` itself is unchanged — still used by per-ticket creation paths in `payment/crud.py` and `attendee/crud.py::add_product`.

## Frontend changes

- `portal/src/components/CompanionPasses.tsx` and `portal/src/components/CompanionView.tsx`: derive `checkInCode = attendee.tickets?.[0]?.check_in_code ?? attendee.check_in_code ?? null` and use it for both the `canShowCheckIn` gate and the `<QRcode>` prop.
- OpenAPI client regenerated for portal and backoffice.

## Test plan

- [ ] CI: backend ruff (verified locally), pytest, portal biome ci (verified), portal tsc (verified), backoffice biome ci, backoffice tsc.
- [ ] Manual smoke once deployed to dev:
  - Companion sees their QR code on `/portal/[popupSlug]/passes` (CompanionPasses) and on the directory entry (CompanionView).
  - Existing companions with a populated `attendee.check_in_code` still see their QR (fallback path).
  - Newly created companions get an attendee row with `check_in_code=NULL`; they see the per-ticket QR after a payment lands.