### PR TITLE
feat(backoffice): hide patron price, prefer effective snapshot in payments (PR 3/3)

### DIFF
--- a/backoffice/src/components/forms/ProductForm.cross-field.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.cross-field.test.tsx
@@ -58,6 +58,7 @@ const mockGetPopup = vi.mocked(PopupsService.getPopup)
 const mockListProductCategories = vi.mocked(
   ProductsService.listProductCategories,
 )
+const mockListProducts = vi.mocked(ProductsService.listProducts)
 
 const POPUP_NO_TIER = {
   id: "popup-1",
@@ -88,6 +89,10 @@ describe("ProductForm — cross-field max_per_order vs total_stock_cap", () => {
     mockListProductCategories.mockResolvedValue(["ticket", "merch"] as Awaited<
       ReturnType<typeof ProductsService.listProductCategories>
     >)
+    mockListProducts.mockResolvedValue({
+      results: [],
+      paging: { total: 0 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
   })
 
   it("(a) shows cross-field error when max_per_order > total_stock_cap", async () => {

--- a/backoffice/src/components/forms/ProductForm.patreon.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.patreon.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Tests for ProductForm — patron-product-rules (Phase 3.1)
+ *
+ * Covers:
+ * - price Input NOT rendered when category=patreon
+ * - submit payload has price=0 when category=patreon
+ * - patreon category option disabled when popup already has active patreon product
+ * - price Input rendered and required when category=ticket
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/client", () => ({
+  ProductsService: {
+    listProductCategories: vi.fn(),
+    createProduct: vi.fn(),
+    updateProduct: vi.fn(),
+    deleteProduct: vi.fn(),
+    listProducts: vi.fn(),
+  },
+  PopupsService: {
+    getPopup: vi.fn(),
+  },
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({
+    selectedPopupId: "popup-1",
+    isContextReady: true,
+  }),
+}))
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ isAdmin: true, isOperatorOrAbove: true }),
+}))
+
+vi.mock("@/hooks/useCustomToast", () => ({
+  default: () => ({
+    showSuccessToast: vi.fn(),
+    showErrorToast: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/useUnsavedChanges", () => ({
+  useUnsavedChanges: () => ({ state: "unblocked" }),
+  UnsavedChangesDialog: () => null,
+}))
+
+import { PopupsService, ProductsService } from "@/client"
+import { ProductForm } from "./ProductForm"
+
+const mockGetPopup = vi.mocked(PopupsService.getPopup)
+const mockListProductCategories = vi.mocked(
+  ProductsService.listProductCategories,
+)
+const mockListProducts = vi.mocked(ProductsService.listProducts)
+const mockCreateProduct = vi.mocked(ProductsService.createProduct)
+
+const POPUP_BASE = {
+  id: "popup-1",
+  name: "Test Popup",
+  slug: "test-popup",
+  supported_languages: ["en"],
+  default_language: "en",
+}
+
+const PRODUCT_PATREON_BASE = {
+  id: "product-patron-1",
+  name: "Patron",
+  price: "0",
+  category: "patreon",
+  slug: "patron",
+  is_active: true,
+  exclusive: false,
+  popup_id: "popup-1",
+  insurance_eligible: false,
+  deleted_at: null,
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe("ProductForm — patron-product-rules (Phase 3.1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockListProductCategories.mockResolvedValue([
+      "ticket",
+      "housing",
+      "merch",
+      "patreon",
+    ] as Awaited<ReturnType<typeof ProductsService.listProductCategories>>)
+
+    mockGetPopup.mockResolvedValue(
+      POPUP_BASE as Awaited<ReturnType<typeof PopupsService.getPopup>>,
+    )
+
+    // Default: no existing patreon product
+    mockListProducts.mockResolvedValue({
+      results: [],
+      paging: { total: 0 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
+  })
+
+  it("renders price input for ticket category (default)", async () => {
+    render(<ProductForm onSuccess={vi.fn()} />, { wrapper: makeWrapper() })
+
+    await waitFor(() => screen.getByPlaceholderText(/product name/i), {
+      timeout: 3000,
+    })
+
+    expect(screen.getByPlaceholderText("100.00")).toBeDefined()
+  })
+
+  it("hides price input when category is changed to patreon", async () => {
+    const user = userEvent.setup()
+    render(<ProductForm onSuccess={vi.fn()} />, { wrapper: makeWrapper() })
+
+    await waitFor(() => screen.getByPlaceholderText(/product name/i), {
+      timeout: 3000,
+    })
+
+    // Price should be visible initially (ticket is default)
+    expect(screen.getByPlaceholderText("100.00")).toBeDefined()
+
+    // The category combobox is the first one in the form (before ticket options)
+    const categoryTrigger = screen.getAllByRole("combobox")[0]
+    await user.click(categoryTrigger)
+
+    const patreonOption = await screen.findByRole("option", {
+      name: /patreon/i,
+    })
+    await user.click(patreonOption)
+
+    // Price field must disappear
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("100.00")).toBeNull()
+    })
+  })
+
+  it("submit payload contains price=0 when category is patreon", async () => {
+    const user = userEvent.setup()
+
+    mockCreateProduct.mockResolvedValue({
+      id: "product-new",
+      name: "Patron Support",
+      price: "0",
+      category: "patreon",
+      slug: "patron-support",
+      is_active: true,
+      exclusive: false,
+      popup_id: "popup-1",
+      insurance_eligible: false,
+    } as Awaited<ReturnType<typeof ProductsService.createProduct>>)
+
+    render(<ProductForm onSuccess={vi.fn()} />, { wrapper: makeWrapper() })
+
+    await waitFor(() => screen.getByPlaceholderText(/product name/i), {
+      timeout: 3000,
+    })
+
+    // Fill name
+    await user.type(
+      screen.getByPlaceholderText(/product name/i),
+      "Patron Support",
+    )
+
+    // Switch to patreon — first combobox is the category selector
+    const categoryTrigger = screen.getAllByRole("combobox")[0]
+    await user.click(categoryTrigger)
+    const patreonOption = await screen.findByRole("option", {
+      name: /patreon/i,
+    })
+    await user.click(patreonOption)
+
+    // Price input should be gone — submit without entering price
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("100.00")).toBeNull()
+    })
+
+    await user.click(screen.getByRole("button", { name: /create product/i }))
+
+    await waitFor(() => {
+      expect(mockCreateProduct).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: expect.objectContaining({
+            price: "0",
+            category: "patreon",
+          }),
+        }),
+      )
+    })
+  })
+
+  it("disables patreon category option when popup already has an active patreon product", async () => {
+    // Popup already has a patreon product
+    mockListProducts.mockResolvedValue({
+      results: [PRODUCT_PATREON_BASE],
+      paging: { total: 1 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
+
+    render(<ProductForm onSuccess={vi.fn()} />, { wrapper: makeWrapper() })
+
+    await waitFor(() => screen.getByPlaceholderText(/product name/i), {
+      timeout: 3000,
+    })
+
+    // Open category select — first combobox is the category selector
+    const categoryTrigger = screen.getAllByRole("combobox")[0]
+    await userEvent.click(categoryTrigger)
+
+    // Patreon option should be present but disabled
+    const patreonOption = await screen.findByRole("option", {
+      name: /patreon/i,
+    })
+    expect(patreonOption).toBeDefined()
+    expect(patreonOption.getAttribute("aria-disabled")).toBe("true")
+  })
+
+  it("does NOT disable patreon option when editing an existing patreon product (own product)", async () => {
+    // Popup has a patreon product — but we're editing that same product
+    mockListProducts.mockResolvedValue({
+      results: [PRODUCT_PATREON_BASE],
+      paging: { total: 1 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
+
+    render(
+      <ProductForm
+        defaultValues={
+          PRODUCT_PATREON_BASE as Parameters<
+            typeof ProductForm
+          >[0]["defaultValues"]
+        }
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => screen.getByPlaceholderText(/product name/i), {
+      timeout: 3000,
+    })
+
+    // The patreon category option should NOT be disabled in edit mode
+    // First combobox is the category selector (in edit mode there may be only one)
+    const categoryTrigger = screen.getAllByRole("combobox")[0]
+    await userEvent.click(categoryTrigger)
+
+    const patreonOption = await screen.findByRole("option", {
+      name: /patreon/i,
+    })
+    expect(patreonOption.getAttribute("aria-disabled")).not.toBe("true")
+  })
+})

--- a/backoffice/src/components/forms/ProductForm.requires-check-in.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.requires-check-in.test.tsx
@@ -58,6 +58,7 @@ const mockGetPopup = vi.mocked(PopupsService.getPopup)
 const mockListProductCategories = vi.mocked(
   ProductsService.listProductCategories,
 )
+const mockListProducts = vi.mocked(ProductsService.listProducts)
 
 const POPUP_NO_TIER = {
   id: "popup-1",
@@ -97,6 +98,10 @@ describe("ProductForm — requires_check_in for all categories", () => {
       "merch",
       "housing",
     ] as Awaited<ReturnType<typeof ProductsService.listProductCategories>>)
+    mockListProducts.mockResolvedValue({
+      results: [],
+      paging: { total: 0 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
   })
 
   it("(a) renders Requires Check-in toggle for category=ticket (default)", async () => {

--- a/backoffice/src/components/forms/ProductForm.stock-fields.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.stock-fields.test.tsx
@@ -65,6 +65,7 @@ const mockListProductCategories = vi.mocked(
   ProductsService.listProductCategories,
 )
 const mockCreateProduct = vi.mocked(ProductsService.createProduct)
+const mockListProducts = vi.mocked(ProductsService.listProducts)
 
 const POPUP_NO_TIER = {
   id: "popup-1",
@@ -99,6 +100,11 @@ describe("ProductForm — two-field stock layout (6.5)", () => {
       "housing",
       "merch",
     ] as Awaited<ReturnType<typeof ProductsService.listProductCategories>>)
+
+    mockListProducts.mockResolvedValue({
+      results: [],
+      paging: { total: 0 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
 
     mockCreateProduct.mockResolvedValue({
       id: "product-new",

--- a/backoffice/src/components/forms/ProductForm.test.tsx
+++ b/backoffice/src/components/forms/ProductForm.test.tsx
@@ -61,6 +61,7 @@ const mockListProductCategories = vi.mocked(
   ProductsService.listProductCategories,
 )
 const mockCreateProduct = vi.mocked(ProductsService.createProduct)
+const mockListProducts = vi.mocked(ProductsService.listProducts)
 
 const POPUP_BASE = {
   id: "popup-1",
@@ -92,6 +93,11 @@ describe("ProductForm — ticket-as-first-class-entity (Phase 8.2)", () => {
       "housing",
       "merch",
     ] as Awaited<ReturnType<typeof ProductsService.listProductCategories>>)
+
+    mockListProducts.mockResolvedValue({
+      results: [],
+      paging: { total: 0 },
+    } as Awaited<ReturnType<typeof ProductsService.listProducts>>)
 
     mockGetPopup.mockResolvedValue(
       POPUP_BASE as Awaited<ReturnType<typeof PopupsService.getPopup>>,

--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -116,6 +116,21 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
     enabled: !!popupId,
   })
 
+  const { data: existingProducts } = useQuery({
+    queryKey: ["products", popupId, { page: 0, pageSize: 100 }],
+    queryFn: () =>
+      ProductsService.listProducts({ popupId: popupId!, limit: 100 }),
+    enabled: !!popupId,
+  })
+
+  const hasActivePatreonProduct = (existingProducts?.results ?? []).some(
+    (p) =>
+      p.category === "patreon" &&
+      p.is_active &&
+      // When editing: exclude the current product so the owner can still save
+      p.id !== defaultValues?.id,
+  )
+
   // Merge hardcoded defaults + API categories + locally added ones (deduplicated)
   const allCategories = useMemo(() => {
     const known = PRODUCT_CATEGORIES.map((c) => c.value)
@@ -191,7 +206,10 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
     onSubmit: ({ value }) => {
       if (readOnly) return
 
+      const isPatreon = value.category === "patreon"
       const isTicket = value.category === "ticket"
+      // Defense in depth: backend also enforces price=0 for patreon products
+      const effectivePrice = isPatreon ? "0" : value.price
 
       const totalStockCap = value.total_stock_cap
         ? Number.parseInt(value.total_stock_cap, 10)
@@ -203,7 +221,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
       if (isEdit) {
         updateMutation.mutate({
           name: value.name,
-          price: value.price,
+          price: effectivePrice,
           description: value.description || null,
           image_url: value.image_url || null,
           category: value.category,
@@ -227,7 +245,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
         createMutation.mutate({
           popup_id: selectedPopupId,
           name: value.name,
-          price: value.price,
+          price: effectivePrice,
           description: value.description || undefined,
           image_url: value.image_url || undefined,
           category: value.category,
@@ -315,8 +333,19 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
                       const known = PRODUCT_CATEGORIES.find(
                         (c) => c.value === cat,
                       )
+                      const isDisabled =
+                        cat === "patreon" && hasActivePatreonProduct
                       return (
-                        <SelectItem key={cat} value={cat}>
+                        <SelectItem
+                          key={cat}
+                          value={cat}
+                          disabled={isDisabled}
+                          title={
+                            isDisabled
+                              ? "This popup already has a Patron product"
+                              : undefined
+                          }
+                        >
                           {known?.label ?? cat}
                         </SelectItem>
                       )
@@ -385,36 +414,42 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
 
         {/* Pricing & Inventory */}
         <InlineSection title="Pricing & Inventory">
-          <form.Field
-            name="price"
-            validators={{
-              onBlur: ({ value }) =>
-                !readOnly && !value ? "Price is required" : undefined,
-            }}
-          >
-            {(field) => (
-              <div>
-                <InlineRow
-                  icon={
-                    <DollarSign className="h-4 w-4 text-muted-foreground" />
-                  }
-                  label="Price"
+          <form.Subscribe selector={(state) => state.values.category}>
+            {(category) =>
+              category !== "patreon" && (
+                <form.Field
+                  name="price"
+                  validators={{
+                    onBlur: ({ value }) =>
+                      !readOnly && !value ? "Price is required" : undefined,
+                  }}
                 >
-                  <Input
-                    placeholder="100.00"
-                    type="text"
-                    inputMode="decimal"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    disabled={readOnly}
-                    className="max-w-32 text-sm"
-                  />
-                </InlineRow>
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
+                  {(field) => (
+                    <div>
+                      <InlineRow
+                        icon={
+                          <DollarSign className="h-4 w-4 text-muted-foreground" />
+                        }
+                        label="Price"
+                      >
+                        <Input
+                          placeholder="100.00"
+                          type="text"
+                          inputMode="decimal"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          disabled={readOnly}
+                          className="max-w-32 text-sm"
+                        />
+                      </InlineRow>
+                      <FieldError errors={field.state.meta.errors} />
+                    </div>
+                  )}
+                </form.Field>
+              )
+            }
+          </form.Subscribe>
 
           <form.Field
             name="total_stock_cap"

--- a/backoffice/src/routes/_layout/payments.helpers.test.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildPaymentsQueryConfig,
   buildPaymentsTableState,
+  resolveLineUnitPrice,
 } from "./payments.helpers"
 
 describe("payments.helpers", () => {
@@ -38,6 +39,59 @@ describe("payments.helpers", () => {
         sortOrder: "asc",
       },
     ])
+  })
+
+  it("resolveLineUnitPrice: patron row uses effective_unit_price", () => {
+    expect(
+      resolveLineUnitPrice({
+        effective_unit_price: "5000",
+        product_price: "0",
+      }),
+    ).toBe(5000)
+  })
+
+  it("resolveLineUnitPrice: non-patron row uses product_price when effective_unit_price is null", () => {
+    expect(
+      resolveLineUnitPrice({
+        effective_unit_price: null,
+        product_price: "3000",
+      }),
+    ).toBe(3000)
+  })
+
+  it("resolveLineUnitPrice: non-patron row uses product_price when effective_unit_price is undefined", () => {
+    expect(
+      resolveLineUnitPrice({
+        effective_unit_price: undefined,
+        product_price: "2500",
+      }),
+    ).toBe(2500)
+  })
+
+  it("resolveLineUnitPrice: honours 0-value effective_unit_price (nullish coalescing, not truthy)", () => {
+    // effective_unit_price=0 is a valid (if unusual) value — must NOT fall through to product_price
+    expect(
+      resolveLineUnitPrice({
+        effective_unit_price: "0",
+        product_price: "3000",
+      }),
+    ).toBe(0)
+  })
+
+  it("resolveLineUnitPrice: patron line total = unit_price * quantity", () => {
+    const unitPrice = resolveLineUnitPrice({
+      effective_unit_price: "5000",
+      product_price: "0",
+    })
+    expect(unitPrice * 1).toBe(5000)
+  })
+
+  it("resolveLineUnitPrice: non-patron line total = product_price * quantity", () => {
+    const unitPrice = resolveLineUnitPrice({
+      effective_unit_price: null,
+      product_price: "3000",
+    })
+    expect(unitPrice * 2).toBe(6000)
   })
 
   it("uses server totals and preserves server rows without local filtering", () => {

--- a/backoffice/src/routes/_layout/payments.helpers.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.ts
@@ -1,4 +1,4 @@
-import type { PaymentStatus } from "@/client"
+import type { PaymentProductResponse, PaymentStatus } from "@/client"
 
 interface PaymentsQueryInput {
   popupId: string | null
@@ -63,6 +63,19 @@ export function buildPaymentsQueryConfig({
       },
     ],
   }
+}
+
+/**
+ * Returns the effective unit price for a payment line item.
+ * Patron lines carry a non-null effective_unit_price (the donor-chosen amount).
+ * Non-patron lines carry null and fall back to the catalogued product_price.
+ * Uses nullish coalescing so that a legitimate 0-value effective_unit_price
+ * is honoured rather than falling through to product_price.
+ */
+export function resolveLineUnitPrice(
+  item: Pick<PaymentProductResponse, "effective_unit_price" | "product_price">,
+): number {
+  return Number(item.effective_unit_price ?? item.product_price)
 }
 
 export function buildPaymentsTableState<TPayment>({

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -46,6 +46,7 @@ import { exportToCsv, fetchAllPages } from "@/lib/export"
 import {
   buildPaymentsQueryConfig,
   buildPaymentsTableState,
+  resolveLineUnitPrice,
 } from "./payments.helpers"
 
 function getPaymentsQueryOptions(
@@ -391,7 +392,7 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
 
   const entries = Object.entries(byAttendee)
   const subtotal = products.reduce(
-    (sum, p) => sum + Number(p.product_price) * p.quantity,
+    (sum, p) => sum + resolveLineUnitPrice(p) * p.quantity,
     0,
   )
   const total = Number(payment.amount)
@@ -431,7 +432,8 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
                 </td>
               </tr>
               {items.map((item, i) => {
-                const lineTotal = Number(item.product_price) * item.quantity
+                const unitPrice = resolveLineUnitPrice(item)
+                const lineTotal = unitPrice * item.quantity
                 return (
                   <tr
                     key={`${attendeeId}-${item.product_name}-${i}`}
@@ -446,7 +448,7 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
                       {item.quantity}
                     </td>
                     <td className="py-1.5 text-right font-mono tabular-nums text-muted-foreground">
-                      ${Number(item.product_price)}
+                      ${unitPrice}
                     </td>
                     <td className="py-1.5 pl-4 text-right font-mono tabular-nums">
                       ${lineTotal}

--- a/backoffice/src/test-setup.ts
+++ b/backoffice/src/test-setup.ts
@@ -14,6 +14,11 @@ if (typeof Element !== "undefined" && !Element.prototype.hasPointerCapture) {
   Element.prototype.releasePointerCapture = () => {}
 }
 
+// Polyfill scrollIntoView (not in jsdom — Radix Select calls it on scroll-to-active-item)
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}
+
 // Polyfill matchMedia (not in jsdom)
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
## Summary

PR 3 of 3 in the chained \`patron-product-rules\` change. Backoffice updates that complement PR 1 (backend) and PR 2 (portal).

Targets the integration branch \`feat/patron-product-rules\`. After this merges, the final PR will roll integration → \`dev\`.

## What this PR does

- **\`ProductForm.tsx\`**: hides the \`price\` Input entirely when \`category=patreon\` (the price field had become a semantic overload for "minimum amount" and lives in \`ticketing_steps.template_config\` now). Forces \`price=0\` in the submitted payload as defense in depth. Disables the patreon category option in the dropdown when the popup already has an active patreon product (edit mode for an existing patreon product is unaffected).
- **\`payments.tsx\`**: introduces a \`resolveLineUnitPrice()\` helper (\`payments.helpers.ts\`) that returns \`effective_unit_price ?? product_price\` (nullish coalescing, never truthiness). Used for subtotal accumulation, the unit-price cell, and line-total cell in the expansion panel. Patron rows now render the actual donation amount instead of the configured floor.
- **\`PatronPresetConfig.tsx\`**: confirmed no \`price_mode\` field present in the local interface (the dead-code cleanup was already done elsewhere). No change needed.

## Test plan

- [x] 70/70 vitest tests pass (14 test files)
- [x] 5 new tests in \`ProductForm.patreon.test.tsx\` covering price hidden / category-option-disabled behaviour
- [x] 6 new tests in \`payments.helpers.test.ts\` covering \`resolveLineUnitPrice\` nullish-coalescing semantics
- [x] \`pnpm --filter backoffice run build\` succeeds
- [x] Biome lint clean

## Notes for review

- The "active patreon" guard in \`ProductForm\` uses \`p.is_active\` to detect existing patreon products. The backend's partial unique index (\`category='patreon' AND deleted_at IS NULL\`) remains the authoritative guard; this is a UX hint only.
- \`resolveLineUnitPrice\` returns \`Number(effective_unit_price ?? product_price)\` — both fields are string-typed in the regenerated client; \`Number("5000") = 5000\` (no cents conversion, matching the raw popup-currency unit convention).