### PR TITLE
feat(form-builder): field_type override, half_row width, draft validation

### DIFF
--- a/backend/app/alembic/versions/c5d3e8a2f9b1_basefieldconfigs_field_type.py
+++ b/backend/app/alembic/versions/c5d3e8a2f9b1_basefieldconfigs_field_type.py
@@ -1,0 +1,26 @@
+"""add field_type override column to basefieldconfigs
+
+Revision ID: c5d3e8a2f9b1
+Revises: merge_0049_8b4d5e6f
+Create Date: 2026-05-15
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c5d3e8a2f9b1"
+down_revision = "merge_0049_8b4d5e6f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "basefieldconfigs",
+        sa.Column("field_type", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("basefieldconfigs", "field_type")

--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -28,6 +28,17 @@ if TYPE_CHECKING:
     from app.api.human.models import Humans
 
 
+def _is_draft_status(status_value: object) -> bool:
+    """True when an application is being created/saved as a draft.
+
+    Treats a missing status as draft because the DB column defaults to draft
+    when no value is provided.
+    """
+    if status_value is None:
+        return True
+    return getattr(status_value, "value", status_value) == ApplicationStatus.DRAFT.value
+
+
 class RedFlaggedHumanError(Exception):
     """Raised when attempting to accept an application from a red-flagged human."""
 
@@ -267,10 +278,17 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 detail="Popup not found",
             )
 
+        # Drafts are partial saves: skip "required field is missing" checks but
+        # still validate types/constraints on any values the user did provide.
+        is_draft = _is_draft_status(getattr(app_data, "status", None))
+
         # Validate custom_fields against form field definitions
         if validate_custom_fields and app_data.custom_fields:
             is_valid, errors = form_fields_crud.validate_custom_fields(
-                session, app_data.popup_id, app_data.custom_fields
+                session,
+                app_data.popup_id,
+                app_data.custom_fields,
+                skip_required=is_draft,
             )
             if not is_valid:
                 raise HTTPException(
@@ -287,7 +305,7 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             )
 
         # Validate required base fields against BaseFieldConfigs
-        if validate_custom_fields:
+        if validate_custom_fields and not is_draft:
             is_valid, errors = form_fields_crud.validate_base_fields(
                 session, app_data.popup_id, app_data.model_dump(), human
             )
@@ -489,10 +507,17 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 detail="Popup not found",
             )
 
+        # Drafts are partial saves: skip "required field is missing" checks but
+        # still validate types/constraints on any values the user did provide.
+        is_draft = _is_draft_status(getattr(app_data, "status", None))
+
         # Validate custom_fields against form field definitions
         if validate_custom_fields and app_data.custom_fields:
             is_valid, errors = form_fields_crud.validate_custom_fields(
-                session, app_data.popup_id, app_data.custom_fields
+                session,
+                app_data.popup_id,
+                app_data.custom_fields,
+                skip_required=is_draft,
             )
             if not is_valid:
                 raise HTTPException(
@@ -525,7 +550,7 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             )
 
         # Validate required base fields against BaseFieldConfigs
-        if validate_custom_fields:
+        if validate_custom_fields and not is_draft:
             is_valid, errors = form_fields_crud.validate_base_fields(
                 session, app_data.popup_id, app_data.model_dump(), human
             )

--- a/backend/app/api/base_field_config/constants.py
+++ b/backend/app/api/base_field_config/constants.py
@@ -62,6 +62,7 @@ BASE_FIELD_DEFINITIONS: dict[str, dict[str, Any]] = {
         "default_position": 3,
         "default_placeholder": "City, State/Region, Country",
         "default_help_text": "Please format it like [City, State/Region, Country].",
+        "allowed_field_types": ["text", "country_select"],
     },
     "gender": {
         "type": "select",

--- a/backend/app/api/base_field_config/schemas.py
+++ b/backend/app/api/base_field_config/schemas.py
@@ -21,6 +21,9 @@ class BaseFieldConfigBase(SQLModel):
     options: list[str] | None = Field(
         default=None, sa_column=Column(ARRAY(String), nullable=True)
     )
+    # NULL = fall back to the catalog's hardcoded type. Only meaningful when the
+    # catalog entry declares `allowed_field_types` (validated at PATCH time).
+    field_type: str | None = Field(default=None, nullable=True)
 
 
 class BaseFieldConfigPublic(BaseModel):
@@ -35,6 +38,7 @@ class BaseFieldConfigPublic(BaseModel):
     placeholder: str | None = None
     help_text: str | None = None
     options: list[str] | None = None
+    field_type: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -47,6 +51,7 @@ class BaseFieldConfigUpdate(BaseModel):
     placeholder: str | None = None
     help_text: str | None = None
     options: list[str] | None = None
+    field_type: str | None = None
 
 
 class CatalogField(BaseModel):

--- a/backend/app/api/form_field/crud.py
+++ b/backend/app/api/form_field/crud.py
@@ -137,8 +137,13 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         session: Session,
         popup_id: uuid.UUID,
         custom_fields: dict[str, Any] | None,
+        skip_required: bool = False,
     ) -> tuple[bool, list[str]]:
         """Validate custom_fields against form field definitions.
+
+        When ``skip_required`` is True, presence/emptiness checks on required
+        fields are bypassed (used for draft saves), but type and constraint
+        validation still runs on whatever values were provided.
 
         Returns tuple of (is_valid, list_of_errors).
         """
@@ -161,11 +166,12 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         errors: list[str] = []
 
         # Check required fields
-        for field in fields:
-            if field.section_id and field.section_id in hidden_section_ids:
-                continue
-            if field.required and field.name not in custom_fields:
-                errors.append(f"Required field '{field.label}' is missing")
+        if not skip_required:
+            for field in fields:
+                if field.section_id and field.section_id in hidden_section_ids:
+                    continue
+                if field.required and field.name not in custom_fields:
+                    errors.append(f"Required field '{field.label}' is missing")
 
         # Validate provided values
         for field_name, value in custom_fields.items():
@@ -177,7 +183,7 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
 
             # Skip validation for None/empty values on non-required fields
             if value is None or value == "":
-                if field.required:
+                if field.required and not skip_required:
                     errors.append(f"Required field '{field.label}' cannot be empty")
                 continue
 
@@ -327,7 +333,7 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
             if config.section_id and config.section_id in hidden_section_ids:
                 continue
             entry: dict[str, Any] = {
-                "type": definition["type"],
+                "type": config.field_type or definition["type"],
                 "target": definition["target"],
                 "label": config.label or "",
                 "required": config.required,

--- a/backend/app/api/form_field/router.py
+++ b/backend/app/api/form_field/router.py
@@ -49,7 +49,7 @@ def _base_config_to_public(config: BaseFieldConfigs) -> FormFieldPublic:
         popup_id=config.popup_id,
         name=config.field_name,
         label=config.label or "",
-        field_type=definition["type"],
+        field_type=config.field_type or definition["type"],
         section_id=config.section_id,
         section_label=section_label,
         position=config.position,
@@ -60,6 +60,7 @@ def _base_config_to_public(config: BaseFieldConfigs) -> FormFieldPublic:
         protected=True,
         removable=definition.get("removable", True),
         target=definition["target"],
+        allowed_field_types=definition.get("allowed_field_types"),
     )
 
 
@@ -367,6 +368,26 @@ async def update_form_field(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Field '{base_config.field_name}' is required and cannot be made optional",
             )
+
+        # `field_type` is only writeable on base configs whose catalog entry
+        # whitelists alternatives — and only to a value inside that whitelist.
+        allowed_field_types = definition.get("allowed_field_types")
+        if "field_type" in field_in.model_fields_set:
+            if not allowed_field_types:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Field '{base_config.field_name}' does not allow type overrides",
+                )
+            new_type = field_in.field_type
+            if new_type is not None and new_type not in allowed_field_types:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Field type '{new_type}' is not allowed for "
+                        f"'{base_config.field_name}'"
+                    ),
+                )
+            update_data["field_type"] = new_type
 
         config_update = BaseFieldConfigUpdate(**update_data)
         updated_config = base_field_configs_crud.update(db, base_config, config_update)

--- a/backend/app/api/form_field/schemas.py
+++ b/backend/app/api/form_field/schemas.py
@@ -42,8 +42,9 @@ class FormFieldBase(SQLModel):
                               max_selections?: int }
 
     `width` overrides the frontend's type-based heuristic when set
-    ("full" spans both columns, "half" stays single-column). NULL falls back
-    to the heuristic.
+    ("full" spans both columns, "half" stays single-column, "half_row" is
+    half-width but consumes a full row so no field renders alongside it).
+    NULL falls back to the heuristic.
     """
 
     tenant_id: uuid.UUID = Field(foreign_key="tenants.id", index=True)
@@ -92,10 +93,13 @@ class FormFieldPublic(BaseModel):
     min_date: str | None = None
     max_date: str | None = None
     config: dict[str, Any] | None = None
-    width: Literal["full", "half"] | None = None
+    width: Literal["full", "half", "half_row"] | None = None
     protected: bool = False
     removable: bool = True
     target: str | None = None
+    # Populated only for base fields whose catalog entry declares
+    # `allowed_field_types` — signals the UI to render a restricted type picker.
+    allowed_field_types: list[str] | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -113,7 +117,7 @@ class FormFieldCreate(BaseModel):
     min_date: str | None = None
     max_date: str | None = None
     config: dict[str, Any] | None = None
-    width: Literal["full", "half"] | None = None
+    width: Literal["full", "half", "half_row"] | None = None
 
     model_config = ConfigDict(str_strip_whitespace=True)
 
@@ -130,4 +134,4 @@ class FormFieldUpdate(BaseModel):
     min_date: str | None = None
     max_date: str | None = None
     config: dict[str, Any] | None = None
-    width: Literal["full", "half"] | None = None
+    width: Literal["full", "half", "half_row"] | None = None

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -2881,6 +2881,17 @@ export const BaseFieldConfigPublicSchema = {
                 }
             ],
             title: 'Options'
+        },
+        field_type: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Field Type'
         }
     },
     type: 'object',
@@ -2970,6 +2981,17 @@ export const BaseFieldConfigUpdateSchema = {
                 }
             ],
             title: 'Options'
+        },
+        field_type: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Field Type'
         }
     },
     type: 'object',
@@ -6944,7 +6966,7 @@ export const FormFieldCreateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    enum: ['full', 'half']
+                    enum: ['full', 'half', 'half_row']
                 },
                 {
                     type: 'null'
@@ -7094,7 +7116,7 @@ export const FormFieldPublicSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    enum: ['full', 'half']
+                    enum: ['full', 'half', 'half_row']
                 },
                 {
                     type: 'null'
@@ -7122,6 +7144,20 @@ export const FormFieldPublicSchema = {
                 }
             ],
             title: 'Target'
+        },
+        allowed_field_types: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Allowed Field Types'
         }
     },
     type: 'object',
@@ -7261,7 +7297,7 @@ export const FormFieldUpdateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    enum: ['full', 'half']
+                    enum: ['full', 'half', 'half_row']
                 },
                 {
                     type: 'null'

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -609,6 +609,7 @@ export type BaseFieldConfigPublic = {
     placeholder?: (string | null);
     help_text?: (string | null);
     options?: (Array<(string)> | null);
+    field_type?: (string | null);
 };
 
 export type BaseFieldConfigUpdate = {
@@ -619,6 +620,7 @@ export type BaseFieldConfigUpdate = {
     placeholder?: (string | null);
     help_text?: (string | null);
     options?: (Array<(string)> | null);
+    field_type?: (string | null);
 };
 
 /**
@@ -1416,7 +1418,7 @@ export type FormFieldCreate = {
     config?: ({
     [key: string]: unknown;
 } | null);
-    width?: ('full' | 'half' | null);
+    width?: ('full' | 'half' | 'half_row' | null);
 };
 
 export type FormFieldPublic = {
@@ -1438,10 +1440,11 @@ export type FormFieldPublic = {
     config?: ({
     [key: string]: unknown;
 } | null);
-    width?: ('full' | 'half' | null);
+    width?: ('full' | 'half' | 'half_row' | null);
     protected?: boolean;
     removable?: boolean;
     target?: (string | null);
+    allowed_field_types?: (Array<(string)> | null);
 };
 
 export type FormFieldUpdate = {
@@ -1458,7 +1461,7 @@ export type FormFieldUpdate = {
     config?: ({
     [key: string]: unknown;
 } | null);
-    width?: ('full' | 'half' | null);
+    width?: ('full' | 'half' | 'half_row' | null);
 };
 
 export type FormSectionCreate = {

--- a/backoffice/src/components/form-builder/CanvasField.tsx
+++ b/backoffice/src/components/form-builder/CanvasField.tsx
@@ -65,7 +65,12 @@ export function CanvasField({
     transition,
   }
 
-  const isFullWidth = resolveFieldWidth(field) === "full"
+  const resolvedWidth = resolveFieldWidth(field)
+  const isFullWidth = resolvedWidth === "full"
+  // half_row is handled one level up (SectionDropZone renders an empty
+  // sibling cell next to a half_row field so the next field gets pushed to
+  // the next row). At this level it renders like a regular half-width field.
+  const outerClassName = isFullWidth ? "md:col-span-2" : ""
 
   const handleClick = () => {
     onSelect(field.id)
@@ -85,22 +90,14 @@ export function CanvasField({
 
   if (isDragging) {
     return (
-      <div
-        ref={setNodeRef}
-        style={style}
-        className={`${isFullWidth ? "md:col-span-2" : ""}`}
-      >
+      <div ref={setNodeRef} style={style} className={outerClassName}>
         <div className="rounded-md border-2 border-dashed border-primary/30 bg-primary/5 min-h-[72px]" />
       </div>
     )
   }
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={`${isFullWidth ? "md:col-span-2" : ""}`}
-    >
+    <div ref={setNodeRef} style={style} className={outerClassName}>
       <button
         type="button"
         onClick={handleClick}

--- a/backoffice/src/components/form-builder/FieldConfigPanel.tsx
+++ b/backoffice/src/components/form-builder/FieldConfigPanel.tsx
@@ -27,7 +27,7 @@ import useCustomToast from "@/hooks/useCustomToast"
 import { createErrorHandler } from "@/utils"
 import { canRemoveField, FIELD_TYPES, isSpecialField } from "./constants"
 
-type FieldWidth = "full" | "half" | null
+type FieldWidth = "full" | "half" | "half_row" | null
 
 interface FieldConfigPanelProps {
   field: FormFieldPublic
@@ -116,6 +116,13 @@ export function FieldConfigPanel({
 
   const isProtected = isSpecialField(field)
   const isElemental = isProtected && !canRemoveField(field)
+  const allowedFieldTypes = field.allowed_field_types ?? null
+  const hasAllowedFieldTypes =
+    !!allowedFieldTypes && allowedFieldTypes.length > 0
+  const typeSelectDisabled = isProtected && !hasAllowedFieldTypes
+  const visibleFieldTypes = hasAllowedFieldTypes
+    ? FIELD_TYPES.filter((t) => allowedFieldTypes?.includes(t.value))
+    : FIELD_TYPES
 
   const handleSave = () => {
     const optionsArray = localValues.options
@@ -136,8 +143,9 @@ export function FieldConfigPanel({
       requestBody.required = localValues.required
     }
 
-    // Protected (base) fields have a fixed type defined by the catalog.
-    if (!isProtected) {
+    // Protected (base) fields have a fixed type defined by the catalog, unless
+    // the catalog whitelists alternatives via `allowed_field_types`.
+    if (!isProtected || hasAllowedFieldTypes) {
       requestBody.field_type = localValues.field_type || undefined
     }
 
@@ -209,11 +217,11 @@ export function FieldConfigPanel({
           value={localValues.field_type}
           onValueChange={(val) => handleChange("field_type", val)}
         >
-          <SelectTrigger disabled={isProtected}>
+          <SelectTrigger disabled={typeSelectDisabled}>
             <SelectValue placeholder="Select type" />
           </SelectTrigger>
           <SelectContent>
-            {FIELD_TYPES.map((type) => (
+            {visibleFieldTypes.map((type) => (
               <SelectItem key={type.value} value={type.value}>
                 {type.label}
               </SelectItem>
@@ -435,6 +443,7 @@ export function FieldConfigPanel({
           <SelectContent>
             <SelectItem value="auto">Auto (by type)</SelectItem>
             <SelectItem value="half">Half (one column)</SelectItem>
+            <SelectItem value="half_row">Half (alone in row)</SelectItem>
             <SelectItem value="full">Full (both columns)</SelectItem>
           </SelectContent>
         </Select>

--- a/backoffice/src/components/form-builder/SectionDropZone.tsx
+++ b/backoffice/src/components/form-builder/SectionDropZone.tsx
@@ -1,7 +1,7 @@
 import { useDroppable } from "@dnd-kit/core"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { Check, Eye, EyeOff, Pencil, Trash2, X } from "lucide-react"
-import { useRef, useState } from "react"
+import { Fragment, useRef, useState } from "react"
 import type {
   FormFieldPublic,
   FormSectionPublic,
@@ -13,7 +13,11 @@ import { Input } from "@/components/ui/input"
 import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
 import { CanvasField } from "./CanvasField"
-import { isSpecialField, isSpecialSection } from "./constants"
+import {
+  isSpecialField,
+  isSpecialSection,
+  resolveFieldWidth,
+} from "./constants"
 
 interface SectionDropZoneProps {
   sectionKey: string
@@ -306,17 +310,24 @@ export function SectionDropZone({
                 {isOver ? "Drop here" : "Drag and drop fields here"}
               </div>
             )}
-            {fields.map((field) => (
-              <CanvasField
-                key={field.id}
-                field={field}
-                sectionKey={sectionKey}
-                isSelected={selectedFieldId === field.id}
-                isSpecial={isSpecialField(field)}
-                onSelect={onSelectField}
-                onDelete={onDeleteField}
-              />
-            ))}
+            {fields.map((field) => {
+              const isHalfRow = resolveFieldWidth(field) === "half_row"
+              return (
+                <Fragment key={field.id}>
+                  <CanvasField
+                    field={field}
+                    sectionKey={sectionKey}
+                    isSelected={selectedFieldId === field.id}
+                    isSpecial={isSpecialField(field)}
+                    onSelect={onSelectField}
+                    onDelete={onDeleteField}
+                  />
+                  {isHalfRow && (
+                    <div className="hidden md:block" aria-hidden="true" />
+                  )}
+                </Fragment>
+              )
+            })}
           </div>
         </SortableContext>
       </div>

--- a/backoffice/src/components/form-builder/constants.ts
+++ b/backoffice/src/components/form-builder/constants.ts
@@ -39,7 +39,7 @@ export function formFieldPublicToFormFieldSchema(
     min_date: f.min_date ?? null,
     max_date: f.max_date ?? null,
     config: f.config ?? undefined,
-    width: f.width ?? null,
+    width: (f.width as "full" | "half" | "half_row" | null | undefined) ?? null,
   }
 }
 
@@ -47,11 +47,11 @@ export function formFieldPublicToFormFieldSchema(
  * shared helper so the backoffice canvas matches the portal exactly. */
 export function resolveFieldWidth(
   field: FormFieldPublic | FormFieldSchema,
-): "full" | "half" {
+): "full" | "half" | "half_row" {
   const t = "field_type" in field ? field.field_type : field.type
   const w =
     "width" in field
-      ? (field.width as "full" | "half" | null | undefined)
+      ? (field.width as "full" | "half" | "half_row" | null | undefined)
       : null
   return resolveFieldWidthShared({ type: t, field_type: t, width: w ?? null })
 }

--- a/packages/shared-form-ui/src/components/Form/ImageUploadForm.tsx
+++ b/packages/shared-form-ui/src/components/Form/ImageUploadForm.tsx
@@ -87,11 +87,15 @@ export function ImageUploadForm({
 
   return (
     <FormInputWrapper>
-      {label && <LabelRequired isRequired={isRequired}>{label}</LabelRequired>}
-      {subtitle && (
-        <LabelMuted className="text-sm text-muted-foreground">
-          {subtitle}
-        </LabelMuted>
+      {(label || subtitle) && (
+        <div className="flex flex-col gap-2">
+          {label && <LabelRequired isRequired={isRequired}>{label}</LabelRequired>}
+          {subtitle && (
+            <LabelMuted className="text-sm text-muted-foreground">
+              {subtitle}
+            </LabelMuted>
+          )}
+        </div>
       )}
 
       {value ? (

--- a/packages/shared-form-ui/src/components/Form/MultiSelectDetailedForm.tsx
+++ b/packages/shared-form-ui/src/components/Form/MultiSelectDetailedForm.tsx
@@ -143,10 +143,14 @@ export function MultiSelectDetailedForm({
           </button>
         </PopoverTrigger>
         <PopoverContent
-          className="w-[--radix-popover-trigger-width] p-0"
+          className="flex w-[--radix-popover-trigger-width] flex-col overflow-hidden p-0"
+          style={{
+            maxHeight:
+              "min(var(--radix-popover-content-available-height), 20rem)",
+          }}
           align="start"
         >
-          <div className="flex items-center gap-2 border-b px-3 py-2">
+          <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
             <Search className="h-4 w-4 text-muted-foreground" aria-hidden />
             <input
               type="text"
@@ -157,7 +161,7 @@ export function MultiSelectDetailedForm({
               aria-label="Search options"
             />
           </div>
-          <div className="max-h-80 overflow-y-auto p-1">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-1">
             {filtered.length === 0 && (
               <div className="px-3 py-2 text-sm text-muted-foreground">
                 No options found

--- a/packages/shared-form-ui/src/components/Form/RichTextForm.tsx
+++ b/packages/shared-form-ui/src/components/Form/RichTextForm.tsx
@@ -28,7 +28,13 @@ const markdownClass =
   "[&>ol]:my-1 [&>ol]:list-decimal [&>ol]:pl-5 " +
   "[&_strong]:font-semibold [&_em]:italic"
 
-function Markdown({ source }: { source: string }) {
+function Markdown({
+  source,
+  stopAnchorPropagation,
+}: {
+  source: string
+  stopAnchorPropagation?: boolean
+}) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
@@ -39,6 +45,11 @@ function Markdown({ source }: { source: string }) {
             target="_blank"
             rel="noopener noreferrer"
             className="text-primary underline"
+            // Prevent the surrounding <label> from toggling the checkbox when
+            // the user actually intends to follow the link.
+            onClick={
+              stopAnchorPropagation ? (e) => e.stopPropagation() : undefined
+            }
           >
             {children}
           </a>
@@ -77,12 +88,18 @@ export function RichTextForm({
             required={isRequired}
             className="mt-0.5 shrink-0 mr-2"
           />
-          {/* Plain div (not <label>) so anchor clicks open the link instead of
-              toggling the checkbox. ml-2.5 (10px) over gap-x — gap-x has
+          {/* <label htmlFor> so clicking anywhere on the text toggles the
+              checkbox. Anchor clicks call stopPropagation in <Markdown> so they
+              still open the link. ml-2.5 (10px) over gap-x — gap-x has
               occasionally compressed inside narrow flex parents. */}
-          <div className={`${markdownClass} ml-2.5 flex-1 min-w-0`}>
-            <Markdown source={content} />
-          </div>
+          <label
+            htmlFor={id}
+            className={`${markdownClass} ml-2.5 flex-1 min-w-0 ${
+              disabled ? "cursor-not-allowed" : "cursor-pointer"
+            }`}
+          >
+            <Markdown source={content} stopAnchorPropagation />
+          </label>
         </div>
         {error && <p className="text-red-500 text-sm">{error}</p>}
       </FormInputWrapper>

--- a/packages/shared-form-ui/src/types.ts
+++ b/packages/shared-form-ui/src/types.ts
@@ -30,7 +30,7 @@ export interface FormFieldSchema {
   max_date?: string | null
   config?: Record<string, unknown>
   /** Layout override. When undefined/null, falls back to a type-based heuristic. */
-  width?: "full" | "half" | null
+  width?: "full" | "half" | "half_row" | null
 }
 
 export type FormSectionKind = "standard" | "companions" | "scholarship"

--- a/packages/shared-form-ui/src/utils.ts
+++ b/packages/shared-form-ui/src/utils.ts
@@ -21,9 +21,15 @@ const FULL_WIDTH_TYPES = new Set([
 export function resolveFieldWidth(field: {
   type?: string
   field_type?: string
-  width?: "full" | "half" | null
-}): "full" | "half" {
-  if (field.width === "full" || field.width === "half") return field.width
+  width?: "full" | "half" | "half_row" | null
+}): "full" | "half" | "half_row" {
+  if (
+    field.width === "full" ||
+    field.width === "half" ||
+    field.width === "half_row"
+  ) {
+    return field.width
+  }
   const t = field.field_type ?? field.type
   return t && FULL_WIDTH_TYPES.has(t) ? "full" : "half"
 }

--- a/portal/src/app/portal/[popupSlug]/application/components/dynamic-application-form.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/components/dynamic-application-form.tsx
@@ -106,8 +106,25 @@ const BaseField = memo(function BaseField({
     )
   }
 
+  const resolved = resolveFieldWidth(field)
+  if (resolved === "half_row") {
+    return (
+      <div className="md:col-span-2 md:grid md:grid-cols-2 md:gap-4">
+        <div>
+          <DynamicField
+            name={name}
+            field={field}
+            value={value}
+            error={error}
+            onChange={onChange}
+            hideLabelAndSubtitle={name === "info_not_shared"}
+          />
+        </div>
+      </div>
+    )
+  }
   return (
-    <div className={resolveFieldWidth(field) === "full" ? "md:col-span-2" : ""}>
+    <div className={resolved === "full" ? "md:col-span-2" : ""}>
       <DynamicField
         name={name}
         field={field}
@@ -352,15 +369,49 @@ export function DynamicApplicationForm({
             <div key={id}>
               <SectionWrapper title={title} subtitle={subtitle}>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  {fields.map(({ name, field, isCustom }) =>
-                    isCustom ? (
+                  {fields.map(({ name, field, isCustom }) => {
+                    if (!isCustom) {
+                      return (
+                        <BaseField
+                          key={name}
+                          name={name}
+                          field={field}
+                          value={values[name]}
+                          error={errors[name]}
+                          onChange={handleChange}
+                          displayGender={displayGender}
+                          handleGenderChange={handleGenderChange}
+                          genderSpecifyValue={getString(
+                            values,
+                            "gender_specify",
+                          )}
+                          genderSpecifyError={errors.gender_specify}
+                        />
+                      )
+                    }
+                    const resolved = resolveFieldWidth(field)
+                    if (resolved === "half_row") {
+                      return (
+                        <div
+                          key={name}
+                          className="md:col-span-2 md:grid md:grid-cols-2 md:gap-4"
+                        >
+                          <div>
+                            <DynamicField
+                              name={name}
+                              field={field}
+                              value={values[name]}
+                              error={errors[name]}
+                              onChange={handleChange}
+                            />
+                          </div>
+                        </div>
+                      )
+                    }
+                    return (
                       <div
                         key={name}
-                        className={
-                          resolveFieldWidth(field) === "full"
-                            ? "md:col-span-2"
-                            : ""
-                        }
+                        className={resolved === "full" ? "md:col-span-2" : ""}
                       >
                         <DynamicField
                           name={name}
@@ -370,21 +421,8 @@ export function DynamicApplicationForm({
                           onChange={handleChange}
                         />
                       </div>
-                    ) : (
-                      <BaseField
-                        key={name}
-                        name={name}
-                        field={field}
-                        value={values[name]}
-                        error={errors[name]}
-                        onChange={handleChange}
-                        displayGender={displayGender}
-                        handleGenderChange={handleGenderChange}
-                        genderSpecifyValue={getString(values, "gender_specify")}
-                        genderSpecifyError={errors.gender_specify}
-                      />
-                    ),
-                  )}
+                    )
+                  })}
                 </div>
               </SectionWrapper>
               <SectionSeparator />

--- a/portal/src/app/portal/[popupSlug]/application/components/form-section.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/components/form-section.tsx
@@ -31,23 +31,43 @@ export function FormSection({
     <>
       <SectionWrapper title={title} subtitle={subtitle}>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {sorted.map(([name, field]) => (
-            <div
-              key={name}
-              className={
-                resolveFieldWidth(field) === "full" ? "md:col-span-2" : ""
-              }
-            >
-              <DynamicField
-                name={name}
-                field={field}
-                value={values[name]}
-                error={errors[name]}
-                onChange={onChange}
-                hideLabelAndSubtitle={name === "info_not_shared"}
-              />
-            </div>
-          ))}
+          {sorted.map(([name, field]) => {
+            const resolved = resolveFieldWidth(field)
+            if (resolved === "half_row") {
+              return (
+                <div
+                  key={name}
+                  className="md:col-span-2 md:grid md:grid-cols-2 md:gap-6"
+                >
+                  <div>
+                    <DynamicField
+                      name={name}
+                      field={field}
+                      value={values[name]}
+                      error={errors[name]}
+                      onChange={onChange}
+                      hideLabelAndSubtitle={name === "info_not_shared"}
+                    />
+                  </div>
+                </div>
+              )
+            }
+            return (
+              <div
+                key={name}
+                className={resolved === "full" ? "md:col-span-2" : ""}
+              >
+                <DynamicField
+                  name={name}
+                  field={field}
+                  value={values[name]}
+                  error={errors[name]}
+                  onChange={onChange}
+                  hideLabelAndSubtitle={name === "info_not_shared"}
+                />
+              </div>
+            )
+          })}
         </div>
       </SectionWrapper>
       <SectionSeparator />

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -2881,6 +2881,17 @@ export const BaseFieldConfigPublicSchema = {
                 }
             ],
             title: 'Options'
+        },
+        field_type: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Field Type'
         }
     },
     type: 'object',
@@ -2970,6 +2981,17 @@ export const BaseFieldConfigUpdateSchema = {
                 }
             ],
             title: 'Options'
+        },
+        field_type: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Field Type'
         }
     },
     type: 'object',
@@ -6944,7 +6966,7 @@ export const FormFieldCreateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    enum: ['full', 'half']
+                    enum: ['full', 'half', 'half_row']
                 },
                 {
                     type: 'null'
@@ -7094,7 +7116,7 @@ export const FormFieldPublicSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    enum: ['full', 'half']
+                    enum: ['full', 'half', 'half_row']
                 },
                 {
                     type: 'null'
@@ -7122,6 +7144,20 @@ export const FormFieldPublicSchema = {
                 }
             ],
             title: 'Target'
+        },
+        allowed_field_types: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Allowed Field Types'
         }
     },
     type: 'object',
@@ -7261,7 +7297,7 @@ export const FormFieldUpdateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    enum: ['full', 'half']
+                    enum: ['full', 'half', 'half_row']
                 },
                 {
                     type: 'null'

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -609,6 +609,7 @@ export type BaseFieldConfigPublic = {
     placeholder?: (string | null);
     help_text?: (string | null);
     options?: (Array<(string)> | null);
+    field_type?: (string | null);
 };
 
 export type BaseFieldConfigUpdate = {
@@ -619,6 +620,7 @@ export type BaseFieldConfigUpdate = {
     placeholder?: (string | null);
     help_text?: (string | null);
     options?: (Array<(string)> | null);
+    field_type?: (string | null);
 };
 
 /**
@@ -1416,7 +1418,7 @@ export type FormFieldCreate = {
     config?: ({
     [key: string]: unknown;
 } | null);
-    width?: ('full' | 'half' | null);
+    width?: ('full' | 'half' | 'half_row' | null);
 };
 
 export type FormFieldPublic = {
@@ -1438,10 +1440,11 @@ export type FormFieldPublic = {
     config?: ({
     [key: string]: unknown;
 } | null);
-    width?: ('full' | 'half' | null);
+    width?: ('full' | 'half' | 'half_row' | null);
     protected?: boolean;
     removable?: boolean;
     target?: (string | null);
+    allowed_field_types?: (Array<(string)> | null);
 };
 
 export type FormFieldUpdate = {
@@ -1458,7 +1461,7 @@ export type FormFieldUpdate = {
     config?: ({
     [key: string]: unknown;
 } | null);
-    width?: ('full' | 'half' | null);
+    width?: ('full' | 'half' | 'half_row' | null);
 };
 
 export type FormSectionCreate = {

--- a/portal/src/components/Sidebar/HeaderBar.tsx
+++ b/portal/src/components/Sidebar/HeaderBar.tsx
@@ -29,6 +29,16 @@ function useHideOnScroll() {
     const onScroll = (event: Event) => {
       const target = event.target
       if (!target) return
+      // Ignore scrolls inside floating UI (popovers, dropdowns, dialogs,
+      // toasts). They are local overflow containers, not page-level scroll.
+      if (
+        target instanceof HTMLElement &&
+        target.closest(
+          "[data-radix-popper-content-wrapper],[role='dialog'],[data-sonner-toaster]",
+        )
+      ) {
+        return
+      }
       const el =
         target instanceof Document
           ? (document.scrollingElement ?? document.documentElement)


### PR DESCRIPTION
## Summary
- Base fields can opt into alternative input types when the catalog whitelists them via `allowed_field_types` (e.g. `city` can be `text` or `country_select`). New nullable `field_type` column on `basefieldconfigs` plus validation in the PATCH route; UI gates the type picker accordingly.
- New `half_row` width option (half-width but consumes a full row) across `shared-form-ui`, backoffice canvas, and portal renderers.
- Draft application saves skip required-field validation but still validate types/constraints on provided values.
- UI polish: ImageUpload label/subtitle wrapper, MultiSelect popover height, RichText label/anchor click handling, HeaderBar ignores scrolls inside popovers/dialogs/toasts.

## Test plan
- [ ] Run alembic upgrade head — `basefieldconfigs.field_type` column is added.
- [ ] PATCH a non-whitelisted base field with `field_type` → 400; PATCH `city` with `country_select` → succeeds, GET returns the override.
- [ ] Save an application as draft with missing required fields → succeeds; submit (non-draft) with same payload → fails with required-field errors.
- [ ] In backoffice form-builder, set a field width to `half_row` → portal renders it half-width with no sibling on the row.
- [ ] In portal, click a link inside a RichText checkbox label → opens link without toggling the checkbox; click the surrounding text → toggles.
- [ ] Open a popover/dialog in portal and scroll inside it → header does not hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)