### PR TITLE
fix(backend): sync group membership junction and preserve historical group_id

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -440,6 +440,27 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             )
             self.create_snapshot(session, application, event)
 
+        # Sync membership junction: Application.group_id records origin (historical),
+        # GroupMembers records currently-active membership. Keep them aligned on creation
+        # so max_members validation and is_member() reflect the new application.
+        if data.get("group_id") and not human.red_flag:
+            from app.api.group.models import GroupMembers  # noqa: PLC0415
+
+            existing_member = session.exec(
+                select(GroupMembers).where(
+                    GroupMembers.group_id == data["group_id"],
+                    GroupMembers.human_id == human_id,
+                )
+            ).first()
+            if not existing_member:
+                session.add(
+                    GroupMembers(
+                        tenant_id=tenant_id,
+                        group_id=data["group_id"],
+                        human_id=human_id,
+                    )
+                )
+
         session.commit()
         session.refresh(application)
         return application

--- a/backend/app/api/application/models.py
+++ b/backend/app/api/application/models.py
@@ -103,6 +103,11 @@ class Applications(ApplicationBase, table=True):
     tenant: "Tenants" = Relationship(back_populates="applications")
     popup: "Popups" = Relationship(back_populates="applications")
     human: "Humans" = Relationship(back_populates="applications")
+    # Historical link: records the group through which this application was
+    # created (invite link / referral). It is NOT a vigente membership signal —
+    # use GroupMembers (Groups.members) for that. group_id is preserved when a
+    # member is removed from the junction, so an application can outlive its
+    # membership.
     group: Optional["Groups"] = Relationship(back_populates="applications")
     attendees: list["Attendees"] = Relationship(
         back_populates="application",

--- a/backend/app/api/group/crud.py
+++ b/backend/app/api/group/crud.py
@@ -37,10 +37,12 @@ class GroupsCRUD(BaseCRUD[Groups, GroupCreate, GroupUpdate]):
         return session.exec(statement).first()
 
     def get_with_members(self, session: Session, group_id: uuid.UUID) -> Groups | None:
-        """Get a group with eager loaded applications, attendees, and products.
+        """Get a group with eager loaded vigente members and their applications.
 
-        Use this when you need to access group.applications and their nested
-        attendees/products to avoid N+1 queries.
+        Members are sourced from the GroupMembers junction (vigente membership).
+        Applications are eager-loaded to hydrate each member's products. Note that
+        Application.group_id is historical: an application can keep pointing to this
+        group after the human is removed from the junction.
         """
         from app.api.application.models import Applications
         from app.api.attendee.models import AttendeeProducts, Attendees
@@ -49,6 +51,7 @@ class GroupsCRUD(BaseCRUD[Groups, GroupCreate, GroupUpdate]):
             select(Groups)
             .where(Groups.id == group_id)
             .options(
+                selectinload(Groups.members),  # type: ignore[arg-type]
                 selectinload(Groups.applications)  # type: ignore[arg-type]
                 .selectinload(Applications.attendees)  # ty: ignore[invalid-argument-type]
                 .selectinload(Attendees.attendee_products)  # ty: ignore[invalid-argument-type]

--- a/backend/app/api/group/models.py
+++ b/backend/app/api/group/models.py
@@ -104,6 +104,9 @@ class Groups(GroupBase, table=True):
     # Relationships
     tenant: "Tenants" = Relationship(back_populates="groups")
     popup: "Popups" = Relationship(back_populates="groups")
+    # Historical: every application ever created through this group's invite
+    # link, including humans no longer in `members`. For vigente membership
+    # always use `members` (GroupMembers junction).
     applications: list["Applications"] = Relationship(back_populates="group")
 
     # Many-to-many with humans for leaders
@@ -112,7 +115,10 @@ class Groups(GroupBase, table=True):
         link_model=GroupLeaders,
     )
 
-    # Many-to-many with humans for members
+    # Vigente members: who currently counts against max_members and is eligible
+    # for the group discount on future purchases. Kept in sync with new
+    # applications via application/crud.create_internal; removable via the
+    # leader/admin endpoint without touching Application.group_id.
     members: list["Humans"] = Relationship(
         back_populates="groups_as_member",
         link_model=GroupMembers,

--- a/backend/app/api/group/router.py
+++ b/backend/app/api/group/router.py
@@ -40,6 +40,48 @@ def _check_leader_permission(group: Groups, human_id: uuid.UUID) -> None:
         )
 
 
+def _build_members(group: Groups) -> list[GroupMemberPublic]:
+    """Build the vigente members list of a group.
+
+    Source of truth is the GroupMembers junction (group.members). Products and
+    profile data are hydrated from each member's application in this popup, if
+    one exists (it should, given the sync in application creation).
+    """
+    apps_by_human = {app.human_id: app for app in group.applications}
+
+    members: list[GroupMemberPublic] = []
+    for human in group.members:
+        application = apps_by_human.get(human.id)
+        products = []
+        if application:
+            # Each AttendeeProducts row is one ticket — dedupe by product_id so
+            # the member's product list shows each product once.
+            seen_pids: set[uuid.UUID] = set()
+            for attendee in application.attendees:
+                for ap in attendee.attendee_products:
+                    if ap.product_id in seen_pids:
+                        continue
+                    seen_pids.add(ap.product_id)
+                    products.append(ap.product)
+
+        custom = (application.custom_fields if application else None) or {}
+        members.append(
+            GroupMemberPublic(
+                id=human.id,
+                first_name=human.first_name or "",
+                last_name=human.last_name or "",
+                email=human.email,
+                telegram=human.telegram,
+                organization=custom.get("organization"),
+                role=custom.get("role"),
+                gender=human.gender,
+                local_resident=None,
+                products=products,
+            )
+        )
+    return members
+
+
 @router.get("", response_model=ListModel[GroupPublic])
 async def list_groups(
     db: TenantSession,
@@ -80,39 +122,9 @@ async def get_group(
             detail="Group not found",
         )
 
-    # Build members list from applications (relationships already eager loaded)
-    members = []
-    for application in group.applications:
-        # Each AttendeeProducts row is one ticket — dedupe by product_id so
-        # the member's product list shows each product once.
-        products = []
-        seen_pids: set[uuid.UUID] = set()
-        for attendee in application.attendees:
-            for ap in attendee.attendee_products:
-                if ap.product_id in seen_pids:
-                    continue
-                seen_pids.add(ap.product_id)
-                products.append(ap.product)
-
-        human = application.human
-        custom = application.custom_fields or {}
-        member = GroupMemberPublic(
-            id=application.human_id,
-            first_name=human.first_name or "",
-            last_name=human.last_name or "",
-            email=human.email,
-            telegram=human.telegram,
-            organization=custom.get("organization"),
-            role=custom.get("role"),
-            gender=human.gender,
-            local_resident=None,
-            products=products,
-        )
-        members.append(member)
-
     return GroupWithMembers(
         **GroupPublic.model_validate(group).model_dump(),
-        members=members,
+        members=_build_members(group),
     )
 
 
@@ -249,39 +261,9 @@ async def get_my_group(
 
     _check_leader_permission(group, current_human.id)
 
-    # Build members list (relationships already eager loaded)
-    members = []
-    for application in group.applications:
-        # Each AttendeeProducts row is one ticket — dedupe by product_id so
-        # the member's product list shows each product once.
-        products = []
-        seen_pids: set[uuid.UUID] = set()
-        for attendee in application.attendees:
-            for ap in attendee.attendee_products:
-                if ap.product_id in seen_pids:
-                    continue
-                seen_pids.add(ap.product_id)
-                products.append(ap.product)
-
-        human = application.human
-        custom = application.custom_fields or {}
-        member = GroupMemberPublic(
-            id=application.human_id,
-            first_name=human.first_name or "",
-            last_name=human.last_name or "",
-            email=human.email,
-            telegram=human.telegram,
-            organization=custom.get("organization"),
-            role=custom.get("role"),
-            gender=human.gender,
-            local_resident=None,
-            products=products,
-        )
-        members.append(member)
-
     return GroupWithMembers(
         **GroupPublic.model_validate(group).model_dump(),
-        members=members,
+        members=_build_members(group),
     )
 
 
@@ -605,10 +587,11 @@ async def remove_group_member(
             detail="Member not found in group",
         )
 
-    # Get application
+    # Block removal if the member already purchased — their products are tied
+    # to the application and removing the discount eligibility post-purchase is
+    # meaningless (price is already consolidated in payment).
     application = applications_crud.get_by_human_popup(db, human_id, group.popup_id)
     if application:
-        # Check if member has products
         for attendee in application.attendees:
             if attendee.products:
                 raise HTTPException(
@@ -616,12 +599,8 @@ async def remove_group_member(
                     detail="Cannot remove member with purchased products",
                 )
 
-        # Remove group association (don't delete application)
-        # Note: created_by_leader tracking not implemented on model
-        application.group_id = None
-        db.add(application)
-
-    # Remove from group members
+    # Remove from vigente membership only. Application.group_id is preserved as
+    # historical record of where this application originated.
     crud.groups_crud.remove_member(db, group.id, human_id)
     db.commit()
 


### PR DESCRIPTION
## Summary

- `Application.group_id` now represents the **historical** origin of an application (invite link / referral), while `GroupMembers` represents **vigente** membership. The two used to diverge when humans applied via an invite link, producing phantom members visible in GET endpoints but invisible to `max_members` validation.
- `application/crud.create_internal` inserts a `GroupMembers` row when the application is created with a `group_id` (skipped on red-flag). Direct adds keep their existing transactional commit.
- `group/crud.get_with_members` eager-loads `Groups.members`.
- `group/router` GET endpoints now read vigente members from the junction and hydrate products from a per-application lookup. `DELETE` no longer nulls `Application.group_id`, so the historical link is preserved.
- `application/models.py`, `group/models.py`: documented the historical-vs-vigente semantics on the affected relationships.

## Test plan

- [ ] Invite-link flow: human applies via an invite link → `GroupMembers` has a corresponding row; the same human appears once in `GET /groups/{id}` and counts toward `max_members`.
- [ ] Direct add: existing direct-add path still works and remains transactional.
- [ ] `DELETE` member: removes from `GroupMembers` but leaves `Application.group_id` intact (history preserved).
- [ ] Red-flag application created with `group_id`: no `GroupMembers` row inserted.