### PR TITLE
fix(portal): popup image fallback on /profile

### DIFF
--- a/portal/src/components/profile/PopupsHistory.tsx
+++ b/portal/src/components/profile/PopupsHistory.tsx
@@ -2,9 +2,46 @@ import { Calendar, Clock, MapPin } from "lucide-react"
 import Image from "next/image"
 import { useTranslation } from "react-i18next"
 import type { HumanProfileStatsPopup, PopupPublic } from "@/client"
+import { cn } from "@/lib/utils"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 import { Card } from "../ui/card"
+
+function PopupThumb({
+  imageUrl,
+  name,
+  className,
+}: {
+  imageUrl?: string | null
+  name: string
+  className?: string
+}) {
+  if (imageUrl) {
+    return (
+      <div className={cn("relative overflow-hidden", className)}>
+        <Image
+          src={imageUrl}
+          alt={name}
+          fill
+          sizes="(max-width: 768px) 100vw, 33vw"
+          className="object-cover"
+        />
+      </div>
+    )
+  }
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center bg-gradient-to-br from-neutral-200 to-neutral-300",
+        className,
+      )}
+    >
+      <span className="text-3xl font-bold text-neutral-400">
+        {name?.charAt(0).toUpperCase() ?? "?"}
+      </span>
+    </div>
+  )
+}
 
 type ApplicationStatus = "draft" | "in review" | "accepted" | "rejected"
 
@@ -161,12 +198,10 @@ const PopupsHistory = ({ popups }: { popups: HumanProfileStatsPopup[] }) => {
                 key={popup.popup_name}
                 className="flex items-center gap-4 p-4 border border-[#e2e8f0] rounded-lg"
               >
-                <Image
-                  src={popup.image_url || "/placeholder.svg"}
-                  alt={popup.popup_name}
-                  width={70}
-                  height={70}
-                  className="object-cover aspect-square rounded-lg"
+                <PopupThumb
+                  imageUrl={popup.image_url}
+                  name={popup.popup_name}
+                  className="w-[70px] h-[70px] rounded-lg"
                 />
                 <div className="flex-1">
                   <h5 className="text-xl font-semibold text-foreground mb-2">
@@ -219,16 +254,11 @@ const PopupsHistory = ({ popups }: { popups: HumanProfileStatsPopup[] }) => {
               {pastPopups.map((popup) => (
                 <Card key={popup.popup_id} className="p-4">
                   <div className="relative mb-3">
-                    <Image
-                      src={popup.image_url || "/placeholder.svg"}
-                      alt={popup.popup_name}
-                      width={160}
-                      height={160}
-                      className="w-full h-auto max-h-[140px] object-cover rounded-lg aspect-auto object-top"
+                    <PopupThumb
+                      imageUrl={popup.image_url}
+                      name={popup.popup_name}
+                      className="w-full max-h-[140px] aspect-video rounded-lg"
                     />
-                    {/* <div className="absolute top-2 left-2 bg-[#dcfce7] text-[#166534] px-2 py-1 rounded text-xs font-medium">
-                      Completed
-                    </div> */}
                   </div>
                   <div>
                     <h5 className="text-lg font-semibold text-foreground mb-2">


### PR DESCRIPTION
## Summary

- Mirror the EventCard.Image pattern on /portal/profile popup thumbnails: when the popup has no image_url, render a neutral gradient with the popup's first letter instead of falling back to a non-existent /placeholder.svg (which rendered as a broken image).

## Test plan

- [ ] /portal/profile, with a popup that has no image_url, shows the gradient + first-letter fallback in both Upcoming Pop-Ups and Past Pop-Ups thumbnails.
- [ ] Popups that do have image_url keep rendering the cover image as before.