### PR TITLE
feat(roles): add OPERATOR role between ADMIN and VIEWER

### DIFF
--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -38,7 +38,7 @@ from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, 
 from app.core.dependencies.users import (
     CurrentAdmin,
     CurrentHuman,
-    CurrentWriter,
+    CurrentOperator,
     HumanTenantSession,
     TenantSession,
 )
@@ -140,7 +140,7 @@ def _build_application_public(
 @router.get("", response_model=ListModel[ApplicationPublic])
 async def list_applications(
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
     popup_id: uuid.UUID | None = None,
     human_id: uuid.UUID | None = None,
     reviewed_by: uuid.UUID | None = None,
@@ -195,7 +195,7 @@ async def list_applications(
 async def create_application_admin(
     app_in: ApplicationAdminCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> ApplicationPublic:
     """Create an application as admin (BO only - superadmin for testing).
 
@@ -241,7 +241,7 @@ async def create_application_admin(
 async def get_application(
     application_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
 ) -> ApplicationPublic:
     """Get a single application (BO only)."""
     application = crud.applications_crud.get(db, application_id)

--- a/backend/app/api/application_review/router.py
+++ b/backend/app/api/application_review/router.py
@@ -14,7 +14,7 @@ from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.user.models import Users
 from app.core.db import engine
-from app.core.dependencies.users import CurrentAdmin, CurrentWriter, TenantSession
+from app.core.dependencies.users import CurrentOperator, TenantSession
 from app.services.email_helpers import send_application_status_email
 
 router = APIRouter(prefix="/applications", tags=["application-reviews"])
@@ -85,7 +85,7 @@ def _reviews_to_public_list(reviews: list) -> list[ApplicationReviewPublic]:
 async def list_reviews(
     application_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[ApplicationReviewPublic]:
@@ -114,7 +114,7 @@ async def list_reviews(
 async def get_review_summary(
     application_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
 ) -> ReviewSummary:
     """Get a summary of reviews for an application."""
     from app.api.application.crud import applications_crud
@@ -166,7 +166,7 @@ async def submit_review(
     application_id: uuid.UUID,
     review_in: ApplicationReviewCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> ApplicationReviewPublic:
     """Submit or update a review for an application.
 
@@ -227,7 +227,7 @@ async def submit_review(
 @router.get("/pending-review", response_model=ListModel)
 async def list_pending_reviews(
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
     popup_id: uuid.UUID | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
@@ -290,7 +290,7 @@ async def list_pending_reviews(
 @router.get("/my-reviews", response_model=ListModel[ApplicationReviewPublic])
 async def list_my_reviews(
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[ApplicationReviewPublic]:

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -26,7 +26,7 @@ from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, 
 from app.core.dependencies.users import (
     CurrentCheckInOperator,
     CurrentHuman,
-    CurrentWriter,
+    CurrentOperator,
     HumanTenantSession,
     TenantSession,
 )
@@ -418,7 +418,7 @@ async def update_attendee(
     attendee_id: uuid.UUID,
     attendee_in: AttendeeUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> AttendeeWithOriginPublic:
     """Update an attendee (BO only)."""
 
@@ -440,7 +440,7 @@ async def update_attendee(
 async def delete_attendee(
     attendee_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     """Delete an attendee (BO only)."""
 

--- a/backend/app/api/auth/router.py
+++ b/backend/app/api/auth/router.py
@@ -33,7 +33,12 @@ async def user_login(
     email, expiration_minutes = await login_user(
         session=session,
         email=request.email,
-        allowed_roles={UserRole.SUPERADMIN, UserRole.ADMIN, UserRole.VIEWER},
+        allowed_roles={
+            UserRole.SUPERADMIN,
+            UserRole.ADMIN,
+            UserRole.OPERATOR,
+            UserRole.VIEWER,
+        },
     )
 
     return AuthCodeSentResponse(
@@ -56,7 +61,12 @@ async def user_authenticate(
         session=session,
         email=request.email,
         code=request.code,
-        allowed_roles={UserRole.SUPERADMIN, UserRole.ADMIN, UserRole.VIEWER},
+        allowed_roles={
+            UserRole.SUPERADMIN,
+            UserRole.ADMIN,
+            UserRole.OPERATOR,
+            UserRole.VIEWER,
+        },
     )
 
     access_token = create_access_token(subject=user.id, token_type="user")
@@ -71,7 +81,7 @@ async def scanner_login(
     session: SessionDep,
 ) -> AuthCodeSentResponse:
     """
-    Initiate scanner login. Accepts CHECK_IN_CONTROLLER, ADMIN, and SUPERADMIN.
+    Initiate scanner login. Accepts CHECK_IN_CONTROLLER, OPERATOR, ADMIN, and SUPERADMIN.
     VIEWER is rejected pre-OTP — must not receive a code they can't redeem.
     """
     email, expiration_minutes = await login_user(
@@ -80,6 +90,7 @@ async def scanner_login(
         allowed_roles={
             UserRole.SUPERADMIN,
             UserRole.ADMIN,
+            UserRole.OPERATOR,
             UserRole.CHECK_IN_CONTROLLER,
         },
     )
@@ -98,14 +109,19 @@ async def scanner_authenticate(
 ) -> Token:
     """
     Authenticate a scanner operator and return a JWT token.
-    Only SUPERADMIN, ADMIN, and CHECK_IN_CONTROLLER are accepted.
+    Only SUPERADMIN, ADMIN, OPERATOR, and CHECK_IN_CONTROLLER are accepted.
     VIEWER is rejected with 403.
     """
     user = await authenticate_user(
         session=session,
         email=request.email,
         code=request.code,
-        allowed_roles={UserRole.SUPERADMIN, UserRole.ADMIN, UserRole.CHECK_IN_CONTROLLER},
+        allowed_roles={
+            UserRole.SUPERADMIN,
+            UserRole.ADMIN,
+            UserRole.OPERATOR,
+            UserRole.CHECK_IN_CONTROLLER,
+        },
     )
 
     access_token = create_access_token(subject=user.id, token_type="user")

--- a/backend/app/api/coupon/router.py
+++ b/backend/app/api/coupon/router.py
@@ -16,8 +16,8 @@ from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, 
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     SessionDep,
     TenantSession,
 )
@@ -122,7 +122,7 @@ async def validate_coupon(
 async def create_coupon(
     coupon_in: CouponCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> CouponPublic:
     """Create a new coupon (BO only)."""
 
@@ -167,7 +167,7 @@ async def update_coupon(
     coupon_id: uuid.UUID,
     coupon_in: CouponUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> CouponPublic:
     """Update a coupon (BO only)."""
 
@@ -196,7 +196,7 @@ async def update_coupon(
 async def delete_coupon(
     coupon_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     """Delete a coupon (BO only)."""
 

--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -32,7 +32,7 @@ from app.api.payment.schemas import PaymentStatus, PaymentType
 from app.api.popup.crud import popups_crud
 from app.api.product.models import Products
 from app.api.product.schemas import CATEGORY_HOUSING, CATEGORY_TICKET
-from app.core.dependencies.users import CurrentAdmin, TenantSession
+from app.core.dependencies.users import CurrentOperator, TenantSession
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -40,7 +40,7 @@ router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 @router.get("/stats", response_model=DashboardStats)
 async def get_dashboard_stats(
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
     popup_id: uuid.UUID = Query(..., description="Popup ID to get stats for"),
 ) -> DashboardStats:
     """Get registration statistics for a popup (legacy endpoint)."""
@@ -54,7 +54,7 @@ async def get_dashboard_stats(
 @router.get("/enriched", response_model=EnrichedDashboardStats)
 async def get_enriched_dashboard(
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
     popup_id: uuid.UUID = Query(..., description="Popup ID to get stats for"),
 ) -> EnrichedDashboardStats:
     """Get enriched dashboard with KPIs, trends, breakdowns, and distributions."""

--- a/backend/app/api/email_template/router.py
+++ b/backend/app/api/email_template/router.py
@@ -15,7 +15,7 @@ from app.api.email_template.schemas import (
 )
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
-from app.core.dependencies.users import CurrentUser, CurrentWriter, TenantSession
+from app.core.dependencies.users import CurrentOperator, CurrentUser, TenantSession
 
 router = APIRouter(prefix="/email-templates", tags=["email-templates"])
 
@@ -207,7 +207,7 @@ async def preview_template(
 @router.post("/send-test", status_code=status.HTTP_200_OK)
 async def send_test_email(
     body: SendTestRequest,
-    _: CurrentWriter,
+    _: CurrentOperator,
     db: TenantSession,
 ) -> dict[str, str]:
     from app.services.email.templates import (
@@ -331,7 +331,7 @@ async def get_email_template(
 async def create_email_template(
     template_in: EmailTemplateCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> EmailTemplatePublic:
     from app.services.email.templates import (
         get_template_scope,
@@ -418,7 +418,7 @@ async def update_email_template(
     template_id: uuid.UUID,
     template_in: EmailTemplateUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> EmailTemplatePublic:
     template = crud.email_template_crud.get(db, template_id)
 
@@ -436,7 +436,7 @@ async def update_email_template(
 async def delete_email_template(
     template_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     template = crud.email_template_crud.get(db, template_id)
 

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -35,9 +35,8 @@ from app.api.event.schemas import (
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
-    CurrentAdmin,
     CurrentHuman,
-    CurrentWriter,
+    CurrentOperator,
     HumanTenantSession,
     SessionDep,
     TenantSession,
@@ -590,7 +589,7 @@ async def list_public_calendar(
 @router.get("", response_model=ListModel[EventPublic])
 async def list_events(
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
     popup_id: uuid.UUID | None = None,
     event_status: EventStatus | None = None,
     kind: str | None = None,
@@ -638,7 +637,7 @@ async def list_events(
 async def get_event(
     event_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -652,7 +651,7 @@ async def get_event(
 async def create_event(
     event_in: EventCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> EventPublic:
     from app.api.event.models import Events
     from app.api.popup.crud import popups_crud
@@ -716,7 +715,7 @@ async def update_event(
     event_id: uuid.UUID,
     event_in: EventUpdate,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -778,7 +777,7 @@ async def update_event(
 async def cancel_event(
     event_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -800,7 +799,7 @@ async def cancel_event(
 async def delete_event(
     event_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> None:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -826,7 +825,7 @@ async def set_recurrence(
     event_id: uuid.UUID,
     payload: RecurrenceUpdate,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventPublic:
     """Set/replace/clear the RRULE on a series master.
 
@@ -880,7 +879,7 @@ async def detach_occurrence(
     event_id: uuid.UUID,
     payload: OccurrenceRef,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventPublic:
     """Materialize a single occurrence of a recurring series as its own row.
 
@@ -977,7 +976,7 @@ async def delete_occurrence(
     event_id: uuid.UUID,
     payload: OccurrenceRef,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> None:
     """Skip a single occurrence by appending it to the master's EXDATEs.
 
@@ -1062,7 +1061,7 @@ def _run_availability_check(
 async def check_availability(
     payload: EventAvailabilityCheck,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
 ) -> EventAvailabilityResult:
     """Check whether a venue is free for a candidate time window."""
     return _run_availability_check(db, payload)
@@ -1091,7 +1090,7 @@ async def check_availability_portal(
 async def list_invitations(
     event_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
 ) -> list[EventInvitationPublic]:
     from sqlmodel import select
 
@@ -1185,7 +1184,7 @@ async def bulk_invite(
     event_id: uuid.UUID,
     payload: EventInvitationBulkCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> EventInvitationBulkResult:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1202,7 +1201,7 @@ async def delete_invitation(
     event_id: uuid.UUID,
     invitation_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> None:
     inv = crud.invitations_crud.get(db, invitation_id)
     if not inv or inv.event_id != event_id:
@@ -1351,7 +1350,7 @@ async def approve_event(
     event_id: uuid.UUID,
     payload: EventApprovalPayload,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1391,7 +1390,7 @@ async def reject_event(
     event_id: uuid.UUID,
     payload: EventApprovalPayload,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1453,7 +1452,7 @@ async def delete_portal_invitation(
 async def export_event_ics(
     event_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentAdmin,
+    _: CurrentOperator,
 ) -> Response:
     event = crud.events_crud.get(db, event_id)
     if not event:

--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -15,8 +15,8 @@ from app.api.event_participant.schemas import (
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
     TenantSession,
 )
@@ -87,7 +87,7 @@ async def list_participants(
 async def admin_add_participant(
     participant_in: EventParticipantCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> EventParticipantPublic:
     """Admin adds a participant to an event (backoffice)."""
     from app.api.event.crud import events_crud
@@ -135,7 +135,7 @@ async def update_participant(
     participant_id: uuid.UUID,
     participant_in: EventParticipantUpdate,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> EventParticipantPublic:
     """Update a participant (backoffice)."""
 
@@ -154,7 +154,7 @@ async def update_participant(
 async def delete_participant(
     participant_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> None:
     """Delete a participant (backoffice)."""
 

--- a/backend/app/api/form_field/router.py
+++ b/backend/app/api/form_field/router.py
@@ -23,8 +23,8 @@ from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, 
 from app.api.translation.service import delete_translations_for_entity
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
     TenantSession,
 )
@@ -185,7 +185,7 @@ async def create_base_field_config(
     popup_id: uuid.UUID,
     field_name: str,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> FormFieldPublic:
     """Add a catalog base field to a popup by creating its BaseFieldConfig."""
     from app.api.popup.crud import popups_crud
@@ -290,7 +290,7 @@ async def get_form_field(
 async def create_form_field(
     field_in: FormFieldCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> FormFieldPublic:
     if current_user.role == UserRole.SUPERADMIN:
         from app.api.popup.crud import popups_crud
@@ -327,7 +327,7 @@ async def update_form_field(
     field_id: uuid.UUID,
     field_in: FormFieldUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> FormFieldPublic:
     field = crud.form_fields_crud.get(db, field_id)
 
@@ -382,7 +382,7 @@ async def update_form_field(
 async def delete_form_field(
     field_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     field = crud.form_fields_crud.get(db, field_id)
 

--- a/backend/app/api/form_section/router.py
+++ b/backend/app/api/form_section/router.py
@@ -15,7 +15,7 @@ from app.api.form_section.schemas import (
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.translation.service import delete_translations_for_entity
-from app.core.dependencies.users import CurrentUser, CurrentWriter, TenantSession
+from app.core.dependencies.users import CurrentOperator, CurrentUser, TenantSession
 
 router = APIRouter(prefix="/form-sections", tags=["form-sections"])
 
@@ -83,7 +83,7 @@ async def get_form_section(
 async def create_form_section(
     section_in: FormSectionCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> FormSectionPublic:
     from app.api.popup.crud import popups_crud
 
@@ -145,7 +145,7 @@ async def update_form_section(
     section_id: uuid.UUID,
     section_in: FormSectionUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> FormSectionPublic:
     section = crud.form_sections_crud.get(db, section_id)
 
@@ -163,7 +163,7 @@ async def update_form_section(
 async def delete_form_section(
     section_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     section = crud.form_sections_crud.get(db, section_id)
 

--- a/backend/app/api/group/router.py
+++ b/backend/app/api/group/router.py
@@ -21,8 +21,8 @@ from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, 
 from app.api.translation.service import delete_translations_for_entity
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     SessionDep,
     TenantSession,
 )
@@ -120,7 +120,7 @@ async def get_group(
 async def create_group(
     group_in: GroupCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> GroupPublic:
     """Create a new group (BO only)."""
 
@@ -162,7 +162,7 @@ async def update_group(
     group_id: uuid.UUID,
     group_in: GroupAdminUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> GroupPublic:
     """Update a group (BO only - full admin access)."""
 
@@ -190,7 +190,7 @@ async def update_group(
 async def delete_group(
     group_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     """Delete a group (BO only)."""
 

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -23,8 +23,8 @@ from app.api.payment.schemas import (
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
     SessionDep,
     TenantSession,
@@ -461,7 +461,7 @@ async def update_payment(
     payment_id: uuid.UUID,
     payment_in: PaymentUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> PaymentPublic:
     """Update a payment (BO only)."""
 

--- a/backend/app/api/popup/router.py
+++ b/backend/app/api/popup/router.py
@@ -37,7 +37,7 @@ from app.api.translation.service import (
 from app.core.dependencies.users import (
     CurrentCheckInOperator,
     CurrentHuman,
-    CurrentWriter,
+    CurrentOperator,
     HumanTenantSession,
     SessionDep,
     TenantSession,
@@ -173,7 +173,7 @@ async def get_popup(
 async def create_popup(
     popup_in: PopupCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
     x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> PopupAdmin:
     if current_user.role == UserRole.SUPERADMIN:
@@ -221,7 +221,7 @@ async def update_popup(
     popup_id: uuid.UUID,
     popup_in: PopupUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> PopupAdmin:
     popup = crud.get(db, popup_id)
 
@@ -351,7 +351,7 @@ async def update_popup(
 async def delete_popup(
     popup_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     popup = crud.get(db, popup_id)
 

--- a/backend/app/api/product/router.py
+++ b/backend/app/api/product/router.py
@@ -22,9 +22,9 @@ from app.api.translation.service import (
 )
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentSuperadmin,
     CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
     SessionDep,
     TenantSession,
@@ -197,7 +197,7 @@ async def get_product(
 async def create_product(
     product_in: ProductCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> ProductPublic:
     """Create a new product."""
 
@@ -240,7 +240,7 @@ async def update_product(
     product_id: uuid.UUID,
     product_in: ProductUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> ProductPublic:
     """Update a product."""
 
@@ -271,7 +271,7 @@ async def update_product(
 async def delete_product(
     product_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     """Delete a product.
 

--- a/backend/app/api/shared/enums.py
+++ b/backend/app/api/shared/enums.py
@@ -4,6 +4,7 @@ from enum import Enum, StrEnum
 class UserRole(str, Enum):
     SUPERADMIN = "superadmin"
     ADMIN = "admin"
+    OPERATOR = "operator"
     VIEWER = "viewer"
     CHECK_IN_CONTROLLER = "check_in_controller"
 

--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -9,7 +9,12 @@ from app.api.tenant import crud
 from app.api.tenant.credential_schemas import CredentialInfo, TenantCredentialResponse
 from app.api.tenant.schemas import TenantCreate, TenantPublic, TenantUpdate
 from app.core.config import settings
-from app.core.dependencies.users import CurrentAdmin, CurrentSuperadmin, SessionDep
+from app.core.dependencies.users import (
+    CurrentAdmin,
+    CurrentOperator,
+    CurrentSuperadmin,
+    SessionDep,
+)
 from app.core.redis import domain_cache
 from app.core.tenant_db import get_tenant_credential, revoke_tenant_credentials
 
@@ -103,10 +108,10 @@ async def list_tenants(
 async def get_tenant(
     tenant_id: uuid.UUID,
     db: SessionDep,
-    current_user: CurrentAdmin,
+    current_user: CurrentOperator,
 ) -> TenantPublic:
-    # Admins can only view their own tenant
-    if current_user.role == UserRole.ADMIN and current_user.tenant_id != tenant_id:
+    # Non-superadmins can only view their own tenant
+    if current_user.role != UserRole.SUPERADMIN and current_user.tenant_id != tenant_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot access other tenants",

--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -12,8 +12,8 @@ from app.api.ticketing_step.schemas import (
 )
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
     TenantSession,
 )
@@ -79,7 +79,7 @@ async def get_ticketing_step(
 async def create_ticketing_step(
     step_in: TicketingStepCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> TicketingStepPublic:
     if current_user.role == UserRole.SUPERADMIN:
         from app.api.popup.crud import popups_crud
@@ -112,7 +112,7 @@ async def update_ticketing_step(
     step_id: uuid.UUID,
     step_in: TicketingStepUpdate,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> TicketingStepPublic:
     step = crud.ticketing_steps_crud.get(db, step_id)
 
@@ -137,7 +137,7 @@ async def update_ticketing_step(
 async def delete_ticketing_step(
     step_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> None:
     step = crud.ticketing_steps_crud.get(db, step_id)
 

--- a/backend/app/api/track/router.py
+++ b/backend/app/api/track/router.py
@@ -8,8 +8,8 @@ from app.api.track import crud
 from app.api.track.schemas import TrackCreate, TrackPublic, TrackUpdate
 from app.core.dependencies.users import (
     CurrentHuman,
+    CurrentOperator,
     CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
     TenantSession,
 )
@@ -71,7 +71,7 @@ async def get_track(
 async def create_track(
     track_in: TrackCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
 ) -> TrackPublic:
     from app.api.popup.crud import popups_crud
     from app.api.shared.enums import UserRole
@@ -106,7 +106,7 @@ async def update_track(
     track_id: uuid.UUID,
     track_in: TrackUpdate,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> TrackPublic:
     track = crud.tracks_crud.get(db, track_id)
     if not track:
@@ -121,7 +121,7 @@ async def update_track(
 async def delete_track(
     track_id: uuid.UUID,
     db: TenantSession,
-    _: CurrentWriter,
+    _: CurrentOperator,
 ) -> None:
     track = crud.tracks_crud.get(db, track_id)
     if not track:

--- a/backend/app/api/translation/router.py
+++ b/backend/app/api/translation/router.py
@@ -8,7 +8,7 @@ from app.api.shared.enums import UserRole
 from app.api.translation.crud import translations_crud
 from app.api.translation.schemas import TranslationCreate, TranslationPublic
 from app.api.translation.service import TRANSLATABLE_FIELDS
-from app.core.dependencies.users import CurrentUser, CurrentWriter, TenantSession
+from app.core.dependencies.users import CurrentOperator, CurrentUser, TenantSession
 
 router = APIRouter(prefix="/translations", tags=["translations"])
 
@@ -29,7 +29,7 @@ async def list_translations(
 async def upsert_translation(
     translation_in: TranslationCreate,
     db: TenantSession,
-    current_user: CurrentWriter,
+    current_user: CurrentOperator,
     x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> TranslationPublic:
     """Create or update a translation for an entity."""
@@ -63,7 +63,7 @@ class AITranslateRequest(BaseModel):
 async def ai_translate(
     request: AITranslateRequest,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
 ) -> dict[str, str]:
     """Use AI to generate draft translations for an entity. Returns translated fields (not saved)."""
     if request.entity_type not in TRANSLATABLE_FIELDS:
@@ -115,7 +115,7 @@ async def ai_translate(
 async def delete_translation(
     translation_id: uuid.UUID,
     db: TenantSession,
-    _current_user: CurrentWriter,
+    _current_user: CurrentOperator,
     _x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> None:
     """Delete a translation."""

--- a/backend/app/api/user/crud.py
+++ b/backend/app/api/user/crud.py
@@ -31,6 +31,7 @@ class UsersCRUD(BaseCRUD[Users, UserCreate, UserUpdate]):
         skip: int = 0,
         limit: int = 100,
         search: str | None = None,
+        roles_in: list[UserRole] | None = None,
     ) -> tuple[list[Users], int]:
         """Find users with optional filters."""
 
@@ -41,6 +42,9 @@ class UsersCRUD(BaseCRUD[Users, UserCreate, UserUpdate]):
 
         if role is not None:
             statement = statement.where(Users.role == role)
+
+        if roles_in is not None:
+            statement = statement.where(col(Users.role).in_(roles_in))
 
         # Apply text search if provided
         if search:

--- a/backend/app/api/user/router.py
+++ b/backend/app/api/user/router.py
@@ -7,7 +7,7 @@ from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.user import crud
 from app.api.user.schemas import UserCreate, UserPublic, UserUpdate
-from app.core.dependencies.users import CurrentAdmin, CurrentUser, SessionDep
+from app.core.dependencies.users import CurrentOperator, CurrentUser, SessionDep
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -15,11 +15,17 @@ ROLE_HIERARCHY = {
     UserRole.SUPERADMIN: [
         UserRole.SUPERADMIN,
         UserRole.ADMIN,
+        UserRole.OPERATOR,
         UserRole.VIEWER,
         UserRole.CHECK_IN_CONTROLLER,
     ],
     UserRole.ADMIN: [
         UserRole.ADMIN,
+        UserRole.OPERATOR,
+        UserRole.VIEWER,
+        UserRole.CHECK_IN_CONTROLLER,
+    ],
+    UserRole.OPERATOR: [
         UserRole.VIEWER,
         UserRole.CHECK_IN_CONTROLLER,
     ],
@@ -31,19 +37,35 @@ ROLE_HIERARCHY = {
 @router.get("", response_model=ListModel[UserPublic])
 async def list_users(
     db: SessionDep,
-    current_user: CurrentAdmin,
+    current_user: CurrentOperator,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
     tenant_id: uuid.UUID | None = None,
     role: UserRole | None = None,
     search: str | None = None,
 ) -> ListModel[UserPublic]:
-    # Admins can only see users in their tenant
-    if current_user.role == UserRole.ADMIN:
+    # Non-superadmins are scoped to their own tenant
+    if current_user.role != UserRole.SUPERADMIN:
         tenant_id = current_user.tenant_id
 
+    # Operators only see users they're allowed to manage (strictly lower roles)
+    roles_in: list[UserRole] | None = None
+    if current_user.role == UserRole.OPERATOR:
+        roles_in = ROLE_HIERARCHY[UserRole.OPERATOR]
+        if role is not None and role not in roles_in:
+            return ListModel[UserPublic](
+                results=[],
+                paging=Paging(offset=skip, limit=limit, total=0),
+            )
+
     users, total = crud.find_filtered(
-        db, tenant_id=tenant_id, role=role, skip=skip, limit=limit, search=search
+        db,
+        tenant_id=tenant_id,
+        role=role,
+        skip=skip,
+        limit=limit,
+        search=search,
+        roles_in=roles_in,
     )
 
     return ListModel[UserPublic](
@@ -67,7 +89,7 @@ async def get_current_user_info(
 async def get_user(
     user_id: uuid.UUID,
     db: SessionDep,
-    current_user: CurrentAdmin,
+    current_user: CurrentOperator,
 ) -> UserPublic:
     user = crud.get(db, user_id)
 
@@ -77,11 +99,24 @@ async def get_user(
             detail="User not found",
         )
 
-    # Admins can only view users in their tenant
-    if current_user.role == UserRole.ADMIN and user.tenant_id != current_user.tenant_id:
+    # Non-superadmins can only view users in their tenant
+    if (
+        current_user.role != UserRole.SUPERADMIN
+        and user.tenant_id != current_user.tenant_id
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot access users from other tenants",
+        )
+
+    # Operators can only view users whose role is within their hierarchy
+    if (
+        current_user.role == UserRole.OPERATOR
+        and user.role not in ROLE_HIERARCHY[UserRole.OPERATOR]
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot access this user",
         )
 
     return UserPublic.model_validate(user)
@@ -91,7 +126,7 @@ async def get_user(
 async def create_user(
     user_in: UserCreate,
     db: SessionDep,
-    current_user: CurrentAdmin,
+    current_user: CurrentOperator,
 ) -> UserPublic:
     allowed_roles = ROLE_HIERARCHY.get(current_user.role, [])
     if user_in.role not in allowed_roles:
@@ -132,7 +167,7 @@ async def update_user(
     user_id: uuid.UUID,
     user_in: UserUpdate,
     db: SessionDep,
-    current_user: CurrentAdmin,
+    current_user: CurrentOperator,
 ) -> UserPublic:
     user = crud.get(db, user_id)
 
@@ -142,15 +177,28 @@ async def update_user(
             detail="User not found",
         )
 
-    # Admins can only update users in their tenant
-    if current_user.role == UserRole.ADMIN and user.tenant_id != current_user.tenant_id:
+    # Non-superadmins can only update users in their tenant
+    if (
+        current_user.role != UserRole.SUPERADMIN
+        and user.tenant_id != current_user.tenant_id
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot update users from other tenants",
         )
 
-    # Admins cannot change roles to superadmin or promote to a higher level
-    if current_user.role == UserRole.ADMIN and user_in.role:
+    # Operators can only update users whose role is within their hierarchy
+    if (
+        current_user.role == UserRole.OPERATOR
+        and user.role not in ROLE_HIERARCHY[UserRole.OPERATOR]
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot update this user",
+        )
+
+    # Non-superadmins cannot assign roles outside their hierarchy
+    if current_user.role != UserRole.SUPERADMIN and user_in.role:
         allowed_roles = ROLE_HIERARCHY.get(current_user.role, [])
         if user_in.role not in allowed_roles:
             raise HTTPException(
@@ -176,7 +224,7 @@ async def update_user(
 async def delete_user(
     user_id: uuid.UUID,
     db: SessionDep,
-    current_user: CurrentAdmin,
+    current_user: CurrentOperator,
 ) -> None:
     user = crud.get(db, user_id)
 
@@ -186,8 +234,11 @@ async def delete_user(
             detail="User not found",
         )
 
-    # Admins can only delete users in their tenant
-    if current_user.role == UserRole.ADMIN and user.tenant_id != current_user.tenant_id:
+    # Non-superadmins can only delete users in their tenant
+    if (
+        current_user.role != UserRole.SUPERADMIN
+        and user.tenant_id != current_user.tenant_id
+    ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot delete users from other tenants",
@@ -202,6 +253,16 @@ async def delete_user(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Cannot delete other admins",
+        )
+
+    # Operators can only delete users whose role is within their hierarchy
+    if (
+        current_user.role == UserRole.OPERATOR
+        and user.role not in ROLE_HIERARCHY[UserRole.OPERATOR]
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot delete this user",
         )
 
     if user.id == current_user.id:

--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -148,6 +148,21 @@ def get_admin(
     return current_user
 
 
+def get_operator(
+    current_user: Annotated["UserPublic", Depends(get_current_user)],
+) -> "UserPublic":
+    if current_user.role not in [
+        UserRole.SUPERADMIN,
+        UserRole.ADMIN,
+        UserRole.OPERATOR,
+    ]:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Operator access required",
+        )
+    return current_user
+
+
 def require_write_permission(
     current_user: Annotated["UserPublic", Depends(get_current_user)],
 ) -> "UserPublic":
@@ -165,6 +180,7 @@ def get_check_in_operator(
     if current_user.role not in [
         UserRole.SUPERADMIN,
         UserRole.ADMIN,
+        UserRole.OPERATOR,
         UserRole.CHECK_IN_CONTROLLER,
     ]:
         raise HTTPException(
@@ -178,6 +194,7 @@ CurrentUser = Annotated["UserPublic", Depends(get_current_user)]
 CurrentHuman = Annotated["HumanPublic", Depends(get_current_human)]
 CurrentSuperadmin = Annotated["UserPublic", Depends(get_superadmin)]
 CurrentAdmin = Annotated["UserPublic", Depends(get_admin)]
+CurrentOperator = Annotated["UserPublic", Depends(get_operator)]
 CurrentWriter = Annotated["UserPublic", Depends(require_write_permission)]
 CurrentCheckInOperator = Annotated["UserPublic", Depends(get_check_in_operator)]
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -229,6 +229,60 @@ def admin_token_tenant_b(admin_user_tenant_b: Users) -> str:
 
 
 @pytest.fixture(scope="session")
+def operator_user_tenant_a(db: Session, tenant_a: Tenants) -> Users:
+    user = db.exec(
+        select(Users).where(
+            Users.email == "operator-a@test.com",
+            Users.deleted == False,  # noqa: E712
+        )
+    ).first()
+
+    if user is None:
+        user = Users(
+            email="operator-a@test.com",
+            role=UserRole.OPERATOR,
+            tenant_id=tenant_a.id,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    return user
+
+
+@pytest.fixture(scope="session")
+def operator_user_tenant_b(db: Session, tenant_b: Tenants) -> Users:
+    user = db.exec(
+        select(Users).where(
+            Users.email == "operator-b@test.com",
+            Users.deleted == False,  # noqa: E712
+        )
+    ).first()
+
+    if user is None:
+        user = Users(
+            email="operator-b@test.com",
+            role=UserRole.OPERATOR,
+            tenant_id=tenant_b.id,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    return user
+
+
+@pytest.fixture(scope="session")
+def operator_token_tenant_a(operator_user_tenant_a: Users) -> str:
+    return create_access_token(subject=operator_user_tenant_a.id, token_type="user")
+
+
+@pytest.fixture(scope="session")
+def operator_token_tenant_b(operator_user_tenant_b: Users) -> str:
+    return create_access_token(subject=operator_user_tenant_b.id, token_type="user")
+
+
+@pytest.fixture(scope="session")
 def viewer_user_tenant_b(db: Session, tenant_b: Tenants) -> Users:
     user = db.exec(
         select(Users).where(

--- a/backend/tests/test_operator_role.py
+++ b/backend/tests/test_operator_role.py
@@ -1,0 +1,390 @@
+"""Tests for the OPERATOR role.
+
+OPERATOR sits between ADMIN and VIEWER. Operators can run day-to-day operations
+on the product (events, popups, products, coupons, email templates, reviews,
+invitations, attendees, refunds, API keys) but cannot touch structural settings
+(admin users, approval strategies, event_settings, base_field_configs) and cannot
+manage their own peers or anyone above them in the hierarchy.
+
+These tests use the assert_authorized / assert_forbidden helpers established
+in _role_assertions.py.
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.shared.enums import UserRole
+from app.api.user.models import Users
+from app.core.security import create_access_token
+from tests._role_assertions import assert_authorized, assert_forbidden
+
+
+# ---------------------------------------------------------------------------
+# OPERATOR is authorized on operational routes (CRUD on products, events, etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorAuthorizedOnOperationalRoutes:
+    """OPERATOR is in the allow-list for operational read/write routes."""
+
+    def test_operator_can_list_events(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_authorized(client, "GET", "/api/v1/events", operator_token_tenant_a)
+
+    def test_operator_can_list_applications(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_authorized(
+            client, "GET", "/api/v1/applications", operator_token_tenant_a
+        )
+
+    def test_operator_can_get_dashboard_stats(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        response = client.get(
+            "/api/v1/dashboard/stats?popup_id=" + str(uuid.uuid4()),
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+        )
+        assert response.status_code != 403, (
+            f"OPERATOR must not get 403 on GET /dashboard/stats, "
+            f"got {response.status_code}: {response.text}"
+        )
+
+    def test_operator_can_list_reviews(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        response = client.get(
+            f"/api/v1/applications/{uuid.uuid4()}/reviews",
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+        )
+        assert response.status_code != 403, (
+            f"OPERATOR must not get 403 on GET /applications/{{id}}/reviews, "
+            f"got {response.status_code}: {response.text}"
+        )
+
+    def test_operator_can_bulk_invite(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        response = client.post(
+            f"/api/v1/events/{uuid.uuid4()}/invitations",
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+            json={"emails": ["test@test.com"]},
+        )
+        # 404 acceptable (event doesn't exist); what matters is NOT 403
+        assert response.status_code != 403, (
+            f"OPERATOR must not get 403 on POST /events/{{id}}/invitations, "
+            f"got {response.status_code}: {response.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OPERATOR is forbidden on structural / SUPERADMIN-only routes
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorForbiddenOnStructuralRoutes:
+    """OPERATOR is NOT in the allow-list for approval strategy, event settings,
+    base field configs, or any superadmin-only route."""
+
+    def test_operator_cannot_create_approval_strategy(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "POST",
+            f"/api/v1/popups/{uuid.uuid4()}/approval-strategy",
+            operator_token_tenant_a,
+            json={"strategy_type": "single_reviewer"},
+        )
+
+    def test_operator_cannot_patch_approval_strategy(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "PATCH",
+            f"/api/v1/popups/{uuid.uuid4()}/approval-strategy",
+            operator_token_tenant_a,
+            json={"strategy_type": "single_reviewer"},
+        )
+
+    def test_operator_cannot_delete_approval_strategy(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "DELETE",
+            f"/api/v1/popups/{uuid.uuid4()}/approval-strategy",
+            operator_token_tenant_a,
+        )
+
+    def test_operator_cannot_upsert_event_settings(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "PUT",
+            f"/api/v1/event-settings/{uuid.uuid4()}",
+            operator_token_tenant_a,
+            json={},
+        )
+
+    def test_operator_cannot_patch_base_field_config(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "PATCH",
+            f"/api/v1/base-field-configs/{uuid.uuid4()}",
+            operator_token_tenant_a,
+            json={"label": "x"},
+        )
+
+    def test_operator_cannot_create_human(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        """POST /humans is SUPERADMIN-only — OPERATOR must get 403."""
+        assert_forbidden(
+            client,
+            "POST",
+            "/api/v1/humans",
+            operator_token_tenant_a,
+            json={"email": f"test-{uuid.uuid4().hex[:6]}@test.com"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# ROLE_HIERARCHY — OPERATOR can only manage VIEWER and CHECK_IN_CONTROLLER
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorRoleHierarchy:
+    """OPERATOR cannot create/edit/delete users with role ADMIN, OPERATOR,
+    or SUPERADMIN. Only roles strictly below OPERATOR (VIEWER, CHECK_IN_CONTROLLER)."""
+
+    def test_operator_can_create_viewer(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        response = client.post(
+            "/api/v1/users",
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+            json={
+                "email": f"new-viewer-{uuid.uuid4().hex[:6]}@test.com",
+                "role": "viewer",
+            },
+        )
+        assert response.status_code == 201, (
+            f"OPERATOR must be able to create VIEWER, got {response.status_code}: "
+            f"{response.text}"
+        )
+
+    def test_operator_can_create_check_in_controller(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        response = client.post(
+            "/api/v1/users",
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+            json={
+                "email": f"new-controller-{uuid.uuid4().hex[:6]}@test.com",
+                "role": "check_in_controller",
+            },
+        )
+        assert response.status_code == 201, (
+            f"OPERATOR must be able to create CHECK_IN_CONTROLLER, got "
+            f"{response.status_code}: {response.text}"
+        )
+
+    def test_operator_cannot_create_admin(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "POST",
+            "/api/v1/users",
+            operator_token_tenant_a,
+            json={
+                "email": f"new-admin-{uuid.uuid4().hex[:6]}@test.com",
+                "role": "admin",
+            },
+        )
+
+    def test_operator_cannot_create_operator_peer(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "POST",
+            "/api/v1/users",
+            operator_token_tenant_a,
+            json={
+                "email": f"new-op-{uuid.uuid4().hex[:6]}@test.com",
+                "role": "operator",
+            },
+        )
+
+    def test_operator_cannot_create_superadmin(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "POST",
+            "/api/v1/users",
+            operator_token_tenant_a,
+            json={
+                "email": f"new-sa-{uuid.uuid4().hex[:6]}@test.com",
+                "role": "superadmin",
+            },
+        )
+
+    def test_operator_cannot_delete_admin(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+        admin_user_tenant_a: Users,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "DELETE",
+            f"/api/v1/users/{admin_user_tenant_a.id}",
+            operator_token_tenant_a,
+        )
+
+    def test_operator_cannot_patch_admin(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+        admin_user_tenant_a: Users,
+    ) -> None:
+        assert_forbidden(
+            client,
+            "PATCH",
+            f"/api/v1/users/{admin_user_tenant_a.id}",
+            operator_token_tenant_a,
+            json={"full_name": "Mallory"},
+        )
+
+    def test_operator_cannot_delete_peer_operator(
+        self,
+        client: TestClient,
+        db: Session,
+        operator_token_tenant_a: str,
+        operator_user_tenant_a: Users,
+    ) -> None:
+        # Create a second operator in the same tenant
+        peer_email = f"peer-op-{uuid.uuid4().hex[:6]}@test.com"
+        peer = Users(
+            email=peer_email,
+            role=UserRole.OPERATOR,
+            tenant_id=operator_user_tenant_a.tenant_id,
+        )
+        db.add(peer)
+        db.commit()
+        db.refresh(peer)
+
+        assert_forbidden(
+            client,
+            "DELETE",
+            f"/api/v1/users/{peer.id}",
+            operator_token_tenant_a,
+        )
+
+    def test_operator_list_users_excludes_admins_and_peers(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+        admin_user_tenant_a: Users,
+        operator_user_tenant_a: Users,
+    ) -> None:
+        response = client.get(
+            "/api/v1/users",
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+        )
+        assert response.status_code == 200, response.text
+        roles_seen = {u["role"] for u in response.json()["results"]}
+        # Only viewer + check_in_controller should be returned
+        assert roles_seen.issubset({"viewer", "check_in_controller"}), (
+            f"OPERATOR list_users returned forbidden roles: {roles_seen}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OPERATOR uses CRUD credentials (not READONLY) for tenant DB
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorUsesCrudCredentials:
+    """OPERATOR should have write access to the tenant DB (CRUD, not READONLY).
+    A read-only credential would reject any INSERT.
+    """
+
+    def test_operator_can_create_via_tenant_session(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        """Create a coupon to force a write through TenantSession.
+
+        If OPERATOR got READONLY credentials by mistake, this would fail
+        with a 500/DB permission error rather than 201/400.
+        """
+        response = client.post(
+            "/api/v1/coupons",
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+            json={
+                "code": f"OP-{uuid.uuid4().hex[:6].upper()}",
+                "popup_id": str(uuid.uuid4()),  # any UUID; we just want past the gate
+                "discount_value": 10,
+                "discount_type": "percentage",
+            },
+        )
+        # 422 (validation), 404 (popup not found), 400 (bad) — all acceptable.
+        # 403 (forbidden) and 500 (permission denied via READONLY) are NOT acceptable.
+        assert response.status_code != 403, (
+            f"OPERATOR must not get 403 on POST /coupons: {response.text}"
+        )
+        assert response.status_code != 500, (
+            f"OPERATOR must not get 500 (likely READONLY DB role) on POST /coupons: "
+            f"{response.text}"
+        )
+
+
+# Suppress unused-import warning for create_access_token (used by other tests
+# via fixtures defined in conftest.py — keeping import here documents the
+# token-creation pattern in case operator fixtures get moved).
+_ = create_access_token
+_ = select

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -14675,7 +14675,7 @@ export const UserPublicSchema = {
 
 export const UserRoleSchema = {
     type: 'string',
-    enum: ['superadmin', 'admin', 'viewer', 'check_in_controller'],
+    enum: ['superadmin', 'admin', 'operator', 'viewer', 'check_in_controller'],
     title: 'UserRole'
 } as const;
 

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2887,7 +2887,7 @@ export type UserPublic = {
     id: string;
 };
 
-export type UserRole = 'superadmin' | 'admin' | 'viewer' | 'check_in_controller';
+export type UserRole = 'superadmin' | 'admin' | 'operator' | 'viewer' | 'check_in_controller';
 
 /**
  * Statuses that users can set (subset of ApplicationStatus).

--- a/backoffice/src/components/Admin/UserActionsMenu.tsx
+++ b/backoffice/src/components/Admin/UserActionsMenu.tsx
@@ -19,7 +19,7 @@ interface UserActionsMenuProps {
 
 export const UserActionsMenu = ({ user }: UserActionsMenuProps) => {
   const [open, setOpen] = useState(false)
-  const { user: currentUser, isSuperadmin } = useAuth()
+  const { user: currentUser, isSuperadmin, isOperator } = useAuth()
 
   // Don't show actions for current user
   if (user.id === currentUser?.id) {
@@ -28,6 +28,16 @@ export const UserActionsMenu = ({ user }: UserActionsMenuProps) => {
 
   // Non-superadmins can only manage users with lower or equal roles
   if (!isSuperadmin && user.role === "superadmin") {
+    return null
+  }
+
+  // Operators cannot manage admins, fellow operators, or superadmins
+  if (
+    isOperator &&
+    (user.role === "admin" ||
+      user.role === "operator" ||
+      user.role === "superadmin")
+  ) {
     return null
   }
 

--- a/backoffice/src/components/Admin/columns.tsx
+++ b/backoffice/src/components/Admin/columns.tsx
@@ -17,7 +17,11 @@ const getRoleBadgeVariant = (
       return "default"
     case "admin":
       return "secondary"
+    case "operator":
+      return "secondary"
     case "viewer":
+      return "outline"
+    case "check_in_controller":
       return "outline"
     default:
       return "outline"
@@ -30,8 +34,12 @@ const getRoleLabel = (role: UserRole): string => {
       return "Superadmin"
     case "admin":
       return "Admin"
+    case "operator":
+      return "Operator"
     case "viewer":
       return "Viewer"
+    case "check_in_controller":
+      return "Check-in controller"
     default:
       return role
   }

--- a/backoffice/src/components/ApplicationDetail.tsx
+++ b/backoffice/src/components/ApplicationDetail.tsx
@@ -599,7 +599,7 @@ export function ApplicationDetail({
   onReviewSuccess,
   headerExtra,
 }: ApplicationDetailProps) {
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
 
   const { data: schema } = useQuery({
     queryKey: ["form-fields-schema", application.popup_id],
@@ -635,7 +635,7 @@ export function ApplicationDetail({
   })
 
   const isWeightedVoting = approvalStrategy?.strategy_type === "weighted"
-  const canReview = isAdmin && application.status === "in review"
+  const canReview = isOperatorOrAbove && application.status === "in review"
   const companions =
     application.attendees?.filter((a) => a.category !== "main") ?? []
 

--- a/backoffice/src/components/Common/CommandPalette.tsx
+++ b/backoffice/src/components/Common/CommandPalette.tsx
@@ -55,7 +55,7 @@ const createActions = Object.values(CREATE_ROUTES).map((route) => ({
 export function CommandPalette() {
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
-  const { isAdmin, isSuperadmin } = useAuth()
+  const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const isMac =
     typeof navigator !== "undefined" &&
     /Mac|iPhone|iPad/.test(navigator.userAgent)
@@ -78,7 +78,7 @@ export function CommandPalette() {
 
   const allPages = [
     ...pages,
-    ...(isAdmin ? adminPages : []),
+    ...(isOperatorOrAbove ? adminPages : []),
     ...(isSuperadmin ? superadminPages : []),
   ]
 
@@ -95,7 +95,7 @@ export function CommandPalette() {
             </CommandItem>
           ))}
         </CommandGroup>
-        {isAdmin && (
+        {isOperatorOrAbove && (
           <>
             <CommandSeparator />
             <CommandGroup heading="Create">

--- a/backoffice/src/components/Sidebar/AppSidebar.tsx
+++ b/backoffice/src/components/Sidebar/AppSidebar.tsx
@@ -86,7 +86,7 @@ const superadminItems: Item[] = [
 ]
 
 export function AppSidebar() {
-  const { user: currentUser, isAdmin, isSuperadmin } = useAuth()
+  const { user: currentUser, isOperatorOrAbove, isSuperadmin } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
 
   const { data: pendingReviews } = useQuery({
@@ -96,7 +96,7 @@ export function AppSidebar() {
         popupId: selectedPopupId!,
         limit: 1,
       }),
-    enabled: isContextReady && isAdmin,
+    enabled: isContextReady && isOperatorOrAbove,
     staleTime: 60_000,
     refetchInterval: 60_000,
   })
@@ -109,7 +109,7 @@ export function AppSidebar() {
         paymentStatus: "pending",
         limit: 1,
       }),
-    enabled: isContextReady && isAdmin,
+    enabled: isContextReady && isOperatorOrAbove,
     staleTime: 60_000,
     refetchInterval: 60_000,
   })
@@ -145,7 +145,7 @@ export function AppSidebar() {
 
   // For admins (non-superadmin), get their tenant-specific items
   const adminNavigationItems =
-    isAdmin && !isSuperadmin
+    isOperatorOrAbove && !isSuperadmin
       ? getAdminItems(currentUser?.tenant_id)
       : adminItems
 
@@ -181,7 +181,7 @@ export function AppSidebar() {
         </SidebarGroup>
 
         {/* Admin section (visible to admins+) */}
-        {isAdmin && (
+        {isOperatorOrAbove && (
           <SidebarGroup>
             <SidebarGroupLabel>Administration</SidebarGroupLabel>
             <Main items={adminNavigationItems} />

--- a/backoffice/src/components/forms/CouponForm.tsx
+++ b/backoffice/src/components/forms/CouponForm.tsx
@@ -40,9 +40,9 @@ export function CouponForm({ defaultValues, onSuccess }: CouponFormProps) {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId, isContextReady } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const isEdit = !!defaultValues
-  const readOnly = !isAdmin
+  const readOnly = !isOperatorOrAbove
 
   const createMutation = useMutation({
     mutationFn: (data: CouponCreate) =>

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -128,8 +128,8 @@ export function EventForm({
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId } = useWorkspace()
-  const { user, isAdmin } = useAuth()
-  const readOnly = !isAdmin
+  const { user, isOperatorOrAbove } = useAuth()
+  const readOnly = !isOperatorOrAbove
   const isEdit = !!defaultValues
 
   // Display name for the current user used by the "Use my name" quick-fill

--- a/backoffice/src/components/forms/FormFieldForm.tsx
+++ b/backoffice/src/components/forms/FormFieldForm.tsx
@@ -89,9 +89,9 @@ export function FormFieldForm({
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId, isContextReady } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const isEdit = !!defaultValues
-  const readOnly = !isAdmin
+  const readOnly = !isOperatorOrAbove
   const isProtectedField =
     isEdit && defaultValues ? isSpecialField(defaultValues) : false
 

--- a/backoffice/src/components/forms/FormSectionForm.tsx
+++ b/backoffice/src/components/forms/FormSectionForm.tsx
@@ -49,9 +49,9 @@ export function FormSectionForm({
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId, isContextReady } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const isEdit = !!defaultValues
-  const readOnly = !isAdmin
+  const readOnly = !isOperatorOrAbove
   const isProtectedSection =
     isEdit && defaultValues ? isSpecialSection(defaultValues) : false
 

--- a/backoffice/src/components/forms/GroupForm.tsx
+++ b/backoffice/src/components/forms/GroupForm.tsx
@@ -42,9 +42,9 @@ export function GroupForm({ defaultValues, onSuccess }: GroupFormProps) {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId, isContextReady } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const isEdit = !!defaultValues
-  const readOnly = !isAdmin
+  const readOnly = !isOperatorOrAbove
 
   const { data: popupData } = useQuery({
     queryKey: ["popups", defaultValues?.popup_id ?? selectedPopupId],

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -129,9 +129,9 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const isEdit = !!defaultValues
-  const readOnly = !isAdmin
+  const readOnly = !isOperatorOrAbove
 
   const createMutation = useMutation({
     mutationFn: (data: PopupCreate) =>

--- a/backoffice/src/components/forms/ProductForm.cross-field.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.cross-field.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/contexts/WorkspaceContext", () => ({
 }))
 
 vi.mock("@/hooks/useAuth", () => ({
-  default: () => ({ isAdmin: true }),
+  default: () => ({ isAdmin: true, isOperatorOrAbove: true }),
 }))
 
 vi.mock("@/hooks/useCustomToast", () => ({

--- a/backoffice/src/components/forms/ProductForm.requires-check-in.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.requires-check-in.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/contexts/WorkspaceContext", () => ({
 }))
 
 vi.mock("@/hooks/useAuth", () => ({
-  default: () => ({ isAdmin: true }),
+  default: () => ({ isAdmin: true, isOperatorOrAbove: true }),
 }))
 
 vi.mock("@/hooks/useCustomToast", () => ({

--- a/backoffice/src/components/forms/ProductForm.stock-fields.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.stock-fields.test.tsx
@@ -42,7 +42,7 @@ vi.mock("@/contexts/WorkspaceContext", () => ({
 }))
 
 vi.mock("@/hooks/useAuth", () => ({
-  default: () => ({ isAdmin: true }),
+  default: () => ({ isAdmin: true, isOperatorOrAbove: true }),
 }))
 
 vi.mock("@/hooks/useCustomToast", () => ({

--- a/backoffice/src/components/forms/ProductForm.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.test.tsx
@@ -38,7 +38,7 @@ vi.mock("@/contexts/WorkspaceContext", () => ({
 }))
 
 vi.mock("@/hooks/useAuth", () => ({
-  default: () => ({ isAdmin: true }),
+  default: () => ({ isAdmin: true, isOperatorOrAbove: true }),
 }))
 
 vi.mock("@/hooks/useCustomToast", () => ({

--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -95,9 +95,9 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId, isContextReady } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const isEdit = !!defaultValues
-  const readOnly = !isAdmin
+  const readOnly = !isOperatorOrAbove
 
   const [addCategoryOpen, setAddCategoryOpen] = useState(false)
   const [newCategoryName, setNewCategoryName] = useState("")

--- a/backoffice/src/components/forms/TrackForm.tsx
+++ b/backoffice/src/components/forms/TrackForm.tsx
@@ -109,8 +109,8 @@ export function TrackForm({ defaultValues, onSuccess }: TrackFormProps) {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { selectedPopupId } = useWorkspace()
-  const { isAdmin } = useAuth()
-  const readOnly = !isAdmin
+  const { isOperatorOrAbove } = useAuth()
+  const readOnly = !isOperatorOrAbove
   const isEdit = !!defaultValues
 
   const createMutation = useMutation({

--- a/backoffice/src/components/forms/UserForm.tsx
+++ b/backoffice/src/components/forms/UserForm.tsx
@@ -42,6 +42,7 @@ const emailSchema = z.string().email({ message: "Invalid email address" })
 const roleSchema = z.enum([
   "superadmin",
   "admin",
+  "operator",
   "viewer",
   "check_in_controller",
 ] as const)
@@ -60,6 +61,11 @@ const ROLE_OPTIONS: {
     value: "admin",
     label: "Admin",
     description: "Full tenant access",
+  },
+  {
+    value: "operator",
+    label: "Operator",
+    description: "Day-to-day product operations",
   },
   {
     value: "viewer",
@@ -82,14 +88,18 @@ export function UserForm({ defaultValues, onSuccess }: UserFormProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
-  const { isSuperadmin, user: currentUser } = useAuth()
+  const { isSuperadmin, isOperator, user: currentUser } = useAuth()
   const { effectiveTenantId } = useWorkspace()
   const isEdit = !!defaultValues
   const isCurrentUser = currentUser?.id === defaultValues?.id
 
   const availableRoles = isSuperadmin
     ? ROLE_OPTIONS
-    : ROLE_OPTIONS.filter((r) => r.value !== "superadmin")
+    : isOperator
+      ? ROLE_OPTIONS.filter(
+          (r) => r.value === "viewer" || r.value === "check_in_controller",
+        )
+      : ROLE_OPTIONS.filter((r) => r.value !== "superadmin")
 
   const createMutation = useMutation({
     mutationFn: (data: UserCreate) =>
@@ -161,6 +171,7 @@ export function UserForm({ defaultValues, onSuccess }: UserFormProps) {
   const getRoleBadgeVariant = (role: UserRole) => {
     if (role === "superadmin") return "default" as const
     if (role === "admin") return "secondary" as const
+    if (role === "operator") return "secondary" as const
     return "outline" as const
   }
 

--- a/backoffice/src/hooks/useAuth.ts
+++ b/backoffice/src/hooks/useAuth.ts
@@ -23,6 +23,32 @@ const isAdmin = (user: UserPublic | null | undefined): boolean => {
 }
 
 /**
+ * Check if user is operator
+ */
+const isOperator = (user: UserPublic | null | undefined): boolean => {
+  return user?.role === "operator"
+}
+
+/**
+ * Check if user has operator or higher role (operator, admin, superadmin)
+ */
+const isOperatorOrAbove = (user: UserPublic | null | undefined): boolean => {
+  return (
+    user?.role === "superadmin" ||
+    user?.role === "admin" ||
+    user?.role === "operator"
+  )
+}
+
+/**
+ * Check if user can manage admin-level users and structural settings.
+ * Operators cannot — only superadmin and admin can.
+ */
+const canManageAdmins = (user: UserPublic | null | undefined): boolean => {
+  return user?.role === "superadmin" || user?.role === "admin"
+}
+
+/**
  * Check if user is superadmin
  */
 const isSuperadmin = (user: UserPublic | null | undefined): boolean => {
@@ -85,6 +111,9 @@ const useAuth = () => {
     user,
     isUserLoading,
     isAdmin: isAdmin(user),
+    isOperator: isOperator(user),
+    isOperatorOrAbove: isOperatorOrAbove(user),
+    canManageAdmins: canManageAdmins(user),
     isSuperadmin: isSuperadmin(user),
     isViewer: isViewer(user),
     requestCodeMutation,
@@ -93,5 +122,13 @@ const useAuth = () => {
   }
 }
 
-export { isLoggedIn, isAdmin, isSuperadmin, isViewer }
+export {
+  isLoggedIn,
+  isAdmin,
+  isOperator,
+  isOperatorOrAbove,
+  canManageAdmins,
+  isSuperadmin,
+  isViewer,
+}
 export default useAuth

--- a/backoffice/src/hooks/useGlobalShortcuts.ts
+++ b/backoffice/src/hooks/useGlobalShortcuts.ts
@@ -17,7 +17,7 @@ function useGlobalShortcuts({
 }: UseGlobalShortcutsOptions) {
   const navigate = useNavigate()
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { theme, setTheme } = useTheme()
 
   useEffect(() => {
@@ -35,7 +35,7 @@ function useGlobalShortcuts({
           return
         }
 
-        if (!isAdmin) {
+        if (!isOperatorOrAbove) {
           toast.info("You don't have permission to create items")
           return
         }
@@ -65,7 +65,14 @@ function useGlobalShortcuts({
 
     document.addEventListener("keydown", handleKeyDown)
     return () => document.removeEventListener("keydown", handleKeyDown)
-  }, [pathname, isAdmin, theme, setTheme, navigate, onShortcutsDialogToggle])
+  }, [
+    pathname,
+    isOperatorOrAbove,
+    theme,
+    setTheme,
+    navigate,
+    onShortcutsDialogToggle,
+  ])
 }
 
 export default useGlobalShortcuts

--- a/backoffice/src/routes/_layout/admin/index.tsx
+++ b/backoffice/src/routes/_layout/admin/index.tsx
@@ -82,7 +82,7 @@ function AddUserButton() {
 }
 
 function TenantUsersTableContent({ tenantId }: { tenantId: string | null }) {
-  const { user: currentUser } = useAuth()
+  const { user: currentUser, isOperator } = useAuth()
   const searchParams = Route.useSearch()
   const { search, pagination, setSearch, setPagination } = useTableSearchParams(
     searchParams,
@@ -101,9 +101,15 @@ function TenantUsersTableContent({ tenantId }: { tenantId: string | null }) {
 
   if (!users) return <Skeleton className="h-64 w-full" />
 
-  const tenantUsers = users.results.filter(
-    (user: UserPublic) => user.role !== "superadmin",
-  )
+  // Operators can only see roles strictly below them (viewer, check_in_controller).
+  // Others see everyone except superadmins.
+  const tenantUsers = users.results.filter((user: UserPublic) => {
+    if (user.role === "superadmin") return false
+    if (isOperator) {
+      return user.role === "viewer" || user.role === "check_in_controller"
+    }
+    return true
+  })
 
   const tableData: UserTableData[] = tenantUsers.map((user: UserPublic) => ({
     ...user,
@@ -230,7 +236,7 @@ function SuperadminsTable() {
 }
 
 function Admin() {
-  const { isAdmin, isSuperadmin } = useAuth()
+  const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const { effectiveTenantId } = useWorkspace()
 
   return (
@@ -242,7 +248,7 @@ function Admin() {
             Manage user accounts and permissions
           </p>
         </div>
-        {isAdmin && <AddUserButton />}
+        {isOperatorOrAbove && <AddUserButton />}
       </div>
       {isSuperadmin ? (
         <Tabs defaultValue="tenant-users">

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -397,7 +397,7 @@ function ApplicationActionsMenu({
   const navigate = useNavigate()
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [activeDialog, setActiveDialog] = useState<DialogType>(null)
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const currentStatus = application.status
 
   const openDialog = (dialog: DialogType) => {
@@ -406,7 +406,7 @@ function ApplicationActionsMenu({
   }
 
   const canReview =
-    isAdmin && currentStatus === "in review" && !isWeightedVoting
+    isOperatorOrAbove && currentStatus === "in review" && !isWeightedVoting
 
   return (
     <>
@@ -582,7 +582,7 @@ const getColumns = (
 
 function ApplicationsTableContent() {
   const { selectedPopupId } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const navigate = useNavigate()
@@ -760,7 +760,7 @@ function ApplicationsTableContent() {
 
   const isWeightedVoting = approvalStrategy?.strategy_type === "weighted"
   const columns = getColumns(isWeightedVoting, !!reviewerId)
-  const canBulkReview = isAdmin && !isWeightedVoting
+  const canBulkReview = isOperatorOrAbove && !isWeightedVoting
 
   if (!applications) return <Skeleton className="h-64 w-full" />
 
@@ -866,7 +866,7 @@ function AddApplicationButton() {
 }
 
 function Applications() {
-  const { isAdmin, isSuperadmin } = useAuth()
+  const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
   const [isExporting, setIsExporting] = useState(false)
 
@@ -959,7 +959,7 @@ function Applications() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {isContextReady && isAdmin && (
+          {isContextReady && isOperatorOrAbove && (
             <Button variant="outline" asChild>
               <Link to="/applications/review-queue">
                 <ListChecks className="mr-2 h-4 w-4" />

--- a/backoffice/src/routes/_layout/applications/review-queue.tsx
+++ b/backoffice/src/routes/_layout/applications/review-queue.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_layout/applications/review-queue")({
 
 function ReviewQueuePage() {
   const { isContextReady, selectedPopupId } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const [currentIndex, setCurrentIndex] = useState(0)
   const queryClient = useQueryClient()
 
@@ -32,7 +32,7 @@ function ReviewQueuePage() {
         skip: 0,
         limit: 100,
       }),
-    enabled: isContextReady && isAdmin,
+    enabled: isContextReady && isOperatorOrAbove,
   })
 
   const applications = (pendingData?.results ??
@@ -40,7 +40,7 @@ function ReviewQueuePage() {
   const total = applications.length
   const current = applications[currentIndex]
 
-  if (!isContextReady || !isAdmin) {
+  if (!isContextReady || !isOperatorOrAbove) {
     return (
       <div className="flex flex-col gap-6">
         <div>

--- a/backoffice/src/routes/_layout/coupons/index.tsx
+++ b/backoffice/src/routes/_layout/coupons/index.tsx
@@ -138,7 +138,7 @@ function DeleteCoupon({
 
 function CouponActionsMenu({ coupon }: { coupon: CouponPublic }) {
   const [open, setOpen] = useState(false)
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
@@ -150,7 +150,7 @@ function CouponActionsMenu({ coupon }: { coupon: CouponPublic }) {
       <DropdownMenuContent align="end">
         <DropdownMenuItem asChild>
           <Link to="/coupons/$id/edit" params={{ id: coupon.id }}>
-            {isAdmin ? (
+            {isOperatorOrAbove ? (
               <>
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
@@ -163,7 +163,7 @@ function CouponActionsMenu({ coupon }: { coupon: CouponPublic }) {
             )}
           </Link>
         </DropdownMenuItem>
-        {isAdmin && (
+        {isOperatorOrAbove && (
           <DeleteCoupon coupon={coupon} onSuccess={() => setOpen(false)} />
         )}
       </DropdownMenuContent>
@@ -266,7 +266,7 @@ function CouponsTableContent({ popupId }: { popupId: string | null }) {
 }
 
 function Coupons() {
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { selectedPopupId, isContextReady } = useWorkspace()
 
   return (
@@ -278,7 +278,7 @@ function Coupons() {
             Manage discount codes for your popups
           </p>
         </div>
-        {isAdmin && isContextReady && <AddCouponButton />}
+        {isOperatorOrAbove && isContextReady && <AddCouponButton />}
       </div>
       {!isContextReady ? (
         <WorkspaceAlert resource="coupons" />

--- a/backoffice/src/routes/_layout/coupons/new.tsx
+++ b/backoffice/src/routes/_layout/coupons/new.tsx
@@ -14,16 +14,16 @@ export const Route = createFileRoute("/_layout/coupons/new")({
 
 function NewCoupon() {
   const navigate = useNavigate()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to coupons list - they cannot create new coupons
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/coupons" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
+++ b/backoffice/src/routes/_layout/email-templates/$type.edit.tsx
@@ -85,16 +85,16 @@ export function EditorContent({ templateType }: { templateType: string }) {
 function EditEmailTemplate() {
   const { type } = Route.useParams()
   const { needsTenantSelection } = useWorkspace()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
   const navigate = useNavigate()
 
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/email-templates" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/email-templates/email-templates-routing.test.tsx
+++ b/backoffice/src/routes/_layout/email-templates/email-templates-routing.test.tsx
@@ -32,7 +32,11 @@ vi.mock("@/contexts/WorkspaceContext", () => ({
 }))
 
 vi.mock("@/hooks/useAuth", () => ({
-  default: () => ({ isAdmin: true, isUserLoading: false }),
+  default: () => ({
+    isAdmin: true,
+    isOperatorOrAbove: true,
+    isUserLoading: false,
+  }),
 }))
 
 vi.mock("@/components/Common/QueryErrorBoundary", () => ({

--- a/backoffice/src/routes/_layout/email-templates/index.tsx
+++ b/backoffice/src/routes/_layout/email-templates/index.tsx
@@ -112,9 +112,9 @@ export function TemplateList() {
 
 export function EmailTemplatesPage() {
   const { needsTenantSelection, needsPopupSelection } = useWorkspace()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
 
-  if (!isAdmin) {
+  if (!isOperatorOrAbove) {
     return (
       <div className="flex flex-col gap-6 p-6">
         <h1 className="text-2xl font-bold tracking-tight">Email Templates</h1>

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -145,7 +145,7 @@ function EventActionsMenu({
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { showSuccessToast, showErrorToast } = useCustomToast()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
 
   const occurrenceRef = parseOccurrenceId(event.occurrence_id)
   const isOccurrence = occurrenceRef !== null
@@ -241,7 +241,7 @@ function EventActionsMenu({
   return (
     <>
       <div className="flex items-center justify-end gap-0.5">
-        {isAdmin && isPendingApproval && (
+        {isOperatorOrAbove && isPendingApproval && (
           <>
             <Button
               variant="ghost"
@@ -272,17 +272,17 @@ function EventActionsMenu({
         <Button
           variant="ghost"
           size="icon"
-          aria-label={isAdmin ? "Edit event" : "View event"}
-          title={isAdmin ? "Edit" : "View"}
+          aria-label={isOperatorOrAbove ? "Edit event" : "View event"}
+          title={isOperatorOrAbove ? "Edit" : "View"}
           onClick={handleEdit}
         >
-          {isAdmin ? (
+          {isOperatorOrAbove ? (
             <Pencil className="h-4 w-4" />
           ) : (
             <Eye className="h-4 w-4" />
           )}
         </Button>
-        {isAdmin && (
+        {isOperatorOrAbove && (
           <Button
             variant="ghost"
             size="icon"

--- a/backoffice/src/routes/_layout/events/settings.tsx
+++ b/backoffice/src/routes/_layout/events/settings.tsx
@@ -1,11 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { Lock } from "lucide-react"
 import { Suspense } from "react"
 
 import { type EventSettingsCreate, EventSettingsService } from "@/client"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { ChipInput } from "@/components/forms/EventForm/ChipInput"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -17,6 +19,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
+import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { createErrorHandler } from "@/utils"
 
@@ -60,6 +63,8 @@ function EventSettingsForm() {
   const { selectedPopupId } = useWorkspace()
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
+  const { isAdmin } = useAuth()
+  const readOnly = !isAdmin
 
   const { data: settings, isLoading } = useQuery({
     queryKey: ["event-settings", selectedPopupId],
@@ -106,6 +111,16 @@ function EventSettingsForm() {
 
   return (
     <div className="mx-auto space-y-6 max-w-lg">
+      {readOnly && (
+        <Alert>
+          <Lock className="h-4 w-4" />
+          <AlertTitle>Read-only access</AlertTitle>
+          <AlertDescription>
+            Event settings can only be changed by an admin. You can review the
+            current configuration but cannot edit it.
+          </AlertDescription>
+        </Alert>
+      )}
       <div className="space-y-2">
         <div className="flex items-center justify-between rounded-lg border p-4">
           <div className="space-y-0.5">
@@ -116,6 +131,7 @@ function EventSettingsForm() {
           </div>
           <Switch
             checked={currentSettings.event_enabled}
+            disabled={readOnly}
             onCheckedChange={(checked) =>
               upsertMutation.mutate({
                 ...currentSettings,
@@ -136,6 +152,7 @@ function EventSettingsForm() {
         <Label>Who Can Create Events</Label>
         <Select
           value={currentSettings.can_publish_event}
+          disabled={readOnly}
           onValueChange={(value) =>
             upsertMutation.mutate({
               ...currentSettings,
@@ -170,6 +187,7 @@ function EventSettingsForm() {
             </div>
             <Switch
               checked={currentSettings.events_require_approval ?? true}
+              disabled={readOnly}
               onCheckedChange={(checked) =>
                 upsertMutation.mutate({
                   ...currentSettings,
@@ -186,6 +204,7 @@ function EventSettingsForm() {
         <Label>Default Timezone</Label>
         <Select
           value={currentSettings.timezone}
+          disabled={readOnly}
           onValueChange={(value) =>
             upsertMutation.mutate({
               ...currentSettings,
@@ -214,6 +233,7 @@ function EventSettingsForm() {
         <Label>Allowed event tags</Label>
         <ChipInput
           value={currentSettings.allowed_tags ?? []}
+          disabled={readOnly}
           onChange={(next) =>
             upsertMutation.mutate({
               ...currentSettings,
@@ -233,6 +253,7 @@ function EventSettingsForm() {
         <Label>Allowed event types</Label>
         <ChipInput
           value={currentSettings.allowed_kinds ?? []}
+          disabled={readOnly}
           placeholder="Add type (or paste workshop, talk, social)"
           onChange={(next) =>
             upsertMutation.mutate({
@@ -252,6 +273,7 @@ function EventSettingsForm() {
         <Label>Approval notification emails</Label>
         <ChipInput
           value={currentSettings.approval_notification_emails ?? []}
+          disabled={readOnly}
           placeholder="admin@your-popup.com"
           validate={(entry) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(entry)}
           onChange={(next) =>
@@ -288,6 +310,7 @@ function EventSettingsForm() {
           </div>
           <Switch
             checked={currentSettings.humans_can_create_venues ?? false}
+            disabled={readOnly}
             onCheckedChange={(checked) =>
               upsertMutation.mutate({
                 ...currentSettings,
@@ -313,7 +336,7 @@ function EventSettingsForm() {
           </div>
           <Switch
             checked={currentSettings.venues_require_approval ?? true}
-            disabled={!currentSettings.humans_can_create_venues}
+            disabled={readOnly || !currentSettings.humans_can_create_venues}
             onCheckedChange={(checked) =>
               upsertMutation.mutate({
                 ...currentSettings,

--- a/backoffice/src/routes/_layout/events/tracks/index.tsx
+++ b/backoffice/src/routes/_layout/events/tracks/index.tsx
@@ -62,7 +62,7 @@ function TrackActionsMenu({ track }: { track: TrackPublic }) {
   const [deleteOpen, setDeleteOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
 
   const deleteMutation = useMutation({
     mutationFn: () => TracksService.deleteTrack({ trackId: track.id }),
@@ -89,7 +89,7 @@ function TrackActionsMenu({ track }: { track: TrackPublic }) {
               to="/events/tracks/$trackId/edit"
               params={{ trackId: track.id }}
             >
-              {isAdmin ? (
+              {isOperatorOrAbove ? (
                 <>
                   <Pencil className="mr-2 h-4 w-4" />
                   Edit
@@ -102,7 +102,7 @@ function TrackActionsMenu({ track }: { track: TrackPublic }) {
               )}
             </Link>
           </DropdownMenuItem>
-          {isAdmin && (
+          {isOperatorOrAbove && (
             <DropdownMenuItem
               variant="destructive"
               onSelect={(e) => e.preventDefault()}

--- a/backoffice/src/routes/_layout/form-builder/index.tsx
+++ b/backoffice/src/routes/_layout/form-builder/index.tsx
@@ -104,7 +104,7 @@ function getAllFormSectionsQueryOptions(popupId: string | null) {
 }
 
 function FormBuilderPage() {
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
 
   if (!isContextReady) {
@@ -115,7 +115,7 @@ function FormBuilderPage() {
     )
   }
 
-  if (!isAdmin) {
+  if (!isOperatorOrAbove) {
     return (
       <div className="flex flex-col gap-6 p-6">
         <h1 className="text-2xl font-bold tracking-tight">Form Builder</h1>

--- a/backoffice/src/routes/_layout/form-builder/new.tsx
+++ b/backoffice/src/routes/_layout/form-builder/new.tsx
@@ -16,17 +16,17 @@ export const Route = createFileRoute("/_layout/form-builder/new")({
 
 function NewFormField() {
   const navigate = useNavigate()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
   const { isContextReady } = useWorkspace()
 
   // Redirect viewers to form-fields list - they cannot create new fields
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/form-builder" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/form-builder/sections/new.tsx
+++ b/backoffice/src/routes/_layout/form-builder/sections/new.tsx
@@ -16,16 +16,16 @@ export const Route = createFileRoute("/_layout/form-builder/sections/new")({
 
 function NewFormSection() {
   const navigate = useNavigate()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
   const { isContextReady } = useWorkspace()
 
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/form-builder" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/groups/index.tsx
+++ b/backoffice/src/routes/_layout/groups/index.tsx
@@ -215,7 +215,7 @@ function DeleteGroup({
 
 function GroupActionsMenu({ group }: { group: GroupPublic }) {
   const [open, setOpen] = useState(false)
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { data: tenant } = useCurrentTenant()
   const baseUrl = getPortalBaseUrl(tenant)
 
@@ -229,7 +229,7 @@ function GroupActionsMenu({ group }: { group: GroupPublic }) {
       <DropdownMenuContent align="end">
         <DropdownMenuItem asChild>
           <Link to="/groups/$id/edit" params={{ id: group.id }}>
-            {isAdmin ? (
+            {isOperatorOrAbove ? (
               <>
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
@@ -255,7 +255,7 @@ function GroupActionsMenu({ group }: { group: GroupPublic }) {
             </a>
           </DropdownMenuItem>
         )}
-        {isAdmin && (
+        {isOperatorOrAbove && (
           <DeleteGroup group={group} onSuccess={() => setOpen(false)} />
         )}
       </DropdownMenuContent>
@@ -354,7 +354,7 @@ function GroupsTableContent() {
 }
 
 function Groups() {
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { isContextReady } = useWorkspace()
 
   return (
@@ -367,7 +367,7 @@ function Groups() {
             Manage group registrations and discounts
           </p>
         </div>
-        {isAdmin && isContextReady && <AddGroupButton />}
+        {isOperatorOrAbove && isContextReady && <AddGroupButton />}
       </div>
       {isContextReady && (
         <QueryErrorBoundary>

--- a/backoffice/src/routes/_layout/groups/new.tsx
+++ b/backoffice/src/routes/_layout/groups/new.tsx
@@ -14,16 +14,16 @@ export const Route = createFileRoute("/_layout/groups/new")({
 
 function NewGroup() {
   const navigate = useNavigate()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to groups list - they cannot create new groups
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/groups" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/index.tsx
+++ b/backoffice/src/routes/_layout/index.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/_layout/")({
 })
 
 function Dashboard() {
-  const { user: currentUser, isAdmin, isSuperadmin } = useAuth()
+  const { user: currentUser, isOperatorOrAbove, isSuperadmin } = useAuth()
   const { selectedPopupId, selectedTenantId, isContextReady } = useWorkspace()
 
   const {
@@ -70,7 +70,7 @@ function Dashboard() {
           </p>
         </div>
 
-        {isContextReady && isAdmin && (
+        {isContextReady && isOperatorOrAbove && (
           <NeedsAttention
             inReview={enriched?.applications.in_review ?? 0}
             selectedPopupId={selectedPopupId}
@@ -122,7 +122,7 @@ function Dashboard() {
           />
         </div>
 
-        {isContextReady && isAdmin && selectedPopupId && (
+        {isContextReady && isOperatorOrAbove && selectedPopupId && (
           <div>
             <SectionTitle>Recent Activity</SectionTitle>
             <RecentActivity

--- a/backoffice/src/routes/_layout/popups/index.tsx
+++ b/backoffice/src/routes/_layout/popups/index.tsx
@@ -153,7 +153,7 @@ function DeletePopup({
 
 function PopupActionsMenu({ popup }: { popup: PopupAdmin }) {
   const [open, setOpen] = useState(false)
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { data: tenant } = useCurrentTenant()
   const baseUrl = getPortalBaseUrl(tenant)
 
@@ -167,7 +167,7 @@ function PopupActionsMenu({ popup }: { popup: PopupAdmin }) {
       <DropdownMenuContent align="end">
         <DropdownMenuItem asChild>
           <Link to="/popups/$id/edit" params={{ id: popup.id }}>
-            {isAdmin ? (
+            {isOperatorOrAbove ? (
               <>
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
@@ -204,7 +204,7 @@ function PopupActionsMenu({ popup }: { popup: PopupAdmin }) {
             </DropdownMenuItem>
           </>
         )}
-        {isAdmin && (
+        {isOperatorOrAbove && (
           <DeletePopup popup={popup} onSuccess={() => setOpen(false)} />
         )}
       </DropdownMenuContent>
@@ -346,10 +346,11 @@ function PopupsTable() {
 }
 
 function Popups() {
-  const { isAdmin, isSuperadmin } = useAuth()
+  const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const { needsTenantSelection, effectiveTenantId } = useWorkspace()
 
-  const canManagePopups = isAdmin && (!isSuperadmin || !!effectiveTenantId)
+  const canManagePopups =
+    isOperatorOrAbove && (!isSuperadmin || !!effectiveTenantId)
 
   return (
     <div className="flex flex-col gap-6">

--- a/backoffice/src/routes/_layout/popups/new.tsx
+++ b/backoffice/src/routes/_layout/popups/new.tsx
@@ -14,16 +14,16 @@ export const Route = createFileRoute("/_layout/popups/new")({
 
 function NewPopup() {
   const navigate = useNavigate()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to popups list - they cannot create new popups
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/popups" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/products/index.tsx
+++ b/backoffice/src/routes/_layout/products/index.tsx
@@ -99,7 +99,7 @@ function ProductActionsMenu({ product }: { product: ProductPublic }) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
 
   const deleteMutation = useMutation({
     mutationFn: () => ProductsService.deleteProduct({ productId: product.id }),
@@ -122,7 +122,7 @@ function ProductActionsMenu({ product }: { product: ProductPublic }) {
         <DropdownMenuContent align="end">
           <DropdownMenuItem asChild>
             <Link to="/products/$id/edit" params={{ id: product.id }}>
-              {isAdmin ? (
+              {isOperatorOrAbove ? (
                 <>
                   <Pencil className="mr-2 h-4 w-4" />
                   Edit
@@ -135,7 +135,7 @@ function ProductActionsMenu({ product }: { product: ProductPublic }) {
               )}
             </Link>
           </DropdownMenuItem>
-          {isAdmin && (
+          {isOperatorOrAbove && (
             <DropdownMenuItem
               variant="destructive"
               onClick={() => {
@@ -290,7 +290,7 @@ function ProductsTableContent() {
 }
 
 function Products() {
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { isContextReady } = useWorkspace()
 
   return (
@@ -304,7 +304,7 @@ function Products() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {isAdmin && isContextReady && <AddProductButton />}
+          {isOperatorOrAbove && isContextReady && <AddProductButton />}
         </div>
       </div>
       {isContextReady && (

--- a/backoffice/src/routes/_layout/products/new.tsx
+++ b/backoffice/src/routes/_layout/products/new.tsx
@@ -14,16 +14,16 @@ export const Route = createFileRoute("/_layout/products/new")({
 
 function NewProduct() {
   const navigate = useNavigate()
-  const { isAdmin, isUserLoading } = useAuth()
+  const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to products list - they cannot create new products
   useEffect(() => {
-    if (!isUserLoading && !isAdmin) {
+    if (!isUserLoading && !isOperatorOrAbove) {
       navigate({ to: "/products" })
     }
-  }, [isAdmin, isUserLoading, navigate])
+  }, [isOperatorOrAbove, isUserLoading, navigate])
 
-  if (isUserLoading || !isAdmin) {
+  if (isUserLoading || !isOperatorOrAbove) {
     return null
   }
 

--- a/backoffice/src/routes/_layout/ticketing-steps/index.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/index.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/_layout/ticketing-steps/")({
 })
 
 function TicketingStepsPage() {
-  const { isAdmin } = useAuth()
+  const { isOperatorOrAbove } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
 
   if (!isContextReady) {
@@ -42,7 +42,7 @@ function TicketingStepsPage() {
     )
   }
 
-  if (!isAdmin) {
+  if (!isOperatorOrAbove) {
     return (
       <div className="flex flex-col gap-6 p-6">
         <h1 className="text-2xl font-bold tracking-tight">Ticketing Steps</h1>

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -14675,7 +14675,7 @@ export const UserPublicSchema = {
 
 export const UserRoleSchema = {
     type: 'string',
-    enum: ['superadmin', 'admin', 'viewer', 'check_in_controller'],
+    enum: ['superadmin', 'admin', 'operator', 'viewer', 'check_in_controller'],
     title: 'UserRole'
 } as const;
 

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2887,7 +2887,7 @@ export type UserPublic = {
     id: string;
 };
 
-export type UserRole = 'superadmin' | 'admin' | 'viewer' | 'check_in_controller';
+export type UserRole = 'superadmin' | 'admin' | 'operator' | 'viewer' | 'check_in_controller';
 
 /**
  * Statuses that users can set (subset of ApplicationStatus).


### PR DESCRIPTION
## Summary

Adds a fifth backoffice role — **OPERATOR** — sitting between ADMIN and VIEWER, intended for day-to-day product operations without access to structural decisions. Closes the gap where everyone running daily operations needed full ADMIN.

- **OPERATOR can:** CRUD on events, popups, products, coupons, email templates, groups, application reviews, invitations, check-ins, attendees, form fields/sections, tracks, translations, ticketing steps. Refund payments. Create API keys with any scope. Manage VIEWER and CHECK_IN_CONTROLLER users.
- **OPERATOR cannot:** Create/edit ADMIN, OPERATOR peers, or SUPERADMIN users. Touch approval strategies, event settings, base field configs, event venues, humans. Anything SUPERADMIN-only.

## Backend changes

- New `UserRole.OPERATOR` enum value (string-backed, no DB migration needed).
- New `CurrentOperator` dependency; `get_check_in_operator` now allows OPERATOR.
- `/auth/user/*` and `/auth/scanner/*` allow-lists include OPERATOR so the role can log in.
- Operational gates migrated from `CurrentWriter`/`CurrentAdmin` to `CurrentOperator` across ~15 routers.
- Structural gates kept as ADMIN+: approval strategies, event settings, base field configs, event venues, humans, popup reviewers, tenant PATCH.
- `user/router.py` `ROLE_HIERARCHY` extended: OPERATOR can only manage VIEWER + CHECK_IN_CONTROLLER. GET/PATCH/DELETE users enforce this both server-side and via filtered lists.

## Frontend changes (backoffice)

- `useAuth` exposes `isOperator`, `isOperatorOrAbove`, `canManageAdmins`.
- Operational gates use `isOperatorOrAbove` (events, popups, products, coupons, email templates, groups, applications, form builder, dashboard, sidebar, command palette, all their forms).
- Admin module hides ADMIN+ targets from operators; UserForm role selector restricted to VIEWER/CHECK_IN_CONTROLLER when current user is OPERATOR.
- Event Settings page is read-only for non-admins (banner + every input disabled).
- OpenAPI clients regenerated in both `backoffice/src/client/` and `portal/src/client/` to include `'operator'` in the `UserRole` union.

## Tests

- New operator fixtures in `conftest.py` (operator_user/token for tenant A and B).
- New `backend/tests/test_operator_role.py` (21 tests) covering: authorized on operational routes, forbidden on structural routes, ROLE_HIERARCHY constraints (create/patch/delete user), list filtering, and CRUD-credential DB writes through `TenantSession`.
- `test_audit_tightening.py` (46 tests) still passes — VIEWER/CHECK_IN_CONTROLLER still rejected on migrated routes.

## Test plan

- [ ] Backend tests: `cd backend && uv run bash scripts/test.sh` — all green except a pre-existing unrelated failure in `test_enforcement_wiring.py::test_sold_out_product_raises_409` (validation order, not role-related).
- [ ] Backend lint: `cd backend && uv run bash scripts/lint.sh` — passes.
- [ ] Frontend lint: `pnpm lint` — passes.
- [ ] Manual smoke as SUPERADMIN: create an OPERATOR user in tenant A.
- [ ] Manual smoke as OPERATOR:
  - [ ] Can log in via `/auth/user/login`.
  - [ ] Can see and CRUD events, popups, products, coupons, email templates.
  - [ ] Event Settings page renders read-only with banner; no input is editable.
  - [ ] Approval Strategy / Event Settings / Base Field Configs writes return 403.
  - [ ] User Management lists only VIEWER + CHECK_IN_CONTROLLER; create ADMIN → 403.
  - [ ] Can process a payment refund via PATCH `/payments/{id}`.
  - [ ] Can create an API key with `events:write` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)