### PR TITLE
fix(portal): redirect to /passes after $0 payment and on SimpleFI return

### DIFF
--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.test.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.test.tsx
@@ -4,26 +4,17 @@ import ScrollyCheckoutFlow from "./ScrollyCheckoutFlow"
 
 const mockUseSearchParams = vi.fn()
 const mockReadAndClearPendingPaymentRedirectState = vi.fn()
-const mockUsePaymentVerification = vi.fn()
+const mockRouterReplace = vi.fn()
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ popupSlug: "popup-a" }),
   useSearchParams: () => mockUseSearchParams(),
+  useRouter: () => ({ replace: mockRouterReplace }),
 }))
 
 vi.mock("@/hooks/usePaymentRedirect", () => ({
   readAndClearPendingPaymentRedirectState: () =>
     mockReadAndClearPendingPaymentRedirectState(),
-}))
-
-vi.mock("@/hooks/checkout", () => ({
-  usePaymentVerification: (args: unknown) => mockUsePaymentVerification(args),
-}))
-
-vi.mock("@/providers/applicationProvider", () => ({
-  useApplication: () => ({
-    getRelevantApplication: () => null,
-  }),
 }))
 
 vi.mock("@/providers/checkoutProvider", () => ({
@@ -32,12 +23,6 @@ vi.mock("@/providers/checkoutProvider", () => ({
     submitPayment: vi.fn().mockResolvedValue({ success: true }),
     stepConfigs: [],
   }),
-}))
-
-vi.mock("./steps/SuccessStep", () => ({
-  default: ({ paymentStatus }: { paymentStatus: string }) => (
-    <div>{paymentStatus}</div>
-  ),
 }))
 
 vi.mock("./DynamicProductStep", () => ({
@@ -76,32 +61,25 @@ vi.mock("./registries/stepRegistry", () => ({
 
 describe("ScrollyCheckoutFlow", () => {
   beforeEach(() => {
-    mockUsePaymentVerification.mockReturnValue({ paymentStatus: "pending" })
     mockReadAndClearPendingPaymentRedirectState.mockReset()
     mockUseSearchParams.mockReset()
+    mockRouterReplace.mockReset()
   })
 
-  it("restores the saved payment id for checkout-success returns", async () => {
+  it("redirects to /passes when returning from SimpleFI", async () => {
     mockUseSearchParams.mockReturnValue({
       get: (key: string) => (key === "checkout" ? "success" : null),
-    })
-    mockReadAndClearPendingPaymentRedirectState.mockReturnValue({
-      paymentId: "payment-123",
-      popupSlug: "popup-a",
     })
 
     render(<ScrollyCheckoutFlow />)
 
     await waitFor(() => {
-      expect(mockUsePaymentVerification).toHaveBeenLastCalledWith({
-        applicationId: undefined,
-        paymentId: "payment-123",
-        enabled: true,
-      })
+      expect(mockReadAndClearPendingPaymentRedirectState).toHaveBeenCalled()
+      expect(mockRouterReplace).toHaveBeenCalledWith("/portal/popup-a/passes")
     })
   })
 
-  it("ignores redirect state when the return is not checkout-success", async () => {
+  it("does not redirect when the return is not checkout-success", async () => {
     mockUseSearchParams.mockReturnValue({
       get: () => null,
     })
@@ -110,11 +88,7 @@ describe("ScrollyCheckoutFlow", () => {
 
     await waitFor(() => {
       expect(mockReadAndClearPendingPaymentRedirectState).not.toHaveBeenCalled()
-      expect(mockUsePaymentVerification).toHaveBeenLastCalledWith({
-        applicationId: undefined,
-        paymentId: undefined,
-        enabled: false,
-      })
+      expect(mockRouterReplace).not.toHaveBeenCalled()
     })
   })
 })

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -1,11 +1,9 @@
 "use client"
 
-import { useParams, useSearchParams } from "next/navigation"
+import { useParams, useRouter, useSearchParams } from "next/navigation"
 import type { ReactNode } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { usePaymentVerification } from "@/hooks/checkout"
 import { readAndClearPendingPaymentRedirectState } from "@/hooks/usePaymentRedirect"
-import { useApplication } from "@/providers/applicationProvider"
 import { useCheckout } from "@/providers/checkoutProvider"
 import DynamicProductStep from "./DynamicProductStep"
 import { shouldUseDynamicStep } from "./registries/stepRegistry"
@@ -18,7 +16,6 @@ import SnapSection from "./SnapSection"
 import ConfirmStep from "./steps/ConfirmStep"
 import OpenCheckoutBuyerStep from "./steps/OpenCheckoutBuyerStep"
 import PassSelectionSection from "./steps/PassSelectionSection"
-import SuccessStep from "./steps/SuccessStep"
 
 interface ScrollyCheckoutFlowProps {
   onPaymentComplete?: () => void
@@ -43,37 +40,17 @@ function ScrollyCheckoutFlowInner({
 
   const searchParams = useSearchParams()
   const params = useParams<{ popupSlug: string }>()
-  const { getRelevantApplication } = useApplication()
-  const application = getRelevantApplication()
-  const [restoredPaymentId, setRestoredPaymentId] = useState<string | null>(
-    null,
-  )
-  const [redirectStateRestored, setRedirectStateRestored] = useState(false)
+  const router = useRouter()
 
   const isSimpleFIReturn = searchParams.get("checkout") === "success"
 
   useEffect(() => {
-    if (!isSimpleFIReturn) {
-      setRestoredPaymentId(null)
-      setRedirectStateRestored(true)
-      return
-    }
-
-    const redirectState = readAndClearPendingPaymentRedirectState()
-    const paymentId =
-      redirectState?.popupSlug === params.popupSlug
-        ? redirectState.paymentId
-        : null
-
-    setRestoredPaymentId(paymentId)
-    setRedirectStateRestored(true)
-  }, [isSimpleFIReturn, params.popupSlug])
-
-  const { paymentStatus } = usePaymentVerification({
-    applicationId: application?.id,
-    paymentId: restoredPaymentId ?? undefined,
-    enabled: redirectStateRestored && isSimpleFIReturn,
-  })
+    if (!isSimpleFIReturn) return
+    // Discard any persisted redirect state from a prior session so it does
+    // not leak into the next purchase.
+    readAndClearPendingPaymentRedirectState()
+    router.replace(`/portal/${params.popupSlug}/passes`)
+  }, [isSimpleFIReturn, params.popupSlug, router])
 
   const handlePayment = async () => {
     const result = await submitPayment()
@@ -298,10 +275,8 @@ function ScrollyCheckoutFlowInner({
 
   if (isSimpleFIReturn) {
     return (
-      <div className="min-h-screen">
-        <SuccessStep
-          paymentStatus={redirectStateRestored ? paymentStatus : "verifying"}
-        />
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-current opacity-60" />
       </div>
     )
   }

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
 import { toast } from "sonner"
 import type { CheckoutMode } from "@/checkout/popupCheckoutPolicy"
@@ -77,6 +78,7 @@ export function usePaymentSubmit({
   buyerData,
 }: UsePaymentSubmitParams) {
   const queryClient = useQueryClient()
+  const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   // Reset isSubmitting when page is restored from bfcache
@@ -212,7 +214,19 @@ export function usePaymentSubmit({
               })
             : Promise.resolve(),
         ])
-        setCurrentStep("success")
+        if (popupSlug) {
+          if (submitMode === "open-ticketing") {
+            const paymentId = data.id ?? data.payment_id
+            const qs = paymentId ? `?payment_id=${paymentId}` : ""
+            router.replace(`/checkout/${popupSlug}/thank-you${qs}`)
+          } else {
+            router.replace(`/portal/${popupSlug}/passes`)
+          }
+        } else {
+          // Fallback when slug is unavailable: keep the legacy success step
+          // so the success state is at least visible.
+          setCurrentStep("success")
+        }
         setIsSubmitting(false)
         return { success: true }
       }
@@ -252,6 +266,7 @@ export function usePaymentSubmit({
     popupId,
     popupSlug,
     submitMode,
+    router,
   ])
 
   return { submitPayment, isSubmitting }

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -701,7 +701,7 @@ export function CheckoutProvider({
   const { submitPayment, isSubmitting } = usePaymentSubmit({
     applicationId: application?.id,
     popupId: cityId,
-    popupSlug: submitPopupSlug,
+    popupSlug: submitPopupSlug ?? city?.slug ?? null,
     appCredit,
     checkoutMode: checkoutPolicy.checkoutMode,
     attendeePasses,


### PR DESCRIPTION
## Summary

- `$0` orders (free product or 100% coupon) now leave Review & Confirm and land on `/portal/{slug}/passes` (application flow) or `/checkout/{slug}/thank-you` (open-ticketing).
- Returning from SimpleFI no longer shows the 30s countdown success screen; we redirect straight to `/portal/{slug}/passes`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- `usePaymentSubmit.ts`: on `status: "approved"`, `router.replace` to the right destination instead of just calling `setCurrentStep("success")` (which the Scrolly flow ignored, leaving the UI stuck on Review & Confirm).
- `ScrollyCheckoutFlow.tsx`: remove `SuccessStep` render + `usePaymentVerification` polling on SimpleFI return; redirect immediately to `/portal/{slug}/passes` and show a brief loader during the transition.
- `checkoutProvider.tsx`: fall back `popupSlug` to `city.slug` so the application flow has a slug to redirect to.
- Updated `ScrollyCheckoutFlow.test.tsx` to assert the new redirect behavior.

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [x] Portal type check passes (`pnpm exec tsc --noEmit`)
- [x] Biome clean on touched files
- [x] `vitest run src/components/checkout-flow/ScrollyCheckoutFlow.test.tsx` passes
- [ ] Manual testing: \$0 order via 100% coupon, \$0 order via free product, paid order returning from SimpleFI

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass (pre-existing failures in `VariantTicketSelect.test.tsx` are unrelated and present on `dev`)
- [ ] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`) — no backend changes
- [ ] Database migrations are included if schema changed — no schema changes