### PR TITLE
Promote dev to main

### DIFF
--- a/backend/app/alembic/versions/f7fa8db4239a_popup_credits_enabled.py
+++ b/backend/app/alembic/versions/f7fa8db4239a_popup_credits_enabled.py
@@ -1,0 +1,41 @@
+"""popup_credits_enabled: add popup-level toggle for credits feature.
+
+Adds:
+  - popups.credits_enabled (bool, NOT NULL, default false)
+
+Defaults to false: existing popups do NOT have credits enabled until an admin
+opts in per popup. Gates the credit logic in payment/crud.py and the credit UI
+in portal.
+
+Revision ID: f7fa8db4239a
+Revises: c5d3e8a2f9b1
+Create Date: 2026-05-15 17:17:22.765387
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f7fa8db4239a"
+down_revision: str = "c5d3e8a2f9b1"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "popups",
+        sa.Column(
+            "credits_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("popups", "credits_enabled")

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -161,12 +161,26 @@ def _get_credit(application: Applications, discount_value: Decimal) -> Decimal:
     Each AttendeeProducts row represents one ticket (quantity=1). Patron rows
     are donations, not refundable ticket purchases — they contribute nothing to
     credit. Tickets purchased alongside a patron donation do contribute.
+
+    Only week and day passes convert into credit. Month/full passes already
+    purchased never grant credit toward a new purchase (you cannot "upgrade"
+    out of a longer duration into something larger). Mirrors the portal-side
+    filter in useCreditCalculation.
+
+    Gated by popup.credits_enabled: returns 0 when the popup has credits
+    disabled (default for new/un-migrated popups).
     """
+    if not application.popup or not application.popup.credits_enabled:
+        return Decimal("0")
+
     total = Decimal("0")
     for attendee in application.attendees:
         for ap in attendee.attendee_products:
-            if ap.product.category != "patreon":
-                total += ap.product.price
+            if ap.product.category == "patreon":
+                continue
+            if ap.product.duration_type not in ("week", "day"):
+                continue
+            total += ap.product.price
 
     credit = Decimal(str(application.credit)) if application.credit else Decimal("0")
     return _get_discounted_price(total, discount_value) + credit
@@ -1394,8 +1408,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         # Handle zero or negative amount (credit covers cost)
         if preview.amount <= 0:
             if preview.amount < 0:
-                # Store remaining credit
-                application.credit = -preview.amount
+                # Store remaining credit only when the popup has credits enabled.
+                # Otherwise, clamp to zero — we neither charge nor accumulate.
+                if application.popup and application.popup.credits_enabled:
+                    application.credit = -preview.amount
                 preview.amount = Decimal("0")
             else:
                 application.credit = Decimal("0")

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -142,6 +142,10 @@ class PopupBase(SQLModel):
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
+    credits_enabled: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
 
     @field_validator("currency")
     @classmethod
@@ -186,6 +190,7 @@ class PopupCreate(SQLModel):
     events_enabled: bool = True
     self_check_in_enabled: bool = False
     show_attendee_directory: bool = False
+    credits_enabled: bool = False
 
     @field_validator("currency")
     @classmethod
@@ -248,6 +253,7 @@ class PopupUpdate(SQLModel):
     events_enabled: bool | None = None
     self_check_in_enabled: bool | None = None
     show_attendee_directory: bool | None = None
+    credits_enabled: bool | None = None
 
     @field_validator("currency")
     @classmethod
@@ -311,6 +317,7 @@ class PopupPublic(SQLModel):
     application_layout: ApplicationLayout = ApplicationLayout.single_page
     events_enabled: bool = True
     show_attendee_directory: bool = False
+    credits_enabled: bool = False
 
 
 class PopupAdmin(PopupBase):

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -10713,6 +10713,11 @@ export const PopupAdminSchema = {
             title: 'Show Attendee Directory',
             default: false
         },
+        credits_enabled: {
+            type: 'boolean',
+            title: 'Credits Enabled',
+            default: false
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -11059,6 +11064,11 @@ export const PopupCreateSchema = {
             type: 'boolean',
             title: 'Show Attendee Directory',
             default: false
+        },
+        credits_enabled: {
+            type: 'boolean',
+            title: 'Credits Enabled',
+            default: false
         }
     },
     type: 'object',
@@ -11320,6 +11330,11 @@ export const PopupPublicSchema = {
         show_attendee_directory: {
             type: 'boolean',
             title: 'Show Attendee Directory',
+            default: false
+        },
+        credits_enabled: {
+            type: 'boolean',
+            title: 'Credits Enabled',
             default: false
         }
     },
@@ -11857,6 +11872,17 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Show Attendee Directory'
+        },
+        credits_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Credits Enabled'
         }
     },
     additionalProperties: false,

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2179,6 +2179,7 @@ export type PopupAdmin = {
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
     show_attendee_directory?: boolean;
+    credits_enabled?: boolean;
     id: string;
 };
 
@@ -2221,6 +2222,7 @@ export type PopupCreate = {
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
     show_attendee_directory?: boolean;
+    credits_enabled?: boolean;
 };
 
 /**
@@ -2260,6 +2262,7 @@ export type PopupPublic = {
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     show_attendee_directory?: boolean;
+    credits_enabled?: boolean;
 };
 
 /**
@@ -2334,6 +2337,7 @@ export type PopupUpdate = {
     events_enabled?: (boolean | null);
     self_check_in_enabled?: (boolean | null);
     show_attendee_directory?: (boolean | null);
+    credits_enabled?: (boolean | null);
 };
 
 /**

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/Buttons/EditPassesButton.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/Buttons/EditPassesButton.tsx
@@ -1,6 +1,7 @@
 import { PencilIcon, XIcon } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
+import { useCityProvider } from "@/providers/cityProvider"
 import { usePassesProvider } from "@/providers/passesProvider"
 
 interface EditPassesButtonProps {
@@ -10,11 +11,16 @@ interface EditPassesButtonProps {
 const EditPassesButton = ({ onSwitchToBuy }: EditPassesButtonProps) => {
   const { t } = useTranslation()
   const { toggleEditing, isEditing, attendeePasses } = usePassesProvider()
+  const { getCity } = useCityProvider()
+  const creditsEnabled = getCity()?.credits_enabled ?? false
 
   const somePurchased = attendeePasses.some((attendee) =>
     attendee.products.some((product) => product.purchased),
   )
 
+  // Edit mode exists to let users swap purchased passes for credit.
+  // Without credits, there is nothing to do here.
+  if (!creditsEnabled) return null
   if (!somePurchased) return null
 
   const handleEditClick = () => {

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/collapsible"
 import { useCalculateTotal } from "@/hooks/useCalculateTotal"
 import { cn } from "@/lib/utils"
+import { useCityProvider } from "@/providers/cityProvider"
 import type { AttendeePassState } from "@/types/Attendee"
 import type { DiscountProps } from "@/types/discounts"
 import type { ProductsPass } from "@/types/Products"
@@ -26,6 +27,8 @@ const TotalPurchase = ({
 }) => {
   const { t } = useTranslation()
   const { discountApplied } = useDiscountCode()
+  const { getCity } = useCityProvider()
+  const creditsEnabled = getCity()?.credits_enabled ?? false
   const {
     originalTotal,
     total,
@@ -106,10 +109,12 @@ const TotalPurchase = ({
 
             {/* <DiscountMonth attendees={attendees} total={total}/> */}
 
-            <DiscountWeekPurchased
-              attendees={attendees}
-              hasMonthSelected={hasMonthSelected}
-            />
+            {creditsEnabled && (
+              <DiscountWeekPurchased
+                attendees={attendees}
+                hasMonthSelected={hasMonthSelected}
+              />
+            )}
 
             {groupDiscountPercentage >= discountApplied.discount_value ? (
               <GroupDiscountDisplay

--- a/portal/src/app/portal/[popupSlug]/passes/hooks/usePurchaseProducts.ts
+++ b/portal/src/app/portal/[popupSlug]/passes/hooks/usePurchaseProducts.ts
@@ -22,15 +22,22 @@ const usePurchaseProducts = () => {
       const application = getRelevantApplication()
       if (!application) throw new Error("No application found")
 
-      const monthSelectedWithWeekOrDay = attendeePasses.some(
-        (p) =>
-          p.products.some((p) => p.duration_type === "month" && p.selected) &&
-          (p.products.some((p) => p.duration_type === "week" && p.purchased) ||
-            p.products.some((p) => p.duration_type === "day" && p.purchased)),
-      )
+      const creditsEnabled = getCity()?.credits_enabled ?? false
+
+      const monthSelectedWithWeekOrDay =
+        creditsEnabled &&
+        attendeePasses.some(
+          (p) =>
+            p.products.some((p) => p.duration_type === "month" && p.selected) &&
+            (p.products.some(
+              (p) => p.duration_type === "week" && p.purchased,
+            ) ||
+              p.products.some((p) => p.duration_type === "day" && p.purchased)),
+        )
 
       // LEGACY: application.credit removed from API
       const editableMode =
+        creditsEnabled &&
         (isEditing || monthSelectedWithWeekOrDay) &&
         !attendeePasses.some((p) =>
           p.products.some((p) => p.category === "patreon" && p.selected),

--- a/portal/src/checkout/buildPaymentProducts.test.ts
+++ b/portal/src/checkout/buildPaymentProducts.test.ts
@@ -128,9 +128,58 @@ describe("buildPaymentProducts", () => {
       isEditing: false,
       appCredit: 0,
       checkoutMode: CHECKOUT_MODE.PASS_SYSTEM,
+      creditsEnabled: true,
     })
 
     expect(result.isMonthUpgrade).toBe(true)
+    expect(result.products).toEqual([
+      {
+        product_id: "month-new",
+        attendee_id: "attendee-1",
+        quantity: 1,
+      },
+    ])
+  })
+
+  it("disables month upgrade detection when credits_enabled is false", () => {
+    const purchasedWeek = createProduct({
+      id: "week-owned",
+      duration_type: "week",
+      purchased: true,
+      quantity: 1,
+    })
+    const selectedMonth = createProduct({
+      id: "month-new",
+      duration_type: "month",
+      selected: true,
+      quantity: 1,
+    })
+    const attendeePasses = [createAttendee([purchasedWeek, selectedMonth])]
+
+    const result = buildPaymentProducts({
+      attendeePasses,
+      selectedPasses: [
+        {
+          productId: selectedMonth.id,
+          product: selectedMonth,
+          attendeeId: "attendee-1",
+          attendee: attendeePasses[0],
+          quantity: 1,
+          price: 100,
+        },
+      ],
+      housing: null,
+      merch: [],
+      patron: null,
+      dynamicItems: {},
+      isEditing: false,
+      appCredit: 0,
+      checkoutMode: CHECKOUT_MODE.PASS_SYSTEM,
+      creditsEnabled: false,
+    })
+
+    expect(result.isMonthUpgrade).toBe(false)
+    // Only the newly selected month is sent — no purchased week injected.
     expect(result.products).toEqual([
       {
         product_id: "month-new",

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -10713,6 +10713,11 @@ export const PopupAdminSchema = {
             title: 'Show Attendee Directory',
             default: false
         },
+        credits_enabled: {
+            type: 'boolean',
+            title: 'Credits Enabled',
+            default: false
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -11059,6 +11064,11 @@ export const PopupCreateSchema = {
             type: 'boolean',
             title: 'Show Attendee Directory',
             default: false
+        },
+        credits_enabled: {
+            type: 'boolean',
+            title: 'Credits Enabled',
+            default: false
         }
     },
     type: 'object',
@@ -11320,6 +11330,11 @@ export const PopupPublicSchema = {
         show_attendee_directory: {
             type: 'boolean',
             title: 'Show Attendee Directory',
+            default: false
+        },
+        credits_enabled: {
+            type: 'boolean',
+            title: 'Credits Enabled',
             default: false
         }
     },
@@ -11857,6 +11872,17 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Show Attendee Directory'
+        },
+        credits_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Credits Enabled'
         }
     },
     additionalProperties: false,

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2179,6 +2179,7 @@ export type PopupAdmin = {
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
     show_attendee_directory?: boolean;
+    credits_enabled?: boolean;
     id: string;
 };
 
@@ -2221,6 +2222,7 @@ export type PopupCreate = {
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
     show_attendee_directory?: boolean;
+    credits_enabled?: boolean;
 };
 
 /**
@@ -2260,6 +2262,7 @@ export type PopupPublic = {
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     show_attendee_directory?: boolean;
+    credits_enabled?: boolean;
 };
 
 /**
@@ -2334,6 +2337,7 @@ export type PopupUpdate = {
     events_enabled?: (boolean | null);
     self_check_in_enabled?: (boolean | null);
     show_attendee_directory?: (boolean | null);
+    credits_enabled?: (boolean | null);
 };
 
 /**

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -39,12 +39,14 @@ export default function ConfirmStep() {
     stepConfigs,
     buyerValues,
     buyerGeneralError,
+    creditsEnabled,
   } = useCheckout()
   const { getCity } = useCityProvider()
   const popup = getCity()
   const { getRelevantApplication } = useApplication()
   const application = getRelevantApplication()
-  const accountCredit = application?.credit ? Number(application.credit) : 0
+  const accountCredit =
+    creditsEnabled && application?.credit ? Number(application.credit) : 0
 
   const [promoInput, setPromoInput] = useState(cart.promoCode)
   const [promoError, setPromoError] = useState("")

--- a/portal/src/components/checkout-flow/variants/VariantPatronPreset.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantPatronPreset.tsx
@@ -142,6 +142,34 @@ interface PatronLayoutProps {
   onSkip?: () => void
 }
 
+function ProductDescription({
+  description,
+  className,
+  gap = "space-y-3",
+}: {
+  description: string
+  className: string
+  gap?: string
+}) {
+  const paragraphs = description
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean)
+  return (
+    <div className={gap}>
+      {paragraphs.map((para, idx) => (
+        <p
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable paragraph order
+          key={idx}
+          className={cn(className, "whitespace-pre-line")}
+        >
+          {para}
+        </p>
+      ))}
+    </div>
+  )
+}
+
 function PatronDefault({
   product,
   presets,
@@ -158,9 +186,12 @@ function PatronDefault({
     <div className="space-y-4">
       <div className="bg-checkout-card-bg rounded-2xl shadow-sm border border-border overflow-hidden p-5">
         {product.description && (
-          <p className="text-sm text-muted-foreground mb-4">
-            {product.description}
-          </p>
+          <div className="mb-4">
+            <ProductDescription
+              description={product.description}
+              className="text-sm text-muted-foreground leading-relaxed"
+            />
+          </div>
         )}
 
         <div className="flex gap-2 mb-3">
@@ -246,9 +277,13 @@ function PatronCompact({
     <div className="space-y-3">
       <div className="bg-checkout-card-bg rounded-xl border border-border p-3">
         {product.description && (
-          <p className="text-xs text-muted-foreground mb-3">
-            {product.description}
-          </p>
+          <div className="mb-3">
+            <ProductDescription
+              description={product.description}
+              className="text-xs text-muted-foreground leading-relaxed"
+              gap="space-y-2"
+            />
+          </div>
         )}
 
         <div className="flex gap-1.5 mb-2">
@@ -329,7 +364,10 @@ function PatronGrid({
   return (
     <div className="space-y-4">
       {product.description && (
-        <p className="text-sm text-muted-foreground">{product.description}</p>
+        <ProductDescription
+          description={product.description}
+          className="text-sm text-muted-foreground leading-relaxed"
+        />
       )}
 
       <div className="grid grid-cols-2 gap-3">

--- a/portal/src/hooks/checkout/buildPaymentProducts.ts
+++ b/portal/src/hooks/checkout/buildPaymentProducts.ts
@@ -153,9 +153,13 @@ export function buildPaymentProducts({
       })
     }
 
+    // When no pass is in selectedPasses (e.g., tickets selected via DynamicProductStep),
+    // attach side-products to the application's first existing attendee instead of "".
+    const firstAttendeeId =
+      selectedPasses[0]?.attendeeId ?? attendeePasses[0]?.id ?? ""
+
     // Add merch
     for (const item of merch) {
-      const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
       products.push({
         product_id: item.productId,
         attendee_id: firstAttendeeId,
@@ -165,7 +169,6 @@ export function buildPaymentProducts({
 
     // Add housing
     if (housing) {
-      const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
       const baseQty = housing.pricePerDay ? housing.nights : 1
       products.push({
         product_id: housing.productId,
@@ -176,7 +179,6 @@ export function buildPaymentProducts({
 
     // Add patron
     if (patron) {
-      const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
       products.push({
         product_id: patron.productId,
         attendee_id: firstAttendeeId,
@@ -186,7 +188,6 @@ export function buildPaymentProducts({
     }
 
     // Add dynamic step items
-    const firstAttendeeId = selectedPasses[0]?.attendeeId ?? ""
     for (const items of Object.values(dynamicItems)) {
       for (const item of items) {
         if (item.quantity > 0) {

--- a/portal/src/hooks/checkout/buildPaymentProducts.ts
+++ b/portal/src/hooks/checkout/buildPaymentProducts.ts
@@ -22,6 +22,7 @@ interface BuildPaymentProductsParams {
   isEditing: boolean
   appCredit: string | number | null | undefined
   checkoutMode?: CheckoutMode
+  creditsEnabled?: boolean
 }
 
 interface BuildPaymentProductsResult {
@@ -76,8 +77,10 @@ export function buildPaymentProducts({
   isEditing,
   appCredit,
   checkoutMode = CHECKOUT_MODE.PASS_SYSTEM,
+  creditsEnabled = false,
 }: BuildPaymentProductsParams): BuildPaymentProductsResult {
   const isMonthUpgrade =
+    creditsEnabled &&
     checkoutMode === CHECKOUT_MODE.PASS_SYSTEM &&
     detectMonthUpgrade(attendeePasses)
   const products: PaymentProductRequest[] = []

--- a/portal/src/hooks/checkout/useCreditCalculation.ts
+++ b/portal/src/hooks/checkout/useCreditCalculation.ts
@@ -55,8 +55,7 @@ export function useCreditCalculation({
             (p.duration_type === "week" || p.duration_type === "day"),
         )
         .reduce(
-          (sum, p) =>
-            sum + (p.original_price ?? p.price) * (p.quantity ?? 1),
+          (sum, p) => sum + (p.original_price ?? p.price) * (p.quantity ?? 1),
           0,
         )
 

--- a/portal/src/hooks/checkout/useCreditCalculation.ts
+++ b/portal/src/hooks/checkout/useCreditCalculation.ts
@@ -4,13 +4,16 @@ import type { AttendeePassState } from "@/types/Attendee"
 interface UseCreditCalculationParams {
   attendeePasses: AttendeePassState[]
   isEditing: boolean
+  creditsEnabled: boolean
 }
 
 export function useCreditCalculation({
   attendeePasses,
   isEditing,
+  creditsEnabled,
 }: UseCreditCalculationParams) {
   const editCredit = useMemo(() => {
+    if (!creditsEnabled) return 0
     if (!isEditing) return 0
     return attendeePasses.reduce((total, attendee) => {
       return (
@@ -20,9 +23,10 @@ export function useCreditCalculation({
           .reduce((sum, p) => sum + p.price * (p.quantity ?? 1), 0)
       )
     }, 0)
-  }, [attendeePasses, isEditing])
+  }, [attendeePasses, isEditing, creditsEnabled])
 
   const monthUpgradeCredit = useMemo(() => {
+    if (!creditsEnabled) return 0
     if (isEditing) return 0
 
     const hasPatreonSelected = attendeePasses.some((a) =>
@@ -39,20 +43,26 @@ export function useCreditCalculation({
       )
       if (!hasFullOrMonthSelected) return total
 
-      const hasPurchasedWeekOrDay = attendee.products.some(
-        (p) =>
-          (p.duration_type === "week" || p.duration_type === "day") &&
-          p.purchased,
-      )
-      if (!hasPurchasedWeekOrDay) return total
-
+      // Only week/day purchases convert into credit toward the month/full
+      // upgrade. The old behavior summed every non-patreon purchased product,
+      // which inflated credit by including unrelated purchases (e.g. a
+      // previously bought month from a different attendee group).
       const purchasedCredit = attendee.products
-        .filter((p) => p.category !== "patreon" && p.purchased)
-        .reduce((sum, p) => sum + p.price * (p.quantity ?? 1), 0)
+        .filter(
+          (p) =>
+            p.purchased &&
+            p.category !== "patreon" &&
+            (p.duration_type === "week" || p.duration_type === "day"),
+        )
+        .reduce(
+          (sum, p) =>
+            sum + (p.original_price ?? p.price) * (p.quantity ?? 1),
+          0,
+        )
 
       return total + purchasedCredit
     }, 0)
-  }, [attendeePasses, isEditing])
+  }, [attendeePasses, isEditing, creditsEnabled])
 
   return { editCredit, monthUpgradeCredit }
 }

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -46,6 +46,7 @@ interface UsePaymentSubmitParams {
     lastName: string
     formData: Record<string, unknown>
   } | null
+  creditsEnabled: boolean
 }
 
 interface PaymentSubmitResult {
@@ -76,6 +77,7 @@ export function usePaymentSubmit({
   paymentCompleteRef,
   submitMode,
   buyerData,
+  creditsEnabled,
 }: UsePaymentSubmitParams) {
   const queryClient = useQueryClient()
   const router = useRouter()
@@ -126,6 +128,7 @@ export function usePaymentSubmit({
           isEditing,
           appCredit,
           checkoutMode,
+          creditsEnabled,
         },
       )
 
@@ -267,6 +270,7 @@ export function usePaymentSubmit({
     popupSlug,
     submitMode,
     router,
+    creditsEnabled,
   ])
 
   return { submitPayment, isSubmitting }

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -104,7 +104,21 @@ export function usePaymentSubmit({
       return { success: false, error: "Buyer information not available" }
     }
 
-    if (selectedPasses.length === 0) {
+    // Mirror CartFooter.canContinue: any cart selection counts as "has something
+    // to buy", not just selectedPasses. Tickets selected via DynamicProductStep
+    // land in dynamicItems (not selectedPasses), so a passes-only guard would
+    // block dynamic-tickets flows entirely.
+    const hasDynamicItems = Object.values(dynamicItems).some((items) =>
+      items.some((i) => i.quantity > 0),
+    )
+    const hasAnyCartSelection =
+      selectedPasses.length > 0 ||
+      !!housing ||
+      merch.length > 0 ||
+      !!patron ||
+      hasDynamicItems
+
+    if (!hasAnyCartSelection) {
       return {
         success: false,
         error: isEditing

--- a/portal/src/hooks/useCalculateTotal.ts
+++ b/portal/src/hooks/useCalculateTotal.ts
@@ -13,10 +13,12 @@ export function useCalculateTotal() {
   const { getRelevantApplication } = useApplication()
   const application = getRelevantApplication()
   const { getCity } = useCityProvider()
+  const city = getCity()
   const { attendeePasses } = usePassesProvider()
   const { discountApplied } = useDiscount()
   const { data: groups = [] } = useGroupsQuery()
-  const checkoutPolicy = resolvePopupCheckoutPolicy(getCity())
+  const checkoutPolicy = resolvePopupCheckoutPolicy(city)
+  const creditsEnabled = city?.credits_enabled ?? false
 
   return useMemo(() => {
     let groupDiscountValue = 0
@@ -30,7 +32,10 @@ export function useCalculateTotal() {
       }
     }
 
-    const calculator = new TotalCalculator(checkoutPolicy.checkoutMode)
+    const calculator = new TotalCalculator(
+      checkoutPolicy.checkoutMode,
+      creditsEnabled,
+    )
     const result = calculator.calculate(
       attendeePasses,
       discountApplied,
@@ -50,6 +55,7 @@ export function useCalculateTotal() {
     application,
     attendeePasses,
     checkoutPolicy.checkoutMode,
+    creditsEnabled,
     discountApplied,
     groups,
   ])

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -112,6 +112,7 @@ interface CheckoutContextValue {
   setBuyerField: (fieldName: string, value: unknown) => void
   isBuyerInfoComplete: boolean
   cartUiEnabled: boolean
+  creditsEnabled: boolean
 }
 
 const CheckoutContext = createContext<CheckoutContextValue | null>(null)
@@ -156,8 +157,11 @@ export function CheckoutProvider({
   const products = productsOverride ?? queriedProducts
   const isAuthenticated = useIsAuthenticated()
   const application = getRelevantApplication()
-  const appCredit = accountCreditOverride ?? application?.credit
   const city = getCity()
+  const creditsEnabled = city?.credits_enabled ?? false
+  const appCredit = creditsEnabled
+    ? (accountCreditOverride ?? application?.credit)
+    : 0
   const checkoutPolicy = resolvePopupCheckoutPolicy(city)
   const cityId = city?.id ? String(city.id) : null
 
@@ -435,10 +439,11 @@ export function CheckoutProvider({
     scheduleSave,
   ])
 
-  // Credit calculations
+  // Credit calculations — gated by popup.credits_enabled
   const { editCredit, monthUpgradeCredit } = useCreditCalculation({
     attendeePasses,
     isEditing,
+    creditsEnabled,
   })
 
   // Insurance calculations
@@ -720,6 +725,7 @@ export function CheckoutProvider({
     setPromoError,
     paymentCompleteRef,
     submitMode,
+    creditsEnabled,
     buyerData:
       submitMode === "open-ticketing"
         ? {
@@ -804,6 +810,7 @@ export function CheckoutProvider({
     },
     isBuyerInfoComplete,
     cartUiEnabled,
+    creditsEnabled,
   }
 
   return (

--- a/portal/src/strategies/TotalStrategy.ts
+++ b/portal/src/strategies/TotalStrategy.ts
@@ -217,6 +217,7 @@ class SimpleQuantityPriceStrategy extends BasePriceStrategy {
 export class TotalCalculator {
   constructor(
     private readonly checkoutMode: CheckoutMode = CHECKOUT_MODE.PASS_SYSTEM,
+    private readonly creditsEnabled: boolean = false,
   ) {}
 
   calculate(
@@ -292,8 +293,30 @@ export class TotalCalculator {
     )
 
     if (hasPatreon) return new PatreonPriceStrategy()
+    // When credits are disabled, fall back to a straight pricing strategy that
+    // does not subtract purchased products from the new selection. The
+    // upgrade/downgrade math only makes sense as a credit, which is gated.
+    if (!this.creditsEnabled) {
+      return new NoCreditPriceStrategy()
+    }
     if (hasMonthly) return new MonthlyPriceStrategy()
     if (hasMonthPurchased) return new MonthlyPurchasedPriceStrategy()
     return new WeeklyPriceStrategy()
+  }
+}
+
+class NoCreditPriceStrategy extends BasePriceStrategy {
+  calculate(products: ProductsPass[], discount: DiscountProps): TotalResult {
+    const total = products
+      .filter((p) => p.selected && !p.purchased)
+      .reduce(
+        (sum, product) => sum + product.price * (product.quantity ?? 1),
+        0,
+      )
+    const originalTotal = this.calculateOriginalTotal(products)
+    const discountAmount = discount.discount_value
+      ? originalTotal * (discount.discount_value / 100)
+      : 0
+    return { total, originalTotal, discountAmount }
   }
 }


### PR DESCRIPTION
## Summary
- fix(portal): unblock Pay when tickets are selected via DynamicProductStep — submit guard now mirrors `CartFooter.canContinue` (any cart selection counts), and side-products fall back to the application's first attendee when `selectedPasses` is empty
- feat(portal): render patron description as paragraphs
- feat(credits): gate credits per popup and fix month-upgrade credit math (#129)

## Test plan
- [ ] Portal `/portal/<slug>/passes/buy`: select a ticket via the dynamic step and confirm Pay → SimpleFI redirect (regression of the silent failure)
- [ ] Patron step: description with multiple paragraphs renders as separate paragraphs
- [ ] Credits-enabled popup: month upgrade applies credit; credits-disabled popup ignores credit math

🤖 Generated with [Claude Code](https://claude.com/claude-code)