### PR TITLE
 feat(portal): flag already-scanned QR codes on attendee passes (yellow)

### DIFF
--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -16,7 +16,11 @@ from app.api.attendee.schemas import (
     TicketProductSnapshot,
     TicketPublic,
 )
-from app.api.check_in.crud import get_check_in_summary, record_check_in
+from app.api.check_in.crud import (
+    get_check_in_summary,
+    get_last_scan_by_tickets,
+    record_check_in,
+)
 from app.api.check_in.schemas import CheckInPayload
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
@@ -35,7 +39,10 @@ _AttendeeLimit = Annotated[
 ]
 
 
-def _build_attendee_with_origin(attendee) -> AttendeeWithOriginPublic:
+def _build_attendee_with_origin(
+    attendee,
+    last_scan_by_ticket: dict | None = None,
+) -> AttendeeWithOriginPublic:
     """Build an AttendeeWithOriginPublic from an Attendees ORM row.
 
     Constructs the response manually to avoid the Pydantic from_attributes
@@ -51,6 +58,11 @@ def _build_attendee_with_origin(attendee) -> AttendeeWithOriginPublic:
     (free / application grant) or no snapshot row exists (e.g., cancelled
     payment whose snapshot rows were deleted). start_date, end_date, and
     duration_type are not snapshotted and always read from the live product.
+
+    last_scan_by_ticket is an optional {attendee_product_id: last_scan_at} map
+    precomputed by the caller (typically via get_last_scan_by_tickets) so the
+    portal can flag already-scanned QR codes without an N+1 lookup. Missing
+    keys mean the ticket has never been scanned.
     """
     snapshot_by_pair = {
         (pp.payment_id, pp.product_id): pp for pp in attendee.payment_products
@@ -83,6 +95,9 @@ def _build_attendee_with_origin(attendee) -> AttendeeWithOriginPublic:
                 product_name=product_name,
                 product_category=product_category,
                 duration_type=(ap.product.duration_type if ap.product else None),
+                last_scan_at=(
+                    last_scan_by_ticket.get(ap.id) if last_scan_by_ticket else None
+                ),
             )
         )
     origin = "application" if attendee.application_id is not None else "direct_sale"
@@ -134,7 +149,11 @@ async def list_my_attendees_by_popup(
     attendees, total = crud.attendees_crud.find_by_human_popup(
         db, human_id=current_human.id, popup_id=popup_id, skip=skip, limit=limit
     )
-    results = [_build_attendee_with_origin(a) for a in attendees]
+    # Single aggregation across every ticket on the page so the portal can flag
+    # already-scanned QR codes without N+1 lookups per attendee.
+    ticket_ids = [ap.id for a in attendees for ap in a.attendee_products]
+    last_scan_by_ticket = get_last_scan_by_tickets(db, ticket_ids)
+    results = [_build_attendee_with_origin(a, last_scan_by_ticket) for a in attendees]
     return ListModel[AttendeeWithOriginPublic](
         results=results,
         paging=Paging(offset=skip, limit=limit, total=total),
@@ -202,7 +221,10 @@ async def create_my_attendee_for_popup(
         gender=attendee_in.gender,
     )
 
-    return _build_attendee_with_origin(attendee)
+    last_scan_by_ticket = get_last_scan_by_tickets(
+        db, [ap.id for ap in attendee.attendee_products]
+    )
+    return _build_attendee_with_origin(attendee, last_scan_by_ticket)
 
 
 @router.patch(
@@ -255,7 +277,10 @@ async def update_my_attendee_for_popup(
         )
 
     updated = crud.attendees_crud.update_attendee(db, attendee, attendee_in)
-    return _build_attendee_with_origin(updated)
+    last_scan_by_ticket = get_last_scan_by_tickets(
+        db, [ap.id for ap in updated.attendee_products]
+    )
+    return _build_attendee_with_origin(updated, last_scan_by_ticket)
 
 
 @router.delete(
@@ -382,7 +407,10 @@ async def get_attendee(
             detail="Attendee not found",
         )
 
-    return _build_attendee_with_origin(attendee)
+    last_scan_by_ticket = get_last_scan_by_tickets(
+        db, [ap.id for ap in attendee.attendee_products]
+    )
+    return _build_attendee_with_origin(attendee, last_scan_by_ticket)
 
 
 @router.patch("/{attendee_id}", response_model=AttendeeWithOriginPublic)
@@ -402,7 +430,10 @@ async def update_attendee(
         )
 
     updated = crud.attendees_crud.update_attendee(db, attendee, attendee_in)
-    return _build_attendee_with_origin(updated)
+    last_scan_by_ticket = get_last_scan_by_tickets(
+        db, [ap.id for ap in updated.attendee_products]
+    )
+    return _build_attendee_with_origin(updated, last_scan_by_ticket)
 
 
 @router.delete("/{attendee_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/attendee/schemas.py
+++ b/backend/app/api/attendee/schemas.py
@@ -170,6 +170,10 @@ class AttendeeProductPublic(BaseModel):
     related Product at response-build time (current product state, not
     snapshot-at-purchase). All are optional with None defaults for backward
     compatibility with old clients that do not read them.
+
+    last_scan_at is the most recent occurred_at from check_ins for this ticket
+    (None when the ticket has never been scanned). Populated by the router from
+    a batched aggregation so portal UIs can flag already-used QR codes.
     """
 
     id: uuid.UUID
@@ -181,6 +185,7 @@ class AttendeeProductPublic(BaseModel):
     product_name: str | None = None
     product_category: str | None = None
     duration_type: str | None = None
+    last_scan_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True, extra="forbid")
 

--- a/backend/app/api/check_in/crud.py
+++ b/backend/app/api/check_in/crud.py
@@ -1,6 +1,8 @@
 """CRUD functions for the check_ins table."""
 
 import uuid
+from collections.abc import Iterable
+from datetime import datetime
 from typing import Any
 
 from sqlmodel import Session, func, select
@@ -97,3 +99,29 @@ def get_check_in_summary(
         "first_scan_at": row.first_scan_at,
         "last_scan_at": row.last_scan_at,
     }
+
+
+def get_last_scan_by_tickets(
+    session: Session,
+    ticket_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, datetime]:
+    """Return {attendee_product_id: max(occurred_at)} for the given ticket IDs.
+
+    Only tickets that have at least one check-in row appear in the result —
+    callers should treat missing keys as "never scanned". Implemented as a
+    single aggregation to avoid N+1 when an attendee has multiple tickets.
+    """
+    ticket_id_list = list(ticket_ids)
+    if not ticket_id_list:
+        return {}
+
+    rows = session.exec(
+        select(
+            CheckIn.attendee_product_id,
+            func.max(CheckIn.occurred_at).label("last_scan_at"),
+        )
+        .where(CheckIn.attendee_product_id.in_(ticket_id_list))  # type: ignore[union-attr]
+        .group_by(CheckIn.attendee_product_id)
+    ).all()
+
+    return {row.attendee_product_id: row.last_scan_at for row in rows}

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -1843,6 +1843,18 @@ export const AttendeeProductPublicSchema = {
                 }
             ],
             title: 'Duration Type'
+        },
+        last_scan_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Scan At'
         }
     },
     additionalProperties: false,
@@ -1857,7 +1869,11 @@ can decide whether to render a QR code without an extra round-trip.
 product_name, product_category, and duration_type are denormalized from the
 related Product at response-build time (current product state, not
 snapshot-at-purchase). All are optional with None defaults for backward
-compatibility with old clients that do not read them.`
+compatibility with old clients that do not read them.
+
+last_scan_at is the most recent occurred_at from check_ins for this ticket
+(None when the ticket has never been scanned). Populated by the router from
+a batched aggregation so portal UIs can flag already-used QR codes.`
 } as const;
 
 export const AttendeePublicSchema = {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -379,6 +379,10 @@ export type AttendeeListItem = {
  * related Product at response-build time (current product state, not
  * snapshot-at-purchase). All are optional with None defaults for backward
  * compatibility with old clients that do not read them.
+ *
+ * last_scan_at is the most recent occurred_at from check_ins for this ticket
+ * (None when the ticket has never been scanned). Populated by the router from
+ * a batched aggregation so portal UIs can flag already-used QR codes.
  */
 export type AttendeeProductPublic = {
     id: string;
@@ -390,6 +394,7 @@ export type AttendeeProductPublic = {
     product_name?: (string | null);
     product_category?: (string | null);
     duration_type?: (string | null);
+    last_scan_at?: (string | null);
 };
 
 /**

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
@@ -252,7 +252,7 @@ const AttendeeTicket = ({
                           className={cn(
                             "transition-colors cursor-pointer flex-shrink-0",
                             isScanned
-                              ? "text-red-500 hover:text-red-700"
+                              ? "text-yellow-500 hover:text-yellow-700"
                               : "text-pass-text hover:text-pass-title",
                           )}
                         >

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
@@ -83,8 +83,12 @@ const AttendeeTicket = ({
     .filter((e) => e.product_category !== "patreon")
     .sort(compareByCategory)
 
-  // Inline QR modal state — drives the shared <QRcode> modal at bottom of file
-  const [activeCode, setActiveCode] = useState<string | null>(null)
+  // Inline QR modal state — drives the shared <QRcode> modal at bottom of file.
+  // Tracks lastScanAt alongside the code so the modal can flag already-used QRs.
+  const [activeTicket, setActiveTicket] = useState<{
+    code: string
+    lastScanAt: string | null
+  } | null>(null)
 
   // Collapsible open states
   const defaultLocalOpen = isLocalResident ? localProducts.length > 0 : false
@@ -215,6 +219,7 @@ const AttendeeTicket = ({
               <div className="w-full">
                 {ticketEntries.map((entry, idx) => {
                   const CategoryIcon = getCategoryIcon(entry.product_category)
+                  const isScanned = entry.last_scan_at != null
                   return (
                     <div
                       key={entry.id}
@@ -233,9 +238,23 @@ const AttendeeTicket = ({
                       {entry.requires_check_in === true && (
                         <button
                           type="button"
-                          onClick={() => setActiveCode(entry.check_in_code)}
-                          aria-label={t("passes.check_in_code")}
-                          className="text-pass-text hover:text-pass-title transition-colors cursor-pointer flex-shrink-0"
+                          onClick={() =>
+                            setActiveTicket({
+                              code: entry.check_in_code,
+                              lastScanAt: entry.last_scan_at ?? null,
+                            })
+                          }
+                          aria-label={
+                            isScanned
+                              ? t("passes.qr_already_scanned")
+                              : t("passes.check_in_code")
+                          }
+                          className={cn(
+                            "transition-colors cursor-pointer flex-shrink-0",
+                            isScanned
+                              ? "text-red-500 hover:text-red-700"
+                              : "text-pass-text hover:text-pass-title",
+                          )}
                         >
                           <QrCode className="w-5 h-5" />
                         </button>
@@ -244,10 +263,11 @@ const AttendeeTicket = ({
                   )
                 })}
                 <QRcode
-                  check_in_code={activeCode ?? ""}
-                  isOpen={activeCode !== null}
+                  check_in_code={activeTicket?.code ?? ""}
+                  lastScanAt={activeTicket?.lastScanAt ?? null}
+                  isOpen={activeTicket !== null}
                   onOpenChange={(open) => {
-                    if (!open) setActiveCode(null)
+                    if (!open) setActiveTicket(null)
                   }}
                 />
               </div>

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/QRcode.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/QRcode.tsx
@@ -87,8 +87,8 @@ const QRcode = ({
           <DialogTitle>Check-in Code</DialogTitle>
         </DialogHeader>
         {lastScanAt ? (
-          <div className="flex items-center gap-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
-            <span className="h-2 w-2 rounded-full bg-red-500" />
+          <div className="flex items-center gap-2 rounded-md bg-yellow-50 px-3 py-2 text-sm text-yellow-700">
+            <span className="h-2 w-2 rounded-full bg-yellow-500" />
             <span>
               {t("passes.qr_already_scanned")} ·{" "}
               {formatRelative(lastScanAt, i18n.language)}

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/QRcode.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/QRcode.tsx
@@ -1,5 +1,6 @@
 import { Download } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import QRCodeReact from "react-qr-code"
 import { Button } from "@/components/ui/button"
 import {
@@ -8,16 +9,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { formatRelative } from "@/lib/relativeTime"
 
 const QRcode = ({
   check_in_code,
   isOpen,
   onOpenChange,
+  lastScanAt,
 }: {
   check_in_code: string
   isOpen: boolean
   onOpenChange: (open: boolean) => void
+  lastScanAt?: string | null
 }) => {
+  const { t, i18n } = useTranslation()
   const qrCodeRef = useRef<HTMLDivElement>(null)
   const [qrValue, setQrValue] = useState("")
 
@@ -81,6 +86,15 @@ const QRcode = ({
         <DialogHeader>
           <DialogTitle>Check-in Code</DialogTitle>
         </DialogHeader>
+        {lastScanAt ? (
+          <div className="flex items-center gap-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            <span>
+              {t("passes.qr_already_scanned")} ·{" "}
+              {formatRelative(lastScanAt, i18n.language)}
+            </span>
+          </div>
+        ) : null}
         <div className="flex flex-col items-center justify-center py-4">
           {check_in_code ? (
             <div className="flex flex-col items-center gap-4">

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -1843,6 +1843,18 @@ export const AttendeeProductPublicSchema = {
                 }
             ],
             title: 'Duration Type'
+        },
+        last_scan_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Scan At'
         }
     },
     additionalProperties: false,
@@ -1857,7 +1869,11 @@ can decide whether to render a QR code without an extra round-trip.
 product_name, product_category, and duration_type are denormalized from the
 related Product at response-build time (current product state, not
 snapshot-at-purchase). All are optional with None defaults for backward
-compatibility with old clients that do not read them.`
+compatibility with old clients that do not read them.
+
+last_scan_at is the most recent occurred_at from check_ins for this ticket
+(None when the ticket has never been scanned). Populated by the router from
+a batched aggregation so portal UIs can flag already-used QR codes.`
 } as const;
 
 export const AttendeePublicSchema = {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -379,6 +379,10 @@ export type AttendeeListItem = {
  * related Product at response-build time (current product state, not
  * snapshot-at-purchase). All are optional with None defaults for backward
  * compatibility with old clients that do not read them.
+ *
+ * last_scan_at is the most recent occurred_at from check_ins for this ticket
+ * (None when the ticket has never been scanned). Populated by the router from
+ * a batched aggregation so portal UIs can flag already-used QR codes.
  */
 export type AttendeeProductPublic = {
     id: string;
@@ -390,6 +394,7 @@ export type AttendeeProductPublic = {
     product_name?: (string | null);
     product_category?: (string | null);
     duration_type?: (string | null);
+    last_scan_at?: (string | null);
 };
 
 /**

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -278,6 +278,7 @@
     "no_passes_yet_prefix": "You do not yet have any passes for {{city}}, please go to",
     "no_passes_yet_suffix": "to purchase",
     "check_in_code": "Check-in code",
+    "qr_already_scanned": "QR already scanned",
     "latam_citizens": "Latam Citizens",
     "standard": "Standard",
     "id_required": "ID Required at check-in *",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -278,6 +278,7 @@
     "no_passes_yet_prefix": "Todavía no tenés pases para {{city}}, por favor andá a",
     "no_passes_yet_suffix": "para comprar",
     "check_in_code": "Código de check-in",
+    "qr_already_scanned": "QR ya escaneado",
     "latam_citizens": "Ciudadanos de Latam",
     "standard": "Estándar",
     "id_required": "Se requiere identificación en el check-in *",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -278,6 +278,7 @@
     "no_passes_yet_prefix": "您还没有 {{city}} 的通行证，请前往",
     "no_passes_yet_suffix": "进行购买",
     "check_in_code": "签到码",
+    "qr_already_scanned": "二维码已扫描",
     "latam_citizens": "拉美公民",
     "standard": "标准",
     "id_required": "签到时需要身份证明 *",

--- a/portal/src/lib/relativeTime.ts
+++ b/portal/src/lib/relativeTime.ts
@@ -1,0 +1,28 @@
+/**
+ * Format an ISO datetime string as a localized relative time
+ * ("hace 2 h", "2 hours ago", "2小时前") using Intl.RelativeTimeFormat.
+ *
+ * Picks the largest unit whose value is >= 1 so we never produce
+ * "3600 seconds ago" when "1 hour ago" would do. Past times produce
+ * negative values; future times produce positive values. Returns an
+ * empty string if the input cannot be parsed.
+ */
+export function formatRelative(iso: string, locale: string): string {
+  const target = new Date(iso).getTime()
+  if (Number.isNaN(target)) return ""
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" })
+  const diffSec = (target - Date.now()) / 1000
+  const absSec = Math.abs(diffSec)
+
+  if (absSec < 60) {
+    return rtf.format(Math.round(diffSec), "second")
+  }
+  if (absSec < 3600) {
+    return rtf.format(Math.round(diffSec / 60), "minute")
+  }
+  if (absSec < 86400) {
+    return rtf.format(Math.round(diffSec / 3600), "hour")
+  }
+  return rtf.format(Math.round(diffSec / 86400), "day")
+}


### PR DESCRIPTION
Cherry-pick de 1b15382 con icono + banner en amarillo en vez de rojo (rojo daba sensación de error, amarillo lee como warning informativo). Base: main @ v1.4.0
