### PR TITLE
feat(backoffice): direct-checkout landing mode toggle (backoffice 3/3)

### DIFF
--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2552,6 +2552,10 @@ export type TenantPublic = {
     logo_url?: (string | null);
     custom_domain?: (string | null);
     custom_domain_active: boolean;
+    /** Manually patched — regenerating the client from the backend schema will replace this. */
+    landing_mode?: ('portal' | 'checkout');
+    /** Computed projection — only present when landing_mode=checkout. Manually patched. */
+    active_popup_slug?: (string | null);
     id: string;
 };
 
@@ -2565,6 +2569,8 @@ export type TenantUpdate = {
     logo_url?: (string | null);
     custom_domain?: (string | null);
     custom_domain_active?: (boolean | null);
+    /** Manually patched — regenerating the client from the backend schema will replace this. */
+    landing_mode?: ('portal' | 'checkout' | null);
 };
 
 /**

--- a/backoffice/src/components/forms/TenantForm.landing-mode.test.tsx
+++ b/backoffice/src/components/forms/TenantForm.landing-mode.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Tests for TenantForm — landing_mode toggle (tenant-direct-checkout-domain)
+ *
+ * Covers:
+ * - BK-1: toggle disabled when custom_domain_active=false
+ * - BK-2: toggle enabled when custom_domain_active=true
+ * - BK-3: warning shown when switching to checkout AND >1 active popup
+ * - BK-4: no warning when switching to checkout AND <=1 active popup
+ * - BK-5: ADMIN cannot see/interact with toggle (hidden for non-superadmin)
+ * - BK-6: PATCH payload includes landing_mode on form submit
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// --- Mocks ---
+
+vi.mock("@/client", () => ({
+  TenantsService: {
+    createTenant: vi.fn(),
+    updateTenant: vi.fn(),
+    deleteTenant: vi.fn(),
+  },
+  PopupsService: {
+    listPopups: vi.fn(),
+  },
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+const mockUseAuth = vi.fn(() => ({ isSuperadmin: true }))
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => mockUseAuth(),
+}))
+
+vi.mock("@/hooks/useCustomToast", () => ({
+  default: () => ({
+    showSuccessToast: vi.fn(),
+    showErrorToast: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/useUnsavedChanges", () => ({
+  useUnsavedChanges: () => ({ state: "unblocked" }),
+  UnsavedChangesDialog: () => null,
+}))
+
+vi.mock("@/components/ui/image-upload", () => ({
+  ImageUpload: () => null,
+}))
+
+import { PopupsService, TenantsService } from "@/client"
+import { TenantForm } from "./TenantForm"
+
+const mockListPopups = vi.mocked(PopupsService.listPopups)
+const mockUpdateTenant = vi.mocked(TenantsService.updateTenant)
+
+// A fully active tenant with custom domain
+const TENANT_WITH_ACTIVE_DOMAIN = {
+  id: "tenant-1",
+  name: "Acme Events",
+  slug: "acme",
+  custom_domain: "tickets.acme.com",
+  custom_domain_active: true,
+  landing_mode: "portal" as const,
+  sender_email: null,
+  sender_name: null,
+  image_url: null,
+  icon_url: null,
+  logo_url: null,
+  deleted: false,
+}
+
+// A tenant with an inactive custom domain
+const TENANT_WITH_INACTIVE_DOMAIN = {
+  ...TENANT_WITH_ACTIVE_DOMAIN,
+  custom_domain_active: false,
+}
+
+function makePopupResult(count: number, status = "active") {
+  return {
+    results: Array.from({ length: count }, (_, i) => ({
+      id: `popup-${i}`,
+      name: `Popup ${i}`,
+      slug: `popup-${i}`,
+      tenant_id: "tenant-1",
+      status,
+    })),
+    total: count,
+  }
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe("TenantForm — landing_mode toggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Reset to superadmin for each test
+    mockUseAuth.mockReturnValue({ isSuperadmin: true })
+    // Default: one active popup (no warning)
+    mockListPopups.mockResolvedValue(
+      makePopupResult(1) as Awaited<
+        ReturnType<typeof PopupsService.listPopups>
+      >,
+    )
+  })
+
+  // BK-1: toggle disabled when domain is inactive
+  it("BK-1: toggle is disabled when custom_domain_active=false", async () => {
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_INACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/landing mode/i)).toBeInTheDocument()
+    })
+
+    const toggle = screen.getByRole("switch", {
+      name: /landing mode|direct checkout/i,
+    })
+    expect(toggle).toBeDisabled()
+  })
+
+  // BK-2: toggle enabled when domain is active
+  it("BK-2: toggle is enabled when custom_domain_active=true", async () => {
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_ACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/landing mode/i)).toBeInTheDocument()
+    })
+
+    const toggle = screen.getByRole("switch", {
+      name: /landing mode|direct checkout/i,
+    })
+    expect(toggle).not.toBeDisabled()
+  })
+
+  // BK-3: warning shown when >1 active popup and toggle flipped to checkout
+  it("BK-3: shows warning when flipped to checkout and >1 active popup", async () => {
+    const user = userEvent.setup()
+    mockListPopups.mockResolvedValue(
+      makePopupResult(3) as Awaited<
+        ReturnType<typeof PopupsService.listPopups>
+      >,
+    )
+
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_ACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /landing mode|direct checkout/i }),
+      ).toBeInTheDocument()
+    })
+
+    const toggle = screen.getByRole("switch", {
+      name: /landing mode|direct checkout/i,
+    })
+    await user.click(toggle)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/more than one active popup/i),
+      ).toBeInTheDocument()
+    })
+  })
+
+  // BK-4: no warning when <=1 active popup
+  it("BK-4: no warning when flipped to checkout and <=1 active popup", async () => {
+    const user = userEvent.setup()
+    // default mock already has 1 popup
+
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_ACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /landing mode|direct checkout/i }),
+      ).toBeInTheDocument()
+    })
+
+    const toggle = screen.getByRole("switch", {
+      name: /landing mode|direct checkout/i,
+    })
+    await user.click(toggle)
+
+    // Wait a tick then verify no warning
+    await waitFor(() => {
+      expect(screen.queryByText(/more than one active popup/i)).toBeNull()
+    })
+  })
+
+  // BK-5: ADMIN cannot see toggle
+  it("BK-5: toggle is not rendered for non-superadmin users", async () => {
+    mockUseAuth.mockReturnValue({ isSuperadmin: false })
+
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_ACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    // Give enough time for the form to settle
+    await new Promise((r) => setTimeout(r, 100))
+
+    expect(
+      screen.queryByRole("switch", { name: /landing mode|direct checkout/i }),
+    ).toBeNull()
+  })
+
+  // BK-6: PATCH payload includes landing_mode on submit
+  it("BK-6: PATCH payload includes landing_mode when form is submitted", async () => {
+    const user = userEvent.setup()
+    mockUpdateTenant.mockResolvedValue(
+      TENANT_WITH_ACTIVE_DOMAIN as Awaited<
+        ReturnType<typeof TenantsService.updateTenant>
+      >,
+    )
+
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_ACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /landing mode|direct checkout/i }),
+      ).toBeInTheDocument()
+    })
+
+    // Flip toggle to checkout
+    const toggle = screen.getByRole("switch", {
+      name: /landing mode|direct checkout/i,
+    })
+    await user.click(toggle)
+
+    // Submit form
+    const submitBtn = screen.getByRole("button", { name: /save changes/i })
+    await user.click(submitBtn)
+
+    await waitFor(() => {
+      expect(mockUpdateTenant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: expect.objectContaining({
+            landing_mode: "checkout",
+          }),
+        }),
+      )
+    })
+  })
+})

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -1,9 +1,20 @@
 import { useForm } from "@tanstack/react-form"
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { Check, Copy, Globe, Image, Info, Lock, Mail, User } from "lucide-react"
+import {
+  Check,
+  Copy,
+  Globe,
+  Image,
+  Info,
+  Lock,
+  Mail,
+  ShoppingCart,
+  User,
+} from "lucide-react"
 import { useState } from "react"
 import {
+  PopupsService,
   type TenantCreate,
   type TenantPublic,
   TenantsService,
@@ -23,6 +34,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { Separator } from "@/components/ui/separator"
+import { Switch } from "@/components/ui/switch"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import {
@@ -66,6 +78,16 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
   }
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const isEdit = !!defaultValues
+
+  // Query active popups for the landing_mode warning (OI-3, ADR-8)
+  const { data: popupsData } = useQuery({
+    queryKey: ["popups", { tenantId: defaultValues?.id, status: "active" }],
+    queryFn: () => PopupsService.listPopups({ limit: 100 }),
+    enabled: isEdit && isSuperadmin,
+  })
+  const activePopupCount = (popupsData?.results ?? []).filter(
+    (p) => p.status === "active",
+  ).length
 
   const createMutation = useMutation({
     mutationFn: (data: TenantCreate) =>
@@ -127,6 +149,9 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
       icon_url: defaultValues?.icon_url ?? "",
       logo_url: defaultValues?.logo_url ?? "",
       custom_domain: defaultValues?.custom_domain ?? "",
+      landing_mode: (defaultValues?.landing_mode ?? "portal") as
+        | "portal"
+        | "checkout",
     },
     onSubmit: ({ value }) => {
       if (isEdit) {
@@ -139,6 +164,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           logo_url: value.logo_url || null,
           // Map empty string to null for domain; never send custom_domain_active
           custom_domain: value.custom_domain || null,
+          landing_mode: value.landing_mode,
         })
       } else {
         createMutation.mutate({
@@ -424,6 +450,58 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
                 )}
               </AlertDescription>
             </Alert>
+
+            {/* Landing Mode toggle — SUPERADMIN only (ADR-4, ADR-8) */}
+            {isSuperadmin && (
+              <form.Field name="landing_mode">
+                {(field) => {
+                  const isDomainActive = !!defaultValues?.custom_domain_active
+                  const isCheckout = field.state.value === "checkout"
+                  const showMultiPopupWarning =
+                    isCheckout && activePopupCount > 1
+
+                  return (
+                    <div>
+                      <InlineRow
+                        icon={
+                          <ShoppingCart className="h-4 w-4 text-muted-foreground" />
+                        }
+                        label="Landing Mode"
+                        description={
+                          isDomainActive
+                            ? "Switch to Direct Checkout to send visitors straight to the checkout flow."
+                            : "Activate the custom domain first to enable direct-checkout mode."
+                        }
+                      >
+                        <Switch
+                          id="landing_mode"
+                          aria-label="Landing Mode"
+                          checked={isCheckout}
+                          onCheckedChange={(val) =>
+                            field.handleChange(val ? "checkout" : "portal")
+                          }
+                          disabled={!isDomainActive}
+                        />
+                      </InlineRow>
+
+                      {showMultiPopupWarning && (
+                        <Alert className="border-orange-200 bg-orange-50 text-orange-900 mt-2">
+                          <Info className="h-4 w-4 text-orange-600" />
+                          <AlertDescription className="text-orange-800">
+                            This tenant has more than one active popup. Only one
+                            will be used as the landing checkout — the one with
+                            the earliest start date. Make sure the intended
+                            popup is a <strong>direct-sale popup</strong>.
+                            Application-type popups are not eligible and will
+                            show a Coming Soon page instead.
+                          </AlertDescription>
+                        </Alert>
+                      )}
+                    </div>
+                  )
+                }}
+              </form.Field>
+            )}
           </InlineSection>
         )}
 


### PR DESCRIPTION
## Summary

PR 3 of 3, completing the per-tenant direct-checkout custom domain feature. Adds the operator-facing toggle in the backoffice. Backend (PR #92) and portal (PR #93) already merged.

- New `landing_mode` toggle in `TenantForm.tsx`, placed inside the existing Custom Domain `InlineSection`.
- Disabled when `custom_domain_active=false` (the merged-state validator on the backend would reject anyway; the disabled state surfaces that contract early).
- SUPERADMIN-only — ADMIN does not see the toggle.
- When the operator flips to `checkout`, an advisory `Alert` renders if the tenant has more than one popup in `status=active`. Active-popup count comes from the existing `PopupsService.listPopups` endpoint (filtered client-side by status). Warning copy explicitly mentions "direct-sale popup" so the operator knows the backend resolver filters by `sale_type=direct` — tenants with only application-type popups will see `/coming-soon`.
- Toggle value joins the existing update mutation payload.
- 6 new component tests cover BK-1 through BK-6 (toggle disabled state, warning conditions, role gate, mutation payload).
- Generated client (`types.gen.ts`) manually patched to include `landing_mode` and `active_popup_slug` on `TenantPublic`, and `landing_mode` on `TenantUpdate`. Will be regenerated cleanly the next time `generate-client` runs against the merged backend OpenAPI.

## Test plan

- [x] `pnpm --filter backoffice exec biome ci .` → clean (1 pre-existing schema info, unrelated)
- [x] `pnpm --filter backoffice exec tsc -p tsconfig.build.json --noEmit` → clean
- [x] `pnpm --filter backoffice exec vitest run` → 59/59 tests passing (13 files), includes 6 new BK-* tests
- [ ] Manual: open a tenant with `custom_domain_active=false` → toggle visible but disabled, helper text explains why
- [ ] Manual: activate the custom domain → toggle becomes enabled
- [ ] Manual: ensure the tenant has >1 active popup, flip the toggle to `checkout` → advisory Alert appears mentioning "direct-sale popup"; not blocking the save
- [ ] Manual: log in as ADMIN → toggle is not rendered
- [ ] Manual: submit the form → PATCH payload includes `landing_mode`

## Follow-ups

- After dev settles, run `pnpm generate-client` to replace the manual patches in `portal/src/client/types.gen.ts` (PR #93) and `backoffice/src/client/types.gen.ts` (this PR) with canonical generated types.
- (S-1 from verify) Optionally pass an explicit `xTenantId` to `PopupsService.listPopups` in the warning query — currently relies on the global request interceptor in `backoffice/src/main.tsx`. Works correctly today; explicit form is more intention-revealing.
- **SimpleFi allow-list**: every new `custom_domain` enabled in checkout mode needs to be registered with SimpleFi before going live, if SimpleFi requires pre-registered redirect URLs.