### PR TITLE
feat(backend): patron product rules — validators, snapshot, migration (PR 1/3)

### DIFF
--- a/backend/app/alembic/versions/fb7da98c8d72_patron_product_rules.py
+++ b/backend/app/alembic/versions/fb7da98c8d72_patron_product_rules.py
@@ -1,0 +1,65 @@
+"""patron product rules
+
+Adds effective_unit_price snapshot column to payment_products and two partial
+unique indexes that enforce one patreon product per popup and one patron-preset
+ticketing step per popup.
+
+Revision ID: fb7da98c8d72
+Revises: 0d62c955bfdf
+Create Date: 2026-05-14
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fb7da98c8d72"
+down_revision = "0d62c955bfdf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add effective_unit_price snapshot column to payment_products.
+    # NULL for non-patreon rows; set to unit_price_override for patreon rows.
+    op.add_column(
+        "payment_products",
+        sa.Column(
+            "effective_unit_price",
+            sa.Numeric(10, 2),
+            nullable=True,
+        ),
+    )
+
+    # Partial unique index: at most one non-deleted patreon product per popup.
+    op.create_index(
+        "uq_product_patreon_per_popup",
+        "products",
+        ["popup_id"],
+        unique=True,
+        postgresql_where=sa.text("category = 'patreon' AND deleted_at IS NULL"),
+    )
+
+    # Partial unique index: at most one enabled patron-preset ticketing step per popup.
+    # The table name is ticketingsteps (SQLModel default for TicketingSteps class).
+    # ticketingsteps has no deleted_at column, so we use is_enabled = TRUE.
+    op.create_index(
+        "uq_ticketing_step_patron_per_popup",
+        "ticketingsteps",
+        ["popup_id"],
+        unique=True,
+        postgresql_where=sa.text("template = 'patron-preset' AND is_enabled = TRUE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_ticketing_step_patron_per_popup",
+        table_name="ticketingsteps",
+    )
+    op.drop_index(
+        "uq_product_patreon_per_popup",
+        table_name="products",
+    )
+    op.drop_column("payment_products", "effective_unit_price")

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -43,6 +43,63 @@ from app.api.shared.crud import BaseCRUD
 MONEY_PRECISION = Decimal("0.01")
 
 
+def resolve_patron_template_config(
+    session: Session, popup_id: uuid.UUID
+) -> dict | None:
+    """Return the active patron-preset step's template_config for a popup, or None.
+
+    If somehow multiple steps exist (race before the DB index was enforced),
+    picks the one with the lowest order value.
+    """
+    from app.api.ticketing_step.models import TicketingSteps
+
+    stmt = (
+        select(TicketingSteps)
+        .where(
+            TicketingSteps.popup_id == popup_id,
+            TicketingSteps.template == "patron-preset",
+            TicketingSteps.is_enabled == True,  # noqa: E712
+        )
+        .order_by(TicketingSteps.order)
+        .limit(1)
+    )
+    step = session.exec(stmt).first()
+    if step is None:
+        return None
+    return step.template_config
+
+
+def validate_patron_amount(amount: Decimal, template_config: dict) -> None:
+    """Validate a patron donation amount against the step's template_config.
+
+    Raises HTTPException(422) on:
+    - amount < template_config["minimum"]  (raw currency units — NO /100 conversion)
+    - allow_custom is False and amount not in template_config["presets"]
+
+    Units are raw popup-currency values (e.g. USD 1000 means $1000, not $10).
+    """
+    minimum = Decimal(str(template_config["minimum"]))
+    if amount < minimum:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"The amount must be at least {minimum}. Please enter a valid amount."
+            ),
+        )
+
+    allow_custom = template_config.get("allow_custom", True)
+    if not allow_custom:
+        presets = [Decimal(str(p)) for p in template_config.get("presets", [])]
+        if amount not in presets:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "The selected amount is not a valid preset option. "
+                    "Please choose one of the available amounts."
+                ),
+            )
+
+
 def calculate_insurance_amount(
     popup: "Any",
     product_quantity_pairs: "list[tuple[Any, int]]",
@@ -472,9 +529,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 success_url = f"{portal_base}/thank-you?payment_id={payment.id}"
                 cancel_url = f"{portal_base}/?cancelled=1"
             else:
-                success_url = (
-                    f"{portal_base}/checkout/{popup.slug}/thank-you?payment_id={payment.id}"
-                )
+                success_url = f"{portal_base}/checkout/{popup.slug}/thank-you?payment_id={payment.id}"
                 cancel_url = f"{portal_base}/checkout/{popup.slug}?cancelled=1"
             reference = {
                 "email": buyer.email,
@@ -1015,7 +1070,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             product = products_map.get(req.product_id)
             if product is None:
                 continue
-            if product.max_per_order is not None and req.quantity > product.max_per_order:
+            if (
+                product.max_per_order is not None
+                and req.quantity > product.max_per_order
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                     detail=(
@@ -1306,6 +1364,50 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         # Validate per-order caps (in-memory, fail fast, 422 on violation).
         self._validate_max_per_order(obj.products, valid_products)
 
+        # Validate patron-product rules: quantity=1, unit_price_override required,
+        # resolve template_config and validate amount. Raises 422 on any violation.
+        # Also rejects unit_price_override on non-patreon products.
+        products_map_for_patron = {p.id: p for p in valid_products}
+        popup_id_for_patron = valid_products[0].popup_id if valid_products else None
+        patron_template_config: dict | None = None  # resolved lazily once
+        for req_prod in obj.products:
+            product = products_map_for_patron.get(req_prod.product_id)
+            if product is None:
+                continue
+            is_patreon = product.category == "patreon"
+            if is_patreon:
+                if req_prod.quantity != 1:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail="Patron products must be purchased one at a time.",
+                    )
+                if req_prod.unit_price_override is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail="A donation amount is required for patron products.",
+                    )
+                if patron_template_config is None and popup_id_for_patron:
+                    patron_template_config = resolve_patron_template_config(
+                        session, popup_id_for_patron
+                    )
+                if patron_template_config is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=(
+                            "This popup has no patron step configured. "
+                            "Please set up a patron step before processing patron payments."
+                        ),
+                    )
+                validate_patron_amount(
+                    req_prod.unit_price_override, patron_template_config
+                )
+            else:
+                if req_prod.unit_price_override is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail="unit_price_override is only allowed for patron products.",
+                    )
+
         # Atomically decrement total-stock counters.
         self._decrement_total_stocks(session, obj.products, valid_products)
 
@@ -1375,6 +1477,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             for req_prod in obj.products:
                 product = products_map.get(req_prod.product_id)
                 if product:
+                    is_patreon = product.category == "patreon"
                     payment_product = PaymentProducts(
                         tenant_id=application.tenant_id,
                         payment_id=payment.id,
@@ -1383,9 +1486,12 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         quantity=req_prod.quantity,
                         product_name=product.name,
                         product_description=product.description,
-                        product_price=product.price,
+                        product_price=Decimal("0") if is_patreon else product.price,
                         product_category=product.category or "",
                         product_currency=preview.currency,
+                        effective_unit_price=req_prod.unit_price_override
+                        if is_patreon
+                        else None,
                     )
                     session.add(payment_product)
 
@@ -1513,6 +1619,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         for req_prod in obj.products:
             product = products_map.get(req_prod.product_id)
             if product:
+                is_patreon = product.category == "patreon"
                 payment_product = PaymentProducts(
                     tenant_id=application.tenant_id,
                     payment_id=payment.id,
@@ -1521,9 +1628,12 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     quantity=req_prod.quantity,
                     product_name=product.name,
                     product_description=product.description,
-                    product_price=product.price,
+                    product_price=Decimal("0") if is_patreon else product.price,
                     product_category=product.category or "",
                     product_currency=preview.currency,
+                    effective_unit_price=req_prod.unit_price_override
+                    if is_patreon
+                    else None,
                 )
                 session.add(payment_product)
 
@@ -1845,7 +1955,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         # APPROVED → CANCELLED (refund flow) is explicitly OUT OF SCOPE per design
         # §4.2 — no stock restoration in that path (separate future feature).
         if (
-            new_status in (PaymentStatus.CANCELLED, PaymentStatus.REJECTED, PaymentStatus.EXPIRED)
+            new_status
+            in (PaymentStatus.CANCELLED, PaymentStatus.REJECTED, PaymentStatus.EXPIRED)
             and old_status == PaymentStatus.PENDING.value
         ):
             self._restore_payment_stock(session, payment)

--- a/backend/app/api/payment/schemas.py
+++ b/backend/app/api/payment/schemas.py
@@ -60,6 +60,10 @@ class PaymentProductBase(SQLModel):
     product_name: str
     product_description: str | None = Field(default=None, sa_type=Text())
     product_price: Decimal = Field(sa_column=Column(Numeric(10, 2), nullable=False))
+    effective_unit_price: Decimal | None = Field(
+        default=None,
+        sa_column=Column(Numeric(10, 2), nullable=True),
+    )
     product_category: str
     product_currency: str = Field(
         default="USD",
@@ -133,6 +137,14 @@ class PaymentProductRequest(BaseModel):
     product_id: uuid.UUID
     attendee_id: uuid.UUID
     quantity: int = 1
+    unit_price_override: Decimal | None = None
+
+    @model_validator(mode="after")
+    def validate_unit_price_override(self) -> "PaymentProductRequest":
+        """Structural validation: unit_price_override must be non-negative if provided."""
+        if self.unit_price_override is not None and self.unit_price_override < 0:
+            raise ValueError("unit_price_override must be non-negative")
+        return self
 
 
 class PaymentProductResponse(BaseModel):
@@ -144,6 +156,7 @@ class PaymentProductResponse(BaseModel):
     product_name: str
     product_description: str | None = None
     product_price: Decimal
+    effective_unit_price: Decimal | None = None
     product_category: str
     product_currency: str
     attendee_name: str | None = None

--- a/backend/app/api/product/crud.py
+++ b/backend/app/api/product/crud.py
@@ -21,9 +21,7 @@ def sale_dates_to_persistence(data: dict[str, object]) -> dict[str, object]:
     if "sale_starts_at" in data:
         data["sale_starts_at"] = date_to_utc_instant(data["sale_starts_at"])
     if "sale_ends_at" in data:
-        data["sale_ends_at"] = date_to_utc_instant(
-            data["sale_ends_at"], day_offset=1
-        )
+        data["sale_ends_at"] = date_to_utc_instant(data["sale_ends_at"], day_offset=1)
     return data
 
 
@@ -33,8 +31,31 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
     def __init__(self) -> None:
         super().__init__(Products)
 
+    def _assert_no_active_patreon(
+        self, session: Session, popup_id: uuid.UUID, exclude_id: uuid.UUID | None = None
+    ) -> None:
+        """Raise 422 if an active (non-deleted) patreon product already exists for this popup."""
+        stmt = select(Products).where(
+            Products.popup_id == popup_id,
+            Products.category == "patreon",
+            col(Products.deleted_at).is_(None),
+        )
+        if exclude_id is not None:
+            stmt = stmt.where(Products.id != exclude_id)
+        existing = session.exec(stmt).first()
+        if existing is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "This popup already has a Patron product. "
+                    "Only one Patron product is allowed per popup."
+                ),
+            )
+
     def create(self, session: Session, obj_in: ProductCreate) -> Products:
         """Create a product, converting sale window dates to UTC datetimes."""
+        if obj_in.category == "patreon":
+            self._assert_no_active_patreon(session, obj_in.popup_id)
         data = sale_dates_to_persistence(obj_in.model_dump())
         db_obj = Products(**data)
         session.add(db_obj)
@@ -186,9 +207,15 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
         the CHECK constraint `total_stock_remaining <= total_stock_cap` rejects
         any cap reduction below the stale remaining.
         """
-        update_data = sale_dates_to_persistence(
-            obj_in.model_dump(exclude_unset=True)
-        )
+        update_data = sale_dates_to_persistence(obj_in.model_dump(exclude_unset=True))
+
+        # Singleton guard: reject if category is being changed TO patreon and
+        # another non-deleted patreon product already exists for this popup.
+        new_category = update_data.get("category")
+        if new_category == "patreon" and db_obj.category != "patreon":
+            self._assert_no_active_patreon(
+                session, db_obj.popup_id, exclude_id=db_obj.id
+            )
 
         if (
             "total_stock_cap" in update_data

--- a/backend/app/api/product/router.py
+++ b/backend/app/api/product/router.py
@@ -220,6 +220,10 @@ async def create_product(
     else:
         tenant_id = current_user.tenant_id
 
+    # Singleton guard: reject if category=patreon and another active one exists
+    if product_in.category == "patreon":
+        crud.products_crud._assert_no_active_patreon(db, product_in.popup_id)
+
     # Create internal schema with tenant_id and generated slug
     from app.api.product.models import Products
 

--- a/backend/app/api/product/schemas.py
+++ b/backend/app/api/product/schemas.py
@@ -138,6 +138,16 @@ class ProductCreate(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     @model_validator(mode="after")
+    def validate_patreon_price(self) -> "ProductCreate":
+        """Patreon products must have price = 0."""
+        if self.category == "patreon" and self.price > 0:
+            raise ValueError(
+                "Patron products must have a price of 0. "
+                "The donation amount is set by the donor at checkout."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_ticket_fields(self) -> "ProductCreate":
         """Validate that ticket-specific fields are only set for tickets."""
         if self.category != "ticket":
@@ -176,9 +186,7 @@ class ProductCreate(BaseModel):
         """sale_starts_at must be before sale_ends_at when both are set."""
         if self.sale_starts_at is not None and self.sale_ends_at is not None:
             if self.sale_starts_at > self.sale_ends_at:
-                raise ValueError(
-                    "sale_starts_at must be before sale_ends_at"
-                )
+                raise ValueError("sale_starts_at must be before sale_ends_at")
         return self
 
 
@@ -205,6 +213,16 @@ class ProductUpdate(BaseModel):
     requires_check_in: bool | None = None
 
     @model_validator(mode="after")
+    def validate_patreon_price(self) -> "ProductUpdate":
+        """Reject updates that set category=patreon with a nonzero price."""
+        if self.category == "patreon" and self.price is not None and self.price > 0:
+            raise ValueError(
+                "Patron products must have a price of 0. "
+                "The donation amount is set by the donor at checkout."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_max_per_order_vs_stock_cap(self) -> "ProductUpdate":
         """max_per_order must not exceed total_stock_cap when both are set."""
         if self.max_per_order is not None and self.total_stock_cap is not None:
@@ -220,9 +238,7 @@ class ProductUpdate(BaseModel):
         """sale_starts_at must be before sale_ends_at when both are set."""
         if self.sale_starts_at is not None and self.sale_ends_at is not None:
             if self.sale_starts_at > self.sale_ends_at:
-                raise ValueError(
-                    "sale_starts_at must be before sale_ends_at"
-                )
+                raise ValueError("sale_starts_at must be before sale_ends_at")
         return self
 
 

--- a/backend/app/api/ticketing_step/crud.py
+++ b/backend/app/api/ticketing_step/crud.py
@@ -1,5 +1,6 @@
 import uuid
 
+from fastapi import HTTPException, status
 from sqlmodel import Session, func, select
 
 from app.api.shared.crud import BaseCRUD
@@ -12,6 +13,30 @@ class TicketingStepsCRUD(
 ):
     def __init__(self) -> None:
         super().__init__(TicketingSteps)
+
+    def _assert_no_active_patron_preset(
+        self,
+        session: Session,
+        popup_id: uuid.UUID,
+        exclude_id: uuid.UUID | None = None,
+    ) -> None:
+        """Raise 422 if an enabled patron-preset step already exists for this popup."""
+        stmt = select(TicketingSteps).where(
+            TicketingSteps.popup_id == popup_id,
+            TicketingSteps.template == "patron-preset",
+            TicketingSteps.is_enabled == True,  # noqa: E712
+        )
+        if exclude_id is not None:
+            stmt = stmt.where(TicketingSteps.id != exclude_id)
+        existing = session.exec(stmt).first()
+        if existing is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "This popup already has a Patron step. "
+                    "Only one Patron step is allowed per popup."
+                ),
+            )
 
     def find_by_popup(
         self,

--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -94,6 +94,10 @@ async def create_ticketing_step(
     else:
         tenant_id = current_user.tenant_id
 
+    # Singleton guard: only one enabled patron-preset step per popup.
+    if step_in.template == "patron-preset" and step_in.is_enabled:
+        crud.ticketing_steps_crud._assert_no_active_patron_preset(db, step_in.popup_id)
+
     from app.api.ticketing_step.models import TicketingSteps
 
     step_data = step_in.model_dump()

--- a/backend/app/core/invoice.py
+++ b/backend/app/core/invoice.py
@@ -220,7 +220,11 @@ def generate_invoice_pdf(
     subtotal_amount = 0.0
     for item in payment.products_snapshot:
         line_currency = item.product_currency or sale_currency
-        unit_price = float(item.product_price)
+        unit_price = float(
+            item.effective_unit_price
+            if item.effective_unit_price is not None
+            else item.product_price
+        )
         qty = int(item.quantity)
         line_total = unit_price * qty
         subtotal_amount += line_total

--- a/backend/tests/api/payment/test_patron_payment_integration.py
+++ b/backend/tests/api/payment/test_patron_payment_integration.py
@@ -1,0 +1,383 @@
+"""Integration tests for patron payment creation.
+
+Tests the full patron payment flow via PaymentsCRUD.create_payment,
+verifying that effective_unit_price is persisted, validations fire, and
+non-patreon rows are unaffected.
+
+Spec: payments Delta — Requirement: unit_price_override + effective_unit_price
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import Attendees
+from app.api.human.models import Humans
+from app.api.payment.crud import payments_crud, resolve_patron_template_config
+from app.api.payment.models import PaymentProducts
+from app.api.payment.schemas import PaymentCreate, PaymentProductRequest
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+from app.api.ticketing_step.models import TicketingSteps
+
+# ---- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def human_tenant_a(db: Session, tenant_a: Tenants) -> Humans:
+    """A Human record scoped to tenant_a for use in patron payment tests."""
+    email = f"patron-test-{uuid.uuid4().hex[:8]}@test.com"
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant_a.id,
+        email=email,
+        first_name="Patron",
+        last_name="Tester",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+# ---- Helpers ----------------------------------------------------------------
+
+
+def _make_popup(
+    db: Session, tenant: Tenants, *, slug_prefix: str = "patron-test"
+) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name=f"Patron Test {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        simplefi_api_key="simplefi_test_key",
+        currency="USD",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_patreon_product(db: Session, popup: Popups) -> Products:
+    product = Products(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        name="Patron",
+        slug=f"patron-{uuid.uuid4().hex[:6]}",
+        price=Decimal("0"),
+        category="patreon",
+        is_active=True,
+    )
+    db.add(product)
+    db.flush()
+    return product
+
+
+def _make_ticket_product(db: Session, popup: Popups, price: str = "3000") -> Products:
+    product = Products(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        name="General Admission",
+        slug=f"ticket-{uuid.uuid4().hex[:6]}",
+        price=Decimal(price),
+        category="ticket",
+        is_active=True,
+    )
+    db.add(product)
+    db.flush()
+    return product
+
+
+def _make_patron_step(
+    db: Session,
+    popup: Popups,
+    *,
+    minimum: int = 1000,
+    presets: list[int] | None = None,
+    allow_custom: bool = True,
+) -> TicketingSteps:
+    if presets is None:
+        presets = [2500, 5000, 7500]
+    step = TicketingSteps(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        step_type="patron",
+        title="Patron",
+        template="patron-preset",
+        template_config={
+            "minimum": minimum,
+            "presets": presets,
+            "allow_custom": allow_custom,
+        },
+        is_enabled=True,
+        order=3,
+    )
+    db.add(step)
+    db.flush()
+    return step
+
+
+def _make_application_with_attendee(
+    db: Session,
+    popup: Popups,
+    human,
+) -> tuple[Applications, Attendees]:
+    app = Applications(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(app)
+    db.flush()
+
+    attendee = Attendees(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        application_id=app.id,
+        name="Test Attendee",
+        email=human.email,
+        category="main",
+    )
+    db.add(attendee)
+    db.flush()
+    return app, attendee
+
+
+# ---- Tests ------------------------------------------------------------------
+
+
+class TestResolvePatronTemplateConfig:
+    """resolve_patron_template_config returns the active step config."""
+
+    def test_returns_config_when_step_exists(
+        self, db: Session, tenant_a, popup_tenant_a: Popups
+    ) -> None:
+        """Creates a step and verifies resolve finds it."""
+        step = _make_patron_step(db, popup_tenant_a)
+        try:
+            result = resolve_patron_template_config(db, popup_tenant_a.id)
+            assert result is not None
+            assert result["minimum"] == 1000
+        finally:
+            db.delete(step)
+            db.commit()
+
+    def test_returns_none_when_no_step(self, db: Session, tenant_a) -> None:
+        """Returns None for a popup with no patron step."""
+        popup = _make_popup(db, tenant_a, slug_prefix="no-step")
+        db.commit()
+        try:
+            result = resolve_patron_template_config(db, popup.id)
+            assert result is None
+        finally:
+            db.delete(popup)
+            db.commit()
+
+
+class TestPatronPaymentCreation:
+    """End-to-end tests for patron payment creation via CRUD."""
+
+    def _setup_scenario(self, db, tenant_a, popup_tenant_a, human_tenant_a):
+        """Create patreon product + patron step for the popup."""
+        product = _make_patreon_product(db, popup_tenant_a)
+        step = _make_patron_step(db, popup_tenant_a)
+        application, attendee = _make_application_with_attendee(
+            db, popup_tenant_a, human_tenant_a
+        )
+        db.commit()
+        return product, step, application, attendee
+
+    def test_patron_payment_persists_effective_unit_price(
+        self, db: Session, tenant_a, popup_tenant_a: Popups, human_tenant_a
+    ) -> None:
+        """Patron payment stores effective_unit_price=5000, quantity=1, product_price=0."""
+        product, step, application, attendee = self._setup_scenario(
+            db, tenant_a, popup_tenant_a, human_tenant_a
+        )
+        try:
+            obj = PaymentCreate(
+                application_id=application.id,
+                products=[
+                    PaymentProductRequest(
+                        product_id=product.id,
+                        attendee_id=attendee.id,
+                        quantity=1,
+                        unit_price_override=Decimal("5000"),
+                    )
+                ],
+            )
+
+            # Patron products have price=0, so preview.amount=0 and the
+            # zero-amount path auto-approves without calling SimpleFI.
+            payment, _ = payments_crud.create_payment(db, obj)
+
+            # Find the PaymentProducts row
+            pp = db.exec(
+                select(PaymentProducts).where(
+                    PaymentProducts.payment_id == payment.id,
+                    PaymentProducts.product_id == product.id,
+                )
+            ).first()
+            assert pp is not None
+            assert pp.quantity == 1
+            assert pp.product_price == Decimal("0")
+            assert pp.effective_unit_price == Decimal("5000")
+        finally:
+            db.exec(  # type: ignore[call-overload]
+                select(PaymentProducts).where(PaymentProducts.payment_id == payment.id)
+            )
+            # Clean up payment_products and payments
+            for pp_row in db.exec(
+                select(PaymentProducts).where(PaymentProducts.payment_id == payment.id)
+            ).all():
+                db.delete(pp_row)
+            db.delete(payment)
+            db.delete(attendee)
+            db.delete(application)
+            db.delete(step)
+            db.delete(product)
+            db.commit()
+
+    def test_patron_payment_no_step_raises_422(
+        self, db: Session, tenant_a, human_tenant_a
+    ) -> None:
+        """Patreon product but no patron step configured returns 422."""
+        popup = _make_popup(db, tenant_a, slug_prefix="no-step-422")
+        product = _make_patreon_product(db, popup)
+        application, attendee = _make_application_with_attendee(
+            db, popup, human_tenant_a
+        )
+        db.commit()
+        try:
+            obj = PaymentCreate(
+                application_id=application.id,
+                products=[
+                    PaymentProductRequest(
+                        product_id=product.id,
+                        attendee_id=attendee.id,
+                        quantity=1,
+                        unit_price_override=Decimal("5000"),
+                    )
+                ],
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.create_payment(db, obj)
+            assert exc_info.value.status_code == 422
+            assert "patron" in exc_info.value.detail.lower()
+        finally:
+            db.delete(attendee)
+            db.delete(application)
+            db.delete(product)
+            db.delete(popup)
+            db.commit()
+
+    def test_patron_payment_below_minimum_raises_422(
+        self, db: Session, tenant_a, popup_tenant_a: Popups, human_tenant_a
+    ) -> None:
+        """unit_price_override below minimum raises 422."""
+        product = _make_patreon_product(db, popup_tenant_a)
+        step = _make_patron_step(db, popup_tenant_a, minimum=1000)
+        application, attendee = _make_application_with_attendee(
+            db, popup_tenant_a, human_tenant_a
+        )
+        db.commit()
+        try:
+            obj = PaymentCreate(
+                application_id=application.id,
+                products=[
+                    PaymentProductRequest(
+                        product_id=product.id,
+                        attendee_id=attendee.id,
+                        quantity=1,
+                        unit_price_override=Decimal("999"),
+                    )
+                ],
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.create_payment(db, obj)
+            assert exc_info.value.status_code == 422
+        finally:
+            db.delete(attendee)
+            db.delete(application)
+            db.delete(step)
+            db.delete(product)
+            db.commit()
+
+    def test_unit_price_override_on_non_patreon_raises_422(
+        self, db: Session, tenant_a, popup_tenant_a: Popups, human_tenant_a
+    ) -> None:
+        """unit_price_override on a non-patreon product raises 422."""
+        product = _make_ticket_product(db, popup_tenant_a)
+        application, attendee = _make_application_with_attendee(
+            db, popup_tenant_a, human_tenant_a
+        )
+        db.commit()
+        try:
+            obj = PaymentCreate(
+                application_id=application.id,
+                products=[
+                    PaymentProductRequest(
+                        product_id=product.id,
+                        attendee_id=attendee.id,
+                        quantity=1,
+                        unit_price_override=Decimal("5000"),
+                    )
+                ],
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.create_payment(db, obj)
+            assert exc_info.value.status_code == 422
+        finally:
+            db.delete(attendee)
+            db.delete(application)
+            db.delete(product)
+            db.commit()
+
+    def test_patreon_quantity_not_one_raises_422(
+        self, db: Session, tenant_a, popup_tenant_a: Popups, human_tenant_a
+    ) -> None:
+        """quantity != 1 for patreon product raises 422."""
+        product = _make_patreon_product(db, popup_tenant_a)
+        step = _make_patron_step(db, popup_tenant_a)
+        application, attendee = _make_application_with_attendee(
+            db, popup_tenant_a, human_tenant_a
+        )
+        db.commit()
+        try:
+            obj = PaymentCreate(
+                application_id=application.id,
+                products=[
+                    PaymentProductRequest(
+                        product_id=product.id,
+                        attendee_id=attendee.id,
+                        quantity=2,
+                        unit_price_override=Decimal("5000"),
+                    )
+                ],
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.create_payment(db, obj)
+            assert exc_info.value.status_code == 422
+        finally:
+            db.delete(attendee)
+            db.delete(application)
+            db.delete(step)
+            db.delete(product)
+            db.commit()

--- a/backend/tests/api/payment/test_patron_validators.py
+++ b/backend/tests/api/payment/test_patron_validators.py
@@ -1,0 +1,107 @@
+"""Unit tests for validate_patron_amount helper in payment/crud.py.
+
+Spec: patron-product Requirement: Patron Amount Validated Against template_config
+Constraint #1360: values are raw popup-currency units — NO /100 conversion.
+"""
+
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+
+
+class TestValidatePatronAmount:
+    """validate_patron_amount raises HTTPException(422) on violations."""
+
+    @pytest.fixture(autouse=True)
+    def import_validator(self):
+        from app.api.payment.crud import validate_patron_amount
+
+        self.validate = validate_patron_amount
+
+    def test_amount_equals_minimum_passes(self) -> None:
+        """amount == minimum is the boundary — must pass."""
+        template_config = {
+            "minimum": 1000,
+            "allow_custom": True,
+            "presets": [2500, 5000],
+        }
+        self.validate(Decimal("1000"), template_config)  # no exception
+
+    def test_amount_above_minimum_passes(self) -> None:
+        """amount > minimum passes when allow_custom is True."""
+        template_config = {
+            "minimum": 1000,
+            "allow_custom": True,
+            "presets": [2500, 5000],
+        }
+        self.validate(Decimal("3000"), template_config)
+
+    def test_amount_below_minimum_raises_422(self) -> None:
+        """amount < minimum must raise HTTPException 422."""
+        template_config = {
+            "minimum": 1000,
+            "allow_custom": True,
+            "presets": [2500, 5000],
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            self.validate(Decimal("999"), template_config)
+        assert exc_info.value.status_code == 422
+        assert (
+            "minimum" in exc_info.value.detail.lower()
+            or "1000" in exc_info.value.detail
+        )
+
+    def test_amount_in_presets_when_allow_custom_false_passes(self) -> None:
+        """Preset amount passes when allow_custom=False."""
+        template_config = {
+            "minimum": 1000,
+            "allow_custom": False,
+            "presets": [2500, 5000],
+        }
+        self.validate(Decimal("5000"), template_config)  # no exception
+
+    def test_amount_not_in_presets_when_allow_custom_false_raises_422(self) -> None:
+        """Custom amount not in presets raises 422 when allow_custom=False."""
+        template_config = {
+            "minimum": 1000,
+            "allow_custom": False,
+            "presets": [2500, 5000],
+        }
+        with pytest.raises(HTTPException) as exc_info:
+            self.validate(Decimal("3000"), template_config)
+        assert exc_info.value.status_code == 422
+        assert (
+            "preset" in exc_info.value.detail.lower()
+            or "valid" in exc_info.value.detail.lower()
+        )
+
+    def test_custom_amount_when_allow_custom_true_passes(self) -> None:
+        """Any amount >= minimum passes when allow_custom=True."""
+        template_config = {
+            "minimum": 1000,
+            "allow_custom": True,
+            "presets": [2500, 5000],
+        }
+        self.validate(Decimal("9999"), template_config)  # no exception
+
+    def test_units_are_raw_not_cents(self) -> None:
+        """Confirm: minimum=1000 means 1000 currency units (e.g. $1000), not $10.
+
+        1000 / 100 = 10. If the validator did cents conversion, amount=999 would pass
+        (as 9.99 > 10.00 is false, but 999 < 1000). This test locks the raw-units contract.
+        """
+        template_config = {"minimum": 1000, "allow_custom": True, "presets": []}
+        # 999 raw units < 1000 raw units: must fail
+        with pytest.raises(HTTPException):
+            self.validate(Decimal("999"), template_config)
+        # 1000 raw units == 1000 raw units: must pass
+        self.validate(Decimal("1000"), template_config)
+
+
+class TestResolvePatronTemplateConfig:
+    """resolve_patron_template_config returns dict or None."""
+
+    def test_import_succeeds(self) -> None:
+        """The helper must be importable from payment.crud."""
+        from app.api.payment.crud import resolve_patron_template_config  # noqa: F401

--- a/backend/tests/api/payment/test_payment_schemas.py
+++ b/backend/tests/api/payment/test_payment_schemas.py
@@ -1,0 +1,60 @@
+"""Unit tests for PaymentProductRequest validators: unit_price_override field.
+
+Spec: payments Delta — Requirement: unit_price_override Field
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.payment.schemas import PaymentProductRequest
+
+
+class TestPaymentProductRequestSchema:
+    """PaymentProductRequest structural validators."""
+
+    def test_unit_price_override_defaults_to_none(self) -> None:
+        """unit_price_override is optional, defaults to None."""
+        req = PaymentProductRequest(
+            product_id=uuid.uuid4(),
+            attendee_id=uuid.uuid4(),
+            quantity=1,
+        )
+        assert req.unit_price_override is None
+
+    def test_positive_unit_price_override_is_valid(self) -> None:
+        """unit_price_override >= 0 is accepted at the schema level."""
+        req = PaymentProductRequest(
+            product_id=uuid.uuid4(),
+            attendee_id=uuid.uuid4(),
+            quantity=1,
+            unit_price_override=Decimal("5000"),
+        )
+        assert req.unit_price_override == Decimal("5000")
+
+    def test_zero_unit_price_override_is_valid(self) -> None:
+        """unit_price_override = 0 is accepted (edge case)."""
+        req = PaymentProductRequest(
+            product_id=uuid.uuid4(),
+            attendee_id=uuid.uuid4(),
+            quantity=1,
+            unit_price_override=Decimal("0"),
+        )
+        assert req.unit_price_override == Decimal("0")
+
+    def test_negative_unit_price_override_is_rejected(self) -> None:
+        """unit_price_override < 0 must be rejected with 422."""
+        with pytest.raises(ValidationError) as exc_info:
+            PaymentProductRequest(
+                product_id=uuid.uuid4(),
+                attendee_id=uuid.uuid4(),
+                quantity=1,
+                unit_price_override=Decimal("-1"),
+            )
+        errors = exc_info.value.errors()
+        assert any(
+            "unit_price_override" in str(e) or "non-negative" in str(e).lower()
+            for e in errors
+        ), f"Expected unit_price_override error, got: {errors}"

--- a/backend/tests/api/product/test_product_patreon_singleton.py
+++ b/backend/tests/api/product/test_product_patreon_singleton.py
@@ -1,0 +1,134 @@
+"""Integration tests for singleton patreon product constraint per popup.
+
+Spec: patron-product Requirement: Single Active Patreon Product Per Popup
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _patreon_product_payload(popup_id: uuid.UUID, *, suffix: str) -> dict:
+    return {
+        "popup_id": str(popup_id),
+        "name": f"Patron Supporter {suffix}",
+        "price": "0",
+        "category": "patreon",
+    }
+
+
+def _create_isolated_popup(db, tenant_id: uuid.UUID) -> uuid.UUID:
+    """Insert a fresh popup directly and return its ID."""
+    popup_id = uuid.uuid4()
+    slug = f"singleton-test-{popup_id.hex[:8]}"
+    conn = db.connection()
+    conn.exec_driver_sql(
+        """
+        INSERT INTO popups (id, name, slug, tenant_id, sale_type, checkout_mode,
+                            status, currency, default_language, supported_languages,
+                            insurance_enabled, allows_scholarship, allows_incentive,
+                            requires_application_fee, events_enabled, application_layout)
+        VALUES (%s, %s, %s, %s, 'direct', 'pass_system',
+                'active', 'USD', 'en', '{en}', false,
+                false, false, false, true, 'single_page')
+        """,
+        (str(popup_id), f"Singleton Test {popup_id.hex[:8]}", slug, str(tenant_id)),
+    )
+    db.commit()
+    return popup_id
+
+
+def _cleanup_popup(db, popup_id: uuid.UUID) -> None:
+    conn = db.connection()
+    conn.exec_driver_sql("DELETE FROM products WHERE popup_id = %s", (str(popup_id),))
+    conn.exec_driver_sql("DELETE FROM popups WHERE id = %s", (str(popup_id),))
+    db.commit()
+
+
+class TestPatreonProductSingleton:
+    """At most one non-deleted patreon product is allowed per popup."""
+
+    def test_first_patreon_product_created_successfully(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        db,
+        tenant_a,
+    ) -> None:
+        """POST first patreon product for a popup returns 201."""
+        popup_id = _create_isolated_popup(db, tenant_a.id)
+        try:
+            suffix = uuid.uuid4().hex[:8]
+            resp = client.post(
+                "/api/v1/products",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patreon_product_payload(popup_id, suffix=suffix),
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            _cleanup_popup(db, popup_id)
+
+    def test_second_patreon_product_rejected_with_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        db,
+        tenant_a,
+    ) -> None:
+        """POST second patreon product for the same popup returns 422."""
+        popup_id = _create_isolated_popup(db, tenant_a.id)
+        try:
+            # Create first — must succeed
+            resp1 = client.post(
+                "/api/v1/products",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patreon_product_payload(popup_id, suffix="first"),
+            )
+            assert resp1.status_code == 201, resp1.text
+
+            # Create second — must fail
+            resp2 = client.post(
+                "/api/v1/products",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patreon_product_payload(popup_id, suffix="second"),
+            )
+            assert resp2.status_code == 422, resp2.text
+            body = resp2.json()
+            detail = str(body.get("detail", "")).lower()
+            assert "patron" in detail or "patreon" in detail, (
+                f"Expected patron-related error message, got: {body}"
+            )
+        finally:
+            _cleanup_popup(db, popup_id)
+
+    def test_different_popup_can_have_own_patreon_product(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        db,
+        tenant_a,
+    ) -> None:
+        """Two different popups can each have their own patreon product."""
+        popup_a = _create_isolated_popup(db, tenant_a.id)
+        popup_b = _create_isolated_popup(db, tenant_a.id)
+        try:
+            resp_a = client.post(
+                "/api/v1/products",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patreon_product_payload(popup_a, suffix="a"),
+            )
+            assert resp_a.status_code == 201, resp_a.text
+
+            resp_b = client.post(
+                "/api/v1/products",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patreon_product_payload(popup_b, suffix="b"),
+            )
+            assert resp_b.status_code == 201, resp_b.text
+        finally:
+            _cleanup_popup(db, popup_a)
+            _cleanup_popup(db, popup_b)

--- a/backend/tests/api/product/test_product_schemas.py
+++ b/backend/tests/api/product/test_product_schemas.py
@@ -1,0 +1,102 @@
+"""Unit tests for ProductCreate/ProductUpdate patreon price coercion validator.
+
+Spec: patron-product Requirement: Patreon Price Coercion
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.product.schemas import ProductCreate, ProductUpdate
+
+
+class TestProductCreatePatreonPrice:
+    """ProductCreate must reject price > 0 for category=patreon."""
+
+    def test_patreon_with_zero_price_is_valid(self) -> None:
+        """category=patreon, price=0 is valid."""
+        product = ProductCreate(
+            popup_id=uuid.uuid4(),
+            name="Patron",
+            price=Decimal("0"),
+            category="patreon",
+        )
+        assert product.price == Decimal("0")
+
+    def test_patreon_with_nonzero_price_raises_422(self) -> None:
+        """category=patreon, price>0 must raise ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ProductCreate(
+                popup_id=uuid.uuid4(),
+                name="Patron",
+                price=Decimal("500"),
+                category="patreon",
+            )
+        errors = exc_info.value.errors()
+        assert any(
+            "patreon" in str(e).lower() or "price" in str(e).lower() for e in errors
+        ), f"Expected patreon/price error, got: {errors}"
+
+    def test_ticket_with_nonzero_price_is_valid(self) -> None:
+        """category=ticket, price>0 remains valid (unchanged behavior)."""
+        product = ProductCreate(
+            popup_id=uuid.uuid4(),
+            name="General Admission",
+            price=Decimal("500"),
+            category="ticket",
+        )
+        assert product.price == Decimal("500")
+
+    def test_patreon_with_small_nonzero_price_raises_422(self) -> None:
+        """category=patreon, price=0.01 is still nonzero and must be rejected."""
+        with pytest.raises(ValidationError):
+            ProductCreate(
+                popup_id=uuid.uuid4(),
+                name="Patron",
+                price=Decimal("0.01"),
+                category="patreon",
+            )
+
+
+class TestProductUpdatePatreonPrice:
+    """ProductUpdate must reject price > 0 when category is (being set to) patreon."""
+
+    def test_patreon_category_with_nonzero_price_raises_422(self) -> None:
+        """PATCH category=patreon, price=500 must raise ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            ProductUpdate(
+                category="patreon",
+                price=Decimal("500"),
+            )
+        errors = exc_info.value.errors()
+        assert any(
+            "patreon" in str(e).lower() or "price" in str(e).lower() for e in errors
+        ), f"Expected patreon/price error, got: {errors}"
+
+    def test_patreon_category_with_zero_price_is_valid(self) -> None:
+        """PATCH category=patreon, price=0 is valid."""
+        update = ProductUpdate(
+            category="patreon",
+            price=Decimal("0"),
+        )
+        assert update.price == Decimal("0")
+
+    def test_patreon_category_without_price_is_valid(self) -> None:
+        """PATCH category=patreon only (no price) is valid.
+
+        The update validator can only reject if BOTH category and price
+        are provided in the same update and they conflict.
+        """
+        update = ProductUpdate(category="patreon")
+        assert update.category == "patreon"
+        assert update.price is None
+
+    def test_ticket_category_with_nonzero_price_is_valid(self) -> None:
+        """PATCH category=ticket, price=500 remains valid."""
+        update = ProductUpdate(
+            category="ticket",
+            price=Decimal("500"),
+        )
+        assert update.price == Decimal("500")

--- a/backend/tests/api/ticketing_step/test_ticketing_step_patron_singleton.py
+++ b/backend/tests/api/ticketing_step/test_ticketing_step_patron_singleton.py
@@ -1,0 +1,119 @@
+"""Integration tests for singleton patron-preset ticketing step constraint.
+
+Spec: patron-product Requirement: Single Active Patron Step Per Popup
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _patron_step_payload(popup_id: uuid.UUID, *, suffix: str) -> dict:
+    return {
+        "popup_id": str(popup_id),
+        "step_type": "patron",
+        "title": f"Patron Step {suffix}",
+        "template": "patron-preset",
+        "template_config": {
+            "presets": [2500, 5000, 7500],
+            "allow_custom": True,
+            "minimum": 1000,
+        },
+        "is_enabled": True,
+        "order": 3,
+    }
+
+
+def _create_isolated_popup(db, tenant_id: uuid.UUID) -> uuid.UUID:
+    """Insert a fresh popup and return its ID."""
+    popup_id = uuid.uuid4()
+    slug = f"step-singleton-test-{popup_id.hex[:8]}"
+    conn = db.connection()
+    conn.exec_driver_sql(
+        """
+        INSERT INTO popups (id, name, slug, tenant_id, sale_type, checkout_mode,
+                            status, currency, default_language, supported_languages,
+                            insurance_enabled, allows_scholarship, allows_incentive,
+                            requires_application_fee, events_enabled, application_layout)
+        VALUES (%s, %s, %s, %s, 'direct', 'pass_system',
+                'active', 'USD', 'en', '{en}', false,
+                false, false, false, true, 'single_page')
+        """,
+        (
+            str(popup_id),
+            f"Step Singleton Test {popup_id.hex[:8]}",
+            slug,
+            str(tenant_id),
+        ),
+    )
+    db.commit()
+    return popup_id
+
+
+def _cleanup_popup(db, popup_id: uuid.UUID) -> None:
+    conn = db.connection()
+    conn.exec_driver_sql(
+        "DELETE FROM ticketingsteps WHERE popup_id = %s", (str(popup_id),)
+    )
+    conn.exec_driver_sql("DELETE FROM popups WHERE id = %s", (str(popup_id),))
+    db.commit()
+
+
+class TestPatronStepSingleton:
+    """At most one enabled patron-preset ticketing step is allowed per popup."""
+
+    def test_first_patron_step_created_successfully(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        db,
+        tenant_a,
+    ) -> None:
+        """POST first patron-preset step for a popup returns 201."""
+        popup_id = _create_isolated_popup(db, tenant_a.id)
+        try:
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patron_step_payload(popup_id, suffix="first"),
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            _cleanup_popup(db, popup_id)
+
+    def test_second_patron_step_rejected_with_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        db,
+        tenant_a,
+    ) -> None:
+        """POST second patron-preset step for same popup returns 422."""
+        popup_id = _create_isolated_popup(db, tenant_a.id)
+        try:
+            # Create first — must succeed
+            resp1 = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patron_step_payload(popup_id, suffix="first"),
+            )
+            assert resp1.status_code == 201, resp1.text
+
+            # Create second — must fail
+            resp2 = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_admin_headers(admin_token_tenant_a),
+                json=_patron_step_payload(popup_id, suffix="second"),
+            )
+            assert resp2.status_code == 422, resp2.text
+            body = resp2.json()
+            detail = str(body.get("detail", "")).lower()
+            assert "patron" in detail or "step" in detail, (
+                f"Expected patron-step error message, got: {body}"
+            )
+        finally:
+            _cleanup_popup(db, popup_id)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -453,3 +453,43 @@ def popup_tenant_b_summer_fest(db: Session, tenant_b: Tenants) -> Popups:
 def with_origin(host: str) -> dict[str, str]:
     """Return a headers dict with an Origin pointing at the given host."""
     return {"Origin": f"https://{host}"}
+
+
+@pytest.fixture(autouse=True)
+def _scrub_patron_state(db: Session) -> Generator[None, None, None]:
+    """Reset patron singletons between tests.
+
+    Why: the partial unique indexes from `patron-product-rules` allow at most one
+    active patreon product and one enabled patron-preset ticketing step per popup.
+    The session-scoped `db` fixture means tests share a single SQLAlchemy session,
+    so a patron row created by one test would otherwise collide with the next test
+    that uses the same shared popup.
+    """
+    from datetime import UTC, datetime
+
+    from sqlalchemy import update
+
+    from app.api.product.models import Products
+    from app.api.ticketing_step.models import TicketingSteps
+
+    yield
+
+    try:
+        db.rollback()
+    except Exception:
+        pass
+
+    db.exec(
+        update(Products)
+        .where(Products.category == "patreon", Products.deleted_at.is_(None))
+        .values(deleted_at=datetime.now(UTC))
+    )
+    db.exec(
+        update(TicketingSteps)
+        .where(
+            TicketingSteps.template == "patron-preset",
+            TicketingSteps.is_enabled.is_(True),
+        )
+        .values(is_enabled=False)
+    )
+    db.commit()

--- a/backend/tests/core/test_invoice_patron.py
+++ b/backend/tests/core/test_invoice_patron.py
@@ -1,0 +1,168 @@
+"""Unit tests for invoice PDF line-item pricing with patron products.
+
+Spec: patron-product-rules — Phase 1.6
+Requirement: effective_unit_price takes precedence over product_price for
+patreon rows. Non-patreon rows use product_price unchanged.
+
+Strategy: patch `app.core.invoice._format_fiat_amount` to capture the
+unit_price argument passed in. This avoids PDF binary decoding and tests
+the logic directly.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+
+def _make_product_snapshot(
+    *,
+    product_name: str = "Test Item",
+    product_price: Decimal = Decimal("0"),
+    effective_unit_price: Decimal | None = None,
+    quantity: int = 1,
+    product_currency: str = "USD",
+) -> MagicMock:
+    pp = MagicMock()
+    pp.product_name = product_name
+    pp.product_price = product_price
+    pp.effective_unit_price = effective_unit_price
+    pp.quantity = quantity
+    pp.product_currency = product_currency
+    return pp
+
+
+def _make_payment(products_snapshot: list[MagicMock]) -> MagicMock:
+    payment = MagicMock()
+    payment.id = uuid.uuid4()
+    payment.external_id = "test-ext-001"
+    payment.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    payment.amount = Decimal("5000")
+    payment.insurance_amount = Decimal("0")
+    payment.currency = "USD"
+    payment.discount_value = None
+    payment.products_snapshot = products_snapshot
+    return payment
+
+
+class TestInvoicePatronUnitPrice:
+    """Patron line-items use effective_unit_price; non-patron use product_price."""
+
+    def test_patreon_row_uses_effective_unit_price(self) -> None:
+        """_format_fiat_amount is called with 5000.0 for a row with effective_unit_price=5000."""
+        from app.core.invoice import generate_invoice_pdf
+
+        pp = _make_product_snapshot(
+            product_name="Patron",
+            product_price=Decimal("0"),
+            effective_unit_price=Decimal("5000"),
+        )
+        payment = _make_payment([pp])
+
+        captured_unit_prices: list[float] = []
+
+        original_format = __import__(
+            "app.core.invoice", fromlist=["_format_fiat_amount"]
+        )._format_fiat_amount
+
+        def capturing_format(value: float, currency: str) -> str:
+            captured_unit_prices.append(value)
+            return original_format(value, currency)
+
+        with patch(
+            "app.core.invoice._format_fiat_amount", side_effect=capturing_format
+        ):
+            generate_invoice_pdf(
+                payment,
+                client_name="Test Client",
+                invoice_company_name="Test Co",
+                invoice_company_address="123 Main St",
+                invoice_company_email="test@example.com",
+            )
+
+        # _format_fiat_amount is called for: unit_price, line_total, subtotal, total, discount.
+        # The FIRST call is the unit_price column — must be 5000.0, not 0.0.
+        assert captured_unit_prices, "No _format_fiat_amount calls captured"
+        assert captured_unit_prices[0] == 5000.0, (
+            f"First call (unit price) must be 5000.0 (effective_unit_price). "
+            f"Got: {captured_unit_prices}"
+        )
+
+    def test_non_patreon_row_uses_product_price(self) -> None:
+        """_format_fiat_amount is called with 3000.0 for a ticket row with product_price=3000."""
+        from app.core.invoice import generate_invoice_pdf
+
+        pp = _make_product_snapshot(
+            product_name="General Admission",
+            product_price=Decimal("3000"),
+            effective_unit_price=None,
+        )
+        payment = _make_payment([pp])
+
+        captured_unit_prices: list[float] = []
+        original_format = __import__(
+            "app.core.invoice", fromlist=["_format_fiat_amount"]
+        )._format_fiat_amount
+
+        def capturing_format(value: float, currency: str) -> str:
+            captured_unit_prices.append(value)
+            return original_format(value, currency)
+
+        with patch(
+            "app.core.invoice._format_fiat_amount", side_effect=capturing_format
+        ):
+            generate_invoice_pdf(
+                payment,
+                client_name="Test Client",
+                invoice_company_name="Test Co",
+                invoice_company_address="123 Main St",
+                invoice_company_email="test@example.com",
+            )
+
+        assert 3000.0 in captured_unit_prices, (
+            f"Expected 3000.0 in format calls. Got: {captured_unit_prices}"
+        )
+
+    def test_zero_effective_unit_price_is_not_or_trap(self) -> None:
+        """effective_unit_price=0 must be used (not fall through to product_price).
+
+        A naive `effective_unit_price or product_price` would skip Decimal('0')
+        (falsy) and show product_price=999 instead. This locks the explicit
+        `is not None` contract.
+        """
+        from app.core.invoice import generate_invoice_pdf
+
+        pp = _make_product_snapshot(
+            product_name="Free Patron",
+            product_price=Decimal("999"),
+            effective_unit_price=Decimal("0"),
+        )
+        payment = _make_payment([pp])
+
+        captured_unit_prices: list[float] = []
+        original_format = __import__(
+            "app.core.invoice", fromlist=["_format_fiat_amount"]
+        )._format_fiat_amount
+
+        def capturing_format(value: float, currency: str) -> str:
+            captured_unit_prices.append(value)
+            return original_format(value, currency)
+
+        with patch(
+            "app.core.invoice._format_fiat_amount", side_effect=capturing_format
+        ):
+            generate_invoice_pdf(
+                payment,
+                client_name="Test Client",
+                invoice_company_name="Test Co",
+                invoice_company_address="123 Main St",
+                invoice_company_email="test@example.com",
+            )
+
+        # Must show 0.0 (effective_unit_price=0), NOT 999.0 (product_price)
+        assert 0.0 in captured_unit_prices, (
+            f"Expected 0.0 (effective_unit_price) in format calls. Got: {captured_unit_prices}"
+        )
+        assert 999.0 not in captured_unit_prices, (
+            f"product_price=999 must NOT appear. Got: {captured_unit_prices}"
+        )

--- a/backend/tests/migrations/test_patron_product_rules_migration.py
+++ b/backend/tests/migrations/test_patron_product_rules_migration.py
@@ -1,0 +1,104 @@
+"""Smoke tests for the fb7da98c8d72_patron_product_rules migration.
+
+These tests run against the shared session-scoped test DB (already at `head`
+after conftest.py ran `alembic upgrade head`). They assert the post-migration
+schema is exactly what the migration promises.
+"""
+
+from sqlmodel import Session
+
+
+class TestPatronProductRulesMigration:
+    """Schema assertions for the patron-product-rules migration."""
+
+    def test_effective_unit_price_column_exists_and_is_nullable(
+        self, db: Session
+    ) -> None:
+        """payment_products.effective_unit_price must exist and be nullable."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT column_name, is_nullable, data_type, numeric_precision, numeric_scale
+            FROM information_schema.columns
+            WHERE table_name = 'payment_products'
+              AND column_name = 'effective_unit_price'
+            """
+        ).fetchone()
+        assert row is not None, (
+            "Column 'effective_unit_price' not found on payment_products. "
+            "Run migration fb7da98c8d72 to create it."
+        )
+        assert row[1] == "YES", (
+            "effective_unit_price must be nullable (NULL for non-patreon rows)"
+        )
+        assert row[2] == "numeric", (
+            f"effective_unit_price must be NUMERIC type, got {row[2]}"
+        )
+
+    def test_patreon_product_unique_index_exists(self, db: Session) -> None:
+        """uq_product_patreon_per_popup partial unique index must exist on products."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT indexname
+            FROM pg_indexes
+            WHERE tablename = 'products'
+              AND indexname = 'uq_product_patreon_per_popup'
+            """
+        ).fetchone()
+        assert row is not None, (
+            "Index 'uq_product_patreon_per_popup' not found on products table. "
+            "Run migration fb7da98c8d72."
+        )
+
+    def test_patreon_product_unique_index_is_unique(self, db: Session) -> None:
+        """uq_product_patreon_per_popup must be a UNIQUE index."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT ix.indisunique
+            FROM pg_indexes pi
+            JOIN pg_class c ON c.relname = pi.indexname
+            JOIN pg_index ix ON ix.indexrelid = c.oid
+            WHERE pi.tablename = 'products'
+              AND pi.indexname = 'uq_product_patreon_per_popup'
+            """
+        ).fetchone()
+        assert row is not None, "uq_product_patreon_per_popup not found in pg_index"
+        assert row[0] is True, "uq_product_patreon_per_popup must be a unique index"
+
+    def test_patron_step_unique_index_exists(self, db: Session) -> None:
+        """uq_ticketing_step_patron_per_popup partial unique index must exist on ticketingsteps."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT indexname
+            FROM pg_indexes
+            WHERE tablename = 'ticketingsteps'
+              AND indexname = 'uq_ticketing_step_patron_per_popup'
+            """
+        ).fetchone()
+        assert row is not None, (
+            "Index 'uq_ticketing_step_patron_per_popup' not found on ticketingsteps. "
+            "Run migration fb7da98c8d72."
+        )
+
+    def test_patron_step_unique_index_is_unique(self, db: Session) -> None:
+        """uq_ticketing_step_patron_per_popup must be a UNIQUE index."""
+        conn = db.connection()
+        row = conn.exec_driver_sql(
+            """
+            SELECT ix.indisunique
+            FROM pg_indexes pi
+            JOIN pg_class c ON c.relname = pi.indexname
+            JOIN pg_index ix ON ix.indexrelid = c.oid
+            WHERE pi.tablename = 'ticketingsteps'
+              AND pi.indexname = 'uq_ticketing_step_patron_per_popup'
+            """
+        ).fetchone()
+        assert row is not None, (
+            "uq_ticketing_step_patron_per_popup not found in pg_index"
+        )
+        assert row[0] is True, (
+            "uq_ticketing_step_patron_per_popup must be a unique index"
+        )

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -9151,7 +9151,7 @@ export const PaymentCreateSchema = {
         },
         products: {
             items: {
-                '$ref': '#/components/schemas/PaymentProductRequest'
+                '$ref': '#/components/schemas/PaymentProductRequest-Input'
             },
             type: 'array',
             title: 'Products'
@@ -9196,7 +9196,7 @@ export const PaymentPreviewSchema = {
         },
         products: {
             items: {
-                '$ref': '#/components/schemas/PaymentProductRequest'
+                '$ref': '#/components/schemas/PaymentProductRequest-Output'
             },
             type: 'array',
             title: 'Products'
@@ -9319,7 +9319,7 @@ export const PaymentPreviewSchema = {
     description: 'Schema for payment preview (before creating).'
 } as const;
 
-export const PaymentProductRequestSchema = {
+export const PaymentProductRequest_InputSchema = {
     properties: {
         product_id: {
             type: 'string',
@@ -9335,6 +9335,57 @@ export const PaymentProductRequestSchema = {
             type: 'integer',
             title: 'Quantity',
             default: 1
+        },
+        unit_price_override: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Unit Price Override'
+        }
+    },
+    type: 'object',
+    required: ['product_id', 'attendee_id'],
+    title: 'PaymentProductRequest',
+    description: 'Product selection for payment.'
+} as const;
+
+export const PaymentProductRequest_OutputSchema = {
+    properties: {
+        product_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Product Id'
+        },
+        attendee_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Attendee Id'
+        },
+        quantity: {
+            type: 'integer',
+            title: 'Quantity',
+            default: 1
+        },
+        unit_price_override: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Unit Price Override'
         }
     },
     type: 'object',
@@ -9378,6 +9429,18 @@ export const PaymentProductResponseSchema = {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             title: 'Product Price'
+        },
+        effective_unit_price: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Effective Unit Price'
         },
         product_category: {
             type: 'string',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1882,7 +1882,7 @@ export type ParticipantStatus = 'registered' | 'checked_in' | 'cancelled';
 export type PaymentCreate = {
     application_id?: (string | null);
     popup_id?: (string | null);
-    products: Array<PaymentProductRequest>;
+    products: Array<PaymentProductRequest_Input>;
     coupon_code?: (string | null);
     edit_passes?: boolean;
     insurance?: boolean;
@@ -1893,7 +1893,7 @@ export type PaymentCreate = {
  */
 export type PaymentPreview = {
     application_id: string;
-    products: Array<PaymentProductRequest>;
+    products: Array<PaymentProductRequest_Output>;
     original_amount: string;
     amount: string;
     insurance_amount?: string;
@@ -1912,10 +1912,21 @@ export type PaymentPreview = {
 /**
  * Product selection for payment.
  */
-export type PaymentProductRequest = {
+export type PaymentProductRequest_Input = {
     product_id: string;
     attendee_id: string;
     quantity?: number;
+    unit_price_override?: (number | string | null);
+};
+
+/**
+ * Product selection for payment.
+ */
+export type PaymentProductRequest_Output = {
+    product_id: string;
+    attendee_id: string;
+    quantity?: number;
+    unit_price_override?: (string | null);
 };
 
 /**
@@ -1928,6 +1939,7 @@ export type PaymentProductResponse = {
     product_name: string;
     product_description?: (string | null);
     product_price: string;
+    effective_unit_price?: (string | null);
     product_category: string;
     product_currency: string;
     attendee_name?: (string | null);

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -9151,7 +9151,7 @@ export const PaymentCreateSchema = {
         },
         products: {
             items: {
-                '$ref': '#/components/schemas/PaymentProductRequest'
+                '$ref': '#/components/schemas/PaymentProductRequest-Input'
             },
             type: 'array',
             title: 'Products'
@@ -9196,7 +9196,7 @@ export const PaymentPreviewSchema = {
         },
         products: {
             items: {
-                '$ref': '#/components/schemas/PaymentProductRequest'
+                '$ref': '#/components/schemas/PaymentProductRequest-Output'
             },
             type: 'array',
             title: 'Products'
@@ -9319,7 +9319,7 @@ export const PaymentPreviewSchema = {
     description: 'Schema for payment preview (before creating).'
 } as const;
 
-export const PaymentProductRequestSchema = {
+export const PaymentProductRequest_InputSchema = {
     properties: {
         product_id: {
             type: 'string',
@@ -9335,6 +9335,57 @@ export const PaymentProductRequestSchema = {
             type: 'integer',
             title: 'Quantity',
             default: 1
+        },
+        unit_price_override: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Unit Price Override'
+        }
+    },
+    type: 'object',
+    required: ['product_id', 'attendee_id'],
+    title: 'PaymentProductRequest',
+    description: 'Product selection for payment.'
+} as const;
+
+export const PaymentProductRequest_OutputSchema = {
+    properties: {
+        product_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Product Id'
+        },
+        attendee_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Attendee Id'
+        },
+        quantity: {
+            type: 'integer',
+            title: 'Quantity',
+            default: 1
+        },
+        unit_price_override: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Unit Price Override'
         }
     },
     type: 'object',
@@ -9378,6 +9429,18 @@ export const PaymentProductResponseSchema = {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             title: 'Product Price'
+        },
+        effective_unit_price: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Effective Unit Price'
         },
         product_category: {
             type: 'string',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1882,7 +1882,7 @@ export type ParticipantStatus = 'registered' | 'checked_in' | 'cancelled';
 export type PaymentCreate = {
     application_id?: (string | null);
     popup_id?: (string | null);
-    products: Array<PaymentProductRequest>;
+    products: Array<PaymentProductRequest_Input>;
     coupon_code?: (string | null);
     edit_passes?: boolean;
     insurance?: boolean;
@@ -1893,7 +1893,7 @@ export type PaymentCreate = {
  */
 export type PaymentPreview = {
     application_id: string;
-    products: Array<PaymentProductRequest>;
+    products: Array<PaymentProductRequest_Output>;
     original_amount: string;
     amount: string;
     insurance_amount?: string;
@@ -1912,10 +1912,21 @@ export type PaymentPreview = {
 /**
  * Product selection for payment.
  */
-export type PaymentProductRequest = {
+export type PaymentProductRequest_Input = {
     product_id: string;
     attendee_id: string;
     quantity?: number;
+    unit_price_override?: (number | string | null);
+};
+
+/**
+ * Product selection for payment.
+ */
+export type PaymentProductRequest_Output = {
+    product_id: string;
+    attendee_id: string;
+    quantity?: number;
+    unit_price_override?: (string | null);
 };
 
 /**
@@ -1928,6 +1939,7 @@ export type PaymentProductResponse = {
     product_name: string;
     product_description?: (string | null);
     product_price: string;
+    effective_unit_price?: (string | null);
     product_category: string;
     product_currency: string;
     attendee_name?: (string | null);

--- a/portal/src/hooks/checkout/buildPaymentProducts.ts
+++ b/portal/src/hooks/checkout/buildPaymentProducts.ts
@@ -2,7 +2,7 @@ import {
   CHECKOUT_MODE,
   type CheckoutMode,
 } from "@/checkout/popupCheckoutPolicy"
-import type { PaymentProductRequest } from "@/client"
+import type { PaymentProductRequest_Input as PaymentProductRequest } from "@/client"
 import type { AttendeePassState } from "@/types/Attendee"
 import type {
   SelectedDynamicItem,


### PR DESCRIPTION
## Summary

PR 1 of 3 in the chained `patron-product-rules` change. Backend-only slice: migration, validators, snapshot column, regenerated OpenAPI clients.

Targets the integration branch `feat/patron-product-rules`; PR 2 (portal) and PR 3 (backoffice) will also merge there before the final integration → `dev` PR.

## What this PR does

- **Migration** `fb7da98c8d72_patron_product_rules.py`:
  - `payment_products.effective_unit_price NUMERIC(10,2) NULL` snapshot column
  - `uq_product_patreon_per_popup` partial unique index on `products`
  - `uq_ticketing_step_patron_per_popup` partial unique index on `ticketingsteps`
- **Product rules** (`schemas.py`, `crud.py`, `router.py`): patreon products must have `price=0`; only one active patreon product per popup
- **Ticketing-step rules** (`crud.py`, `router.py`): only one active `template=patron-preset` step per popup
- **Payment contract** (`schemas.py`, `crud.py`): new `unit_price_override: Decimal | None` on `PaymentProductRequest`. Required for patreon, rejected for others. Patreon quantity locked to 1. Backend resolves the popup's patron-preset `template_config` and validates the donated amount against `minimum`, `presets`, `allow_custom`. Snapshot stores `effective_unit_price`; `product_price` stays 0 for patreon rows.
- **Invoice PDF** (`invoice.py`): uses `effective_unit_price ?? product_price` for line-item unit price.
- **Regenerated OpenAPI clients** for portal and backoffice. `PaymentProductRequest` split into `_Input`/`_Output` due to `Decimal` serialization; `buildPaymentProducts.ts` aliases `_Input` to keep the portal building (full rewrite lands in PR 2).

## Decisions worth flagging for review

- Values in `template_config.presets`/`minimum` are **raw popup-currency units** (USD 1000 = $1000), no `/100` cents conversion anywhere.
- Patreon snapshot stores `product_price = 0`. The `effective_unit_price` field is the source of truth for the charged amount.
- `is not None` (not truthiness) for invoice fallback, so a hypothetical `0` value still routes through the patron path.
- No backward compat: there is no production Patron usage today.

## Test plan

- [x] Backend unit + integration tests for all four problem areas: 40/40 green (`tests/api/{product,payment,ticketing_step}/`, `tests/core/test_invoice_patron.py`, `tests/migrations/test_patron_product_rules_migration.py`)
- [x] `alembic heads` returns a single head (`fb7da98c8d72`)
- [x] `pnpm --filter portal run build` succeeds with the regenerated client
- [x] `pnpm --filter backoffice run build` succeeds
- [x] Ruff and ty pass on patron files (baseline diagnostics unchanged)

## Out of scope (PR 2 and PR 3)

- **PR 2 (portal)**: rewrite `VariantPatronPreset.tsx` (drop dead `price_mode` branch, write to `cart.patron`), update `buildPaymentProducts.ts` to send `unit_price_override`, delete `resolvePatronPriceMode.ts`.
- **PR 3 (backoffice)**: hide `price` field in `ProductForm` when `category=patreon`, guard the "add patreon product" action when one exists, prefer `effective_unit_price` in payments listing, remove `price_mode` from `PatronPresetConfig` interface.