### PR TITLE
fix(portal): support dynamic checkout ticket payments

### DIFF
--- a/portal/src/checkout/buildPaymentProducts.test.ts
+++ b/portal/src/checkout/buildPaymentProducts.test.ts
@@ -139,6 +139,41 @@ describe("buildPaymentProducts", () => {
       },
     ])
   })
+
+  it("assigns dynamic checkout items to the attendee when no pass item exists", () => {
+    const attendeePasses = [createAttendee([])]
+    const dynamicProduct = createProduct({ id: "general-admission" })
+
+    const result = buildPaymentProducts({
+      attendeePasses,
+      selectedPasses: [],
+      housing: null,
+      merch: [],
+      patron: null,
+      dynamicItems: {
+        tickets: [
+          {
+            productId: dynamicProduct.id,
+            product: dynamicProduct,
+            quantity: 1,
+            price: dynamicProduct.price,
+            stepType: "tickets",
+          },
+        ],
+      },
+      isEditing: false,
+      appCredit: 0,
+      checkoutMode: CHECKOUT_MODE.SIMPLE_QUANTITY,
+    })
+
+    expect(result.products).toEqual([
+      {
+        product_id: "general-admission",
+        attendee_id: "attendee-1",
+        quantity: 1,
+      },
+    ])
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -2,6 +2,7 @@
 
 import { Building2, Calendar, Check, Home } from "lucide-react"
 import Image from "next/image"
+import type { KeyboardEvent } from "react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
@@ -76,6 +77,13 @@ function formatDateInput(date: Date): string {
 function parseDate(dateStr: string): Date {
   const ymd = dateStr.split("T")[0]
   return new Date(`${ymd}T00:00:00`)
+}
+
+function handleCardKeyDown(event: KeyboardEvent, onSelect: () => void) {
+  if (event.target !== event.currentTarget) return
+  if (event.key !== "Enter" && event.key !== " ") return
+  event.preventDefault()
+  onSelect()
 }
 
 /* ── Shared date picker section ───────────────────────────── */
@@ -232,8 +240,10 @@ function CompactCard({
   const maxQty = resolveMaxQuantity(product)
 
   return (
-    <button
-      type="button"
+    // biome-ignore lint/a11y/useSemanticElements: cannot use a button because quantity controls inside the card are also buttons.
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => {
         if (supportsQty && quantity === 0) {
           onIncrement()
@@ -241,8 +251,17 @@ function CompactCard({
           onSelect()
         }
       }}
+      onKeyDown={(event) =>
+        handleCardKeyDown(event, () => {
+          if (supportsQty && quantity === 0) {
+            onIncrement()
+          } else {
+            onSelect()
+          }
+        })
+      }
       className={cn(
-        "w-full flex items-center gap-3 rounded-xl border-l-4 px-3 py-3 text-left transition-all",
+        "w-full flex items-center gap-3 rounded-xl border-l-4 px-3 py-3 text-left transition-all cursor-pointer",
         isSelected
           ? "border-l-primary bg-primary/10"
           : "border-l-border bg-checkout-card-bg hover:bg-muted",
@@ -314,7 +333,7 @@ function CompactCard({
           {formatCurrency(totalPrice)}
         </p>
       </div>
-    </button>
+    </div>
   )
 }
 
@@ -349,8 +368,10 @@ function GridCard({
   const maxQty = resolveMaxQuantity(product)
 
   return (
-    <button
-      type="button"
+    // biome-ignore lint/a11y/useSemanticElements: cannot use a button because quantity controls inside the card are also buttons.
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => {
         if (supportsQty && quantity === 0) {
           onIncrement()
@@ -358,8 +379,17 @@ function GridCard({
           onSelect()
         }
       }}
+      onKeyDown={(event) =>
+        handleCardKeyDown(event, () => {
+          if (supportsQty && quantity === 0) {
+            onIncrement()
+          } else {
+            onSelect()
+          }
+        })
+      }
       className={cn(
-        "relative flex flex-col rounded-2xl border overflow-hidden text-left transition-all bg-checkout-card-bg",
+        "relative flex flex-col rounded-2xl border overflow-hidden text-left transition-all bg-checkout-card-bg cursor-pointer",
         isSelected
           ? "border-primary ring-2 ring-primary/20"
           : "border-border hover:border-muted-foreground/30",
@@ -447,7 +477,7 @@ function GridCard({
           </span>
         </div>
       </div>
-    </button>
+    </div>
   )
 }
 
@@ -526,9 +556,11 @@ function DefaultSectionCard({
           const quantity = getQuantity(product.id)
 
           return (
-            <button
+            // biome-ignore lint/a11y/useSemanticElements: cannot use a button because quantity controls inside the card are also buttons.
+            <div
               key={product.id}
-              type="button"
+              role="button"
+              tabIndex={0}
               onClick={() => {
                 if (supportsQty && quantity === 0) {
                   onIncrement(product.id)
@@ -536,8 +568,17 @@ function DefaultSectionCard({
                   onProductSelect(product.id)
                 }
               }}
+              onKeyDown={(event) =>
+                handleCardKeyDown(event, () => {
+                  if (supportsQty && quantity === 0) {
+                    onIncrement(product.id)
+                  } else {
+                    onProductSelect(product.id)
+                  }
+                })
+              }
               className={cn(
-                "w-full flex items-center justify-between p-3 rounded-xl border-2 transition-all text-left",
+                "w-full flex items-center justify-between p-3 rounded-xl border-2 transition-all text-left cursor-pointer",
                 isSelected
                   ? "border-primary bg-primary/10"
                   : "border-border bg-muted hover:border-muted-foreground/30",
@@ -596,7 +637,7 @@ function DefaultSectionCard({
                   {formatCurrency(totalPrice)}
                 </p>
               </div>
-            </button>
+            </div>
           )
         })}
       </div>

--- a/portal/src/hooks/checkout/buildPaymentProducts.ts
+++ b/portal/src/hooks/checkout/buildPaymentProducts.ts
@@ -81,6 +81,7 @@ export function buildPaymentProducts({
     checkoutMode === CHECKOUT_MODE.PASS_SYSTEM &&
     detectMonthUpgrade(attendeePasses)
   const products: PaymentProductRequest[] = []
+  const fallbackAttendeeId = attendeePasses[0]?.id ?? ""
 
   if (isEditing) {
     // Editing mode: send kept + new products
@@ -109,6 +110,7 @@ export function buildPaymentProducts({
     }
   } else {
     const hasAccountCredit = appCredit ? Number(appCredit) > 0 : false
+    const firstAttendeeId = selectedPasses[0]?.attendeeId ?? fallbackAttendeeId
 
     // When there's account credit or month upgrade, include purchased products
     // so the backend can recalculate totals with credits applied
@@ -152,7 +154,6 @@ export function buildPaymentProducts({
 
     // Add merch
     for (const item of merch) {
-      const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
       products.push({
         product_id: item.productId,
         attendee_id: firstAttendeeId,
@@ -162,7 +163,6 @@ export function buildPaymentProducts({
 
     // Add housing
     if (housing) {
-      const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
       const baseQty = housing.pricePerDay ? housing.nights : 1
       products.push({
         product_id: housing.productId,
@@ -173,7 +173,6 @@ export function buildPaymentProducts({
 
     // Add patron
     if (patron) {
-      const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
       products.push({
         product_id: patron.productId,
         attendee_id: firstAttendeeId,
@@ -183,7 +182,6 @@ export function buildPaymentProducts({
     }
 
     // Add dynamic step items
-    const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
     for (const items of Object.values(dynamicItems)) {
       for (const item of items) {
         if (item.quantity > 0) {

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -100,7 +100,17 @@ export function usePaymentSubmit({
       return { success: false, error: "Buyer information not available" }
     }
 
-    if (selectedPasses.length === 0) {
+    const hasDynamicItems = Object.values(dynamicItems).some((items) =>
+      items.some((item) => item.quantity > 0),
+    )
+    const hasCheckoutItems =
+      selectedPasses.length > 0 ||
+      !!housing ||
+      merch.length > 0 ||
+      !!patron ||
+      hasDynamicItems
+
+    if (!hasCheckoutItems) {
       return {
         success: false,
         error: isEditing

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -149,7 +149,7 @@ export function CheckoutProvider({
   const { attendeePasses, toggleProduct, isEditing, toggleEditing } =
     usePassesProvider()
   const { discountApplied, setDiscount, resetDiscount } = useDiscount()
-  const { getRelevantApplication } = useApplication()
+  const { getRelevantApplication, participation } = useApplication()
   const { getCity } = useCityProvider()
   const { products: queriedProducts, loading: isLoadingProducts } =
     useGetPassesData()
@@ -697,9 +697,14 @@ export function CheckoutProvider({
     setDynamicItems({})
   }, [clearPersistedCart, clearHousing, setMerch, clearPatron, clearPromoCode])
 
+  const participationApplicationId =
+    participation?.type === "applicant"
+      ? participation.application_id
+      : undefined
+
   // Submit payment (consolidated via usePaymentSubmit)
   const { submitPayment, isSubmitting } = usePaymentSubmit({
-    applicationId: application?.id,
+    applicationId: application?.id ?? participationApplicationId,
     popupId: cityId,
     popupSlug: submitPopupSlug,
     appCredit,


### PR DESCRIPTION
## Summary
- Allow checkout payment submission when configured ticket steps store selections as dynamic items instead of selected passes.
- Assign dynamic checkout items to the first attendee when no selected pass exists, matching the Tech Summit ticket-step flow.
- Fix nested housing quantity controls to avoid invalid button nesting and hydration warnings.

## Verification
- pnpm --filter portal lint
- pnpm --filter portal test src/checkout/buildPaymentProducts.test.ts src/hooks/checkout/usePaymentVerification.test.tsx src/components/checkout-flow/ScrollyCheckoutFlow.test.tsx src/app/checkout/components/CheckoutFlow.test.tsx
- pnpm --filter portal build
- Browser smoke: fran@example.com General Admission checkout redirects to SimpleFI

## Notes
- Full portal test suite still has pre-existing failures in VariantTicketSelect attendee-category filtering tests unrelated to this change.