### PR TITLE
feat(portal): scroll to focused event card on return from event detail

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -70,10 +70,15 @@ export default function EventDetailPage() {
   const searchParams = useSearchParams()
   // Originating events-page URL search (e.g. "view=day&date=2026-05-15"),
   // set by Day-view links so "Back to events" can return to the same spot.
+  // We also stamp `focus=<eventId>` so the events page can scroll the
+  // matching card into view; the page consumes the param once and cleans
+  // it from the URL, so it survives a refresh on this detail page but
+  // never sticks around on the list once used.
   const fromSearch = searchParams.get("from") ?? ""
+  const focusQs = `focus=${encodeURIComponent(params.eventId)}`
   const backHref = fromSearch
-    ? `/portal/${city?.slug}/events?${fromSearch}`
-    : `/portal/${city?.slug}/events`
+    ? `/portal/${city?.slug}/events?${fromSearch}&${focusQs}`
+    : `/portal/${city?.slug}/events?${focusQs}`
   // For an expanded recurring instance, the calendar passes the occurrence's
   // ISO start time via ?occ=. We render that in place of the master's
   // start_time (and shift end_time by the same offset) so the user sees the
@@ -335,6 +340,16 @@ export default function EventDetailPage() {
       <div className="flex items-center justify-between gap-2">
         <Link
           href={backHref}
+          // Next.js's default `scroll={true}` triggers a scroll-to-top
+          // on navigation, scheduled in a layout-level layout-effect
+          // that runs *after* the page's own layout-effects. That
+          // overrode the events page's `scrollIntoView` on the focused
+          // card and left the user back at scrollTop=0 even though
+          // `?focus=` was consumed. Disabling auto-scroll here lets the
+          // page own the scroll position; `focus=` is always present on
+          // this back href so the page will scroll the card into view
+          // itself.
+          scroll={false}
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" /> {t("events.common.back_to_events")}

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -359,6 +359,7 @@ export function CalendarBody({
                   return (
                     <div
                       key={event.id}
+                      id={`event-card-${event.id}`}
                       className={cn(
                         "relative rounded-xl border bg-card hover:shadow-md transition-shadow overflow-hidden",
                         isHighlighted &&

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -672,6 +672,7 @@ export function DayBody({
                         return (
                           <Link
                             key={event.id}
+                            id={`event-card-${event.id}`}
                             href={eventHref(event)}
                             onClick={(e) => handleEventClick(event, e)}
                             className={cn(
@@ -907,6 +908,7 @@ export function DayBody({
                         return (
                           <Link
                             key={event.id}
+                            id={`event-card-${event.id}`}
                             href={eventHref(event)}
                             onClick={(e) => handleEventClick(event, e)}
                             className={cn(

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -163,7 +163,11 @@ export function ListBody({
                 }
               }
               return (
-                <div key={event.id} className={cardClass}>
+                <div
+                  key={event.id}
+                  id={`event-card-${event.id}`}
+                  className={cardClass}
+                >
                   <Link
                     href={href}
                     onClick={handleClick}

--- a/portal/src/app/portal/[popupSlug]/events/page.test.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.test.tsx
@@ -1,0 +1,404 @@
+import { render, waitFor } from "@testing-library/react"
+import { StrictMode } from "react"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest"
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+//
+// The events page wires up many real dependencies (TanStack Query, several
+// services, lib body components, i18n). We mock all of them so each test
+// can focus on the `?focus=<eventId>` scroll-into-view contract without
+// pulling in real network/state code. The pattern follows
+// `portal/src/app/coming-soon/page.test.tsx`.
+//
+// `currentSearch` and `mockReplace` are referenced from inside the
+// `next/navigation` factory by closure. Vitest hoists `vi.mock` above the
+// imports, but the factory body is only invoked when the mocked module is
+// loaded — by which point the top-level `let`/`const` here are
+// initialised. Functions inside the factory close over the live bindings,
+// not snapshots, so updates to `currentSearch` propagate to subsequent
+// `useSearchParams()` calls.
+
+let currentSearch = ""
+
+const mockReplace = vi.fn((url: string) => {
+  const q = url.indexOf("?")
+  currentSearch = q >= 0 ? url.slice(q + 1) : ""
+  if (typeof window !== "undefined") {
+    window.history.replaceState({}, "", url)
+  }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/portal/festival/events",
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@/providers/cityProvider", () => ({
+  useCityProvider: () => ({
+    getCity: () => ({
+      id: "city-1",
+      slug: "festival",
+      name: "Festival",
+      events_enabled: true,
+      start_date: "2026-05-10",
+      end_date: "2026-05-20",
+    }),
+  }),
+}))
+
+// Minimal event-shaped objects. Only `id` and `title` are touched by the
+// stub bodies; the page's selection/sorting code only looks at `id`,
+// `start_time`, and `owner_id`.
+const mockEvents = [
+  {
+    id: "evt-1",
+    title: "Event One",
+    start_time: "2026-05-11T10:00:00Z",
+    end_time: "2026-05-11T11:00:00Z",
+    status: "published",
+    owner_id: "h-1",
+  },
+  {
+    id: "evt-2",
+    title: "Event Two",
+    start_time: "2026-05-12T10:00:00Z",
+    end_time: "2026-05-12T11:00:00Z",
+    status: "published",
+    owner_id: "h-1",
+  },
+  {
+    id: "evt-3",
+    title: "Event Three",
+    start_time: "2026-05-13T10:00:00Z",
+    end_time: "2026-05-13T11:00:00Z",
+    status: "published",
+    owner_id: "h-1",
+  },
+]
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+    const key = queryKey[0]
+    if (key === "portal-events") {
+      return { data: { results: mockEvents }, isLoading: false }
+    }
+    if (key === "current-human") {
+      return { data: { id: "h-1" }, isLoading: false }
+    }
+    if (key === "portal-tracks") {
+      return { data: { results: [] }, isLoading: false }
+    }
+    if (key === "portal-events-hidden-count") {
+      return { data: { count: 0 }, isLoading: false }
+    }
+    return { data: null, isLoading: false }
+  },
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}))
+
+// The page imports services for queryFn bodies; useQuery is mocked so
+// none of these are actually invoked. Empty stubs are enough.
+vi.mock("@/client", () => ({
+  EventsService: {},
+  EventParticipantsService: {},
+  HumansService: {},
+  TracksService: {},
+}))
+
+vi.mock("@/app/portal/[popupSlug]/events/lib/useEventTimezone", () => ({
+  useEventTimezone: () => ({
+    timezone: "UTC",
+    formatTime: (s: string) => s,
+    formatDateShort: (s: string) => s,
+    formatDayKey: (s: string) => s.slice(0, 10),
+  }),
+  usePortalEventSettings: () => ({
+    data: {
+      event_enabled: true,
+      allowed_tags: [],
+      can_publish_event: "everyone",
+    },
+    isLoading: false,
+  }),
+}))
+
+const mockConsumeEventsViewState = vi.fn().mockReturnValue(null)
+vi.mock("@/app/portal/[popupSlug]/events/lib/eventsViewState", () => ({
+  consumeEventsViewState: (...args: unknown[]) =>
+    mockConsumeEventsViewState(...args),
+  saveEventsViewState: vi.fn(),
+}))
+
+// Captures the latest `onViewChange` so a test can simulate a toolbar
+// click without poking around inside the real ViewSwitcher.
+let mockOnViewChange: ((v: string) => void) | null = null
+vi.mock("@/app/portal/[popupSlug]/events/lib/EventsToolbar", () => ({
+  EventsToolbar: ({ onViewChange }: { onViewChange: (v: string) => void }) => {
+    mockOnViewChange = onViewChange
+    return (
+      <button
+        type="button"
+        data-testid="toolbar-switch-view"
+        onClick={() => onViewChange("calendar")}
+      >
+        switch
+      </button>
+    )
+  },
+}))
+
+// Minimal ListBody stub. Renders one div per event with the same DOM id
+// convention as the real component, so `document.getElementById` finds
+// the focused card.
+vi.mock("@/app/portal/[popupSlug]/events/lib/ListBody", () => ({
+  ListBody: ({ events }: { events: Array<{ id: string; title: string }> }) => (
+    <div data-testid="list-body">
+      {events.map((e) => (
+        <div key={e.id} id={`event-card-${e.id}`} data-testid={`card-${e.id}`}>
+          {e.title}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock("@/app/portal/[popupSlug]/events/lib/CalendarBody", () => ({
+  CalendarBody: () => <div data-testid="calendar-body" />,
+}))
+
+vi.mock("@/app/portal/[popupSlug]/events/lib/DayBody", () => ({
+  DayBody: () => <div data-testid="day-body" />,
+}))
+
+// Import the page AFTER mocks so the module resolves to the mocked
+// dependencies. The path is relative because the test sits in the same
+// directory as `page.tsx`.
+import EventsPage from "./page"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setLocationSearch(search: string) {
+  // Both the mocked useSearchParams and the page's direct read from
+  // window.location.search must reflect the test URL — the page captures
+  // `focus` straight from window.location.search.
+  const qs = search.startsWith("?") ? search.slice(1) : search
+  currentSearch = qs
+  const url = qs ? `/portal/festival/events?${qs}` : "/portal/festival/events"
+  window.history.replaceState({}, "", url)
+}
+
+function injectPortalScrollMain(): HTMLElement {
+  // The events page reads `document.getElementById("portal-scroll")` to
+  // apply its outer-scroll restore. The test environment lacks the portal
+  // shell that normally renders it, so we synthesize the element here.
+  const existing = document.getElementById("portal-scroll")
+  if (existing) return existing
+  const main = document.createElement("main")
+  main.id = "portal-scroll"
+  document.body.appendChild(main)
+  return main
+}
+
+let scrollIntoViewTargets: HTMLElement[] = []
+let scrollIntoViewSpy: Mock
+
+beforeEach(() => {
+  currentSearch = ""
+  window.history.replaceState({}, "", "/portal/festival/events")
+  mockReplace.mockClear()
+  mockConsumeEventsViewState.mockReset().mockReturnValue(null)
+  mockOnViewChange = null
+  document.getElementById("portal-scroll")?.remove()
+
+  scrollIntoViewTargets = []
+  scrollIntoViewSpy = vi.fn(function (this: HTMLElement) {
+    scrollIntoViewTargets.push(this)
+  })
+  // jsdom doesn't implement scrollIntoView. We track which element it was
+  // called on (via `this`) so each test can assert the correct card was
+  // focused, not just that *some* scrollIntoView was called.
+  Element.prototype.scrollIntoView =
+    scrollIntoViewSpy as unknown as typeof Element.prototype.scrollIntoView
+
+  // Make `requestAnimationFrame` run its callback synchronously. The
+  // focus-scroll retry loop and the outer-scroll restore loop both
+  // schedule via rAF; without this they'd run asynchronously across many
+  // 16ms ticks, slowing tests down and making the retry path (FOC-5)
+  // flaky under default `waitFor` timeouts.
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+    (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0 as unknown as number
+    },
+  )
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.getElementById("portal-scroll")?.remove()
+})
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+describe("EventsPage – focus param", () => {
+  it("FOC-1: scrolls the focused card into view and cleans the URL (list view)", async () => {
+    setLocationSearch("?focus=evt-2")
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(scrollIntoViewTargets).toHaveLength(1)
+    })
+
+    expect(scrollIntoViewTargets[0]?.id).toBe("event-card-evt-2")
+    // router.replace was called to clean the focus param. The resulting
+    // URL must not contain `focus=`.
+    expect(mockReplace).toHaveBeenCalled()
+    const cleanCall = mockReplace.mock.calls.find(
+      ([url]) => !String(url).includes("focus="),
+    )
+    expect(cleanCall).toBeTruthy()
+    for (const [url] of mockReplace.mock.calls) {
+      expect(String(url)).not.toMatch(/focus=/)
+    }
+  })
+
+  it("FOC-2: setView after focus consume does not re-introduce focus to the URL", async () => {
+    setLocationSearch("?focus=evt-2")
+
+    const { rerender } = render(<EventsPage />)
+
+    await waitFor(() => expect(scrollIntoViewTargets.length).toBeGreaterThan(0))
+
+    // Simulate Next.js re-rendering after router.replace mutated the URL
+    // — that's what would refresh useSearchParams() in production.
+    rerender(<EventsPage />)
+
+    expect(mockOnViewChange).toBeTruthy()
+    mockOnViewChange?.("calendar")
+
+    // Across every router.replace invocation, the `focus` param must
+    // never reappear.
+    for (const [url] of mockReplace.mock.calls) {
+      expect(String(url)).not.toMatch(/focus=/)
+    }
+    // And the last replace did set view=calendar — proving setView ran.
+    const lastUrl = String(mockReplace.mock.calls.at(-1)?.[0] ?? "")
+    expect(lastUrl).toMatch(/view=calendar/)
+  })
+
+  it("FOC-3: without focus param, outer scrollTop is restored and scrollIntoView is not called", async () => {
+    mockConsumeEventsViewState.mockReturnValue({
+      scroll: { outer: 250 },
+      listFilters: null,
+    })
+    const main = injectPortalScrollMain()
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(main.scrollTop).toBe(250)
+    })
+
+    expect(scrollIntoViewTargets).toHaveLength(0)
+  })
+
+  it("FOC-4: focus param takes priority over sessionStorage outer-scroll restore", async () => {
+    mockConsumeEventsViewState.mockReturnValue({
+      scroll: { outer: 250 },
+      listFilters: null,
+    })
+    const main = injectPortalScrollMain()
+    setLocationSearch("?focus=evt-2")
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(scrollIntoViewTargets.length).toBeGreaterThan(0)
+    })
+
+    expect(scrollIntoViewTargets[0]?.id).toBe("event-card-evt-2")
+    // Outer restore must have been skipped — main.scrollTop stays at 0.
+    expect(main.scrollTop).toBe(0)
+  })
+
+  it("FOC-5: missing focus target does not throw and the param is eventually cleaned", async () => {
+    setLocationSearch("?focus=does-not-exist")
+
+    expect(() => render(<EventsPage />)).not.toThrow()
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalled()
+    })
+
+    // Final URL contains no focus param even though no card matched.
+    const lastUrl = String(mockReplace.mock.calls.at(-1)?.[0] ?? "")
+    expect(lastUrl).not.toMatch(/focus=/)
+    // No card was scrolled into view (none matched the id).
+    expect(scrollIntoViewTargets).toHaveLength(0)
+  })
+
+  it("FOC-7: navigation transition — useSearchParams has focus, window.location lags", async () => {
+    // Simulates a Next.js client-side navigation back from the detail
+    // page: `<Link>` triggers a transition where the router store (and
+    // therefore useSearchParams) is updated synchronously with the new
+    // `?focus=` param, but `window.location.search` still points at the
+    // outgoing route until the transition commits. Reading focus from
+    // useSearchParams must work; if the page only consulted
+    // window.location.search it would miss the param and never scroll.
+    currentSearch = "focus=evt-2"
+    window.history.replaceState({}, "", "/portal/festival/events/some-event")
+
+    render(<EventsPage />)
+
+    await waitFor(() => {
+      expect(scrollIntoViewTargets).toHaveLength(1)
+    })
+    expect(scrollIntoViewTargets[0]?.id).toBe("event-card-evt-2")
+  })
+
+  it("FOC-6: StrictMode double-mount calls scrollIntoView exactly once", async () => {
+    setLocationSearch("?focus=evt-2")
+
+    render(
+      <StrictMode>
+        <EventsPage />
+      </StrictMode>,
+    )
+
+    await waitFor(() => expect(scrollIntoViewTargets.length).toBeGreaterThan(0))
+
+    // The first mount consumes the param and cleans the URL. The second
+    // (StrictMode) mount reads an empty window.location.search and skips
+    // the scroll — so the total stays at exactly one call.
+    expect(scrollIntoViewTargets).toHaveLength(1)
+    expect(scrollIntoViewTargets[0]?.id).toBe("event-card-evt-2")
+  })
+})

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -50,6 +50,19 @@ export default function EventsPage() {
   const { getCity } = useCityProvider()
   const city = getCity()
 
+  // `useSearchParams()` is router-aware: when the user returns from the
+  // detail page via the `<Link>` back-button, Next.js wraps the
+  // navigation in a transition and the new URL is committed to the
+  // router store *before* the page renders — so this hook reflects
+  // `?focus=<id>` (and `?view=`, `?date=`) from the first render, even
+  // though `window.location.search` may still point at the previous
+  // route during the transition. Reading from here is what makes the
+  // post-navigation focus/filter restore actually fire (a hard refresh
+  // doesn't have this distinction and works either way).
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
   // One-shot restore of UI state from sessionStorage when the user comes
   // back from an event detail page. The detail page's "Back to events"
   // link round-trips `?view=...&date=...`; we use those to look up the
@@ -64,15 +77,44 @@ export default function EventsPage() {
   if (restoreSnapshotRef.current === null) {
     let value: EventsViewSnapshot | null = null
     if (typeof window !== "undefined") {
-      const params = new URLSearchParams(window.location.search)
-      const v = (params.get("view") as EventsView | null) ?? "list"
-      const d = params.get("date")
+      // Prefer router-aware searchParams; fall back to window.location
+      // only if it lags (e.g. SSR/hydration edge cases).
+      const vFromRouter =
+        (searchParams.get("view") as EventsView | null) ?? null
+      const dFromRouter = searchParams.get("date")
+      let v: EventsView = vFromRouter ?? "list"
+      let d: string | null = dFromRouter
+      if (vFromRouter == null && dFromRouter == null) {
+        const fallback = new URLSearchParams(window.location.search)
+        v = (fallback.get("view") as EventsView | null) ?? "list"
+        d = fallback.get("date")
+      }
       value = consumeEventsViewState(v, d)
     }
     restoreSnapshotRef.current = { value }
   }
   const restoredFilters = restoreSnapshotRef.current.value?.listFilters
   const restoredScroll = restoreSnapshotRef.current.value?.scroll
+
+  // The detail page round-trips `?focus=<eventId>` on its back link so we
+  // can scroll the matching card into view on return — more reliable than
+  // restoring an outer scrollTop, which drifts when card heights change
+  // (fonts, images, recurrence summary settling late) or the viewport
+  // differs. Captured once on the very first render so router.replace()
+  // calls from setView / setSelectedDate can't wipe it before we consume
+  // it, and StrictMode's double-render doesn't read a stale value the
+  // second time. We read from `useSearchParams()` (router-aware, set
+  // synchronously by `router.push` during a client-side transition) and
+  // fall back to `window.location.search` so a hard refresh on the
+  // events page with the param in the URL still works.
+  const focusEventRef = useRef<{ id: string | null } | null>(null)
+  if (focusEventRef.current === null) {
+    let id: string | null = searchParams.get("focus")
+    if (!id && typeof window !== "undefined") {
+      id = new URLSearchParams(window.location.search).get("focus")
+    }
+    focusEventRef.current = { id }
+  }
 
   const [search, setSearch] = useState(() => restoredFilters?.search ?? "")
   const [rsvpedOnly, setRsvpedOnly] = useState(
@@ -98,9 +140,9 @@ export default function EventsPage() {
   // the "Back to events" link all land on the same view+day with no
   // hydration race. The setters update the URL via `router.replace`
   // (no history entries) and React re-derives on the next render.
-  const router = useRouter()
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
+  // (`router`, `pathname`, and `searchParams` are declared above the
+  // restore-snapshot refs so those refs can read router-aware params on
+  // the first render.)
   const view: EventsView =
     (searchParams.get("view") as EventsView | null) ?? "list"
   const setView = useCallback(
@@ -487,6 +529,10 @@ export default function EventsPage() {
   const didRestoreOuterScrollRef = useRef(false)
   useIsomorphicLayoutEffect(() => {
     if (didRestoreOuterScrollRef.current) return
+    // Focus-by-id takes priority — `scrollIntoView` on the matching card
+    // is more reliable than restoring a cached scrollTop, so we skip the
+    // outer restore entirely to avoid a double-scroll/fight.
+    if (focusEventRef.current?.id) return
     if (!restoredScroll || restoredScroll.outer == null) return
     if (view === "list" && (isLoading || events.length === 0)) return
     didRestoreOuterScrollRef.current = true
@@ -515,6 +561,61 @@ export default function EventsPage() {
       cancelled = true
     }
   }, [view, restoredScroll, isLoading, events.length])
+
+  // Scroll the focused event-card into view after returning from the
+  // detail page. The detail's back link stamps `?focus=<eventId>` and
+  // ListBody/CalendarBody/DayBody render each card with
+  // id={`event-card-${event.id}`}. We use scrollIntoView (not a cached
+  // scrollTop) so it stays correct even if card heights settle late or
+  // the viewport changed. The card may not be mounted on the first pass
+  // (recurrence summary, image, fonts, query result still loading), so
+  // we retry across a handful of frames before giving up. Either way
+  // the `focus` param is cleaned from the URL via router.replace so a
+  // later refresh doesn't re-scroll, and so the URL stays tidy.
+  const didConsumeFocusRef = useRef(false)
+  useIsomorphicLayoutEffect(() => {
+    if (didConsumeFocusRef.current) return
+    const focusId = focusEventRef.current?.id
+    if (!focusId) return
+    // For list view, the query must finish first; otherwise the card
+    // is guaranteed not to be in the DOM yet.
+    if (view === "list" && (isLoading || events.length === 0)) return
+
+    const cleanFocusParam = () => {
+      if (typeof window === "undefined") return
+      const params = new URLSearchParams(window.location.search)
+      if (!params.has("focus")) return
+      params.delete("focus")
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    }
+
+    let cancelled = false
+    let frames = 0
+    const MAX_FRAMES = 30
+    const tryFocus = () => {
+      if (cancelled) return
+      const el = document.getElementById(`event-card-${focusId}`)
+      if (el) {
+        didConsumeFocusRef.current = true
+        el.scrollIntoView({ behavior: "auto", block: "center" })
+        cleanFocusParam()
+        return
+      }
+      if (++frames >= MAX_FRAMES) {
+        // Card never mounted (filtered out, missing, etc.). Clean the
+        // URL anyway so a later interaction doesn't keep retrying.
+        didConsumeFocusRef.current = true
+        cleanFocusParam()
+        return
+      }
+      requestAnimationFrame(tryFocus)
+    }
+    tryFocus()
+    return () => {
+      cancelled = true
+    }
+  }, [view, isLoading, events.length, router, pathname])
 
   if (!moduleEnabled) {
     return (


### PR DESCRIPTION
The detail page's back link now round-trips ?focus=<eventId> and the events page consumes it to scrollIntoView the matching card. Replaces the previous sessionStorage scrollTop restore, which drifted when card heights settled late (fonts, images, recurrence summary line) and was lost across a refresh.

Why: scrollTop-based restore left users on the wrong row whenever layout changed between save and restore. Focus-by-id is layout- independent and survives a hard refresh.

How it works:
- Detail back link stamps ?focus=<eventId> and uses scroll={false} so Next.js's default scroll-to-top doesn't override the page's own scrollIntoView (Next runs that scroll in a layout-effect that fires after the page's effects).
- ListBody / CalendarBody / DayBody cards each render id="event-card-{event.id}".
- The events page captures `focus` via useSearchParams (router-aware, set synchronously during a transition) with window.location.search as fallback for a hard refresh. Stored in a useRef on the first render so subsequent router.replace calls from setView / setSelectedDate can't wipe it, and StrictMode's double-render doesn't re-consume.
- A useLayoutEffect retries scrollIntoView across up to 30 rAF frames before giving up, then cleans the param via router.replace either way so the URL stays tidy.

Covered by 7 RTL+Vitest scenarios (FOC-1..FOC-7), including the navigation-transition case (useSearchParams has focus while window.location lags) and the StrictMode double-mount.

## Summary

Brief description of the changes in this PR.

## Related Issue

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (`pnpm run build`)
- [ ] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality
- [ ] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [ ] Database migrations are included if schema changed
