### PR TITLE
Release: merge dev into main

### DIFF
--- a/backend/app/alembic/versions/0048_venue_weekly_hours_booking_mode.py
+++ b/backend/app/alembic/versions/0048_venue_weekly_hours_booking_mode.py
@@ -1,0 +1,30 @@
+"""Add booking_mode column to venue_weekly_hours.
+
+Per-slot booking permission so a single venue can be permissionless during
+some hours and approval-required during others. NULL is the explicit "fall
+back to venue default" sentinel; no backfill is needed because existing
+venues keep working when every row is NULL.
+
+Revision ID: 0048_venue_slot_booking_mode
+Revises: 0d62c955bfdf
+Create Date: 2026-05-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0048_venue_slot_booking_mode"
+down_revision = "0d62c955bfdf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "venue_weekly_hours",
+        sa.Column("booking_mode", sa.String(length=30), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("venue_weekly_hours", "booking_mode")

--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -34,6 +34,7 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
         start_after: datetime | None = None,
         start_before: datetime | None = None,
         venue_id: uuid.UUID | None = None,
+        location_kind: str | None = None,
         track_ids: list[uuid.UUID] | None = None,
         tags: list[str] | None = None,
         search: str | None = None,
@@ -60,6 +61,14 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
             statement = statement.where(Events.kind == kind)
         if venue_id is not None:
             statement = statement.where(Events.venue_id == venue_id)
+        if location_kind == "custom":
+            # No venue + a custom_location_name (e.g. a Google Maps link).
+            statement = statement.where(Events.venue_id.is_(None))  # type: ignore[union-attr]
+            statement = statement.where(Events.custom_location_name.is_not(None))  # type: ignore[union-attr]
+        elif location_kind == "meeting":
+            # Online-only meetings: no venue and no custom location.
+            statement = statement.where(Events.venue_id.is_(None))  # type: ignore[union-attr]
+            statement = statement.where(Events.custom_location_name.is_(None))  # type: ignore[union-attr]
         if track_ids:
             statement = statement.where(col(Events.track_id).in_(track_ids))
         if tags:

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -99,7 +99,6 @@ def _check_venue_open_hours(
     primary gate, this is the safety net for direct API callers / stale
     clients.
     """
-    from datetime import timedelta
     from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
     from sqlmodel import select
@@ -138,14 +137,35 @@ def _check_venue_open_hours(
     s = _aware(start_time)
     e = _aware(end_time)
 
-    # Build candidate open ranges spanning the request window. Mirrors the
-    # weekly-hours expansion in ``_compute_availability`` but only for the
-    # 1–2 days the request crosses (events virtually never span more).
-    candidate_ranges: list[tuple[datetime, datetime]] = []
-    s_local = s.astimezone(tz)
-    e_local = e.astimezone(tz)
+    expanded = _expand_weekly_slots(weekly_rows, tz, s, e)
+    candidate_ranges: list[tuple[datetime, datetime]] = [
+        (r_s, r_e) for r_s, r_e, _row in expanded
+    ]
+    for exc in open_exceptions:
+        candidate_ranges.append((_aware(exc.start_datetime), _aware(exc.end_datetime)))
+
+    if any(r_s <= s and e <= r_e for r_s, r_e in candidate_ranges):
+        return
+
+    raise HTTPException(
+        status_code=400,
+        detail="Selected time falls outside the venue's open hours.",
+    )
+
+
+def _expand_weekly_slots(weekly_rows, tz, aware_start, aware_end):
+    """Expand weekly_hours rows into concrete ``(open, close, row)`` ranges
+    covering the days that [aware_start, aware_end] crosses, in ``tz``.
+
+    Used by both the open-hours check and the per-slot booking-mode
+    resolver. Returns ranges where ``row`` is the source ``VenueWeeklyHours``
+    so callers can read its ``booking_mode``.
+    """
+    s_local = aware_start.astimezone(tz)
+    e_local = aware_end.astimezone(tz)
     day_cursor = s_local.date()
     last_day = e_local.date()
+    ranges: list[tuple[datetime, datetime, object]] = []
     while day_cursor <= last_day + timedelta(days=1):
         dow = day_cursor.weekday()
         for row in weekly_rows:
@@ -160,18 +180,78 @@ def _check_venue_open_hours(
             close_local = datetime.combine(day_cursor, row.close_time, tzinfo=tz)
             if close_local <= open_local:
                 close_local = close_local + timedelta(days=1)
-            candidate_ranges.append((open_local, close_local))
+            ranges.append((open_local, close_local, row))
         day_cursor = day_cursor + timedelta(days=1)
-    for exc in open_exceptions:
-        candidate_ranges.append((_aware(exc.start_datetime), _aware(exc.end_datetime)))
+    return ranges
 
-    if any(r_s <= s and e <= r_e for r_s, r_e in candidate_ranges):
-        return
 
-    raise HTTPException(
-        status_code=400,
-        detail="Selected time falls outside the venue's open hours.",
+def _resolve_effective_booking_mode(
+    db,
+    venue,
+    start_time: datetime,
+    end_time: datetime,
+) -> str:
+    """Return the most restrictive booking_mode that applies to
+    [start_time, end_time]. Considers every venue_weekly_hours slot that
+    overlaps the window (in the popup's timezone); slots with NULL
+    booking_mode contribute ``venue.booking_mode``. If no slot overlaps,
+    returns ``venue.booking_mode``.
+
+    Precedence: ``unbookable`` > ``approval_required`` > ``free``.
+    """
+    from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+    from sqlmodel import select
+
+    from app.api.event_venue.models import VenueWeeklyHours
+    from app.api.event_venue.router import _resolve_popup_timezone
+    from app.api.event_venue.schemas import VenueBookingMode
+
+    venue_default = venue.booking_mode
+    if isinstance(venue_default, VenueBookingMode):
+        venue_default = venue_default.value
+
+    weekly_rows = list(
+        db.exec(
+            select(VenueWeeklyHours).where(VenueWeeklyHours.venue_id == venue.id)
+        ).all()
     )
+    if not weekly_rows:
+        return venue_default
+
+    tz_name = _resolve_popup_timezone(db, venue.popup_id)
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        tz = ZoneInfo("UTC")
+
+    def _aware(dt: datetime) -> datetime:
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=UTC)
+        return dt
+
+    s = _aware(start_time)
+    e = _aware(end_time)
+
+    expanded = _expand_weekly_slots(weekly_rows, tz, s, e)
+    precedence = {
+        VenueBookingMode.UNBOOKABLE.value: 3,
+        VenueBookingMode.APPROVAL_REQUIRED.value: 2,
+        VenueBookingMode.FREE.value: 1,
+    }
+
+    overlapping_modes: list[str] = []
+    for r_s, r_e, row in expanded:
+        if r_s < e and r_e > s:
+            row_mode = row.booking_mode
+            if isinstance(row_mode, VenueBookingMode):
+                row_mode = row_mode.value
+            overlapping_modes.append(row_mode or venue_default)
+
+    if not overlapping_modes:
+        return venue_default
+
+    return max(overlapping_modes, key=lambda m: precedence.get(m, 0))
 
 
 def _check_venue_availability(
@@ -189,8 +269,11 @@ def _check_venue_availability(
     venue = db.get(EventVenues, venue_id)
     if not venue:
         raise HTTPException(status_code=404, detail="Venue not found")
-    if venue.booking_mode == VenueBookingMode.UNBOOKABLE.value:
-        raise HTTPException(status_code=409, detail="Venue is not bookable")
+    effective_mode = _resolve_effective_booking_mode(db, venue, start_time, end_time)
+    if effective_mode == VenueBookingMode.UNBOOKABLE.value:
+        raise HTTPException(
+            status_code=409, detail="Venue is not bookable at the selected time"
+        )
 
     _check_venue_open_hours(db, venue, start_time, end_time)
 
@@ -1044,11 +1127,15 @@ def _run_availability_check(
     venue = db.get(EventVenues, payload.venue_id)
     if not venue:
         raise HTTPException(status_code=404, detail="Venue not found")
-    if venue.booking_mode == VenueBookingMode.UNBOOKABLE.value:
+    effective_mode = _resolve_effective_booking_mode(
+        db, venue, payload.start_time, payload.end_time
+    )
+    if effective_mode == VenueBookingMode.UNBOOKABLE.value:
         return EventAvailabilityResult(
             available=False,
             conflicts=[],
-            reason="Venue is not bookable",
+            reason="Venue is not bookable at the selected time",
+            effective_booking_mode=effective_mode,
         )
 
     window_start, window_end = crud.compute_booking_window(
@@ -1068,6 +1155,7 @@ def _run_availability_check(
         available=len(conflicts) == 0,
         conflicts=[c.id for c in conflicts],
         reason=None if not conflicts else "Conflicts with existing events",
+        effective_booking_mode=effective_mode,
     )
 
 
@@ -1897,9 +1985,13 @@ async def create_portal_event(
         from app.api.event_venue import crud as venue_crud
 
         venue = venue_crud.event_venues_crud.get(db, event_in.venue_id)
-        if venue and venue.booking_mode == "approval_required":
-            requires_approval = True
-            approval_reason = "Venue requires admin approval."
+        if venue:
+            effective_mode = _resolve_effective_booking_mode(
+                db, venue, event_in.start_time, event_in.end_time
+            )
+            if effective_mode == "approval_required":
+                requires_approval = True
+                approval_reason = "Venue requires admin approval at the selected time."
         if (
             venue
             and venue.capacity

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -1,6 +1,6 @@
 import uuid
 from collections.abc import Iterable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from loguru import logger
@@ -293,8 +293,13 @@ def _check_event_within_popup_window(
     """Reject events that fall outside the popup's [start_date, end_date].
 
     Both popup bounds are optional — only enforced when set. Comparisons
-    are timezone-aware: bounds without tzinfo are treated as UTC. Used by
-    portal-facing endpoints; backoffice/admin paths are not restricted.
+    are timezone-aware: bounds without tzinfo are treated as UTC.
+
+    `end_date` is treated as an inclusive calendar day (the popup form is a
+    date-picker that stores midnight UTC of the chosen day), so events ending
+    anywhere on that day are accepted — i.e. the effective upper bound is
+    `end_date + 1 day`. Used by portal-facing endpoints; backoffice/admin
+    paths are not restricted.
     """
     if popup is None:
         return
@@ -314,7 +319,9 @@ def _check_event_within_popup_window(
                 f"({start_bound.isoformat()})."
             ),
         )
-    if end_bound is not None and _aware(end_time) > _aware(end_bound):
+    if end_bound is not None and _aware(end_time) > _aware(end_bound) + timedelta(
+        days=1
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -601,6 +601,7 @@ async def list_events(
     event_status: EventStatus | None = None,
     kind: str | None = None,
     venue_id: uuid.UUID | None = None,
+    location_kind: str | None = None,
     track_ids: list[uuid.UUID] | None = Query(default=None),
     start_after: datetime | None = None,
     start_before: datetime | None = None,
@@ -608,7 +609,12 @@ async def list_events(
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[EventPublic]:
-    """List events with optional filters (backoffice)."""
+    """List events with optional filters (backoffice).
+
+    ``location_kind`` narrows results to events without a ``venue_id``:
+    - ``"custom"``  → events with a ``custom_location_name`` set.
+    - ``"meeting"`` → online-only events (no venue, no custom location).
+    """
     if popup_id:
         events, total = crud.events_crud.find_by_popup(
             db,
@@ -618,6 +624,7 @@ async def list_events(
             event_status=event_status,
             kind=kind,
             venue_id=venue_id,
+            location_kind=location_kind,
             track_ids=track_ids,
             start_after=start_after,
             start_before=start_before,

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -382,3 +382,8 @@ class EventAvailabilityResult(BaseModel):
     available: bool
     conflicts: list[uuid.UUID] = []
     reason: str | None = None
+    # Effective booking mode resolved against the requested [start_time,
+    # end_time]. Takes per-slot ``venue_weekly_hours.booking_mode`` overrides
+    # into account so the portal can show a precise warning ("this time
+    # requires approval") instead of a venue-wide hint.
+    effective_booking_mode: str | None = None

--- a/backend/app/api/event_venue/models.py
+++ b/backend/app/api/event_venue/models.py
@@ -6,7 +6,7 @@ from sqlalchemy import Text, Time
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Column, DateTime, Field, Relationship, SQLModel
 
-from app.api.event_venue.schemas import EventVenueBase
+from app.api.event_venue.schemas import EventVenueBase, VenueBookingMode
 
 if TYPE_CHECKING:
     from app.api.event.models import Events
@@ -119,6 +119,7 @@ class VenueWeeklyHours(SQLModel, table=True):
         default=None, sa_column=Column(Time(timezone=False))
     )
     is_closed: bool = Field(default=False)
+    booking_mode: VenueBookingMode | None = Field(default=None, max_length=30)
 
     venue: "EventVenues" = Relationship(back_populates="weekly_hours")
 

--- a/backend/app/api/event_venue/router.py
+++ b/backend/app/api/event_venue/router.py
@@ -271,10 +271,10 @@ async def set_weekly_hours(
     # Multiple rows per (venue, day_of_week) are allowed so venues can have
     # split schedules (e.g. 09-11 AND 17-21 the same day). We only dedupe
     # exact duplicates to keep the client idempotent.
-    seen: set[tuple[int, object, object, bool]] = set()
+    seen: set[tuple[int, object, object, bool, object]] = set()
     inserted = 0
     for h in payload.hours:
-        key = (h.day_of_week, h.open_time, h.close_time, h.is_closed)
+        key = (h.day_of_week, h.open_time, h.close_time, h.is_closed, h.booking_mode)
         if key in seen:
             continue
         seen.add(key)
@@ -286,6 +286,7 @@ async def set_weekly_hours(
                 open_time=h.open_time,
                 close_time=h.close_time,
                 is_closed=h.is_closed,
+                booking_mode=h.booking_mode,
             )
         )
         inserted += 1

--- a/backend/app/api/event_venue/schemas.py
+++ b/backend/app/api/event_venue/schemas.py
@@ -93,6 +93,7 @@ class VenueWeeklyHourRef(BaseModel):
     open_time: time | None
     close_time: time | None
     is_closed: bool
+    booking_mode: VenueBookingMode | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -173,6 +174,7 @@ class VenueWeeklyHourInput(BaseModel):
     open_time: time | None = None
     close_time: time | None = None
     is_closed: bool = False
+    booking_mode: VenueBookingMode | None = None
 
 
 class VenueWeeklyHoursUpdate(BaseModel):

--- a/backend/app/api/popup/crud.py
+++ b/backend/app/api/popup/crud.py
@@ -1,7 +1,10 @@
+from typing import Any
+
+from sqlalchemy import case
 from sqlmodel import Session
 
 from app.api.popup.models import Popups
-from app.api.popup.schemas import PopupCreate, PopupUpdate
+from app.api.popup.schemas import PopupCreate, PopupStatus, PopupUpdate
 from app.api.shared.crud import BaseCRUD
 
 
@@ -11,6 +14,23 @@ class PopupsCRUD(BaseCRUD[Popups, PopupCreate, PopupUpdate]):
 
     def get_by_slug(self, session: Session, slug: str) -> Popups | None:
         return self.get_by_field(session, "slug", slug)
+
+    def _apply_sorting(
+        self,
+        statement: Any,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+    ) -> Any:
+        if sort_by:
+            return super()._apply_sorting(statement, sort_by, sort_order)
+        active_first = case(
+            (Popups.status == PopupStatus.active, 0),  # ty: ignore[invalid-argument-type]
+            else_=1,
+        )
+        return statement.order_by(
+            active_first,
+            Popups.start_date.desc().nulls_last(),  # type: ignore[attr-defined]
+        )
 
 
 popups_crud = PopupsCRUD()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -50,12 +50,19 @@ _PAT_ROUTE_POLICIES: dict[str, tuple[tuple[str, bool, ApiKeyScope], ...]] = {
     ),
     "POST": (
         ("/api/v1/events/portal/events", True, "events:write"),
+        ("/api/v1/events/portal/events/", False, "events:write"),
         ("/api/v1/event-venues/portal/venues", True, "venues:write"),
         ("/api/v1/event-participants/portal/register/", False, "rsvp:write"),
         ("/api/v1/event-participants/portal/cancel-registration/", False, "rsvp:write"),
     ),
-    "PATCH": (("/api/v1/event-venues/portal/venues/", False, "venues:write"),),
-    "DELETE": (("/api/v1/event-venues/portal/venues/", False, "venues:write"),),
+    "PATCH": (
+        ("/api/v1/event-venues/portal/venues/", False, "venues:write"),
+        ("/api/v1/events/portal/events/", False, "events:write"),
+    ),
+    "DELETE": (
+        ("/api/v1/event-venues/portal/venues/", False, "venues:write"),
+        ("/api/v1/events/portal/events/", False, "events:write"),
+    ),
 }
 
 

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -8,7 +8,7 @@ from sqlmodel import Session, select
 
 from app.api.api_key import crud as api_key_crud
 from app.api.api_key.models import ApiKeys
-from app.api.event.models import Events
+from app.api.event.models import EventInvitations, Events
 from app.api.event.schemas import EventStatus, EventVisibility
 from app.api.event_settings.models import EventSettings
 from app.api.event_settings.schemas import PublishPermission
@@ -381,6 +381,370 @@ class TestApiKeyPolicy:
         body = resp.json()
         assert len(body) == 2
         assert all("key" not in row for row in body)
+
+    def test_pat_can_patch_own_event(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _set_event_settings(db, tenant_a, popup, events_require_approval=False)
+        human = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=human.id,
+            title="Before",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.PUBLIC,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        raw_key = _make_pat(
+            db,
+            tenant_a,
+            human,
+            scopes=["events:read", "events:write"],
+        )
+
+        resp = client.patch(
+            f"/api/v1/events/portal/events/{event.id}",
+            headers=_pat_auth(raw_key),
+            json={"title": "After"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["title"] == "After"
+
+        db.expire_all()
+        row = db.get(Events, event.id)
+        assert row is not None
+        assert row.title == "After"
+
+    def test_pat_cannot_patch_others_event(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a)
+        attacker = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=owner.id,
+            title="Owned",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.PUBLIC,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        raw_key = _make_pat(
+            db,
+            tenant_a,
+            attacker,
+            scopes=["events:read", "events:write"],
+        )
+
+        resp = client.patch(
+            f"/api/v1/events/portal/events/{event.id}",
+            headers=_pat_auth(raw_key),
+            json={"title": "Hijack"},
+        )
+
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["detail"] == "Only the event owner can edit"
+
+    def test_pat_patch_requires_events_write_scope(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=human.id,
+            title="ReadScopeOnly",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.PUBLIC,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+
+        resp = client.patch(
+            f"/api/v1/events/portal/events/{event.id}",
+            headers=_pat_auth(raw_key),
+            json={"title": "Nope"},
+        )
+
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["detail"] == "API key lacks required scope: events:write"
+
+    def test_pat_can_cancel_own_event(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=human.id,
+            title="Cancelable",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.PUBLIC,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        raw_key = _make_pat(
+            db,
+            tenant_a,
+            human,
+            scopes=["events:read", "events:write"],
+        )
+
+        resp = client.post(
+            f"/api/v1/events/portal/events/{event.id}/cancel",
+            headers=_pat_auth(raw_key),
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == EventStatus.CANCELLED.value
+
+        db.expire_all()
+        row = db.get(Events, event.id)
+        assert row is not None
+        assert row.status == EventStatus.CANCELLED
+
+    def test_pat_can_bulk_invite(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a)
+        invitee = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=owner.id,
+            title="InviteHere",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.UNLISTED,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        raw_key = _make_pat(
+            db,
+            tenant_a,
+            owner,
+            scopes=["events:read", "events:write"],
+        )
+
+        resp = client.post(
+            f"/api/v1/events/portal/events/{event.id}/invitations",
+            headers=_pat_auth(raw_key),
+            json={"emails": [invitee.email]},
+        )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert len(body["invited"]) == 1
+        assert body["invited"][0]["human_id"] == str(invitee.id)
+
+    def test_pat_can_list_invitations(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a)
+        invitee = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=owner.id,
+            title="ListInvites",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.UNLISTED,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.add(
+            EventInvitations(
+                tenant_id=tenant_a.id,
+                event_id=event.id,
+                human_id=invitee.id,
+                invited_by=owner.id,
+            )
+        )
+        db.commit()
+        db.refresh(event)
+
+        raw_key = _make_pat(db, tenant_a, owner, scopes=["events:read"])
+
+        resp = client.get(
+            f"/api/v1/events/portal/events/{event.id}/invitations",
+            headers=_pat_auth(raw_key),
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["human_id"] == str(invitee.id)
+
+    def test_pat_can_delete_invitation(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a)
+        invitee = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=owner.id,
+            title="DeleteInvite",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.UNLISTED,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        inv = EventInvitations(
+            tenant_id=tenant_a.id,
+            event_id=event.id,
+            human_id=invitee.id,
+            invited_by=owner.id,
+        )
+        db.add(inv)
+        db.commit()
+        db.refresh(inv)
+
+        raw_key = _make_pat(
+            db,
+            tenant_a,
+            owner,
+            scopes=["events:read", "events:write"],
+        )
+
+        resp = client.delete(
+            f"/api/v1/events/portal/events/{event.id}/invitations/{inv.id}",
+            headers=_pat_auth(raw_key),
+        )
+
+        assert resp.status_code == 204, resp.text
+
+        inv_id = inv.id
+        db.expunge(inv)
+        remaining = db.exec(
+            select(EventInvitations).where(EventInvitations.id == inv_id)
+        ).first()
+        assert remaining is None
+
+    def test_pat_invitation_routes_require_ownership(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a)
+        attacker = _make_human(db, tenant_a)
+        invitee = _make_human(db, tenant_a)
+        event = Events(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            owner_id=owner.id,
+            title="OwnedInvites",
+            start_time=datetime.now(UTC) + timedelta(days=3),
+            end_time=datetime.now(UTC) + timedelta(days=3, hours=1),
+            timezone="UTC",
+            visibility=EventVisibility.UNLISTED,
+            status=EventStatus.PUBLISHED,
+        )
+        db.add(event)
+        db.commit()
+        db.refresh(event)
+
+        inv = EventInvitations(
+            tenant_id=tenant_a.id,
+            event_id=event.id,
+            human_id=invitee.id,
+            invited_by=owner.id,
+        )
+        db.add(inv)
+        db.commit()
+        db.refresh(inv)
+
+        raw_key = _make_pat(
+            db,
+            tenant_a,
+            attacker,
+            scopes=["events:read", "events:write"],
+        )
+
+        post_resp = client.post(
+            f"/api/v1/events/portal/events/{event.id}/invitations",
+            headers=_pat_auth(raw_key),
+            json={"emails": [invitee.email]},
+        )
+        assert post_resp.status_code == 403, post_resp.text
+        assert (
+            post_resp.json()["detail"] == "Only the event owner can manage invitations"
+        )
+
+        del_resp = client.delete(
+            f"/api/v1/events/portal/events/{event.id}/invitations/{inv.id}",
+            headers=_pat_auth(raw_key),
+        )
+        assert del_resp.status_code == 403, del_resp.text
+        assert (
+            del_resp.json()["detail"] == "Only the event owner can manage invitations"
+        )
 
     def test_flagging_human_revokes_existing_api_keys(
         self,

--- a/backend/tests/test_event_popup_window.py
+++ b/backend/tests/test_event_popup_window.py
@@ -1,0 +1,158 @@
+"""Regression tests for popup [start_date, end_date] event-window validation.
+
+The popup form is a date-picker that stores midnight UTC of the chosen day,
+so `end_date` must behave as an inclusive calendar day — an event ending
+anywhere on that day must be accepted. Without this, picking "June 27" as the
+popup end_date rejected every June 27 event (see Kevin Fishner's New Cities
+lineup for EE26).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.event_settings.models import EventSettings
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+
+def _human_auth(human: Humans) -> dict[str, str]:
+    token = create_access_token(subject=human.id, token_type="human")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_popup(
+    db: Session,
+    tenant: Tenants,
+    *,
+    start_date: datetime | None,
+    end_date: datetime | None,
+) -> Popups:
+    popup = Popups(
+        name=f"Window Test {uuid.uuid4().hex[:6]}",
+        slug=f"window-{uuid.uuid4().hex[:10]}",
+        tenant_id=tenant.id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    # Enable portal event creation for this popup.
+    db.add(EventSettings(tenant_id=tenant.id, popup_id=popup.id))
+    db.commit()
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"window-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Test",
+        last_name="Human",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _event_payload(popup: Popups, *, start: str, end: str) -> dict:
+    return {
+        "popup_id": str(popup.id),
+        "title": "Window Event",
+        "start_time": start,
+        "end_time": end,
+        "timezone": "UTC",
+    }
+
+
+class TestPopupEndDateInclusive:
+    """End_date is the last day of the popup, not the first excluded instant."""
+
+    def test_event_on_end_date_day_is_accepted(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        # Mirrors how the backoffice serializes the date-picker value.
+        popup = _make_popup(
+            db,
+            tenant_a,
+            start_date=datetime(2026, 6, 22, tzinfo=UTC),
+            end_date=datetime(2026, 6, 27, tzinfo=UTC),
+        )
+        human = _make_human(db, tenant_a)
+
+        resp = client.post(
+            "/api/v1/events/portal/events",
+            headers=_human_auth(human),
+            json=_event_payload(
+                popup,
+                start="2026-06-27T15:00:00+00:00",
+                end="2026-06-27T17:00:00+00:00",
+            ),
+        )
+
+        assert resp.status_code == 201, resp.text
+
+    def test_event_past_end_date_day_is_rejected(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(
+            db,
+            tenant_a,
+            start_date=datetime(2026, 6, 22, tzinfo=UTC),
+            end_date=datetime(2026, 6, 27, tzinfo=UTC),
+        )
+        human = _make_human(db, tenant_a)
+
+        resp = client.post(
+            "/api/v1/events/portal/events",
+            headers=_human_auth(human),
+            json=_event_payload(
+                popup,
+                start="2026-06-28T15:00:00+00:00",
+                end="2026-06-28T17:00:00+00:00",
+            ),
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert "end" in resp.json()["detail"].lower()
+
+    def test_event_before_start_date_is_rejected(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(
+            db,
+            tenant_a,
+            start_date=datetime(2026, 6, 22, tzinfo=UTC),
+            end_date=datetime(2026, 6, 27, tzinfo=UTC),
+        )
+        human = _make_human(db, tenant_a)
+
+        resp = client.post(
+            "/api/v1/events/portal/events",
+            headers=_human_auth(human),
+            json=_event_payload(
+                popup,
+                start="2026-06-21T15:00:00+00:00",
+                end="2026-06-21T17:00:00+00:00",
+            ),
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert "start" in resp.json()["detail"].lower()

--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -120,6 +120,7 @@ class TestPopupRLS:
         # Access Tenant A popups
         response_a = client.get(
             "/api/v1/popups",
+            params={"search": "Popup Tenant"},
             headers={
                 "Authorization": f"Bearer {superadmin_token}",
                 "X-Tenant-Id": str(tenant_a.id),
@@ -133,6 +134,7 @@ class TestPopupRLS:
         # Access Tenant B popups
         response_b = client.get(
             "/api/v1/popups",
+            params={"search": "Popup Tenant"},
             headers={
                 "Authorization": f"Bearer {superadmin_token}",
                 "X-Tenant-Id": str(tenant_b.id),
@@ -166,6 +168,7 @@ class TestPopupRLS:
         """Tenant A admin should only see Tenant A popups."""
         response = client.get(
             "/api/v1/popups",
+            params={"search": "Popup Tenant"},
             headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
         )
 
@@ -188,6 +191,7 @@ class TestPopupRLS:
         """Tenant B admin should only see Tenant B popups."""
         response = client.get(
             "/api/v1/popups",
+            params={"search": "Popup Tenant"},
             headers={"Authorization": f"Bearer {admin_token_tenant_b}"},
         )
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -4459,6 +4459,17 @@ export const EventAvailabilityResultSchema = {
                 }
             ],
             title: 'Reason'
+        },
+        effective_booking_mode: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Effective Booking Mode'
         }
     },
     type: 'object',
@@ -15351,6 +15362,16 @@ export const VenueWeeklyHourInputSchema = {
             type: 'boolean',
             title: 'Is Closed',
             default: false
+        },
+        booking_mode: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/VenueBookingMode'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',
@@ -15396,6 +15417,16 @@ export const VenueWeeklyHourRefSchema = {
         is_closed: {
             type: 'boolean',
             title: 'Is Closed'
+        },
+        booking_mode: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/VenueBookingMode'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -1093,7 +1093,7 @@ export class AuthService {
     
     /**
      * Scanner Login
-     * Initiate scanner login. Accepts CHECK_IN_CONTROLLER, ADMIN, and SUPERADMIN.
+     * Initiate scanner login. Accepts CHECK_IN_CONTROLLER, OPERATOR, ADMIN, and SUPERADMIN.
      * VIEWER is rejected pre-OTP — must not receive a code they can't redeem.
      * @param data The data for the request.
      * @param data.requestBody
@@ -1115,7 +1115,7 @@ export class AuthService {
     /**
      * Scanner Authenticate
      * Authenticate a scanner operator and return a JWT token.
-     * Only SUPERADMIN, ADMIN, and CHECK_IN_CONTROLLER are accepted.
+     * Only SUPERADMIN, ADMIN, OPERATOR, and CHECK_IN_CONTROLLER are accepted.
      * VIEWER is rejected with 403.
      * @param data The data for the request.
      * @param data.requestBody
@@ -2181,11 +2181,16 @@ export class EventsService {
     /**
      * List Events
      * List events with optional filters (backoffice).
+     *
+     * ``location_kind`` narrows results to events without a ``venue_id``:
+     * - ``"custom"``  → events with a ``custom_location_name`` set.
+     * - ``"meeting"`` → online-only events (no venue, no custom location).
      * @param data The data for the request.
      * @param data.popupId
      * @param data.eventStatus
      * @param data.kind
      * @param data.venueId
+     * @param data.locationKind
      * @param data.trackIds
      * @param data.startAfter
      * @param data.startBefore
@@ -2208,6 +2213,7 @@ export class EventsService {
                 event_status: data.eventStatus,
                 kind: data.kind,
                 venue_id: data.venueId,
+                location_kind: data.locationKind,
                 track_ids: data.trackIds,
                 start_after: data.startAfter,
                 start_before: data.startBefore,

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -3754,6 +3754,7 @@ export type EventsListEventsData = {
      * Maximum number of items to return
      */
     limit?: number;
+    locationKind?: (string | null);
     popupId?: (string | null);
     search?: (string | null);
     /**

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1001,6 +1001,7 @@ export type EventAvailabilityResult = {
     available: boolean;
     conflicts?: Array<(string)>;
     reason?: (string | null);
+    effective_booking_mode?: (string | null);
 };
 
 /**
@@ -3032,6 +3033,7 @@ export type VenueWeeklyHourInput = {
     open_time?: (string | null);
     close_time?: (string | null);
     is_closed?: boolean;
+    booking_mode?: (VenueBookingMode | null);
 };
 
 export type VenueWeeklyHourRef = {
@@ -3040,6 +3042,7 @@ export type VenueWeeklyHourRef = {
     open_time: (string | null);
     close_time: (string | null);
     is_closed: boolean;
+    booking_mode?: (VenueBookingMode | null);
 };
 
 export type VenueWeeklyHoursUpdate = {

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -85,7 +85,7 @@ interface EventFormProps {
 
 const EVENT_STATUSES = [
   { value: "draft", label: "Draft" },
-  { value: "published", label: "Published" },
+  { value: "published", label: "Public" },
 ] as const
 
 const VISIBILITY_OPTIONS = [

--- a/backoffice/src/components/forms/VenueForm.tsx
+++ b/backoffice/src/components/forms/VenueForm.tsx
@@ -461,7 +461,7 @@ export function VenueForm({ defaultValues, onSuccess }: VenueFormProps) {
         <InlineSection title="Booking">
           <InlineRow
             label="Booking mode"
-            description="How participants can book this venue"
+            description="Default mode for this venue. Individual weekly-hours slots can override it."
           >
             <form.Field name="booking_mode">
               {(field) => (

--- a/backoffice/src/components/forms/VenueForm/WeeklyHoursEditor.tsx
+++ b/backoffice/src/components/forms/VenueForm/WeeklyHoursEditor.tsx
@@ -1,8 +1,20 @@
-import { Clock, Plus, X } from "lucide-react"
+import { ChevronDown, ChevronRight, Clock, Plus, X } from "lucide-react"
+import { useState } from "react"
 
-import type { VenueWeeklyHourInput, VenueWeeklyHourRef } from "@/client"
+import type {
+  VenueBookingMode,
+  VenueWeeklyHourInput,
+  VenueWeeklyHourRef,
+} from "@/client"
 import { Button } from "@/components/ui/button"
 import { InlineSection } from "@/components/ui/inline-form"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { TimePicker } from "@/components/ui/time-picker"
 
@@ -15,6 +27,14 @@ const DAYS_OF_WEEK: { value: number; label: string; short: string }[] = [
   { value: 5, label: "Saturday", short: "Sat" },
   { value: 6, label: "Sunday", short: "Sun" },
 ]
+
+const BOOKING_MODE_LABELS: Record<VenueBookingMode, string> = {
+  free: "Permissionless",
+  approval_required: "Requires approval",
+  unbookable: "Unbookable",
+}
+
+const VENUE_DEFAULT_OPTION = "__default__"
 
 /**
  * Hydrate the editor state from the server's weekly-hours snapshot. Each
@@ -32,6 +52,7 @@ export function buildInitialWeeklyHours(
       open_time: null,
       close_time: null,
       is_closed: true,
+      booking_mode: null,
     }))
   }
   return initial.map((h) => ({
@@ -39,6 +60,7 @@ export function buildInitialWeeklyHours(
     open_time: h.open_time ?? null,
     close_time: h.close_time ?? null,
     is_closed: h.is_closed,
+    booking_mode: h.booking_mode ?? null,
   }))
 }
 
@@ -50,6 +72,92 @@ interface WeeklyHoursEditorProps {
 
 function isOpenSlot(h: VenueWeeklyHourInput): boolean {
   return !h.is_closed && h.open_time != null && h.close_time != null
+}
+
+interface SlotRowProps {
+  slot: VenueWeeklyHourInput
+  canRemove: boolean
+  onChange: (patch: Partial<VenueWeeklyHourInput>) => void
+  onRemove: () => void
+}
+
+function SlotRow({ slot, canRemove, onChange, onRemove }: SlotRowProps) {
+  const [expanded, setExpanded] = useState(false)
+  const hasOverride = slot.booking_mode != null
+
+  return (
+    <div className="pl-[7.25rem] space-y-1.5">
+      <div className="flex items-center gap-2">
+        <TimePicker
+          value={slot.open_time ?? ""}
+          onChange={(v) => onChange({ open_time: v })}
+        />
+        <span className="text-sm text-muted-foreground">to</span>
+        <TimePicker
+          value={slot.close_time ?? ""}
+          onChange={(v) => onChange({ close_time: v })}
+        />
+        {hasOverride && slot.booking_mode && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-900 dark:bg-amber-900/40 dark:text-amber-100">
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+            {BOOKING_MODE_LABELS[slot.booking_mode]}
+          </span>
+        )}
+        {canRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label="Remove slot"
+            onClick={onRemove}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      <button
+        type="button"
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        Advanced
+      </button>
+      {expanded && (
+        <div className="flex items-center gap-2 pt-1">
+          <span className="text-xs text-muted-foreground">Booking mode</span>
+          <Select
+            value={slot.booking_mode ?? VENUE_DEFAULT_OPTION}
+            onValueChange={(v) =>
+              onChange({
+                booking_mode:
+                  v === VENUE_DEFAULT_OPTION ? null : (v as VenueBookingMode),
+              })
+            }
+          >
+            <SelectTrigger className="h-8 w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={VENUE_DEFAULT_OPTION}>
+                Use venue default
+              </SelectItem>
+              <SelectItem value="free">Permissionless</SelectItem>
+              <SelectItem value="approval_required">
+                Requires approval
+              </SelectItem>
+              <SelectItem value="unbookable">Unbookable</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function WeeklyHoursEditor({
@@ -81,6 +189,7 @@ export function WeeklyHoursEditor({
           open_time: "09:00",
           close_time: "17:00",
           is_closed: false,
+          booking_mode: null,
         },
       ])
     } else {
@@ -90,6 +199,7 @@ export function WeeklyHoursEditor({
           open_time: null,
           close_time: null,
           is_closed: true,
+          booking_mode: null,
         },
       ])
     }
@@ -118,6 +228,7 @@ export function WeeklyHoursEditor({
         open_time: newOpen,
         close_time: newClose,
         is_closed: false,
+        booking_mode: null,
       },
     ])
   }
@@ -143,6 +254,7 @@ export function WeeklyHoursEditor({
           open_time: null,
           close_time: null,
           is_closed: true,
+          booking_mode: null,
         },
       ])
     } else {
@@ -195,36 +307,13 @@ export function WeeklyHoursEditor({
               </div>
               {open &&
                 slots.map((slot, idx) => (
-                  <div
+                  <SlotRow
                     key={idx}
-                    className="flex items-center gap-2 pl-[7.25rem]"
-                  >
-                    <TimePicker
-                      value={slot.open_time ?? ""}
-                      onChange={(v) =>
-                        updateSlot(day.value, idx, { open_time: v })
-                      }
-                    />
-                    <span className="text-sm text-muted-foreground">to</span>
-                    <TimePicker
-                      value={slot.close_time ?? ""}
-                      onChange={(v) =>
-                        updateSlot(day.value, idx, { close_time: v })
-                      }
-                    />
-                    {slots.length > 1 && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        aria-label="Remove slot"
-                        onClick={() => removeSlot(day.value, idx)}
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </Button>
-                    )}
-                  </div>
+                    slot={slot}
+                    canRemove={slots.length > 1}
+                    onChange={(patch) => updateSlot(day.value, idx, patch)}
+                    onRemove={() => removeSlot(day.value, idx)}
+                  />
                 ))}
             </div>
           )

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -24,6 +24,7 @@ import {
   EventSettingsService,
   EventsService,
   EventVenuesService,
+  HumansService,
 } from "@/client"
 import { DataTable, SortableHeader } from "@/components/Common/DataTable"
 import { EmptyState } from "@/components/Common/EmptyState"
@@ -419,6 +420,36 @@ function EventActionsMenu({
   )
 }
 
+function EventHostCell({ event }: { event: EventPublic }) {
+  const ownerId = event.owner_id
+  const { data: owner } = useQuery({
+    queryKey: ["human", ownerId],
+    queryFn: () => HumansService.getHuman({ humanId: ownerId }),
+    enabled: !!ownerId,
+    staleTime: 5 * 60_000,
+  })
+
+  const displayName = event.host_display_name?.trim() || null
+  const ownerFullName =
+    owner && (owner.first_name || owner.last_name)
+      ? [owner.first_name, owner.last_name].filter(Boolean).join(" ").trim() ||
+        null
+      : null
+  const primary = displayName || ownerFullName
+  const ownerEmail = owner?.email
+
+  return (
+    <div className="flex flex-col leading-tight max-w-[220px]">
+      <span className="text-sm truncate">{primary ?? "—"}</span>
+      {ownerEmail && (
+        <span className="text-xs text-muted-foreground truncate">
+          {ownerEmail}
+        </span>
+      )}
+    </div>
+  )
+}
+
 function buildEventColumns(
   venueNameById: Map<string, string>,
   timezone: string | undefined,
@@ -481,6 +512,12 @@ function buildEventColumns(
           {row.original.kind || "—"}
         </span>
       ),
+    },
+    {
+      id: "host",
+      accessorKey: "host_display_name",
+      header: "Host",
+      cell: ({ row }) => <EventHostCell event={row.original} />,
     },
     {
       accessorKey: "start_time",
@@ -633,7 +670,7 @@ function EventsTableContent() {
         columns={columns}
         data={events.results}
         searchPlaceholder="Search by title..."
-        hiddenOnMobile={["kind", "venue_id", "start_time"]}
+        hiddenOnMobile={["kind", "host", "venue_id", "start_time"]}
         searchValue={search}
         onSearchChange={setSearch}
         serverPagination={{

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -6,8 +6,10 @@ import {
 } from "@tanstack/react-query"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import type { ColumnDef } from "@tanstack/react-table"
+import { format } from "date-fns"
 import {
   CalendarDays,
+  CalendarIcon,
   CalendarRange,
   CheckCircle2,
   Eye,
@@ -15,16 +17,20 @@ import {
   Plus,
   Repeat,
   Trash2,
+  Video,
   XCircle,
 } from "lucide-react"
-import { Suspense, useMemo, useState } from "react"
+import { Suspense, useCallback, useMemo, useState } from "react"
 
 import {
   type EventPublic,
   EventSettingsService,
+  type EventStatus,
   EventsService,
+  type EventVenuePublic,
   EventVenuesService,
   HumansService,
+  PopupsService,
 } from "@/client"
 import { DataTable, SortableHeader } from "@/components/Common/DataTable"
 import { EmptyState } from "@/components/Common/EmptyState"
@@ -32,6 +38,7 @@ import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
 import {
   Dialog,
   DialogClose,
@@ -42,19 +49,71 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { LoadingButton } from "@/components/ui/loading-button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import {
+  type TableSearchParams,
   useTableSearchParams,
   validateTableSearch,
 } from "@/hooks/useTableSearchParams"
 import { createErrorHandler } from "@/utils"
 
+const VALID_EVENT_STATUSES: Set<string> = new Set([
+  "draft",
+  "published",
+  "cancelled",
+  "pending_approval",
+  "rejected",
+])
+
+const EVENT_STATUS_OPTIONS: { value: EventStatus; label: string }[] = [
+  { value: "draft", label: "Draft" },
+  { value: "published", label: "Public" },
+  { value: "pending_approval", label: "Pending approval" },
+  { value: "cancelled", label: "Cancelled" },
+  { value: "rejected", label: "Rejected" },
+]
+
+type EventsSearchParams = TableSearchParams & {
+  status?: EventStatus
+  venueId?: string
+  startDate?: string
+  endDate?: string
+}
+
 export const Route = createFileRoute("/_layout/events/")({
   component: EventsPage,
-  validateSearch: validateTableSearch,
+  validateSearch: (raw: Record<string, unknown>): EventsSearchParams => ({
+    ...validateTableSearch(raw),
+    ...(typeof raw.status === "string" && VALID_EVENT_STATUSES.has(raw.status)
+      ? { status: raw.status as EventStatus }
+      : {}),
+    ...(typeof raw.venueId === "string" && raw.venueId
+      ? { venueId: raw.venueId }
+      : {}),
+    ...(typeof raw.startDate === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(raw.startDate)
+      ? { startDate: raw.startDate }
+      : {}),
+    ...(typeof raw.endDate === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(raw.endDate)
+      ? { endDate: raw.endDate }
+      : {}),
+  }),
   head: () => ({
     meta: [{ title: "Events - EdgeOS" }],
   }),
@@ -308,7 +367,7 @@ function EventActionsMenu({
             </DialogTitle>
             <DialogDescription>
               {decisionOpen === "approve"
-                ? `Approve "${event.title}"? It will become published and the creator will be notified.`
+                ? `Approve "${event.title}"? It will become public and the creator will be notified.`
                 : `Reject "${event.title}"? The creator will be notified. You can leave an optional reason.`}
             </DialogDescription>
           </DialogHeader>
@@ -549,6 +608,14 @@ function buildEventColumns(
             </span>
           )
         }
+        if (!venueId) {
+          return (
+            <span className="text-muted-foreground/80 inline-flex items-center gap-1.5">
+              <Video className="h-3.5 w-3.5" />
+              Meeting
+            </span>
+          )
+        }
         return <span className="text-muted-foreground">—</span>
       },
     },
@@ -564,14 +631,249 @@ function buildEventColumns(
   ]
 }
 
+function EventStatusFilter({
+  selected,
+  onSelect,
+}: {
+  selected: EventStatus | undefined
+  onSelect: (value: EventStatus | undefined) => void
+}) {
+  return (
+    <Select
+      value={selected ?? "all"}
+      onValueChange={(v) =>
+        onSelect(v === "all" ? undefined : (v as EventStatus))
+      }
+    >
+      <SelectTrigger className="h-9 w-[150px]">
+        <SelectValue placeholder="All statuses" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All statuses</SelectItem>
+        {EVENT_STATUS_OPTIONS.map((opt) => (
+          <SelectItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function EventVenueFilter({
+  venues,
+  selected,
+  onSelect,
+}: {
+  venues: EventVenuePublic[]
+  selected: string | undefined
+  onSelect: (value: string | undefined) => void
+}) {
+  return (
+    <Select
+      value={selected ?? "all"}
+      onValueChange={(v) => onSelect(v === "all" ? undefined : v)}
+    >
+      <SelectTrigger className="h-9 w-[170px]">
+        <SelectValue placeholder="All venues" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All venues</SelectItem>
+        <SelectItem value="meeting">Meeting (online)</SelectItem>
+        <SelectItem value="custom">Custom location</SelectItem>
+        {venues.map((venue) => (
+          <SelectItem key={venue.id} value={venue.id}>
+            {venue.title}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function parseYmd(value: string | undefined): Date | undefined {
+  if (!value) return undefined
+  const [y, m, d] = value.split("-").map(Number)
+  if (!y || !m || !d) return undefined
+  return new Date(y, m - 1, d, 12, 0, 0)
+}
+
+function formatYmd(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, "0")
+  const d = String(date.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
+}
+
+function EventDateRangeFilter({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+  popupStart,
+  popupEnd,
+}: {
+  startDate: string | undefined
+  endDate: string | undefined
+  onStartChange: (value: string | undefined) => void
+  onEndChange: (value: string | undefined) => void
+  popupStart: string | null | undefined
+  popupEnd: string | null | undefined
+}) {
+  const from = parseYmd(startDate)
+  const to = parseYmd(endDate)
+  // The popup defines the event window — disallow picking days outside it
+  // and anchor the calendar to the popup's first day by default.
+  const minDate = parseYmd(popupStart?.slice(0, 10))
+  const maxDate = parseYmd(popupEnd?.slice(0, 10))
+
+  const label =
+    from && to
+      ? `${format(from, "MMM d")} – ${format(to, "MMM d, yyyy")}`
+      : from
+        ? `From ${format(from, "MMM d, yyyy")}`
+        : to
+          ? `Until ${format(to, "MMM d, yyyy")}`
+          : "Any date"
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="h-9 w-[220px] justify-start font-normal"
+        >
+          <CalendarIcon className="mr-2 h-4 w-4 shrink-0" />
+          <span
+            className={`truncate ${from || to ? "" : "text-muted-foreground"}`}
+          >
+            {label}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="range"
+          numberOfMonths={2}
+          defaultMonth={from ?? minDate ?? new Date()}
+          selected={{ from, to }}
+          onSelect={(range) => {
+            onStartChange(range?.from ? formatYmd(range.from) : undefined)
+            onEndChange(range?.to ? formatYmd(range.to) : undefined)
+          }}
+          disabled={(d) => {
+            if (minDate && d < minDate) return true
+            if (maxDate && d > maxDate) return true
+            return false
+          }}
+          startMonth={minDate}
+          endMonth={maxDate}
+          initialFocus
+        />
+        <div className="flex justify-end border-t p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!from && !to}
+            onClick={() => {
+              onStartChange(undefined)
+              onEndChange(undefined)
+            }}
+          >
+            Clear
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 function EventsTableContent() {
   const searchParams = Route.useSearch()
+  const navigate = useNavigate()
   const { selectedPopupId } = useWorkspace()
   const { search, pagination, setSearch, setPagination } = useTableSearchParams(
     searchParams,
     "/events",
   )
-  const [pendingOnly, setPendingOnly] = useState(false)
+  const { status, venueId, startDate, endDate } = searchParams
+
+  const setStatus = useCallback(
+    (value: EventStatus | undefined) => {
+      navigate({
+        to: "/events",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          status: value,
+          page: 0,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
+  const setVenueId = useCallback(
+    (value: string | undefined) => {
+      navigate({
+        to: "/events",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          venueId: value,
+          page: 0,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
+  const setStartDate = useCallback(
+    (value: string | undefined) => {
+      navigate({
+        to: "/events",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          startDate: value,
+          page: 0,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
+  const setEndDate = useCallback(
+    (value: string | undefined) => {
+      navigate({
+        to: "/events",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          endDate: value,
+          page: 0,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
+  const clearFilters = useCallback(() => {
+    navigate({
+      to: "/events",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        status: undefined,
+        venueId: undefined,
+        startDate: undefined,
+        endDate: undefined,
+        page: 0,
+      }),
+      replace: true,
+    })
+  }, [navigate])
+
+  const hasFilters = !!(status || venueId || startDate || endDate)
 
   const { data: events } = useQuery({
     queryKey: [
@@ -581,7 +883,10 @@ function EventsTableContent() {
         page: pagination.pageIndex,
         pageSize: pagination.pageSize,
         search,
-        pendingOnly,
+        status,
+        venueId,
+        startDate,
+        endDate,
       },
     ],
     queryFn: () =>
@@ -590,20 +895,19 @@ function EventsTableContent() {
         search: search || undefined,
         skip: pagination.pageIndex * pagination.pageSize,
         limit: pagination.pageSize,
-        // Backend accepts a single status filter; fetch everything and
-        // narrow client-side for simplicity when the toggle is off.
-        eventStatus: pendingOnly ? "pending_approval" : undefined,
+        eventStatus: status,
+        venueId:
+          venueId && venueId !== "custom" && venueId !== "meeting"
+            ? venueId
+            : undefined,
+        locationKind:
+          venueId === "custom" || venueId === "meeting" ? venueId : undefined,
+        startAfter: startDate ? `${startDate}T00:00:00Z` : undefined,
+        startBefore: endDate ? `${endDate}T23:59:59Z` : undefined,
       }),
     enabled: !!selectedPopupId,
     placeholderData: keepPreviousData,
   })
-
-  const pendingCount = useMemo(
-    () =>
-      events?.results.filter((e) => e.status === "pending_approval").length ??
-      0,
-    [events],
-  )
 
   const { data: venues } = useQuery({
     queryKey: ["event-venues", { popupId: selectedPopupId, limit: 200 }],
@@ -612,6 +916,12 @@ function EventsTableContent() {
         popupId: selectedPopupId!,
         limit: 200,
       }),
+    enabled: !!selectedPopupId,
+  })
+
+  const { data: popup } = useQuery({
+    queryKey: ["popup", selectedPopupId],
+    queryFn: () => PopupsService.getPopup({ popupId: selectedPopupId! }),
     enabled: !!selectedPopupId,
   })
 
@@ -649,23 +959,6 @@ function EventsTableContent() {
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <Button
-          variant={pendingOnly ? "default" : "outline"}
-          size="sm"
-          onClick={() => setPendingOnly((v) => !v)}
-          aria-pressed={pendingOnly}
-        >
-          <CheckCircle2 className="mr-2 h-4 w-4" />
-          Pending approval
-          {!pendingOnly && pendingCount > 0 && (
-            <Badge variant="secondary" className="ml-2">
-              {pendingCount}
-            </Badge>
-          )}
-        </Button>
-      </div>
-
       <DataTable
         columns={columns}
         data={events.results}
@@ -678,25 +971,48 @@ function EventsTableContent() {
           pagination: pagination,
           onPaginationChange: setPagination,
         }}
+        filterBar={
+          <div className="flex flex-wrap items-center gap-2">
+            <EventStatusFilter selected={status} onSelect={setStatus} />
+            <EventVenueFilter
+              venues={venues?.results ?? []}
+              selected={venueId}
+              onSelect={setVenueId}
+            />
+            <EventDateRangeFilter
+              startDate={startDate}
+              endDate={endDate}
+              onStartChange={setStartDate}
+              onEndChange={setEndDate}
+              popupStart={popup?.start_date}
+              popupEnd={popup?.end_date}
+            />
+            {hasFilters && (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>
+                Clear
+              </Button>
+            )}
+          </div>
+        }
         emptyState={
-          !search ? (
+          hasFilters ? (
             <EmptyState
               icon={CalendarDays}
-              title={pendingOnly ? "No pending requests" : "No events yet"}
-              description={
-                pendingOnly
-                  ? "Events awaiting venue approval will appear here."
-                  : "Create the first event for this pop-up."
-              }
+              title="No events match these filters"
+              description="Try adjusting or clearing the filters above."
+            />
+          ) : !search ? (
+            <EmptyState
+              icon={CalendarDays}
+              title="No events yet"
+              description="Create the first event for this pop-up."
               action={
-                pendingOnly ? undefined : (
-                  <Button asChild>
-                    <Link to="/events/new">
-                      <Plus className="mr-2 h-4 w-4" />
-                      Create Event
-                    </Link>
-                  </Button>
-                )
+                <Button asChild>
+                  <Link to="/events/new">
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create Event
+                  </Link>
+                </Button>
               }
             />
           ) : undefined

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
@@ -146,6 +146,7 @@ export function EditEventForm({
     withinOpenHours,
     availability,
     availabilityData,
+    effectiveBookingMode,
   } = useVenueAvailability({
     popupId,
     venueId: form.venueId,
@@ -232,6 +233,7 @@ export function EditEventForm({
           onCustomLocationNameChange={form.setCustomLocationName}
           customLocationUrl={form.customLocationUrl}
           onCustomLocationUrlChange={form.setCustomLocationUrl}
+          effectiveBookingMode={effectiveBookingMode}
         />
         {customLocationMissing && (
           <p className="text-xs text-destructive">

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/VenueSection.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/VenueSection.tsx
@@ -32,6 +32,11 @@ interface VenueSectionProps {
   onCustomLocationNameChange: (next: string) => void
   customLocationUrl: string
   onCustomLocationUrlChange: (next: string) => void
+  /**
+   * Backend-resolved mode for the current [start, end] window. ``null``
+   * until the debounced availability check resolves.
+   */
+  effectiveBookingMode?: string | null
 }
 
 export function VenueSection({
@@ -45,6 +50,7 @@ export function VenueSection({
   onCustomLocationNameChange,
   customLocationUrl,
   onCustomLocationUrlChange,
+  effectiveBookingMode,
 }: VenueSectionProps) {
   const { t } = useTranslation()
   const [picturesOpen, setPicturesOpen] = useState(false)
@@ -97,12 +103,27 @@ export function VenueSection({
           </div>
         </div>
       )}
-      {selectedVenue?.booking_mode === "approval_required" && (
-        <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
-          <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
-          <p>{t("events.form.venue_approval_required")}</p>
-        </div>
-      )}
+      {(() => {
+        let showBanner: boolean
+        if (effectiveBookingMode != null) {
+          showBanner = effectiveBookingMode === "approval_required"
+        } else {
+          const someSlotRequiresApproval =
+            selectedVenue?.weekly_hours?.some(
+              (h) => h.booking_mode === "approval_required",
+            ) ?? false
+          showBanner =
+            selectedVenue?.booking_mode === "approval_required" ||
+            someSlotRequiresApproval
+        }
+        if (!showBanner) return null
+        return (
+          <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+            <p>{t("events.form.venue_approval_required")}</p>
+          </div>
+        )
+      })()}
       {selectedVenue && (
         <div className="text-xs text-muted-foreground space-y-2">
           {pictures.length > 0 && (

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -76,15 +76,20 @@ export default function EventDetailPage() {
   // it from the URL, so it survives a refresh on this detail page but
   // never sticks around on the list once used.
   const fromSearch = searchParams.get("from") ?? ""
-  const focusQs = `focus=${encodeURIComponent(params.eventId)}`
-  const backHref = fromSearch
-    ? `/portal/${city?.slug}/events?${fromSearch}&${focusQs}`
-    : `/portal/${city?.slug}/events?${focusQs}`
   // For an expanded recurring instance, the calendar passes the occurrence's
   // ISO start time via ?occ=. We render that in place of the master's
   // start_time (and shift end_time by the same offset) so the user sees the
   // specific instance they clicked, not the series' first occurrence.
   const occParam = searchParams.get("occ")
+  // Stamp focusOcc alongside focus so the list can scroll to the *specific*
+  // occurrence card on return — without it, all occurrences of a recurring
+  // series share the same event id and the list lands on the first one.
+  const focusQs = occParam
+    ? `focus=${encodeURIComponent(params.eventId)}&focusOcc=${encodeURIComponent(occParam)}`
+    : `focus=${encodeURIComponent(params.eventId)}`
+  const backHref = fromSearch
+    ? `/portal/${city?.slug}/events?${fromSearch}&${focusQs}`
+    : `/portal/${city?.slug}/events?${focusQs}`
   const queryClient = useQueryClient()
   const { timezone, formatTime, formatDateFull } = useEventTimezone(city?.id)
 

--- a/portal/src/app/portal/[popupSlug]/events/components/EventVenueField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/EventVenueField.tsx
@@ -32,6 +32,12 @@ interface EventVenueFieldProps {
   onCustomLocationNameChange: (next: string) => void
   customLocationUrl: string
   onCustomLocationUrlChange: (next: string) => void
+  /**
+   * Booking mode resolved by the backend for the current [start, end]
+   * window. ``null`` when no time is picked yet — in that case the banner
+   * falls back to a conservative venue-wide hint.
+   */
+  effectiveBookingMode?: string | null
 }
 
 export function EventVenueField({
@@ -45,6 +51,7 @@ export function EventVenueField({
   onCustomLocationNameChange,
   customLocationUrl,
   onCustomLocationUrlChange,
+  effectiveBookingMode,
 }: EventVenueFieldProps) {
   const { t } = useTranslation()
   const [picturesOpen, setPicturesOpen] = useState(false)
@@ -100,12 +107,32 @@ export function EventVenueField({
           </div>
         </div>
       )}
-      {selectedVenue?.booking_mode === "approval_required" && (
-        <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
-          <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
-          <p>{t("events.form.venue_approval_required")}</p>
-        </div>
-      )}
+      {(() => {
+        // When the backend has resolved a mode for the selected window, that
+        // is the source of truth: only warn when the user's actual pick
+        // requires approval. Until then, fall back to a conservative hint
+        // covering the venue default and any slot override so the user
+        // isn't blindsided after picking a time.
+        let showBanner: boolean
+        if (effectiveBookingMode != null) {
+          showBanner = effectiveBookingMode === "approval_required"
+        } else {
+          const someSlotRequiresApproval =
+            selectedVenue?.weekly_hours?.some(
+              (h) => h.booking_mode === "approval_required",
+            ) ?? false
+          showBanner =
+            selectedVenue?.booking_mode === "approval_required" ||
+            someSlotRequiresApproval
+        }
+        if (!showBanner) return null
+        return (
+          <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 p-2.5 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-100">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-amber-600 dark:text-amber-400" />
+            <p>{t("events.form.venue_approval_required")}</p>
+          </div>
+        )
+      })()}
       {selectedVenue && (
         <div className="text-xs text-muted-foreground space-y-2">
           {pictures.length > 0 && (

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -359,7 +359,11 @@ export function CalendarBody({
                   return (
                     <div
                       key={event.id}
-                      id={`event-card-${event.id}`}
+                      id={
+                        event.occurrence_id
+                          ? `event-card-${event.id}__${event.start_time}`
+                          : `event-card-${event.id}`
+                      }
                       className={cn(
                         "relative rounded-xl border bg-card hover:shadow-md transition-shadow overflow-hidden",
                         isHighlighted &&

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -672,7 +672,11 @@ export function DayBody({
                         return (
                           <Link
                             key={event.id}
-                            id={`event-card-${event.id}`}
+                            id={
+                              event.occurrence_id
+                                ? `event-card-${event.id}__${event.start_time}`
+                                : `event-card-${event.id}`
+                            }
                             href={eventHref(event)}
                             onClick={(e) => handleEventClick(event, e)}
                             className={cn(
@@ -908,7 +912,11 @@ export function DayBody({
                         return (
                           <Link
                             key={event.id}
-                            id={`event-card-${event.id}`}
+                            id={
+                              event.occurrence_id
+                                ? `event-card-${event.id}__${event.start_time}`
+                                : `event-card-${event.id}`
+                            }
                             href={eventHref(event)}
                             onClick={(e) => handleEventClick(event, e)}
                             className={cn(

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  CalendarDays,
   CheckCircle,
   Clock,
   Crown,
@@ -18,6 +19,7 @@ import { useTranslation } from "react-i18next"
 
 import type { EventPublic } from "@/client"
 import { Badge } from "@/components/ui/badge"
+import { CoverImage } from "./CoverImage"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
 
@@ -162,6 +164,7 @@ export function ListBody({
                   })
                 }
               }
+              const thumbUrl = event.cover_url || event.venue_image_url || null
               return (
                 <div
                   key={event.id}
@@ -175,71 +178,89 @@ export function ListBody({
                       isAuthed ? "block p-3 sm:p-4 pb-11" : "block p-3 sm:p-4"
                     }
                   >
-                    <div className="flex items-start justify-between gap-2 mb-1 pr-8">
-                      <h3 className="font-medium text-sm sm:text-base flex items-center gap-1.5">
-                        {isOwner && (
-                          <Crown
-                            className="h-3.5 w-3.5 shrink-0 text-amber-500"
-                            aria-label={t("events.list.owned_title")}
-                          />
-                        )}
-                        <span>{event.title}</span>
-                      </h3>
-                      {isAuthed && (
-                        <Badge
-                          variant="secondary"
-                          className={statusColors[event.status as string] ?? ""}
-                        >
-                          {t(`events.status.${event.status}`)}
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                      <Clock className="h-3 w-3" />
-                      <span>
-                        {formatTime(event.start_time)} –{" "}
-                        {formatTime(event.end_time)}
-                      </span>
-                    </div>
-                    {event.venue_title && (
-                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
-                        <MapPin className="h-3 w-3" />
-                        <span className="truncate">
-                          {event.venue_title}
-                          {event.venue_location
-                            ? ` · ${event.venue_location}`
-                            : ""}
-                        </span>
+                    <div className="flex items-start gap-3">
+                      <div className="h-14 w-14 sm:h-16 sm:w-16 shrink-0 rounded-lg overflow-hidden">
+                        <CoverImage
+                          src={thumbUrl}
+                          alt={event.title}
+                          className="w-full h-full object-cover"
+                          fallback={
+                            <CalendarDays className="h-5 w-5 text-muted-foreground/40" />
+                          }
+                        />
                       </div>
-                    )}
-                    {(event.rrule || event.recurrence_master_id) && (
-                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
-                        <Repeat className="h-3 w-3" />
-                        <span className="truncate">
-                          {summarizeRrule(event.rrule) ??
-                            t("events.list.part_of_recurring_series")}
-                        </span>
-                      </div>
-                    )}
-                    {event.track_title && (
-                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
-                        <Layers className="h-3 w-3" />
-                        <span className="truncate">{event.track_title}</span>
-                      </div>
-                    )}
-                    {event.tags && event.tags.length > 0 && (
-                      <div className="flex items-center gap-1 mt-1.5 flex-wrap">
-                        {event.tags.slice(0, 3).map((tag: string) => (
-                          <span
-                            key={tag}
-                            className="inline-flex items-center gap-0.5 text-[10px] bg-muted px-1.5 py-0.5 rounded"
-                          >
-                            <Tag className="h-2.5 w-2.5" />
-                            {tag}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2 mb-1 pr-8">
+                          <h3 className="font-medium text-sm sm:text-base flex items-center gap-1.5">
+                            {isOwner && (
+                              <Crown
+                                className="h-3.5 w-3.5 shrink-0 text-amber-500"
+                                aria-label={t("events.list.owned_title")}
+                              />
+                            )}
+                            <span>{event.title}</span>
+                          </h3>
+                          {isAuthed && (
+                            <Badge
+                              variant="secondary"
+                              className={
+                                statusColors[event.status as string] ?? ""
+                              }
+                            >
+                              {t(`events.status.${event.status}`)}
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <Clock className="h-3 w-3" />
+                          <span>
+                            {formatTime(event.start_time)} –{" "}
+                            {formatTime(event.end_time)}
                           </span>
-                        ))}
+                        </div>
+                        {event.venue_title && (
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                            <MapPin className="h-3 w-3" />
+                            <span className="truncate">
+                              {event.venue_title}
+                              {event.venue_location
+                                ? ` · ${event.venue_location}`
+                                : ""}
+                            </span>
+                          </div>
+                        )}
+                        {(event.rrule || event.recurrence_master_id) && (
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                            <Repeat className="h-3 w-3" />
+                            <span className="truncate">
+                              {summarizeRrule(event.rrule) ??
+                                t("events.list.part_of_recurring_series")}
+                            </span>
+                          </div>
+                        )}
+                        {event.track_title && (
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                            <Layers className="h-3 w-3" />
+                            <span className="truncate">
+                              {event.track_title}
+                            </span>
+                          </div>
+                        )}
+                        {event.tags && event.tags.length > 0 && (
+                          <div className="flex items-center gap-1 mt-1.5 flex-wrap">
+                            {event.tags.slice(0, 3).map((tag: string) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center gap-0.5 text-[10px] bg-muted px-1.5 py-0.5 rounded"
+                              >
+                                <Tag className="h-2.5 w-2.5" />
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
                       </div>
-                    )}
+                    </div>
                   </Link>
                   {isAuthed && (
                     <div className="absolute bottom-2 right-2 flex items-center gap-1.5">

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -168,7 +168,11 @@ export function ListBody({
               return (
                 <div
                   key={event.id}
-                  id={`event-card-${event.id}`}
+                  id={
+                    event.occurrence_id
+                      ? `event-card-${event.id}__${event.start_time}`
+                      : `event-card-${event.id}`
+                  }
                   className={cardClass}
                 >
                   <Link

--- a/portal/src/app/portal/[popupSlug]/events/lib/toolbar/parts/TagsPopover.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/toolbar/parts/TagsPopover.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Filter } from "lucide-react"
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import {
@@ -26,6 +27,13 @@ export function TagsPopover({
   const { t } = useTranslation()
   const count = selectedTags.length
   const active = count > 0
+  const sortedTags = useMemo(
+    () =>
+      [...allowedTags].sort((a, b) =>
+        a.localeCompare(b, undefined, { sensitivity: "base" }),
+      ),
+    [allowedTags],
+  )
 
   return (
     <Popover>
@@ -60,7 +68,7 @@ export function TagsPopover({
           )}
         </div>
         <div className="flex flex-wrap gap-2">
-          {allowedTags.map((tag) => {
+          {sortedTags.map((tag) => {
             const isActive = selectedTags.includes(tag)
             return (
               <button

--- a/portal/src/app/portal/[popupSlug]/events/lib/toolbar/parts/TracksPopover.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/toolbar/parts/TracksPopover.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Layers } from "lucide-react"
+import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import {
@@ -26,6 +27,13 @@ export function TracksPopover({
   const { t } = useTranslation()
   const count = selectedTrackIds.length
   const active = count > 0
+  const sortedTracks = useMemo(
+    () =>
+      [...allowedTracks].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      ),
+    [allowedTracks],
+  )
 
   return (
     <Popover>
@@ -60,7 +68,7 @@ export function TracksPopover({
           )}
         </div>
         <div className="flex flex-wrap gap-2">
-          {allowedTracks.map((track) => {
+          {sortedTracks.map((track) => {
             const isActive = selectedTrackIds.includes(track.id)
             return (
               <button

--- a/portal/src/app/portal/[popupSlug]/events/lib/useVenueAvailability.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/useVenueAvailability.ts
@@ -57,6 +57,14 @@ export interface UseVenueAvailabilityResult {
   availabilityData:
     | Awaited<ReturnType<typeof EventVenuesService.getPortalAvailability>>
     | undefined
+  /**
+   * Booking mode resolved by the backend for the currently-selected
+   * [start, end] window — takes per-slot ``weekly_hours.booking_mode``
+   * overrides into account. ``null`` until the debounced check resolves;
+   * callers should fall back to a conservative venue-wide hint in that
+   * window so the user isn't left without context.
+   */
+  effectiveBookingMode: string | null
 }
 
 /**
@@ -246,10 +254,14 @@ export function useVenueAvailability(
   }, [venueId, startIso, openOnlyIntervals, durationMinutes])
 
   const [availability, setAvailability] = useState<Availability>("idle")
+  const [effectiveBookingMode, setEffectiveBookingMode] = useState<
+    string | null
+  >(null)
 
   useEffect(() => {
     if (!venueId || !startIso || !endIso) {
       setAvailability("idle")
+      setEffectiveBookingMode(null)
       return
     }
     const handle = setTimeout(async () => {
@@ -264,8 +276,10 @@ export function useVenueAvailability(
           },
         })
         setAvailability(res.available ? "ok" : "conflict")
+        setEffectiveBookingMode(res.effective_booking_mode ?? null)
       } catch {
         setAvailability("idle")
+        setEffectiveBookingMode(null)
       }
     }, 500)
     return () => clearTimeout(handle)
@@ -281,5 +295,6 @@ export function useVenueAvailability(
     withinOpenHours,
     availability,
     availabilityData,
+    effectiveBookingMode,
   }
 }

--- a/portal/src/app/portal/[popupSlug]/events/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/new/page.tsx
@@ -153,6 +153,7 @@ export default function NewPortalEventPage() {
     withinOpenHours,
     availability,
     availabilityData,
+    effectiveBookingMode,
   } = useVenueAvailability({
     popupId,
     venueId,
@@ -365,6 +366,7 @@ export default function NewPortalEventPage() {
           onCustomLocationNameChange={setCustomLocationName}
           customLocationUrl={customLocationUrl}
           onCustomLocationUrlChange={setCustomLocationUrl}
+          effectiveBookingMode={effectiveBookingMode}
         />
         {customLocationMissing && (
           <p className="text-xs text-destructive">

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -107,13 +107,22 @@ export default function EventsPage() {
   // synchronously by `router.push` during a client-side transition) and
   // fall back to `window.location.search` so a hard refresh on the
   // events page with the param in the URL still works.
-  const focusEventRef = useRef<{ id: string | null } | null>(null)
+  // `occ` is the ISO start_time of the specific recurring occurrence; without
+  // it, every expanded instance of a recurring event would share the same
+  // DOM id and we'd always scroll to the first one.
+  const focusEventRef = useRef<{
+    id: string | null
+    occ: string | null
+  } | null>(null)
   if (focusEventRef.current === null) {
     let id: string | null = searchParams.get("focus")
+    let occ: string | null = searchParams.get("focusOcc")
     if (!id && typeof window !== "undefined") {
-      id = new URLSearchParams(window.location.search).get("focus")
+      const fallback = new URLSearchParams(window.location.search)
+      id = fallback.get("focus")
+      occ = fallback.get("focusOcc")
     }
-    focusEventRef.current = { id }
+    focusEventRef.current = { id, occ }
   }
 
   const [search, setSearch] = useState(() => restoredFilters?.search ?? "")
@@ -563,19 +572,22 @@ export default function EventsPage() {
   }, [view, restoredScroll, isLoading, events.length])
 
   // Scroll the focused event-card into view after returning from the
-  // detail page. The detail's back link stamps `?focus=<eventId>` and
+  // detail page. The detail's back link stamps `?focus=<eventId>` (and
+  // `&focusOcc=<ISO start_time>` for a specific recurring occurrence) and
   // ListBody/CalendarBody/DayBody render each card with
-  // id={`event-card-${event.id}`}. We use scrollIntoView (not a cached
+  // id={`event-card-${event.id}`} — or `event-card-${id}__${start_time}`
+  // for expanded recurring instances. We use scrollIntoView (not a cached
   // scrollTop) so it stays correct even if card heights settle late or
   // the viewport changed. The card may not be mounted on the first pass
   // (recurrence summary, image, fonts, query result still loading), so
   // we retry across a handful of frames before giving up. Either way
-  // the `focus` param is cleaned from the URL via router.replace so a
+  // the `focus` params are cleaned from the URL via router.replace so a
   // later refresh doesn't re-scroll, and so the URL stays tidy.
   const didConsumeFocusRef = useRef(false)
   useIsomorphicLayoutEffect(() => {
     if (didConsumeFocusRef.current) return
     const focusId = focusEventRef.current?.id
+    const focusOcc = focusEventRef.current?.occ
     if (!focusId) return
     // For list view, the query must finish first; otherwise the card
     // is guaranteed not to be in the DOM yet.
@@ -584,18 +596,23 @@ export default function EventsPage() {
     const cleanFocusParam = () => {
       if (typeof window === "undefined") return
       const params = new URLSearchParams(window.location.search)
-      if (!params.has("focus")) return
+      if (!params.has("focus") && !params.has("focusOcc")) return
       params.delete("focus")
+      params.delete("focusOcc")
       const qs = params.toString()
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
     }
+
+    const targetDomId = focusOcc
+      ? `event-card-${focusId}__${focusOcc}`
+      : `event-card-${focusId}`
 
     let cancelled = false
     let frames = 0
     const MAX_FRAMES = 30
     const tryFocus = () => {
       if (cancelled) return
-      const el = document.getElementById(`event-card-${focusId}`)
+      const el = document.getElementById(targetDomId)
       if (el) {
         didConsumeFocusRef.current = true
         el.scrollIntoView({ behavior: "auto", block: "center" })

--- a/portal/src/app/portal/docs/page.tsx
+++ b/portal/src/app/portal/docs/page.tsx
@@ -259,6 +259,80 @@ function ApiDocsBody() {
               },
             ]}
           />
+
+          <Endpoint
+            method="PATCH"
+            path="/api/v1/events/portal/events/{event_id}"
+            scope="events:write"
+            summary="Update an event you own. Calendar-affecting changes (time, venue, title) bump the sequence and dispatch an iTIP UPDATE."
+            body={[
+              { name: "title", type: "string" },
+              { name: "content", type: "string" },
+              { name: "start_time", type: "ISO datetime" },
+              { name: "end_time", type: "ISO datetime" },
+              { name: "timezone", type: "string" },
+              {
+                name: "venue_id",
+                type: "uuid",
+                note: "clears custom_location_*",
+              },
+              {
+                name: "custom_location_name",
+                type: "string",
+                note: "clears venue_id",
+              },
+              { name: "custom_location_url", type: "string" },
+              { name: "cover_url", type: "string" },
+              { name: "meeting_url", type: "string" },
+              { name: "max_participant", type: "int" },
+              { name: "tags", type: "string[]" },
+              { name: "track_id", type: "uuid" },
+              {
+                name: "visibility",
+                type: "enum",
+                note: "public | private | unlisted",
+              },
+              { name: "status", type: "enum" },
+              { name: "host_display_name", type: "string" },
+            ]}
+          />
+
+          <Endpoint
+            method="POST"
+            path="/api/v1/events/portal/events/{event_id}/cancel"
+            scope="events:write"
+            summary="Soft-cancel an event you own. Sets status to CANCELLED and dispatches an iTIP CANCEL to attendees. There is no hard-delete."
+          />
+        </Section>
+
+        <Section title="Invitations" id="invitations">
+          <Endpoint
+            method="GET"
+            path="/api/v1/events/portal/events/{event_id}/invitations"
+            scope="events:read"
+            summary="List invitations for an event you own."
+          />
+
+          <Endpoint
+            method="POST"
+            path="/api/v1/events/portal/events/{event_id}/invitations"
+            scope="events:write"
+            summary="Bulk-invite humans by email. Emails must match existing humans in the tenant; unknown addresses come back under not_found. Owner-only."
+            body={[
+              {
+                name: "emails",
+                type: "string[]",
+                note: "1–1000 entries, case-insensitive",
+              },
+            ]}
+          />
+
+          <Endpoint
+            method="DELETE"
+            path="/api/v1/events/portal/events/{event_id}/invitations/{invitation_id}"
+            scope="events:write"
+            summary="Revoke a single invitation. Owner-only."
+          />
         </Section>
 
         <Section title="RSVP" id="rsvp">

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -4459,6 +4459,17 @@ export const EventAvailabilityResultSchema = {
                 }
             ],
             title: 'Reason'
+        },
+        effective_booking_mode: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Effective Booking Mode'
         }
     },
     type: 'object',
@@ -15351,6 +15362,16 @@ export const VenueWeeklyHourInputSchema = {
             type: 'boolean',
             title: 'Is Closed',
             default: false
+        },
+        booking_mode: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/VenueBookingMode'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',
@@ -15396,6 +15417,16 @@ export const VenueWeeklyHourRefSchema = {
         is_closed: {
             type: 'boolean',
             title: 'Is Closed'
+        },
+        booking_mode: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/VenueBookingMode'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -1093,7 +1093,7 @@ export class AuthService {
     
     /**
      * Scanner Login
-     * Initiate scanner login. Accepts CHECK_IN_CONTROLLER, ADMIN, and SUPERADMIN.
+     * Initiate scanner login. Accepts CHECK_IN_CONTROLLER, OPERATOR, ADMIN, and SUPERADMIN.
      * VIEWER is rejected pre-OTP — must not receive a code they can't redeem.
      * @param data The data for the request.
      * @param data.requestBody
@@ -1115,7 +1115,7 @@ export class AuthService {
     /**
      * Scanner Authenticate
      * Authenticate a scanner operator and return a JWT token.
-     * Only SUPERADMIN, ADMIN, and CHECK_IN_CONTROLLER are accepted.
+     * Only SUPERADMIN, ADMIN, OPERATOR, and CHECK_IN_CONTROLLER are accepted.
      * VIEWER is rejected with 403.
      * @param data The data for the request.
      * @param data.requestBody
@@ -2181,11 +2181,16 @@ export class EventsService {
     /**
      * List Events
      * List events with optional filters (backoffice).
+     *
+     * ``location_kind`` narrows results to events without a ``venue_id``:
+     * - ``"custom"``  → events with a ``custom_location_name`` set.
+     * - ``"meeting"`` → online-only events (no venue, no custom location).
      * @param data The data for the request.
      * @param data.popupId
      * @param data.eventStatus
      * @param data.kind
      * @param data.venueId
+     * @param data.locationKind
      * @param data.trackIds
      * @param data.startAfter
      * @param data.startBefore
@@ -2208,6 +2213,7 @@ export class EventsService {
                 event_status: data.eventStatus,
                 kind: data.kind,
                 venue_id: data.venueId,
+                location_kind: data.locationKind,
                 track_ids: data.trackIds,
                 start_after: data.startAfter,
                 start_before: data.startBefore,

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -3754,6 +3754,7 @@ export type EventsListEventsData = {
      * Maximum number of items to return
      */
     limit?: number;
+    locationKind?: (string | null);
     popupId?: (string | null);
     search?: (string | null);
     /**

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1001,6 +1001,7 @@ export type EventAvailabilityResult = {
     available: boolean;
     conflicts?: Array<(string)>;
     reason?: (string | null);
+    effective_booking_mode?: (string | null);
 };
 
 /**
@@ -3032,6 +3033,7 @@ export type VenueWeeklyHourInput = {
     open_time?: (string | null);
     close_time?: (string | null);
     is_closed?: boolean;
+    booking_mode?: (VenueBookingMode | null);
 };
 
 export type VenueWeeklyHourRef = {
@@ -3040,6 +3042,7 @@ export type VenueWeeklyHourRef = {
     open_time: (string | null);
     close_time: (string | null);
     is_closed: boolean;
+    booking_mode?: (VenueBookingMode | null);
 };
 
 export type VenueWeeklyHoursUpdate = {


### PR DESCRIPTION
## Summary

Promotes 6 commits from `dev` to `main`.

### Features
- **Backoffice events list**: Host column (host_display_name + owner email), plus status/venue/date-range filters backed by URL search params; renames "Published" to "Public" across forms and approval dialog
- **Portal events list**: 56–64px cover thumbnail per card (cover_url → venue_image_url fallback), shared by public calendar and authed list
- **Portal toolbar**: alphabetical sort for tag and track popovers

### Fixes
- `events`: treat popup `end_date` as inclusive calendar day (previously rejected every event on the last day of the popup)
- `portal`: scroll to the specific recurring occurrence on detail back-navigation (stamp occurrence `start_time` into card id + `focusOcc` query param)

## Test plan
- [ ] Backend tests pass (`uv run bash scripts/test.sh`)
- [ ] Backoffice e2e pass (`pnpm run test:e2e`)
- [ ] Smoke check events list filters (status, venue, date range) persist via URL
- [ ] Verify Host column shows host_display_name with owner email fallback
- [ ] Verify portal list shows cover thumbnails with venue image fallback
- [ ] Verify back-from-detail scroll lands on the correct recurring occurrence
- [ ] Verify event on popup end_date is visible on the public calendar