### PR TITLE
release: compare-at price + ticketing picker disambiguation

### DIFF
--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -188,6 +188,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
     defaultValues: {
       name: defaultValues?.name ?? "",
       price: defaultValues?.price?.toString() ?? "",
+      compare_price: defaultValues?.compare_price?.toString() ?? "",
       description: defaultValues?.description ?? "",
       image_url: defaultValues?.image_url ?? "",
       category: (defaultValues?.category ?? "ticket") as ProductCategory,
@@ -210,6 +211,8 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
       const isTicket = value.category === "ticket"
       // Defense in depth: backend also enforces price=0 for patreon products
       const effectivePrice = isPatreon ? "0" : value.price
+      const effectiveComparePrice =
+        isPatreon || !value.compare_price ? null : value.compare_price
 
       const totalStockCap = value.total_stock_cap
         ? Number.parseInt(value.total_stock_cap, 10)
@@ -222,6 +225,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
         updateMutation.mutate({
           name: value.name,
           price: effectivePrice,
+          compare_price: effectiveComparePrice,
           description: value.description || null,
           image_url: value.image_url || null,
           category: value.category,
@@ -246,6 +250,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
           popup_id: selectedPopupId,
           name: value.name,
           price: effectivePrice,
+          compare_price: effectiveComparePrice ?? undefined,
           description: value.description || undefined,
           image_url: value.image_url || undefined,
           category: value.category,
@@ -417,36 +422,83 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
           <form.Subscribe selector={(state) => state.values.category}>
             {(category) =>
               category !== "patreon" && (
-                <form.Field
-                  name="price"
-                  validators={{
-                    onBlur: ({ value }) =>
-                      !readOnly && !value ? "Price is required" : undefined,
-                  }}
-                >
-                  {(field) => (
-                    <div>
-                      <InlineRow
-                        icon={
-                          <DollarSign className="h-4 w-4 text-muted-foreground" />
+                <>
+                  <form.Field
+                    name="price"
+                    validators={{
+                      onBlur: ({ value }) =>
+                        !readOnly && !value ? "Price is required" : undefined,
+                    }}
+                  >
+                    {(field) => (
+                      <div>
+                        <InlineRow
+                          icon={
+                            <DollarSign className="h-4 w-4 text-muted-foreground" />
+                          }
+                          label="Price"
+                        >
+                          <Input
+                            placeholder="100.00"
+                            type="text"
+                            inputMode="decimal"
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            disabled={readOnly}
+                            className="max-w-32 text-sm"
+                          />
+                        </InlineRow>
+                        <FieldError errors={field.state.meta.errors} />
+                      </div>
+                    )}
+                  </form.Field>
+
+                  <form.Field
+                    name="compare_price"
+                    validators={{
+                      onBlur: ({ value, fieldApi }) => {
+                        if (readOnly || !value) return undefined
+                        const num = Number(value)
+                        if (Number.isNaN(num) || num < 0) {
+                          return "Compare-at price must be a positive number."
                         }
-                        label="Price"
-                      >
-                        <Input
-                          placeholder="100.00"
-                          type="text"
-                          inputMode="decimal"
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
-                          onChange={(e) => field.handleChange(e.target.value)}
-                          disabled={readOnly}
-                          className="max-w-32 text-sm"
-                        />
-                      </InlineRow>
-                      <FieldError errors={field.state.meta.errors} />
-                    </div>
-                  )}
-                </form.Field>
+                        const rawPrice = fieldApi.form.getFieldValue("price")
+                        if (rawPrice) {
+                          const price = Number(rawPrice)
+                          if (!Number.isNaN(price) && num <= price) {
+                            return "Compare-at price must be higher than price."
+                          }
+                        }
+                        return undefined
+                      },
+                    }}
+                  >
+                    {(field) => (
+                      <div>
+                        <InlineRow
+                          icon={
+                            <DollarSign className="h-4 w-4 text-muted-foreground" />
+                          }
+                          label="Compare-at price"
+                          description="Crossed-out original price shown next to the current price. Leave empty for no discount."
+                        >
+                          <Input
+                            placeholder="120.00"
+                            type="text"
+                            inputMode="decimal"
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            disabled={readOnly}
+                            className="max-w-32 text-sm"
+                          />
+                        </InlineRow>
+                        <FieldError errors={field.state.meta.errors} />
+                      </div>
+                    )}
+                  </form.Field>
+                </>
               )
             }
           </form.Subscribe>

--- a/backoffice/src/components/ticketing-step-builder/template-configs/HousingDateConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/HousingDateConfig.tsx
@@ -170,6 +170,9 @@ export function HousingDateConfig({
   const products = (productsData?.results ?? []).map((p) => ({
     id: p.id,
     name: p.name,
+    price: p.price,
+    slug: p.slug,
+    is_active: p.is_active,
   }))
 
   const sensors = useSensors(

--- a/backoffice/src/components/ticketing-step-builder/template-configs/SortableSectionCard.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/SortableSectionCard.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
 
 export interface ProductSection {
   key: string
@@ -43,11 +44,19 @@ interface AttendeeCategoryOption {
   label: string
 }
 
+export interface SectionProduct {
+  id: string
+  name: string
+  price?: string
+  slug?: string
+  is_active?: boolean
+}
+
 interface SortableSectionCardProps {
   section: ProductSection
   onUpdate: (key: string, updates: Partial<ProductSection>) => void
   onDelete: (key: string) => void
-  products: Array<{ id: string; name: string }>
+  products: SectionProduct[]
   assignLabel?: string
   showMediaFields?: boolean
   showAttendeeCategories?: boolean
@@ -81,7 +90,7 @@ export function SortableSectionCard({
 
   const assignedProducts = section.product_ids
     .map((id) => products.find((p) => p.id === id))
-    .filter(Boolean) as Array<{ id: string; name: string }>
+    .filter(Boolean) as SectionProduct[]
 
   const availableProducts = products.filter(
     (p) => !section.product_ids.includes(p.id),
@@ -212,28 +221,47 @@ export function SortableSectionCard({
           <Separator />
           <div className="px-3 py-2">
             <div className="flex flex-col gap-1">
-              {assignedProducts.map((p) => (
-                <div
-                  key={p.id}
-                  className="flex items-center gap-2 text-xs text-muted-foreground py-0.5"
-                >
-                  <Package className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{p.name}</span>
-                  <button
-                    type="button"
-                    className="ml-auto shrink-0 hover:text-destructive"
-                    onClick={() =>
-                      onUpdate(section.key, {
-                        product_ids: section.product_ids.filter(
-                          (id) => id !== p.id,
-                        ),
-                      })
-                    }
+              {assignedProducts.map((p) => {
+                const inactive = p.is_active === false
+                return (
+                  <div
+                    key={p.id}
+                    className={cn(
+                      "flex items-center gap-2 text-xs text-muted-foreground py-0.5",
+                      inactive && "opacity-50",
+                    )}
                   >
-                    <X className="h-3 w-3" />
-                  </button>
-                </div>
-              ))}
+                    <Package className="h-3 w-3 shrink-0" />
+                    <span className="truncate">{p.name}</span>
+                    {inactive && (
+                      <span className="shrink-0 rounded border px-1 py-px text-[10px] uppercase tracking-wide">
+                        Inactive
+                      </span>
+                    )}
+                    {p.price != null && (
+                      <span className="ml-auto shrink-0 font-mono tabular-nums">
+                        ${p.price}
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      className={cn(
+                        "shrink-0 hover:text-destructive",
+                        p.price == null && "ml-auto",
+                      )}
+                      onClick={() =>
+                        onUpdate(section.key, {
+                          product_ids: section.product_ids.filter(
+                            (id) => id !== p.id,
+                          ),
+                        })
+                      }
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                )
+              })}
             </div>
           </div>
         </>
@@ -243,22 +271,47 @@ export function SortableSectionCard({
         <div className="px-3 pb-2">
           {showProductPicker ? (
             <div className="flex flex-col gap-1 rounded border p-2 bg-muted/30">
-              {availableProducts.map((p) => (
-                <button
-                  key={p.id}
-                  type="button"
-                  className="flex items-center gap-2 text-xs text-left py-1 px-1 rounded hover:bg-accent"
-                  onClick={() => {
-                    onUpdate(section.key, {
-                      product_ids: [...section.product_ids, p.id],
-                    })
-                    setShowProductPicker(false)
-                  }}
-                >
-                  <Package className="h-3 w-3 shrink-0 text-muted-foreground" />
-                  <span className="truncate">{p.name}</span>
-                </button>
-              ))}
+              {availableProducts.map((p) => {
+                const inactive = p.is_active === false
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    className={cn(
+                      "flex items-center gap-2 text-xs text-left py-1 px-1 rounded hover:bg-accent",
+                      inactive && "opacity-50",
+                    )}
+                    onClick={() => {
+                      onUpdate(section.key, {
+                        product_ids: [...section.product_ids, p.id],
+                      })
+                      setShowProductPicker(false)
+                    }}
+                  >
+                    <Package className="h-3 w-3 shrink-0 text-muted-foreground" />
+                    <div className="flex-1 min-w-0 flex flex-col">
+                      <div className="flex items-center gap-1.5">
+                        <span className="truncate">{p.name}</span>
+                        {inactive && (
+                          <span className="shrink-0 rounded border px-1 py-px text-[10px] uppercase tracking-wide text-muted-foreground">
+                            Inactive
+                          </span>
+                        )}
+                      </div>
+                      {p.slug && (
+                        <span className="truncate font-mono text-[10px] text-muted-foreground/70">
+                          {p.slug}
+                        </span>
+                      )}
+                    </div>
+                    {p.price != null && (
+                      <span className="shrink-0 font-mono tabular-nums text-muted-foreground">
+                        ${p.price}
+                      </span>
+                    )}
+                  </button>
+                )
+              })}
               <Button
                 variant="ghost"
                 size="sm"

--- a/backoffice/src/components/ticketing-step-builder/template-configs/TicketSelectConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/TicketSelectConfig.tsx
@@ -165,6 +165,9 @@ export function TicketSelectConfig({
   const products = productsResults.map((p) => ({
     id: p.id,
     name: p.name,
+    price: p.price,
+    slug: p.slug,
+    is_active: p.is_active,
   }))
 
   const categoriesResults = Array.isArray(categoriesData?.results)


### PR DESCRIPTION
## Highlights

### Compare-at price on products
- Optional `compare_price` on `ProductForm` to render a crossed-out original price next to the current price.
- Validation: positive number, must be greater than `price`. Forced to `null` for patreon products (where `price=0`).

### Ticketing section product picker disambiguation
- Products with identical names (eg. main vs spouse pricing tiers) were indistinguishable in the section product list of ticketing steps.
- Each row now shows the price inline (font-mono tabular-nums).
- Picker rows also show the slug as a subline for the rare case of matching name + price.
- Inactive products are dimmed with an `Inactive` chip.
- Applies to both `TicketSelectConfig` and `HousingDateConfig`.

## Migrations included

None.

## Test plan

- [ ] `pnpm --filter backoffice lint` passes.
- [ ] Manual: open a ticketing step, add a section, verify price/slug/inactive render correctly in the picker.
- [ ] Manual: edit a product, set a compare-at price, verify validation (positive, greater than price) and that saving without it works.