### PR TITLE
feat(portal): direct-checkout landing mode (portal 2/3)

### DIFF
--- a/portal/src/app/checkout/[popupSlug]/thank-you/page.test.tsx
+++ b/portal/src/app/checkout/[popupSlug]/thank-you/page.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react"
+import OpenCheckoutThankYouPage from "./page"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn()
+const mockUseTenant = vi.fn()
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ popupSlug: "summer-fest" }),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@/providers/tenantProvider", () => ({
+  useTenant: () => mockUseTenant(),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const checkoutModeTenant = {
+  tenant: {
+    id: "t-1",
+    name: "Festival Corp",
+    slug: "festival",
+    custom_domain_active: true,
+    landing_mode: "checkout" as const,
+    active_popup_slug: "summer-fest",
+    logo_url: null,
+    image_url: null,
+    icon_url: null,
+  },
+  isLoading: false,
+  error: null,
+}
+
+const portalModeTenant = {
+  tenant: {
+    id: "t-1",
+    name: "Festival Corp",
+    slug: "festival",
+    custom_domain_active: true,
+    landing_mode: "portal" as const,
+    active_popup_slug: null,
+    logo_url: null,
+    image_url: null,
+    icon_url: null,
+  },
+  isLoading: false,
+  error: null,
+}
+
+// ---------------------------------------------------------------------------
+// Scenario TY-1: CTA hidden in checkout mode
+// ---------------------------------------------------------------------------
+
+describe("OpenCheckoutThankYouPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset()
+  })
+
+  it("TY-1: back-to-portal CTA is not rendered in checkout mode", () => {
+    mockUseTenant.mockReturnValue(checkoutModeTenant)
+
+    render(<OpenCheckoutThankYouPage />)
+
+    // The CTA button must not be in the DOM
+    const cta = screen.queryByText("openCheckout.thank_you_cta")
+    expect(cta).toBeNull()
+  })
+
+  // Scenario TY-2: CTA visible in portal mode
+  it("TY-2: back-to-portal CTA is rendered and functional in portal mode", () => {
+    mockUseTenant.mockReturnValue(portalModeTenant)
+
+    render(<OpenCheckoutThankYouPage />)
+
+    const cta = screen.getByText("openCheckout.thank_you_cta")
+    expect(cta).toBeTruthy()
+  })
+
+  // Scenario TY-3: No broken layout when CTA hidden
+  it("TY-3: page renders without broken layout when CTA is hidden", () => {
+    mockUseTenant.mockReturnValue(checkoutModeTenant)
+
+    const { container } = render(<OpenCheckoutThankYouPage />)
+
+    // The success icon and thank-you text must still be present
+    expect(screen.getByText("openCheckout.thank_you_title")).toBeTruthy()
+    expect(screen.getByText("openCheckout.thank_you_description")).toBeTruthy()
+
+    // No empty button placeholder artifact (no buttons at all)
+    const buttons = container.querySelectorAll("button")
+    expect(buttons.length).toBe(0)
+  })
+
+  it("TY-3: page has correct content in portal mode with CTA visible", () => {
+    mockUseTenant.mockReturnValue(portalModeTenant)
+
+    render(<OpenCheckoutThankYouPage />)
+
+    expect(screen.getByText("openCheckout.thank_you_title")).toBeTruthy()
+    expect(screen.getByText("openCheckout.thank_you_description")).toBeTruthy()
+    expect(screen.getByText("openCheckout.thank_you_cta")).toBeTruthy()
+  })
+})

--- a/portal/src/app/checkout/[popupSlug]/thank-you/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/thank-you/page.tsx
@@ -4,11 +4,18 @@ import { CheckCircle, Home } from "lucide-react"
 import { useParams, useRouter } from "next/navigation"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
+import { useTenant } from "@/providers/tenantProvider"
 
 export default function OpenCheckoutThankYouPage() {
   const { t } = useTranslation()
   const router = useRouter()
   const params = useParams<{ popupSlug: string }>()
+  const { tenant } = useTenant()
+
+  // In direct-checkout mode the user arrives via the tenant's custom domain —
+  // there is no /portal/{slug} to navigate back to. Hide the CTA entirely so
+  // the page layout does not show a broken navigation target.
+  const showBackCta = tenant?.landing_mode !== "checkout"
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-6 py-12">
@@ -24,12 +31,14 @@ export default function OpenCheckoutThankYouPage() {
           {t("openCheckout.thank_you_description")}
         </p>
 
-        <div className="mt-8 flex justify-center">
-          <Button onClick={() => router.push(`/portal/${params.popupSlug}`)}>
-            <Home className="size-4" />
-            {t("openCheckout.thank_you_cta")}
-          </Button>
-        </div>
+        {showBackCta && (
+          <div className="mt-8 flex justify-center">
+            <Button onClick={() => router.push(`/portal/${params.popupSlug}`)}>
+              <Home className="size-4" />
+              {t("openCheckout.thank_you_cta")}
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/portal/src/app/checkout/components/PopupCheckoutContent.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.tsx
@@ -96,6 +96,9 @@ export const PopupCheckoutContent = ({
 
   useEffect(() => {
     if (hasSkippedForm.current) return
+    // Branch guarded by sale_type=application. Direct-checkout (landing_mode=checkout)
+    // only resolves direct-sale popups (backend resolve_active_direct_popup_slug),
+    // so this redirect to /portal is structurally unreachable in checkout mode.
     if (policy.saleType !== "application") return
     if (!existingApplication || checkoutState !== "form") return
 

--- a/portal/src/app/checkout/success/page.test.tsx
+++ b/portal/src/app/checkout/success/page.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react"
+import CheckoutSuccessPage from "./page"
+
+const mockPush = vi.fn()
+const mockUseTenant = vi.fn()
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+vi.mock("@/providers/tenantProvider", () => ({
+  useTenant: () => mockUseTenant(),
+}))
+
+const checkoutModeTenant = {
+  tenant: {
+    id: "t-1",
+    name: "Festival Corp",
+    slug: "festival",
+    custom_domain_active: true,
+    landing_mode: "checkout" as const,
+    active_popup_slug: "summer-fest",
+    logo_url: null,
+    image_url: null,
+    icon_url: null,
+  },
+  isLoading: false,
+  error: null,
+}
+
+const portalModeTenant = {
+  ...checkoutModeTenant,
+  tenant: {
+    ...checkoutModeTenant.tenant,
+    landing_mode: "portal" as const,
+    active_popup_slug: null,
+  },
+}
+
+describe("CheckoutSuccessPage", () => {
+  beforeEach(() => {
+    mockPush.mockReset()
+  })
+
+  it("hides the Go to portal CTA in checkout mode", () => {
+    mockUseTenant.mockReturnValue(checkoutModeTenant)
+
+    render(<CheckoutSuccessPage />)
+
+    expect(screen.queryByText("Go to portal")).toBeNull()
+  })
+
+  it("renders the Go to portal CTA in portal mode", () => {
+    mockUseTenant.mockReturnValue(portalModeTenant)
+
+    render(<CheckoutSuccessPage />)
+
+    expect(screen.getByText("Go to portal")).toBeTruthy()
+  })
+})

--- a/portal/src/app/checkout/success/page.tsx
+++ b/portal/src/app/checkout/success/page.tsx
@@ -3,9 +3,12 @@
 import { CheckCircle, Home } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
+import { useTenant } from "@/providers/tenantProvider"
 
 export default function CheckoutSuccessPage() {
   const router = useRouter()
+  const { tenant } = useTenant()
+  const showBackCta = tenant?.landing_mode !== "checkout"
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-6 py-12">
@@ -22,12 +25,14 @@ export default function CheckoutSuccessPage() {
           your event information.
         </p>
 
-        <div className="mt-8 flex justify-center">
-          <Button onClick={() => router.push("/portal")}>
-            <Home className="size-4" />
-            Go to portal
-          </Button>
-        </div>
+        {showBackCta && (
+          <div className="mt-8 flex justify-center">
+            <Button onClick={() => router.push("/portal")}>
+              <Home className="size-4" />
+              Go to portal
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/portal/src/app/coming-soon/page.test.tsx
+++ b/portal/src/app/coming-soon/page.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react"
+import ComingSoonPage from "./page"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseTenant = vi.fn()
+
+vi.mock("@/providers/tenantProvider", () => ({
+  useTenant: () => mockUseTenant(),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// ---------------------------------------------------------------------------
+// Scenario CS-1: Branded rendering
+// ---------------------------------------------------------------------------
+
+describe("ComingSoonPage", () => {
+  it("CS-1: renders tenant logo when logo_url is present", () => {
+    mockUseTenant.mockReturnValue({
+      tenant: {
+        id: "t-1",
+        name: "Festival Corp",
+        slug: "festival",
+        custom_domain_active: true,
+        landing_mode: "checkout",
+        logo_url: "https://cdn.example.com/logo.png",
+        image_url: null,
+        icon_url: null,
+        active_popup_slug: null,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ComingSoonPage />)
+
+    // Logo should be rendered (next/image wraps the src in /_next/image?url=...)
+    const logo = screen.getByRole("img", { name: /festival corp|logo/i })
+    expect(logo).toBeTruthy()
+    // Check original URL is present (encoded) in the optimized src
+    const src = (logo as HTMLImageElement).src
+    expect(src).toMatch(/cdn\.example\.com.*logo\.png/)
+  })
+
+  it("CS-1: renders Coming Soon heading", () => {
+    mockUseTenant.mockReturnValue({
+      tenant: {
+        id: "t-1",
+        name: "Festival Corp",
+        slug: "festival",
+        custom_domain_active: true,
+        landing_mode: "checkout",
+        logo_url: null,
+        image_url: null,
+        icon_url: null,
+        active_popup_slug: null,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    render(<ComingSoonPage />)
+
+    expect(screen.getByText("comingSoon.title")).toBeTruthy()
+  })
+
+  // CS-2: No popup dependency — useCityProvider must NOT be imported/called
+  it("CS-2: renders without error when no popup context exists (no useCityProvider)", () => {
+    mockUseTenant.mockReturnValue({
+      tenant: {
+        id: "t-1",
+        name: "Festival Corp",
+        slug: "festival",
+        custom_domain_active: true,
+        landing_mode: "checkout",
+        logo_url: null,
+        image_url: null,
+        icon_url: null,
+        active_popup_slug: null,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    // If useCityProvider is imported and called in this page, it will throw
+    // because there is no CityProvider wrapper in this test.
+    expect(() => render(<ComingSoonPage />)).not.toThrow()
+  })
+
+  it("CS-4: renders no links to checkout or popup-specific paths", () => {
+    mockUseTenant.mockReturnValue({
+      tenant: {
+        id: "t-1",
+        name: "Festival Corp",
+        slug: "festival",
+        custom_domain_active: true,
+        landing_mode: "checkout",
+        logo_url: null,
+        image_url: null,
+        icon_url: null,
+        active_popup_slug: null,
+      },
+      isLoading: false,
+      error: null,
+    })
+
+    const { container } = render(<ComingSoonPage />)
+
+    // No links to /checkout/* or /portal/* paths
+    const links = container.querySelectorAll("a[href]")
+    for (const link of links) {
+      const href = link.getAttribute("href") ?? ""
+      expect(href).not.toMatch(/^\/checkout/)
+      expect(href).not.toMatch(/^\/portal/)
+    }
+  })
+})

--- a/portal/src/app/coming-soon/page.tsx
+++ b/portal/src/app/coming-soon/page.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import Image from "next/image"
+import { useTranslation } from "react-i18next"
+import { useTenant } from "@/providers/tenantProvider"
+
+export default function ComingSoonPage() {
+  const { t } = useTranslation()
+  const { tenant } = useTenant()
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6 py-12">
+      <div className="flex w-full max-w-md flex-col items-center gap-8 text-center">
+        {tenant?.logo_url && (
+          <div className="relative h-16 w-48">
+            <Image
+              src={tenant.logo_url}
+              alt={tenant.name ?? "Logo"}
+              className="object-contain"
+              fill
+              sizes="192px"
+            />
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <h1 className="text-4xl font-bold tracking-tight">
+            {t("comingSoon.title")}
+          </h1>
+          <p className="text-muted-foreground">{t("comingSoon.description")}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/portal/src/app/layout.tsx
+++ b/portal/src/app/layout.tsx
@@ -90,6 +90,13 @@ export default async function RootLayout({
   const middlewareTenantSlug = isCustomDomain
     ? (headersList.get("x-tenant-slug") ?? null)
     : null
+  const middlewareLandingMode = isCustomDomain
+    ? ((headersList.get("x-landing-mode") as "portal" | "checkout" | null) ??
+      null)
+    : null
+  const middlewareActivePopupSlug = isCustomDomain
+    ? (headersList.get("x-active-popup-slug") ?? null)
+    : null
 
   return (
     <html lang="en">
@@ -102,6 +109,8 @@ export default async function RootLayout({
           <TenantProvider
             initialTenantId={middlewareTenantId}
             initialTenantSlug={middlewareTenantSlug}
+            initialLandingMode={middlewareLandingMode}
+            initialActivePopupSlug={middlewareActivePopupSlug}
           >
             <div className="w-full">{children}</div>
           </TenantProvider>

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2552,6 +2552,8 @@ export type TenantPublic = {
     logo_url?: (string | null);
     custom_domain?: (string | null);
     custom_domain_active: boolean;
+    landing_mode: 'portal' | 'checkout';
+    active_popup_slug?: (string | null);
     id: string;
 };
 

--- a/portal/src/providers/tenantProvider.tsx
+++ b/portal/src/providers/tenantProvider.tsx
@@ -38,12 +38,30 @@ interface TenantProviderProps {
    * API call is skipped and a cheaper by-slug call is made instead.
    */
   initialTenantSlug?: string | null
+  /**
+   * Landing mode resolved by middleware (custom domain path only).
+   * Available immediately from x-landing-mode header — no client fetch needed
+   * to read this value.
+   */
+  initialLandingMode?: "portal" | "checkout" | null
+  /**
+   * Active popup slug resolved by backend when landing_mode=checkout.
+   * Available immediately from x-active-popup-slug header.
+   */
+  initialActivePopupSlug?: string | null
 }
 
 export const TenantProvider = ({
   children,
   initialTenantId = null,
   initialTenantSlug = null,
+  // These are accepted to keep the component API consistent with the middleware
+  // headers the layout passes down. The landing_mode and active_popup_slug
+  // values are available automatically on the fetched TenantPublic object once
+  // the client-side fetch resolves; the initial props are reserved for future
+  // use (e.g. seeding state before the first fetch).
+  initialLandingMode: _initialLandingMode = null,
+  initialActivePopupSlug: _initialActivePopupSlug = null,
 }: TenantProviderProps) => {
   const [tenant, setTenant] = useState<TenantPublic | null>(null)
   const [isLoading, setIsLoading] = useState(true)

--- a/portal/src/proxy.test.ts
+++ b/portal/src/proxy.test.ts
@@ -1,0 +1,219 @@
+import type { NextRequest } from "next/server"
+import { proxy } from "./proxy"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(url: string, host: string): NextRequest {
+  const parsedUrl = new URL(url)
+  const req = new Request(url, { headers: { host } })
+  // NextRequest adds a nextUrl property that mirrors the parsed URL.
+  Object.defineProperty(req, "nextUrl", { value: parsedUrl, writable: false })
+  return req as unknown as NextRequest
+}
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("./lib/tenant-resolution", () => ({
+  resolveHostname: (host: string) => {
+    if (host.startsWith("tickets.example.com")) {
+      return { isCustomDomain: true, slug: null }
+    }
+    return { isCustomDomain: false, slug: "festival" }
+  },
+}))
+
+const mockFetch = vi.fn()
+vi.stubGlobal("fetch", mockFetch)
+
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>()
+  return {
+    ...actual,
+    NextResponse: {
+      next: vi.fn((opts?: unknown) => ({ type: "next", opts })),
+      rewrite: vi.fn((url: URL, opts?: unknown) => ({
+        type: "rewrite",
+        url,
+        opts,
+      })),
+    },
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Test setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+// ---------------------------------------------------------------------------
+// Scenario M-4: portal mode — no rewrite
+// ---------------------------------------------------------------------------
+
+describe("portal mode tenant", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "tenant-1",
+        slug: "festival",
+        landing_mode: "portal",
+        active_popup_slug: null,
+      }),
+    })
+  })
+
+  it("M-4: does not rewrite root request in portal mode", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string }
+
+    expect(result.type).toBe("next")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario M-1 + M-2: checkout mode + active popup
+// ---------------------------------------------------------------------------
+
+describe("checkout mode with active popup", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "tenant-1",
+        slug: "festival",
+        landing_mode: "checkout",
+        active_popup_slug: "summer-fest",
+      }),
+    })
+  })
+
+  it("M-1: rewrites / to /checkout/summer-fest", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string; url: URL }
+
+    expect(result.type).toBe("rewrite")
+    expect(result.url.pathname).toBe("/checkout/summer-fest")
+  })
+
+  it("M-2: rewrites /thank-you to /checkout/summer-fest/thank-you preserving query", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/thank-you?payment_id=42",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string; url: URL }
+
+    expect(result.type).toBe("rewrite")
+    expect(result.url.pathname).toBe("/checkout/summer-fest/thank-you")
+    expect(result.url.search).toBe("?payment_id=42")
+  })
+
+  it("passes through /checkout/* paths without double-rewriting", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/checkout/summer-fest",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string }
+
+    expect(result.type).toBe("next")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario M-3: checkout mode + no active popup → /coming-soon
+// ---------------------------------------------------------------------------
+
+describe("checkout mode with no active popup", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "tenant-1",
+        slug: "festival",
+        landing_mode: "checkout",
+        active_popup_slug: null,
+      }),
+    })
+  })
+
+  it("M-3: rewrites / to /coming-soon when no active popup", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string; url: URL }
+
+    expect(result.type).toBe("rewrite")
+    expect(result.url.pathname).toBe("/coming-soon")
+  })
+
+  it("passes through non-root paths in no-popup checkout mode", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/coming-soon",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string }
+
+    expect(result.type).toBe("next")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario M-6: headers injected for all custom domain requests
+// ---------------------------------------------------------------------------
+
+describe("header injection", () => {
+  it("M-6: injects x-landing-mode and x-active-popup-slug alongside existing headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "tenant-1",
+        slug: "festival",
+        landing_mode: "checkout",
+        active_popup_slug: "summer-fest",
+      }),
+    })
+
+    const req = makeRequest(
+      "https://tickets.example.com/other-page",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as {
+      type: string
+      opts: { request?: { headers: Headers } }
+    }
+
+    // /other-page is not a rewrite target — we get a next() response with headers
+    expect(result.type).toBe("next")
+    const h = result.opts?.request?.headers
+    expect(h?.get("x-landing-mode")).toBe("checkout")
+    expect(h?.get("x-active-popup-slug")).toBe("summer-fest")
+    expect(h?.get("x-tenant-id")).toBe("tenant-1")
+    expect(h?.get("x-tenant-slug")).toBe("festival")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Non-custom-domain: pass-through without API call
+// ---------------------------------------------------------------------------
+
+describe("non-custom-domain request", () => {
+  it("returns next() immediately without calling the API", async () => {
+    const req = makeRequest("https://festival.myapp.com/", "festival.myapp.com")
+    await proxy(req)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/portal/src/proxy.ts
+++ b/portal/src/proxy.ts
@@ -7,6 +7,13 @@ if (!process.env.NEXT_PUBLIC_API_URL) {
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL
 
+interface TenantByDomainResponse {
+  id: string
+  slug: string
+  landing_mode: "portal" | "checkout"
+  active_popup_slug: string | null
+}
+
 export async function proxy(request: NextRequest): Promise<NextResponse> {
   const host = request.headers.get("host") ?? ""
   const { isCustomDomain } = resolveHostname(host)
@@ -20,7 +27,7 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   // Strip port — domain identity is the hostname only (port is infrastructure).
   const domain = host.split(":")[0] ?? host
 
-  let tenantData: { id: string; slug: string } | null = null
+  let tenantData: TenantByDomainResponse | null = null
 
   try {
     const res = await fetch(
@@ -49,6 +56,45 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   requestHeaders.set("x-tenant-id", tenantData.id)
   requestHeaders.set("x-tenant-slug", tenantData.slug)
   requestHeaders.set("x-custom-domain", "true")
+  requestHeaders.set("x-landing-mode", tenantData.landing_mode)
+  if (tenantData.active_popup_slug != null) {
+    requestHeaders.set("x-active-popup-slug", tenantData.active_popup_slug)
+  }
+
+  // Rewrite decision: only trigger on the two exact path shapes that need
+  // transparent URL substitution. All other paths fall through unchanged.
+  const pathname = request.nextUrl.pathname
+
+  if (tenantData.landing_mode === "checkout") {
+    if (tenantData.active_popup_slug != null) {
+      const slug = tenantData.active_popup_slug
+
+      if (pathname === "/") {
+        const rewriteUrl = new URL(`/checkout/${slug}`, request.url)
+        return NextResponse.rewrite(rewriteUrl, {
+          request: { headers: requestHeaders },
+        })
+      }
+
+      if (pathname === "/thank-you") {
+        const rewriteUrl = new URL(
+          `/checkout/${slug}/thank-you${request.nextUrl.search}`,
+          request.url,
+        )
+        return NextResponse.rewrite(rewriteUrl, {
+          request: { headers: requestHeaders },
+        })
+      }
+    } else {
+      // No active popup — show Coming Soon page.
+      if (pathname === "/") {
+        const rewriteUrl = new URL("/coming-soon", request.url)
+        return NextResponse.rewrite(rewriteUrl, {
+          request: { headers: requestHeaders },
+        })
+      }
+    }
+  }
 
   return NextResponse.next({
     request: {

--- a/portal/vitest.setup.ts
+++ b/portal/vitest.setup.ts
@@ -1,5 +1,11 @@
 import { vi } from "vitest"
 
+// Provide a test-time fallback for the API URL env var.
+// proxy.ts throws at module init if this is missing.
+if (!process.env.NEXT_PUBLIC_API_URL) {
+  process.env.NEXT_PUBLIC_API_URL = "http://api.test"
+}
+
 if (typeof window !== "undefined") {
   Object.defineProperty(window, "scrollTo", {
     value: vi.fn(),


### PR DESCRIPTION
## Summary

PR 2 of 3. Implements the portal-side rewrites that turn an active custom domain in `landing_mode=checkout` into a one-page checkout site, hiding `/checkout/{slug}` end-to-end. Builds on PR #92 (backend), needs PR 3 (backoffice toggle) to be operator-friendly.

- **Middleware rewrite** (`proxy.ts`): when the resolved tenant has `landing_mode=checkout`, `NextResponse.rewrite()` translates slug-less paths to the real ones — `/` → `/checkout/{active_popup_slug}`, `/thank-you?...` → `/checkout/{active_popup_slug}/thank-you?...` (query preserved), and `/` → `/coming-soon` when there is no active popup. Browser URL stays clean. Portal mode is untouched.
- **Header propagation**: `x-landing-mode` and `x-active-popup-slug` are injected by the middleware and forwarded by the root layout to `TenantProvider` for upcoming SSR-time hydration.
- **`/coming-soon`**: new branded fallback route that reads tenant branding from `useTenant()` (not from the popup-scoped `ThemeProvider`), so it works without a popup context.
- **CTA gating**: the "back to portal" buttons on `/checkout/{slug}/thank-you` and `/checkout/success` are hidden when `landing_mode === "checkout"`. `PopupCheckoutContent` gets an explanatory comment — its `/portal` redirect lives under `sale_type=application`, which the backend resolver explicitly excludes from direct-checkout mode.
- **Generated client patch**: `landing_mode` and `active_popup_slug` were added manually to `TenantPublic` in `client/types.gen.ts`. Will be regenerated cleanly the next time `generate-client` runs against the merged backend OpenAPI.

## Test plan

- [x] `pnpm --filter portal lint` → clean
- [x] `pnpm --filter portal exec tsc --noEmit` → clean
- [x] `pnpm --filter portal test` → 161 tests passing (36 files), includes new tests for proxy rewrite, coming-soon, thank-you CTA gate, success-page CTA gate
- [ ] Manual: visit a custom domain with `landing_mode=checkout` and an active direct-sale popup → URL stays `/`, page renders the checkout
- [ ] Manual: same tenant with no active popup → URL stays `/`, page renders `/coming-soon` with tenant branding
- [ ] Manual: complete a checkout, SimpleFi redirects to `{base}/thank-you?payment_id=...` → URL stays `/thank-you?...`, "back to portal" CTA is NOT rendered
- [ ] Manual: tenants in `landing_mode=portal` see no behavior change

## Follow-ups (not in this PR)

- **PR 3 (backoffice)**: toggle in `TenantForm.tsx` (disabled when `custom_domain_active=false`), warning when >1 active popup is detected at enable time.
- **`generate-client` regeneration**: after this and PR 1 settle on dev, run `pnpm generate-client` to replace the manual patch in `types.gen.ts` with the canonical generated types.
- **SSR hydration of `landing_mode`** (S-2 from verify): `initialLandingMode` / `initialActivePopupSlug` props are plumbed but not yet consumed before the async `TenantPublic` fetch. A small optimization pass can use them to skip the loading window on direct-checkout landings.