### PR TITLE
feat(popup): order list by active status then start_date desc

### DIFF
--- a/backend/app/api/popup/crud.py
+++ b/backend/app/api/popup/crud.py
@@ -1,7 +1,10 @@
+from typing import Any
+
+from sqlalchemy import case
 from sqlmodel import Session
 
 from app.api.popup.models import Popups
-from app.api.popup.schemas import PopupCreate, PopupUpdate
+from app.api.popup.schemas import PopupCreate, PopupStatus, PopupUpdate
 from app.api.shared.crud import BaseCRUD
 
 
@@ -11,6 +14,23 @@ class PopupsCRUD(BaseCRUD[Popups, PopupCreate, PopupUpdate]):
 
     def get_by_slug(self, session: Session, slug: str) -> Popups | None:
         return self.get_by_field(session, "slug", slug)
+
+    def _apply_sorting(
+        self,
+        statement: Any,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+    ) -> Any:
+        if sort_by:
+            return super()._apply_sorting(statement, sort_by, sort_order)
+        active_first = case(
+            (Popups.status == PopupStatus.active, 0),  # ty: ignore[invalid-argument-type]
+            else_=1,
+        )
+        return statement.order_by(
+            active_first,
+            Popups.start_date.desc().nulls_last(),  # type: ignore[attr-defined]
+        )
 
 
 popups_crud = PopupsCRUD()


### PR DESCRIPTION
## Summary
- Override `PopupsCRUD._apply_sorting` to default to `status='active'` first, then `start_date DESC NULLS LAST`
- Affects the admin `GET /popups`, public `GET /popups/public/list` and portal `GET /popups/portal/list` endpoints (all go through `crud.find`)
- Backoffice sidebar `PopupSelector` already auto-selects `results[0]`, so the active popup is now picked automatically — no front-end changes needed

## Why
Tenants typically have a single active popup. With this ordering, when no popup is selected the sidebar lands on the right one (active and most upcoming/recent) without any custom heuristic in the React component. Explicit `sort_by` callers keep their behavior — the override only kicks in when no `sort_by` is provided.

## Notes
- `Popups` has no `created_at` column, so `start_date` is used as the chronological proxy (NULLS LAST keeps unscheduled drafts at the bottom)
- Pattern reuses `case()` and `.nulls_last()` already present in `application_review/crud.py` and `checkout/crud.py`

## Test plan
- [ ] Backoffice: open sidebar with no popup selected → active popup is preselected
- [ ] Backoffice: with multiple active popups, the one with the latest `start_date` is preselected
- [ ] Tenant with no active popups: most recent non-active popup is preselected
- [ ] Checkout/portal listings still return only active popups, now ordered consistently