### PR TITLE
feat(product): add sale window fields and derive_product_state (drop-tier-groups PR 1/4)

### DIFF
--- a/backend/app/alembic/versions/a1b9c3d7e5f2_drop_tier_groups_use_sale_windows.py
+++ b/backend/app/alembic/versions/a1b9c3d7e5f2_drop_tier_groups_use_sale_windows.py
@@ -1,0 +1,107 @@
+"""drop_tier_groups_use_sale_windows: migration 0045 (additive-only)
+
+Adds native sale window columns to products and backfills them from the
+existing ticket_tier_phase rows. This migration is purely ADDITIVE — it does
+NOT drop any tables or columns. The actual drops of ticket_tier_phase,
+ticket_tier_group, popups.tier_progression_enabled, products.start_date, and
+products.end_date happen in migration 0046 (PR 2), AFTER the live code that
+queries those tables/columns has been removed.
+
+Steps (ADR-3 — order is critical):
+  1. ADD products.sale_starts_at TIMESTAMPTZ NULL
+  2. ADD products.sale_ends_at   TIMESTAMPTZ NULL
+  3. BACKFILL sale window from ticket_tier_phase (10 rows in production)
+  4. BACKFILL product name with phase label where not already present
+
+downgrade() raises NotImplementedError — forward-only per NG7.
+
+Revision ID: a1b9c3d7e5f2
+Revises: 3f8a1c9e4b2d
+Create Date: 2026-05-08
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b9c3d7e5f2"
+down_revision: str = "3f8a1c9e4b2d"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # -------------------------------------------------------------------------
+    # 1 & 2 — Add new sale window columns to products
+    # -------------------------------------------------------------------------
+    op.add_column(
+        "products",
+        sa.Column(
+            "sale_starts_at",
+            TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "products",
+        sa.Column(
+            "sale_ends_at",
+            TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # 3 — Backfill sale window from ticket_tier_phase
+    #
+    # Critical ordering invariant: this UPDATE must run BEFORE dropping
+    # ticket_tier_phase (step 5). We read the phase's window columns and copy
+    # them onto the linked product row (one phase per product, enforced by UNIQUE).
+    # -------------------------------------------------------------------------
+    op.execute(
+        sa.text(
+            """
+            UPDATE products p
+               SET sale_starts_at = ph.sale_starts_at,
+                   sale_ends_at   = ph.sale_ends_at
+              FROM ticket_tier_phase ph
+             WHERE ph.product_id = p.id
+            """
+        )
+    )
+
+    # -------------------------------------------------------------------------
+    # 4 — Backfill product name with phase label (idempotent guard)
+    #
+    # Append ' — <label>' only when the label does not already appear in the
+    # product name. POSITION returns 0 when the substring is absent.
+    # This preserves the visual "phase label — product name" appearance that
+    # admins relied on in the tier group editor.
+    # -------------------------------------------------------------------------
+    op.execute(
+        sa.text(
+            """
+            UPDATE products p
+               SET name = p.name || ' — ' || ph.label
+              FROM ticket_tier_phase ph
+             WHERE ph.product_id = p.id
+               AND POSITION(ph.label IN p.name) = 0
+            """
+        )
+    )
+
+    # Drops of ticket_tier_phase, ticket_tier_group, products.start_date,
+    # products.end_date, and popups.tier_progression_enabled are deferred to
+    # migration 0046 (PR 2) — they require the live code that queries them
+    # (tier_router, _resolve_tier_group, _decrement_shared_tier_stocks,
+    # enrich_product_with_tier) to be removed first to avoid runtime errors.
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Migration a1b9c3d7e5f2 is forward-only. "
+        "To reverse, restore the database from the pre-deploy backup."
+    )

--- a/backend/app/alembic/versions/a1b9c3d7e5f2_drop_tier_groups_use_sale_windows.py
+++ b/backend/app/alembic/versions/a1b9c3d7e5f2_drop_tier_groups_use_sale_windows.py
@@ -28,7 +28,7 @@ from sqlalchemy.dialects.postgresql import TIMESTAMP
 
 # revision identifiers, used by Alembic.
 revision: str = "a1b9c3d7e5f2"
-down_revision: str = "3f8a1c9e4b2d"
+down_revision: str = "c5e9d3b2f8a0"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -308,8 +308,6 @@ async def list_my_tickets(
             TicketProduct(
                 name=seen[pid].name,
                 category=seen[pid].category,
-                start_date=seen[pid].start_date,
-                end_date=seen[pid].end_date,
                 quantity=qty,
             )
             for pid, qty in counts.items()
@@ -622,8 +620,6 @@ def _build_directory_entry(application) -> AttendeesDirectoryEntry:
     # Find main attendee and their products
     main_attendee = application.get_main_attendee()
     products: list[DirectoryProduct] = []
-    check_in = None
-    check_out = None
 
     if main_attendee:
         # Each AttendeeProducts row is one ticket — dedupe by product_id so
@@ -642,16 +638,8 @@ def _build_directory_entry(application) -> AttendeesDirectoryEntry:
                     slug=p.slug,
                     category=p.category,
                     duration_type=p.duration_type,
-                    start_date=p.start_date,
-                    end_date=p.end_date,
                 )
             )
-            if p.start_date:
-                if check_in is None or p.start_date < check_in:
-                    check_in = p.start_date
-            if p.end_date:
-                if check_out is None or p.end_date > check_out:
-                    check_out = p.end_date
 
     has_kids = any(a.category == "kid" for a in application.attendees)
     brings_kids: bool | str = "*" if "brings_kids" in info_hidden else has_kids
@@ -684,8 +672,6 @@ def _build_directory_entry(application) -> AttendeesDirectoryEntry:
         picture_url=human.picture_url if human else None,
         brings_kids=brings_kids,
         participation=products,
-        check_in=check_in,
-        check_out=check_out,
         associated_attendees=associated,
     )
 
@@ -757,8 +743,6 @@ async def export_attendees_directory_csv(
             "Age",
             "Gender",
             "Brings Kids",
-            "Check In",
-            "Check Out",
         ]
     )
     for e in entries:
@@ -774,8 +758,6 @@ async def export_attendees_directory_csv(
                 e.age or "",
                 e.gender or "",
                 str(e.brings_kids),
-                e.check_in.isoformat() if e.check_in else "",
-                e.check_out.isoformat() if e.check_out else "",
             ]
         )
 

--- a/backend/app/api/application/schemas.py
+++ b/backend/app/api/application/schemas.py
@@ -431,8 +431,6 @@ class DirectoryProduct(BaseModel):
     slug: str
     category: str | None = None
     duration_type: str | None = None
-    start_date: datetime | None = None
-    end_date: datetime | None = None
 
 
 class AssociatedAttendee(BaseModel):
@@ -486,8 +484,6 @@ class AttendeesDirectoryEntry(BaseModel):
 
     # Participation
     participation: list[DirectoryProduct] = []
-    check_in: datetime | None = None
-    check_out: datetime | None = None
 
     # Associated attendees (spouse/kids)
     associated_attendees: list[AssociatedAttendee] = []

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -82,8 +82,6 @@ def _build_attendee_with_origin(attendee) -> AttendeeWithOriginPublic:
                 ),
                 product_name=product_name,
                 product_category=product_category,
-                start_date=(ap.product.start_date if ap.product else None),
-                end_date=(ap.product.end_date if ap.product else None),
                 duration_type=(ap.product.duration_type if ap.product else None),
             )
         )
@@ -518,8 +516,6 @@ async def post_check_in(
             name=product.name,
             price=float(product.price),
             category=product.category,
-            start_date=product.start_date,
-            end_date=product.end_date,
         ),
         total_scans=summary["total_scans"],
         first_scan_at=summary["first_scan_at"],
@@ -564,8 +560,6 @@ async def get_tickets_by_email(
                 TicketProduct(
                     name=ap.product.name,
                     category=ap.product.category,
-                    start_date=ap.product.start_date,
-                    end_date=ap.product.end_date,
                     quantity=1,  # each row = 1 ticket
                 )
             )

--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -16,7 +16,6 @@ from app.api.form_field.crud import form_fields_crud
 from app.api.form_section.models import FormSections
 from app.api.popup.models import Popups
 from app.api.popup.schemas import PopupPublic, PopupStatus
-from app.api.product.crud import enrich_product_with_tier
 from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.ticketing_step.models import TicketingSteps
@@ -94,16 +93,7 @@ def runtime_for_slug(session: Session, slug: str, tenant_id: uuid.UUID) -> Check
     return CheckoutRuntimeResponse(
         popup=PopupPublic.model_validate(popup),
         products=[
-            CheckoutRuntimeProduct.model_validate(
-                {
-                    **CheckoutRuntimeProduct.model_validate(p).model_dump(),
-                    **(
-                        enrich_product_with_tier(session, p)
-                        if popup.tier_progression_enabled
-                        else {"tier_group": None, "phase": None}
-                    ),
-                }
-            )
+            CheckoutRuntimeProduct.model_validate(p)
             for p in products
         ],
         buyer_form=[

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from enum import StrEnum
 from typing import Self
 
-from pydantic import field_validator, model_validator
+from pydantic import ConfigDict, field_validator, model_validator
 from sqlalchemy import Boolean, Column, Numeric
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlmodel import Field, SQLModel, String
@@ -183,7 +183,6 @@ class PopupCreate(SQLModel):
     insurance_enabled: bool = False
     insurance_percentage: Decimal | None = None
     application_layout: ApplicationLayout = ApplicationLayout.single_page
-    tier_progression_enabled: bool = False
     events_enabled: bool = True
 
     @field_validator("currency")
@@ -208,6 +207,10 @@ class PopupCreate(SQLModel):
 
 
 class PopupUpdate(SQLModel):
+    # Reject unknown fields so deprecated ones (e.g., the removed
+    # tier_progression_enabled) are surfaced as 422 instead of silently ignored.
+    model_config = ConfigDict(extra="forbid")
+
     name: str | None = None
     tagline: str | None = None
     location: str | None = None
@@ -242,7 +245,6 @@ class PopupUpdate(SQLModel):
     insurance_enabled: bool | None = None
     insurance_percentage: Decimal | None = None
     application_layout: ApplicationLayout | None = None
-    tier_progression_enabled: bool | None = None
     events_enabled: bool | None = None
 
     @field_validator("currency")
@@ -307,7 +309,6 @@ class PopupPublic(SQLModel):
     insurance_enabled: bool = False
     insurance_percentage: Decimal | None = None
     application_layout: ApplicationLayout = ApplicationLayout.single_page
-    tier_progression_enabled: bool = False
     events_enabled: bool = True
 
 

--- a/backend/app/api/product/models.py
+++ b/backend/app/api/product/models.py
@@ -17,8 +17,20 @@ if TYPE_CHECKING:
     from app.api.tenant.models import Tenants
 
 
+# ---------------------------------------------------------------------------
+# Legacy tier-group models — kept in PR 1 to avoid breaking existing tier tests.
+# These classes reference DB tables (ticket_tier_group, ticket_tier_phase) that
+# are dropped by migration 0045. After that migration runs the classes become
+# dead code; they will be deleted in PR 2 alongside test_tier_groups_api.py and
+# test_tier_progression.py.
+# ---------------------------------------------------------------------------
+
+
 class TicketTierGroup(SQLModel, table=True):
-    """Tier group that pools multiple ticket-phase products under a shared inventory cap."""
+    """Tier group that pools multiple ticket-phase products under a shared inventory cap.
+
+    DEPRECATED — table dropped by migration a1b9c3d7e5f2. Will be removed in PR 2.
+    """
 
     __tablename__ = "ticket_tier_group"
 
@@ -39,7 +51,10 @@ class TicketTierGroup(SQLModel, table=True):
 
 
 class TicketTierPhase(SQLModel, table=True):
-    """A single phase (e.g. Early Bird) within a TicketTierGroup, linked to one product."""
+    """A single phase (e.g. Early Bird) within a TicketTierGroup, linked to one product.
+
+    DEPRECATED — table dropped by migration a1b9c3d7e5f2. Will be removed in PR 2.
+    """
 
     __tablename__ = "ticket_tier_phase"
     __table_args__ = (
@@ -62,6 +77,11 @@ class TicketTierPhase(SQLModel, table=True):
 
     # Relationships
     group: Optional["TicketTierGroup"] = Relationship(back_populates="phases")
+
+
+# ---------------------------------------------------------------------------
+# Products model
+# ---------------------------------------------------------------------------
 
 
 class Products(ProductBase, table=True):

--- a/backend/app/api/product/product_state.py
+++ b/backend/app/api/product/product_state.py
@@ -1,0 +1,83 @@
+"""Product sale-state derivation — pure helper.
+
+Implements the truth table from spec capability product-sale-state.
+
+Design: ADR-1 — state derivation is a pure function on Product.
+No DB access, no popup coupling, no side effects.
+"""
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+
+class ProductSaleState(StrEnum):
+    """Derived sale state for a product.
+
+    Computed at read time from product-level sale window fields and stock.
+    Never persisted.
+
+    Priority rule (spec §product-sale-state):
+        sold_out is evaluated LAST and overrides any time-based state.
+    """
+
+    upcoming = "upcoming"
+    on_sale = "on_sale"
+    ended = "ended"
+    sold_out = "sold_out"
+
+
+def derive_product_state(
+    product: Any,
+    now: datetime | None = None,
+) -> ProductSaleState:
+    """Return the derived sale state for a product at the given instant.
+
+    Args:
+        product: Any object exposing ``sale_starts_at``, ``sale_ends_at``
+                 (both ``datetime | None``) and ``total_stock_remaining``
+                 (``int | None``). Accepts SQLModel ORM instances, Pydantic
+                 response models, or plain duck-typed objects (e.g. test stubs).
+        now:     The reference instant.  Defaults to ``datetime.now(UTC)``.
+
+    Returns:
+        A ``ProductSaleState`` enum value.
+
+    Truth table:
+        sale_starts_at  sale_ends_at  now relative to window  → state
+        NULL            NULL          any                     → on_sale
+        NULL            future        now < ends_at           → on_sale
+        NULL            past          now >= ends_at          → ended
+        future          any           now < starts_at         → upcoming
+        past/now        NULL          —                       → on_sale
+        past/now        future        now < ends_at           → on_sale
+        any             past/now      now >= ends_at          → ended
+
+    Stock override (applied after time evaluation):
+        total_stock_remaining is NOT NULL AND <= 0             → sold_out
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    starts: datetime | None = getattr(product, "sale_starts_at", None)
+    ends: datetime | None = getattr(product, "sale_ends_at", None)
+    stock: int | None = getattr(product, "total_stock_remaining", None)
+
+    # ---- time-based state ----
+    # 1. If end window has passed (exclusive upper bound), the sale is ended.
+    if ends is not None and now >= ends:
+        state = ProductSaleState.ended
+
+    # 2. If start is in the future, the sale hasn't opened yet.
+    elif starts is not None and now < starts:
+        state = ProductSaleState.upcoming
+
+    # 3. All remaining cases: either no window, or now is within the window.
+    else:
+        state = ProductSaleState.on_sale
+
+    # ---- stock override (evaluated last, highest priority) ----
+    if stock is not None and stock <= 0:
+        state = ProductSaleState.sold_out
+
+    return state

--- a/backend/app/api/product/schemas.py
+++ b/backend/app/api/product/schemas.py
@@ -59,10 +59,10 @@ class ProductBase(SQLModel):
         default=None, nullable=True
     )
     duration_type: TicketDuration | None = Field(default=None, nullable=True)
-    start_date: datetime | None = Field(
+    sale_starts_at: datetime | None = Field(
         default=None, nullable=True, sa_type=DateTime(timezone=True)
     )
-    end_date: datetime | None = Field(
+    sale_ends_at: datetime | None = Field(
         default=None, nullable=True, sa_type=DateTime(timezone=True)
     )
     is_active: bool = Field(default=True)
@@ -105,8 +105,8 @@ class ProductCreate(BaseModel):
     category: str = "ticket"
     attendee_category: TicketAttendeeCategory | None = None
     duration_type: TicketDuration | None = None
-    start_date: datetime | None = None
-    end_date: datetime | None = None
+    sale_starts_at: datetime | None = None
+    sale_ends_at: datetime | None = None
     is_active: bool = True
     exclusive: bool = False
     total_stock_cap: int | None = Field(default=None, ge=1)
@@ -140,6 +140,16 @@ class ProductCreate(BaseModel):
                 )
         return self
 
+    @model_validator(mode="after")
+    def validate_sale_window(self) -> "ProductCreate":
+        """sale_starts_at must be before sale_ends_at when both are set."""
+        if self.sale_starts_at is not None and self.sale_ends_at is not None:
+            if self.sale_starts_at > self.sale_ends_at:
+                raise ValueError(
+                    "sale_starts_at must be before sale_ends_at"
+                )
+        return self
+
 
 class ProductUpdate(BaseModel):
     """Product schema for updates."""
@@ -153,8 +163,8 @@ class ProductUpdate(BaseModel):
     category: str | None = None
     attendee_category: TicketAttendeeCategory | None = None
     duration_type: TicketDuration | None = None
-    start_date: datetime | None = None
-    end_date: datetime | None = None
+    sale_starts_at: datetime | None = None
+    sale_ends_at: datetime | None = None
     is_active: bool | None = None
     exclusive: bool | None = None
     total_stock_cap: int | None = Field(default=None, ge=1)
@@ -174,6 +184,16 @@ class ProductUpdate(BaseModel):
                 )
         return self
 
+    @model_validator(mode="after")
+    def validate_sale_window(self) -> "ProductUpdate":
+        """sale_starts_at must be before sale_ends_at when both are set."""
+        if self.sale_starts_at is not None and self.sale_ends_at is not None:
+            if self.sale_starts_at > self.sale_ends_at:
+                raise ValueError(
+                    "sale_starts_at must be before sale_ends_at"
+                )
+        return self
+
 
 class ProductBatchItem(BaseModel):
     """Single product in a batch import (popup_id is top-level)."""
@@ -187,8 +207,8 @@ class ProductBatchItem(BaseModel):
     category: str = "ticket"
     attendee_category: TicketAttendeeCategory | None = None
     duration_type: TicketDuration | None = None
-    start_date: datetime | None = None
-    end_date: datetime | None = None
+    sale_starts_at: datetime | None = None
+    sale_ends_at: datetime | None = None
     is_active: bool = True
     exclusive: bool = False
     total_stock_cap: int | None = Field(default=None, ge=1)

--- a/backend/tests/api/attendee/test_attendee_product_denormalization.py
+++ b/backend/tests/api/attendee/test_attendee_product_denormalization.py
@@ -7,7 +7,6 @@ T3.1 — Three scenarios:
 """
 
 import uuid
-from datetime import datetime
 from decimal import Decimal
 
 from sqlmodel import Session
@@ -34,8 +33,6 @@ def _make_product(
     category: str = "ticket",
     requires_check_in: bool = True,
     duration_type: str | None = "week",
-    start_date: datetime | None = None,
-    end_date: datetime | None = None,
 ) -> Products:
     product = Products(
         id=uuid.uuid4(),
@@ -48,8 +45,6 @@ def _make_product(
         requires_check_in=requires_check_in,
         is_active=is_active,
         duration_type=duration_type,
-        start_date=start_date,
-        end_date=end_date,
     )
     db.add(product)
     db.commit()
@@ -119,10 +114,7 @@ def test_denorm_active_product_populates_all_fields(
     tenant_a: Tenants,
     popup_tenant_a: Popups,
 ) -> None:
-    """Active product → all 5 denormalized fields are non-null in the response."""
-    start = datetime(2025, 6, 1)
-    end = datetime(2025, 6, 7)
-
+    """Active product → denormalized fields are populated in the response."""
     product = _make_product(
         db,
         tenant_a,
@@ -131,8 +123,6 @@ def test_denorm_active_product_populates_all_fields(
         category="ticket",
         requires_check_in=True,
         duration_type="week",
-        start_date=start,
-        end_date=end,
     )
     human = _make_human(db, tenant_a, suffix="active")
     attendee = _make_attendee(db, tenant_a, popup_tenant_a, human, suffix="active")
@@ -160,11 +150,6 @@ def test_denorm_active_product_populates_all_fields(
     assert ap.product_name == "Denorm Product active"
     assert ap.product_category == "ticket"
     assert ap.duration_type == "week"
-    # DB returns timezone-aware datetimes; compare by stripping tzinfo for portability
-    assert ap.start_date is not None
-    assert ap.end_date is not None
-    assert ap.start_date.year == start.year and ap.start_date.month == start.month and ap.start_date.day == start.day
-    assert ap.end_date.year == end.year and ap.end_date.month == end.month and ap.end_date.day == end.day
     assert ap.requires_check_in is True
 
 

--- a/backend/tests/api/popup/test_popup_crud.py
+++ b/backend/tests/api/popup/test_popup_crud.py
@@ -1,0 +1,38 @@
+"""Integration tests for Popup CRUD after tier schema removal (spec: migration-backfill).
+
+Scenarios:
+1. PATCH popup with tier_progression_enabled: true → 422 (extra field rejected).
+   (T1.7b / Spec: migration-backfill, Scenario 3 — schema rejects deprecated tier fields)
+"""
+
+from fastapi.testclient import TestClient
+
+from app.api.popup.models import Popups
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# T1.7b — tier_progression_enabled rejected with 422 on PATCH popup
+# ---------------------------------------------------------------------------
+
+
+def test_patch_popup_with_tier_progression_enabled_returns_422(
+    client: TestClient,
+    admin_token_tenant_a: str,
+    popup_tenant_a: Popups,
+) -> None:
+    """PATCH popup with tier_progression_enabled: true → 422 extra-field rejection.
+
+    After removing tier_progression_enabled from PopupUpdate, Pydantic rejects
+    extra fields because the schema no longer declares it.
+    """
+    resp = client.patch(
+        f"/api/v1/popups/{popup_tenant_a.id}",
+        headers=_admin_headers(admin_token_tenant_a),
+        json={"tier_progression_enabled": True},
+    )
+    # Pydantic v2 extra-field rejection returns 422 Unprocessable Entity.
+    assert resp.status_code == 422, resp.text

--- a/backend/tests/api/product/test_product_crud.py
+++ b/backend/tests/api/product/test_product_crud.py
@@ -1,0 +1,141 @@
+"""Integration tests for Product sale-window CRUD (spec: product-sale-window).
+
+Scenarios:
+1. PATCH sets sale window → ProductPublic returns verbatim (T1.7a / Scenario 1)
+2. PATCH clears both to null → ProductPublic returns null on both (T1.7a / Scenario 2)
+3. POST with inverted window → 422 validation error (validator round-trip)
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.api.popup.models import Popups
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_product_payload(popup_id: uuid.UUID, *, suffix: str) -> dict:
+    return {
+        "popup_id": str(popup_id),
+        "name": f"Sale Window Test Product {suffix}",
+        "price": "50.00",
+        "category": "ticket",
+    }
+
+
+# ---------------------------------------------------------------------------
+# T1.7a — Scenario 1: PATCH sets sale window, response returns verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_patch_product_sets_sale_window(
+    client: TestClient,
+    admin_token_tenant_a: str,
+    popup_tenant_a: Popups,
+) -> None:
+    """Admin PATCHes sale_starts_at and sale_ends_at → both returned verbatim."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # 1. Create product
+    create_resp = client.post(
+        "/api/v1/products",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_product_payload(popup_tenant_a.id, suffix=suffix),
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    product_id = create_resp.json()["id"]
+
+    # 2. PATCH with sale window
+    patch_resp = client.patch(
+        f"/api/v1/products/{product_id}",
+        headers=_admin_headers(admin_token_tenant_a),
+        json={
+            "sale_starts_at": "2026-06-01T00:00:00Z",
+            "sale_ends_at": "2026-07-01T00:00:00Z",
+        },
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    data = patch_resp.json()
+
+    assert data["sale_starts_at"] is not None
+    assert data["sale_ends_at"] is not None
+    # ISO strings must round-trip; compare by date portion only (tz formatting may vary)
+    assert data["sale_starts_at"].startswith("2026-06-01")
+    assert data["sale_ends_at"].startswith("2026-07-01")
+
+
+# ---------------------------------------------------------------------------
+# T1.7a — Scenario 2: PATCH clears both to null → both fields return null
+# ---------------------------------------------------------------------------
+
+
+def test_patch_product_clears_sale_window(
+    client: TestClient,
+    admin_token_tenant_a: str,
+    popup_tenant_a: Popups,
+) -> None:
+    """Admin PATCHes null/null → both sale window fields return null."""
+    suffix = uuid.uuid4().hex[:8]
+
+    # 1. Create product
+    create_resp = client.post(
+        "/api/v1/products",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=_create_product_payload(popup_tenant_a.id, suffix=suffix),
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    product_id = create_resp.json()["id"]
+
+    # 2. Set sale window first
+    set_resp = client.patch(
+        f"/api/v1/products/{product_id}",
+        headers=_admin_headers(admin_token_tenant_a),
+        json={
+            "sale_starts_at": "2026-06-01T00:00:00Z",
+            "sale_ends_at": "2026-07-01T00:00:00Z",
+        },
+    )
+    assert set_resp.status_code == 200, set_resp.text
+
+    # 3. Clear both
+    clear_resp = client.patch(
+        f"/api/v1/products/{product_id}",
+        headers=_admin_headers(admin_token_tenant_a),
+        json={
+            "sale_starts_at": None,
+            "sale_ends_at": None,
+        },
+    )
+    assert clear_resp.status_code == 200, clear_resp.text
+    data = clear_resp.json()
+    assert data["sale_starts_at"] is None
+    assert data["sale_ends_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Validator: inverted window → 422
+# ---------------------------------------------------------------------------
+
+
+def test_create_product_with_inverted_sale_window_returns_422(
+    client: TestClient,
+    admin_token_tenant_a: str,
+    popup_tenant_a: Popups,
+) -> None:
+    """sale_starts_at > sale_ends_at must return 422."""
+    suffix = uuid.uuid4().hex[:8]
+    payload = {
+        **_create_product_payload(popup_tenant_a.id, suffix=suffix),
+        "sale_starts_at": "2026-07-01T00:00:00Z",  # starts after ends
+        "sale_ends_at": "2026-06-01T00:00:00Z",
+    }
+
+    resp = client.post(
+        "/api/v1/products",
+        headers=_admin_headers(admin_token_tenant_a),
+        json=payload,
+    )
+    assert resp.status_code == 422, resp.text

--- a/backend/tests/api/product/test_product_state.py
+++ b/backend/tests/api/product/test_product_state.py
@@ -1,0 +1,179 @@
+"""Unit tests for derive_product_state — truth table coverage.
+
+TDD phase: RED-then-GREEN following the spec capability product-sale-state.
+
+Truth table (spec §product-sale-state):
+  | sale_starts_at | sale_ends_at | now relative        | expected  |
+  |----------------|--------------|---------------------|-----------|
+  | NULL           | NULL         | any                 | on_sale   |
+  | NULL           | future       | now < ends_at       | on_sale   |
+  | NULL           | past         | now >= ends_at      | ended     |
+  | future         | NULL         | now < starts_at     | upcoming  |
+  | future         | future       | now < starts_at     | upcoming  |
+  | past           | NULL         | now >= starts_at    | on_sale   |
+  | past           | future       | within window       | on_sale   |
+  | past           | past         | now >= ends_at      | ended     |
+  | exact lower    | future       | now == starts_at    | on_sale   |  (inclusive)
+  | past           | exact upper  | now == ends_at      | ended     |  (exclusive)
+  | past           | future       | within + stock=0    | sold_out  |  (stock overrides)
+  | future         | future       | upcoming + stock=0  | sold_out  |  (stock overrides)
+
+ADR-1: sold_out is NOT in the enum for time-based derivation; stock semantics are
+a separate concern. But per spec, sold_out IS returned when stock_remaining <= 0
+regardless of time window. The function reads total_stock_remaining from the product.
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.api.product.product_state import ProductSaleState, derive_product_state
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=UTC)
+PAST = NOW - timedelta(days=30)
+FUTURE = NOW + timedelta(days=30)
+
+
+def _product(
+    sale_starts_at: datetime | None = None,
+    sale_ends_at: datetime | None = None,
+    total_stock_remaining: int | None = None,
+) -> Any:
+    """Return a minimal object with the fields derive_product_state reads."""
+
+    class _Prod:
+        pass
+
+    p = _Prod()
+    p.sale_starts_at = sale_starts_at
+    p.sale_ends_at = sale_ends_at
+    p.total_stock_remaining = total_stock_remaining
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Time-based truth table
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProductStateTruthTable:
+    """Covers every (sale_starts_at, sale_ends_at) combination from the spec."""
+
+    def test_both_null_returns_on_sale(self) -> None:
+        """NULL/NULL → on_sale (OQ1 locked — null-both defaults to open)."""
+        p = _product(sale_starts_at=None, sale_ends_at=None)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+    def test_null_starts_future_ends_returns_on_sale(self) -> None:
+        """NULL start, future end → on_sale (sale has started, not yet ended)."""
+        p = _product(sale_starts_at=None, sale_ends_at=FUTURE)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+    def test_null_starts_past_ends_returns_ended(self) -> None:
+        """NULL start, past end → ended (window closed)."""
+        p = _product(sale_starts_at=None, sale_ends_at=PAST)
+        assert derive_product_state(p, NOW) == ProductSaleState.ended
+
+    def test_future_starts_null_ends_returns_upcoming(self) -> None:
+        """Future start, NULL end → upcoming (window not yet open)."""
+        p = _product(sale_starts_at=FUTURE, sale_ends_at=None)
+        assert derive_product_state(p, NOW) == ProductSaleState.upcoming
+
+    def test_future_starts_future_ends_returns_upcoming(self) -> None:
+        """Both future → upcoming (now is before the window)."""
+        p = _product(sale_starts_at=FUTURE, sale_ends_at=FUTURE + timedelta(days=10))
+        assert derive_product_state(p, NOW) == ProductSaleState.upcoming
+
+    def test_past_starts_null_ends_returns_on_sale(self) -> None:
+        """Past start, NULL end → on_sale (window open, no close)."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=None)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+    def test_past_starts_future_ends_returns_on_sale(self) -> None:
+        """Past start, future end → on_sale (within the window)."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=FUTURE)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+    def test_past_starts_past_ends_returns_ended(self) -> None:
+        """Both past → ended (window already closed)."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=PAST + timedelta(days=1))
+        assert derive_product_state(p, NOW) == ProductSaleState.ended
+
+    def test_exact_lower_bound_is_inclusive(self) -> None:
+        """now == sale_starts_at → on_sale (inclusive lower bound)."""
+        p = _product(sale_starts_at=NOW, sale_ends_at=FUTURE)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+    def test_exact_upper_bound_is_exclusive(self) -> None:
+        """now == sale_ends_at → ended (exclusive upper bound)."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=NOW)
+        assert derive_product_state(p, NOW) == ProductSaleState.ended
+
+
+# ---------------------------------------------------------------------------
+# Stock exhaustion overrides time window (evaluated last, highest priority)
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProductStateSoldOut:
+    """sold_out overrides any time-based state when total_stock_remaining <= 0."""
+
+    def test_stock_zero_overrides_on_sale(self) -> None:
+        """Within window but stock=0 → sold_out."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=FUTURE, total_stock_remaining=0)
+        assert derive_product_state(p, NOW) == ProductSaleState.sold_out
+
+    def test_stock_zero_overrides_upcoming(self) -> None:
+        """Upcoming but stock=0 → sold_out."""
+        p = _product(sale_starts_at=FUTURE, sale_ends_at=None, total_stock_remaining=0)
+        assert derive_product_state(p, NOW) == ProductSaleState.sold_out
+
+    def test_stock_negative_overrides_on_sale(self) -> None:
+        """Negative stock (over-sold edge case) → sold_out."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=FUTURE, total_stock_remaining=-1)
+        assert derive_product_state(p, NOW) == ProductSaleState.sold_out
+
+    def test_null_stock_does_not_trigger_sold_out(self) -> None:
+        """NULL total_stock_remaining → unlimited; no sold_out override."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=FUTURE, total_stock_remaining=None)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+    def test_positive_stock_does_not_trigger_sold_out(self) -> None:
+        """Positive stock → time window governs normally."""
+        p = _product(sale_starts_at=PAST, sale_ends_at=FUTURE, total_stock_remaining=1)
+        assert derive_product_state(p, NOW) == ProductSaleState.on_sale
+
+
+# ---------------------------------------------------------------------------
+# Default now=None uses datetime.now(UTC)
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveProductStateDefaultNow:
+    def test_default_now_resolves_to_utc(self) -> None:
+        """Calling without now= argument must not raise and must return a valid state."""
+        p = _product(sale_starts_at=None, sale_ends_at=None)
+        result = derive_product_state(p)
+        assert result in iter(ProductSaleState)
+
+
+# ---------------------------------------------------------------------------
+# Enum membership
+# ---------------------------------------------------------------------------
+
+
+class TestProductSaleStateEnum:
+    def test_enum_has_exactly_four_values(self) -> None:
+        """ProductSaleState must define upcoming, on_sale, ended, sold_out."""
+        values = {s.value for s in ProductSaleState}
+        assert values == {"upcoming", "on_sale", "ended", "sold_out"}
+
+    def test_enum_values_are_strings(self) -> None:
+        """ProductSaleState must be a StrEnum (values usable as plain strings)."""
+        assert str(ProductSaleState.on_sale) == "on_sale"
+        assert str(ProductSaleState.upcoming) == "upcoming"
+        assert str(ProductSaleState.ended) == "ended"
+        assert str(ProductSaleState.sold_out) == "sold_out"


### PR DESCRIPTION
## Summary

First slice of the `drop-tier-groups-use-sections` change. **Additive-only** at the DB level — no live code is removed in this PR. The `tier_router`, `TierGroupsCRUD`, `TierPhasesCRUD`, `_resolve_tier_group`, `_decrement_shared_tier_stocks`, and `derive_phase_states` all stay alive and continue to pass their existing tests. Their removal is the next PR.

- New `Product.sale_starts_at` / `sale_ends_at` columns and matching schema fields, replacing the legacy `start_date` / `end_date` at the API surface.
- New `ProductSaleState` enum and pure `derive_product_state(product, now)` helper.
- Migration 0045 backfills the new columns from `ticket_tier_phase` (10 rows in production) and concatenates phase labels into product names where missing.
- API surface drops: `tier_progression_enabled` field on Popup schemas (DB column kept alive); `check_in`/`check_out` on `AttendeesDirectoryEntry`; `start_date`/`end_date` on `DirectoryProduct`; `tier_group`/`phase` embedding on `CheckoutRuntimeProduct`.
- `_build_directory_entry` and `_build_attendee_with_origin` stop reading the legacy `Product.start_date` / `.end_date` (also covers the passes-display spec amendment for the denormalization added by commit `4f22bc1`).

## Why additive-only

The original plan had migration 0045 dropping `ticket_tier_phase`, `ticket_tier_group`, `products.start_date`, and `products.end_date`. But the live code that queries those tables/columns (`_resolve_tier_group` from `add_product`, `_decrement_shared_tier_stocks` from open-ticketing payment creation, the entire `tier_router`) is only removed in PR 2.

If PR 1 dropped the tables, deploying PR 1 alone would crash production: ticket creation and payment creation hit dropped tables and 500. Splitting the migration in two — PR 1 adds, PR 2 drops once consumers are gone — is the standard safe pattern for production schema changes.

## Migration 0045 — additive-only

1. ADD `products.sale_starts_at TIMESTAMPTZ NULL`
2. ADD `products.sale_ends_at TIMESTAMPTZ NULL`
3. BACKFILL `sale_starts_at`/`sale_ends_at` from `ticket_tier_phase` rows joined on `product_id`.
4. BACKFILL product name with phase label where `POSITION(label IN name) = 0` (substring guard).

Forward-only. Drops of `ticket_tier_phase`, `ticket_tier_group`, `products.start_date`, `products.end_date`, and `popups.tier_progression_enabled` are deferred to migration 0046 in PR 2.

## Schema changes

- `Product`: rename `start_date`/`end_date` → `sale_starts_at`/`sale_ends_at` on `ProductBase`, `ProductCreate`, `ProductUpdate`, `ProductBatchItem`. Validator rejects `sale_starts_at > sale_ends_at`. The legacy DB columns stay in place but are unmapped from the SQLModel until PR 2's migration drops them.
- `Popup`: drop `tier_progression_enabled` from `PopupBase`, `PopupCreate`, `PopupUpdate`, `PopupPublic`. `PopupUpdate` gains `extra="forbid"` so legacy payloads still carrying the field 422 instead of silently no-oping.
- API-surface drops listed above.

## New helper

`backend/app/api/product/product_state.py` exports `ProductSaleState` and `derive_product_state(product, now) -> ProductSaleState`. Pure, product-local (no popup-level coupling per OQ2). NULL-both windows default to `on_sale`; `sold_out` is evaluated last and overrides the time-based state.

## Test plan

- [ ] Backend ruff (verified locally — all checks passed).
- [ ] Backend pytest:
  - new `test_product_state.py` covers all branches in spec capability `product-sale-state`.
  - new `test_product_crud.py` covers round-trip of `sale_starts_at`/`sale_ends_at` via the CRUD layer.
  - new `test_popup_crud.py` covers `PopupUpdate` rejecting `tier_progression_enabled`.
  - existing `test_resolve_tier_group.py`, `test_tier_groups_api.py`, `test_tier_progression.py`, `test_integration_stock_lifecycle.py`, `test_stock_restoration.py`, `test_product_crud_atomic.py`, `test_stock_cap_validator.py` all stay green — none of the live tier code they exercise is removed in this PR.
- [ ] Manual smoke after deploy on dev:
  - run `alembic upgrade head` against a fresh dev DB; confirm `sale_starts_at`/`sale_ends_at` are populated for the 10 phase-bound products and phase labels are present in their names.
  - confirm `ticket_tier_phase` and `ticket_tier_group` tables still exist (drop deferred to PR 2).
  - confirm `_resolve_tier_group` and `_decrement_shared_tier_stocks` still function (no regression in existing payment / ticket creation flows).

## Coordinated changes

This PR also covers two coupling items flagged in spec amendment of 2026-05-08:
1. Drop `start_date`/`end_date` reads in `_build_attendee_with_origin` (the denormalization added by commit `4f22bc1`).
2. `test_attendee_product_denormalization.py` updated accordingly.

The third coupling item — removing the date-range UI in the portal `/passes` view — lands in PR 4.

## What's still pending

- **PR 2/4**: delete `tier_router`, `TierGroupsCRUD`, `TierPhasesCRUD`, `tier_groups_crud`, `tier_phases_crud`, `_resolve_tier_group`, `_decrement_shared_tier_stocks`, `enrich_product_with_tier`, `derive_phase_states`, the `TicketTierGroup` and `TicketTierPhase` SQLModel classes, the `tier_progression.py` module, the 7 tier-related tests. Migration 0046 to drop the tables and columns.
- **PR 3/4**: backoffice cleanup (TierGroupPicker, ProductForm tier fields, sale window inputs).
- **PR 4/4**: portal cleanup (PassSelectionSection, OpenCheckoutRuntime, deriveProductState helper, passes-display date-range removal).