### PR TITLE
chore: release dev to main

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -282,6 +282,12 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         # still validate types/constraints on any values the user did provide.
         is_draft = _is_draft_status(getattr(app_data, "status", None))
 
+        # Applications submitted through a group come from the portal's
+        # Express Checkout, which renders a reduced personal-info form. Scope
+        # required validation to that subset so users aren't blocked on fields
+        # the form never asked for.
+        is_express_checkout = bool(getattr(app_data, "group_id", None))
+
         # Validate custom_fields against form field definitions
         if validate_custom_fields and app_data.custom_fields:
             is_valid, errors = form_fields_crud.validate_custom_fields(
@@ -289,6 +295,7 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 app_data.popup_id,
                 app_data.custom_fields,
                 skip_required=is_draft,
+                is_express_checkout=is_express_checkout,
             )
             if not is_valid:
                 raise HTTPException(
@@ -307,7 +314,11 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         # Validate required base fields against BaseFieldConfigs
         if validate_custom_fields and not is_draft:
             is_valid, errors = form_fields_crud.validate_base_fields(
-                session, app_data.popup_id, app_data.model_dump(), human
+                session,
+                app_data.popup_id,
+                app_data.model_dump(),
+                human,
+                is_express_checkout=is_express_checkout,
             )
             if not is_valid:
                 raise HTTPException(
@@ -511,6 +522,10 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         # still validate types/constraints on any values the user did provide.
         is_draft = _is_draft_status(getattr(app_data, "status", None))
 
+        # Group applications use the Express Checkout reduced form on the
+        # portal; mirror that scope here when the admin creates one too.
+        is_express_checkout = bool(getattr(app_data, "group_id", None))
+
         # Validate custom_fields against form field definitions
         if validate_custom_fields and app_data.custom_fields:
             is_valid, errors = form_fields_crud.validate_custom_fields(
@@ -518,6 +533,7 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 app_data.popup_id,
                 app_data.custom_fields,
                 skip_required=is_draft,
+                is_express_checkout=is_express_checkout,
             )
             if not is_valid:
                 raise HTTPException(
@@ -552,7 +568,11 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         # Validate required base fields against BaseFieldConfigs
         if validate_custom_fields and not is_draft:
             is_valid, errors = form_fields_crud.validate_base_fields(
-                session, app_data.popup_id, app_data.model_dump(), human
+                session,
+                app_data.popup_id,
+                app_data.model_dump(),
+                human,
+                is_express_checkout=is_express_checkout,
             )
             if not is_valid:
                 raise HTTPException(

--- a/backend/app/api/form_field/crud.py
+++ b/backend/app/api/form_field/crud.py
@@ -21,6 +21,39 @@ def _slugify(text: str) -> str:
     return text[:80] or "field"
 
 
+# Mirrors the portal `CHECKOUT_BASE_FIELD_KEYS` set in
+# portal/src/app/checkout/types.ts. The /groups Express Checkout renders only
+# base fields in this set OR whose target is "human", plus custom fields that
+# share a section with those base fields. Required validation must use the
+# same subset so backend doesn't reject what the form never asked for.
+EXPRESS_CHECKOUT_BASE_FIELD_NAMES = frozenset(
+    {
+        "email",
+        "first_name",
+        "last_name",
+        "telegram",
+        "gender",
+        "age",
+        "residence",
+    }
+)
+
+
+def _is_express_checkout_base_field(
+    field_name: str, definition: dict[str, Any]
+) -> bool:
+    if field_name in EXPRESS_CHECKOUT_BASE_FIELD_NAMES:
+        return True
+    return definition.get("target") == "human"
+
+
+_EXPRESS_UNSECTIONED_KEY = "__express_unsectioned__"
+
+
+def _section_key(section_id: uuid.UUID | None) -> str:
+    return str(section_id) if section_id else _EXPRESS_UNSECTIONED_KEY
+
+
 class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
     def __init__(self) -> None:
         super().__init__(FormFields)
@@ -85,6 +118,7 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         popup_id: uuid.UUID,
         app_data: dict[str, Any],
         human: Any,
+        is_express_checkout: bool = False,
     ) -> tuple[bool, list[str]]:
         """Validate required base fields are present.
 
@@ -94,6 +128,10 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
 
         Elementals (first_name, last_name) are skipped here because Pydantic
         enforces them at the ApplicationCreate layer.
+
+        When ``is_express_checkout`` is True, required checks are limited to
+        the reduced subset rendered by the portal /groups Express Checkout
+        (mirrors ``isCheckoutBaseField`` in portal/src/app/checkout/types.ts).
         """
         from app.api.base_field_config.constants import BASE_FIELD_DEFINITIONS
         from app.api.base_field_config.crud import base_field_configs_crud
@@ -115,6 +153,10 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
             if not definition.get("removable", True):
                 continue
             if config.section_id and config.section_id in hidden_section_ids:
+                continue
+            if is_express_checkout and not _is_express_checkout_base_field(
+                config.field_name, definition
+            ):
                 continue
 
             field_name = config.field_name
@@ -138,12 +180,17 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         popup_id: uuid.UUID,
         custom_fields: dict[str, Any] | None,
         skip_required: bool = False,
+        is_express_checkout: bool = False,
     ) -> tuple[bool, list[str]]:
         """Validate custom_fields against form field definitions.
 
         When ``skip_required`` is True, presence/emptiness checks on required
         fields are bypassed (used for draft saves), but type and constraint
         validation still runs on whatever values were provided.
+
+        When ``is_express_checkout`` is True, required checks are limited to
+        custom fields whose section also contains an Express Checkout base
+        field (mirrors ``getCheckoutMiniFormSchema`` in the portal).
 
         Returns tuple of (is_valid, list_of_errors).
         """
@@ -163,12 +210,33 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         )
         hidden_section_ids = {s.id for s in sections if s.hidden}
 
+        # When the request comes from the /groups Express Checkout, only
+        # custom fields sharing a section with an Express Checkout base field
+        # were rendered — restrict required validation to that subset.
+        express_section_keys: set[str] = set()
+        if is_express_checkout:
+            from app.api.base_field_config.constants import BASE_FIELD_DEFINITIONS
+            from app.api.base_field_config.crud import base_field_configs_crud
+
+            base_configs = base_field_configs_crud.find_by_popup(session, popup_id)
+            for config in base_configs:
+                definition = BASE_FIELD_DEFINITIONS.get(config.field_name)
+                if not definition:
+                    continue
+                if _is_express_checkout_base_field(config.field_name, definition):
+                    express_section_keys.add(_section_key(config.section_id))
+
         errors: list[str] = []
 
         # Check required fields
         if not skip_required:
             for field in fields:
                 if field.section_id and field.section_id in hidden_section_ids:
+                    continue
+                if (
+                    is_express_checkout
+                    and _section_key(field.section_id) not in express_section_keys
+                ):
                     continue
                 if field.required and field.name not in custom_fields:
                     errors.append(f"Required field '{field.label}' is missing")

--- a/backend/tests/api/form_field/test_form_field_express_checkout.py
+++ b/backend/tests/api/form_field/test_form_field_express_checkout.py
@@ -1,0 +1,189 @@
+"""Tests for Express Checkout (group flow) required-field validation scope.
+
+The portal /groups Express Checkout renders only the personal-information
+subset of the application form (mirrors getCheckoutMiniFormSchema in
+portal/src/app/checkout/types.ts). The backend must mirror that scope when
+validating required fields so users aren't blocked on fields the form never
+showed.
+"""
+
+import uuid
+
+from sqlmodel import Session
+
+from app.api.base_field_config.models import BaseFieldConfigs
+from app.api.form_field.crud import form_fields_crud
+from app.api.form_field.models import FormFields
+from app.api.form_section.models import FormSections
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        name=f"Popup {uuid.uuid4().hex[:8]}",
+        slug=f"popup-{uuid.uuid4().hex[:8]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_section(
+    db: Session, tenant: Tenants, popup: Popups, *, label: str, order: int
+) -> FormSections:
+    section = FormSections(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        label=label,
+        order=order,
+    )
+    db.add(section)
+    db.flush()
+    return section
+
+
+def _make_field(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    section: FormSections,
+    *,
+    name: str,
+    label: str,
+    required: bool,
+) -> FormFields:
+    field = FormFields(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        section_id=section.id,
+        name=name,
+        label=label,
+        field_type="text",
+        required=required,
+    )
+    db.add(field)
+    db.flush()
+    return field
+
+
+class TestExpressCheckoutCustomFields:
+    def test_required_custom_field_outside_personal_section_is_skipped(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """A required custom field in a non-personal section is enforced for
+        regular applications but skipped for Express Checkout (group flow)."""
+        popup = _make_popup(db, tenant_a)
+        personal_section = _make_section(
+            db, tenant_a, popup, label="Personal Information", order=0
+        )
+        extra_section = _make_section(
+            db, tenant_a, popup, label="Organization", order=1
+        )
+
+        # Anchor the personal section with a target=human base field so the
+        # express-checkout scope includes it.
+        db.add(
+            BaseFieldConfigs(
+                tenant_id=tenant_a.id,
+                popup_id=popup.id,
+                field_name="telegram",
+                section_id=personal_section.id,
+                required=False,
+                position=0,
+            )
+        )
+        _make_field(
+            db,
+            tenant_a,
+            popup,
+            extra_section,
+            name="organization",
+            label="Organization you represent",
+            required=True,
+        )
+        db.commit()
+
+        is_valid_regular, errors_regular = form_fields_crud.validate_custom_fields(
+            db, popup.id, {}, is_express_checkout=False
+        )
+        assert not is_valid_regular
+        assert any("Organization you represent" in e for e in errors_regular)
+
+        is_valid_express, errors_express = form_fields_crud.validate_custom_fields(
+            db, popup.id, {}, is_express_checkout=True
+        )
+        assert is_valid_express, errors_express
+
+    def test_required_custom_field_inside_personal_section_is_enforced(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """Required custom fields in the personal section are still enforced
+        under Express Checkout — only fields outside it are scoped out."""
+        popup = _make_popup(db, tenant_a)
+        personal_section = _make_section(
+            db, tenant_a, popup, label="Personal Information", order=0
+        )
+
+        db.add(
+            BaseFieldConfigs(
+                tenant_id=tenant_a.id,
+                popup_id=popup.id,
+                field_name="telegram",
+                section_id=personal_section.id,
+                required=False,
+                position=0,
+            )
+        )
+        _make_field(
+            db,
+            tenant_a,
+            popup,
+            personal_section,
+            name="eth_address",
+            label="ETH address",
+            required=True,
+        )
+        db.commit()
+
+        is_valid, errors = form_fields_crud.validate_custom_fields(
+            db, popup.id, {}, is_express_checkout=True
+        )
+        assert not is_valid
+        assert any("ETH address" in e for e in errors)
+
+
+class TestExpressCheckoutBaseFields:
+    def test_required_application_targeted_base_field_is_skipped(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """Base fields whose target is `application` (e.g. referral) aren't
+        rendered by Express Checkout, so a required configuration must not
+        block a group-flow submission."""
+        popup = _make_popup(db, tenant_a)
+        section = _make_section(
+            db, tenant_a, popup, label="Personal Information", order=0
+        )
+        db.add(
+            BaseFieldConfigs(
+                tenant_id=tenant_a.id,
+                popup_id=popup.id,
+                field_name="referral",
+                section_id=section.id,
+                required=True,
+                position=0,
+            )
+        )
+        db.commit()
+
+        is_valid_regular, errors_regular = form_fields_crud.validate_base_fields(
+            db, popup.id, {}, human=None, is_express_checkout=False
+        )
+        assert not is_valid_regular
+        assert any("refer" in e.lower() for e in errors_regular)
+
+        is_valid_express, errors_express = form_fields_crud.validate_base_fields(
+            db, popup.id, {}, human=None, is_express_checkout=True
+        )
+        assert is_valid_express, errors_express

--- a/backend/tests/test_group_express_checkout_attendee.py
+++ b/backend/tests/test_group_express_checkout_attendee.py
@@ -5,7 +5,6 @@ import uuid
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from app.api.application.models import Applications
 from app.api.application.schemas import ApplicationStatus
 from app.api.attendee.models import Attendees
 from app.api.attendee_category.crud import attendee_categories_crud

--- a/backend/tests/test_group_express_checkout_attendee.py
+++ b/backend/tests/test_group_express_checkout_attendee.py
@@ -1,0 +1,89 @@
+"""Repro test: POST /applications/my with group_id must create a main attendee."""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import Attendees
+from app.api.attendee_category.crud import attendee_categories_crud
+from app.api.group.models import Groups
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+
+def test_group_application_creates_main_attendee(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """POST /applications/my with group_id must auto-accept and create a main attendee."""
+    popup = Popups(
+        name=f"Group Test {uuid.uuid4().hex[:8]}",
+        slug=f"group-test-{uuid.uuid4().hex[:8]}",
+        tenant_id=tenant_a.id,
+    )
+    db.add(popup)
+    db.flush()
+
+    main_cat = attendee_categories_crud.seed_main_for_popup(
+        db, popup.id, tenant_a.id
+    )
+    assert main_cat is not None
+
+    group = Groups(
+        tenant_id=tenant_a.id,
+        popup_id=popup.id,
+        name="Group T",
+        slug=f"group-t-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(group)
+    db.commit()
+    db.refresh(group)
+
+    email = f"group-{uuid.uuid4().hex[:8]}@test.com"
+    human = Humans(
+        tenant_id=tenant_a.id,
+        email=email,
+        first_name="Express",
+        last_name="Checkout",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    token = create_access_token(subject=human.id, token_type="human")
+
+    response = client.post(
+        "/api/v1/applications/my",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "popup_id": str(popup.id),
+            "group_id": str(group.id),
+            "first_name": "Express",
+            "last_name": "Checkout",
+            "status": "in review",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    data = response.json()
+    assert data["status"] == ApplicationStatus.ACCEPTED.value
+
+    app_id = uuid.UUID(data["id"])
+    db_attendees = db.exec(
+        select(Attendees).where(Attendees.application_id == app_id)
+    ).all()
+    assert len(db_attendees) == 1, (
+        f"Expected exactly 1 main attendee, got {len(db_attendees)}"
+    )
+    attendee = db_attendees[0]
+    assert attendee.human_id == human.id
+    assert attendee.category_id == main_cat.id
+
+    assert "attendees" in data
+    assert len(data["attendees"]) == 1
+    assert data["attendees"][0]["id"] == str(attendee.id)

--- a/portal/src/app/checkout/components/UserInfoForm/PersonalInfoForm.tsx
+++ b/portal/src/app/checkout/components/UserInfoForm/PersonalInfoForm.tsx
@@ -6,6 +6,7 @@ import {
 } from "@edgeos/shared-form-ui"
 import { useTranslation } from "react-i18next"
 import { DynamicField } from "@/app/portal/[popupSlug]/application/components/fields/dynamic-field"
+import { Button } from "@/components/ui/button"
 import type { ApplicationFormSchema } from "@/types/form-schema"
 import {
   type CheckoutApplicationValues,
@@ -95,13 +96,14 @@ const PersonalInfoForm = ({
           </div>
 
           {handleChangeEmail && (
-            <button
+            <Button
               type="button"
-              className="mt-[21px] text-sm underline"
+              variant="link"
+              size="default"
               onClick={handleChangeEmail}
             >
               {t("form.change_email")}
-            </button>
+            </Button>
           )}
         </div>
 
@@ -157,6 +159,31 @@ const PersonalInfoForm = ({
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
+      <div className="flex items-end justify-between gap-4">
+        <div className="flex-1 space-y-2">
+          <LabelRequired isRequired={false}>{t("common.email")}</LabelRequired>
+          <Input
+            id="checkout-email"
+            type="email"
+            value={String(formData.email ?? "")}
+            onChange={() => {}}
+            disabled
+            className="w-full"
+          />
+        </div>
+
+        {handleChangeEmail && (
+          <Button
+            type="button"
+            variant="link"
+            size="default"
+            onClick={handleChangeEmail}
+          >
+            {t("form.change_email")}
+          </Button>
+        )}
+      </div>
+
       {sections.map((section, index) => (
         <section key={section.id} className="space-y-4">
           {shouldRenderSectionHeader(section.id, section.title, index) && (
@@ -172,43 +199,6 @@ const PersonalInfoForm = ({
 
           <div className="grid gap-4 md:grid-cols-2">
             {section.fields.map(({ name, field }) => {
-              if (name === "email") {
-                return (
-                  <div key={name} className="space-y-2 md:col-span-2">
-                    <div className="flex items-end justify-between gap-4">
-                      <div className="flex-1 space-y-2">
-                        <LabelRequired isRequired={field.required}>
-                          {field.label}
-                        </LabelRequired>
-                        {field.help_text && (
-                          <p className="text-sm text-muted-foreground">
-                            {field.help_text}
-                          </p>
-                        )}
-                        <Input
-                          id="checkout-email"
-                          type="email"
-                          value={String(formData.email ?? "")}
-                          onChange={() => {}}
-                          disabled
-                          className="w-full"
-                        />
-                      </div>
-
-                      {handleChangeEmail && (
-                        <button
-                          type="button"
-                          className="text-sm underline"
-                          onClick={handleChangeEmail}
-                        >
-                          {t("form.change_email")}
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                )
-              }
-
               if (name === "gender" && genderField) {
                 return (
                   <div key={name} className="space-y-4 md:col-span-2">

--- a/portal/src/app/checkout/components/UserInfoForm/PersonalInfoForm.tsx
+++ b/portal/src/app/checkout/components/UserInfoForm/PersonalInfoForm.tsx
@@ -200,8 +200,18 @@ const PersonalInfoForm = ({
           <div className="grid gap-4 md:grid-cols-2">
             {section.fields.map(({ name, field }) => {
               if (name === "gender" && genderField) {
+                const showSpecify = displayGender === "Specify"
+                const genderSpansFullRow =
+                  Boolean(genderField.help_text) || showSpecify
                 return (
-                  <div key={name} className="space-y-4 md:col-span-2">
+                  <div
+                    key={name}
+                    className={
+                      genderSpansFullRow
+                        ? "space-y-4 md:col-span-2"
+                        : "space-y-4"
+                    }
+                  >
                     <SelectForm
                       label={genderField.label}
                       id="gender"
@@ -215,7 +225,7 @@ const PersonalInfoForm = ({
                       }))}
                     />
 
-                    {displayGender === "Specify" && (
+                    {showSpecify && (
                       <InputForm
                         label={t("form.gender_specify")}
                         id="gender_specify"
@@ -232,15 +242,13 @@ const PersonalInfoForm = ({
                 )
               }
 
+              const spansFullRow =
+                field.type === "textarea" ||
+                field.type === "multiselect" ||
+                Boolean(field.help_text)
+
               return (
-                <div
-                  key={name}
-                  className={
-                    field.type === "textarea" || field.type === "multiselect"
-                      ? "md:col-span-2"
-                      : ""
-                  }
-                >
+                <div key={name} className={spansFullRow ? "md:col-span-2" : ""}>
                   <DynamicField
                     name={name}
                     field={field}

--- a/portal/src/app/checkout/hooks/useApplicationData.ts
+++ b/portal/src/app/checkout/hooks/useApplicationData.ts
@@ -49,6 +49,12 @@ export function hydrateCheckoutApplicationValues({
   values.gender_specify = ""
   values.email_verified = Boolean(human?.email)
 
+  // Email is part of the auth flow, not the form schema, so the loops below
+  // (which iterate schema.base_fields) never set it. Seed it explicitly so the
+  // Express Checkout read-only field renders for already-authenticated users.
+  const resolvedEmail = application?.human?.email ?? human?.email
+  if (resolvedEmail) values.email = resolvedEmail
+
   const isCurrentPopupApplication = application?.popup_id === popupId
 
   for (const [name, field] of Object.entries(checkoutSchema.base_fields)) {

--- a/portal/src/app/checkout/hooks/useCheckoutState.ts
+++ b/portal/src/app/checkout/hooks/useCheckoutState.ts
@@ -170,6 +170,12 @@ const useCheckoutState = ({
         queryKey: queryKeys.profile.current,
         refetchType: "active",
       })
+      // The application create endpoint also creates the main attendee. Refetch
+      // the human's attendees so the passes step sees it (otherwise attendee_id
+      // resolves to "" and the payment POST fails with a UUID parse error).
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.attendees.byHumanPopup(popupId),
+      })
       setCheckoutState("passes")
       setErrorMessage(null)
     },

--- a/portal/src/app/checkout/types.ts
+++ b/portal/src/app/checkout/types.ts
@@ -149,6 +149,7 @@ export function filterCheckoutApplicationValues(
     ...Object.keys(miniFormSchema.custom_fields).map(
       (name) => `custom_${name}`,
     ),
+    "email",
     "gender_specify",
     "email_verified",
   ])

--- a/portal/src/app/portal/[popupSlug]/passes/Tabs/YourPasses.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/Tabs/YourPasses.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from "react-i18next"
 import { TICKET_CATEGORY } from "@/checkout/popupCheckoutPolicy"
 import AddAttendeeButtons from "@/components/checkout-flow/shared/AddAttendeeButtons"
 import { Button } from "@/components/ui/button"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import useAttendee from "@/hooks/useAttendee"
+import { useAttendeeCategories } from "@/hooks/useAttendeeCategories"
 import type { HumanPopupAccess } from "@/hooks/useHumanPopupAccess"
 import { useCityProvider } from "@/providers/cityProvider"
 import { usePassesProvider } from "@/providers/passesProvider"
@@ -16,7 +16,6 @@ import { formatCurrency } from "@/types/checkout"
 import { AttendeeModal } from "../components/AttendeeModal"
 import AttendeeTicket from "../components/common/AttendeeTicket"
 import InvoiceModal from "../components/common/InvoiceModal"
-import Special from "../components/common/Products/Special"
 import useModal from "../hooks/useModal"
 
 interface YourPassesProps {
@@ -27,14 +26,12 @@ interface YourPassesProps {
 const YourPasses = ({ access: _access, onSwitchToBuy }: YourPassesProps) => {
   const { t } = useTranslation()
   const { attendeePasses: attendees, products } = usePassesProvider()
-  const mainAttendee = attendees.find((a) => a.category === "main")
-  const specialProduct = mainAttendee?.products.find(
-    (p) => p.category === "patreon",
-  )
   const searchParams = useSearchParams()
   const isDayCheckout = searchParams.has("day-passes")
   const { getCity } = useCityProvider()
   const city = getCity()
+  const { categories } = useAttendeeCategories(city?.id ? String(city.id) : "")
+  const primaryCategoryId = categories?.find((c) => c.is_primary)?.id ?? null
   const { handleCloseModal, modal } = useModal()
   const { addAttendee } = useAttendee()
   const [isInvoiceModalOpen, setIsInvoiceModalOpen] = useState(false)
@@ -48,7 +45,7 @@ const YourPasses = ({ access: _access, onSwitchToBuy }: YourPassesProps) => {
       p.category === TICKET_CATEGORY &&
       p.is_active !== false &&
       (p.attendee_category_id == null ||
-        p.attendee_category_id === mainAttendee?.category_id),
+        p.attendee_category_id === primaryCategoryId),
   )
   const minPrice =
     mainTickets.length > 0 ? Math.min(...mainTickets.map((p) => p.price)) : null
@@ -92,13 +89,6 @@ const YourPasses = ({ access: _access, onSwitchToBuy }: YourPassesProps) => {
           )}
         </div>
       </div>
-
-      {specialProduct && (
-        <div className="p-0 w-full">
-          <Special product={specialProduct} disabled />
-          <Separator className="my-4" />
-        </div>
-      )}
 
       <div className="flex flex-col gap-4">
         {attendees.length === 0 ? (

--- a/portal/src/app/portal/[popupSlug]/passes/Tabs/YourPasses.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/Tabs/YourPasses.tsx
@@ -1,8 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
 import { ArrowRight, FileText, Sparkles, Ticket } from "lucide-react"
 import { useSearchParams } from "next/navigation"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { TICKET_CATEGORY } from "@/checkout/popupCheckoutPolicy"
+import { TicketingStepsService } from "@/client"
 import AddAttendeeButtons from "@/components/checkout-flow/shared/AddAttendeeButtons"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -17,6 +19,11 @@ import { AttendeeModal } from "../components/AttendeeModal"
 import AttendeeTicket from "../components/common/AttendeeTicket"
 import InvoiceModal from "../components/common/InvoiceModal"
 import useModal from "../hooks/useModal"
+
+interface TicketSelectSectionConfig {
+  product_ids?: string[]
+  attendee_categories?: string[] | null
+}
 
 interface YourPassesProps {
   access: Extract<HumanPopupAccess, { state: "allowed" }>
@@ -40,13 +47,49 @@ const YourPasses = ({ access: _access, onSwitchToBuy }: YourPassesProps) => {
     a.products.some((p) => p.purchased),
   )
 
-  const mainTickets = products.filter(
-    (p) =>
-      p.category === TICKET_CATEGORY &&
-      p.is_active !== false &&
-      (p.attendee_category_id == null ||
-        p.attendee_category_id === primaryCategoryId),
-  )
+  // Product → main-attendee mapping lives in ticketing-step template_config
+  // sections (see VariantTicketSelect.buildSectionGroups). Mirror that logic
+  // here so the "Starting at" price reflects only what the main attendee can
+  // actually buy. Products.attendee_category_id is not populated for popups
+  // configured under the post-migration ticket-as-first-class-entity model,
+  // so we don't fall back to it — that's what produced the $0 bug.
+  const popupId = city?.id ? String(city.id) : null
+  const { data: ticketingStepsData } = useQuery({
+    queryKey: ["ticketing-steps-portal", popupId],
+    queryFn: () =>
+      TicketingStepsService.listPortalTicketingSteps({ popupId: popupId! }),
+    enabled: !!popupId,
+  })
+
+  const mainProductIds: Set<string> | null = (() => {
+    if (!ticketingStepsData || primaryCategoryId == null) return null
+
+    const ticketSelectStep = (ticketingStepsData.results ?? []).find(
+      (s) => s.template === "ticket-select",
+    )
+    const sections = (ticketSelectStep?.template_config?.sections ??
+      []) as TicketSelectSectionConfig[]
+    if (sections.length === 0) return null
+
+    const ids = new Set<string>()
+    for (const section of sections) {
+      const visibleToMain =
+        section.attendee_categories == null ||
+        section.attendee_categories.includes(primaryCategoryId)
+      if (!visibleToMain) continue
+      for (const pid of section.product_ids ?? []) ids.add(pid)
+    }
+    return ids
+  })()
+
+  const mainTickets = mainProductIds
+    ? products.filter(
+        (p) =>
+          p.category === TICKET_CATEGORY &&
+          p.is_active !== false &&
+          mainProductIds.has(p.id),
+      )
+    : []
   const minPrice =
     mainTickets.length > 0 ? Math.min(...mainTickets.map((p) => p.price)) : null
 

--- a/portal/src/components/EventsApiAccessGate.tsx
+++ b/portal/src/components/EventsApiAccessGate.tsx
@@ -7,11 +7,12 @@ import { useApplication } from "@/providers/applicationProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 
 // Mirrors the sidebar's exposure rule for API Keys / API Docs in
-// useResources.ts: shown only on the standard (application-based) flow,
-// for accepted attendees, when the events module is enabled at the popup
-// level. Direct-sale and companion flows never expose these subsections,
-// so navigating to /portal/api-keys or /portal/docs by URL must fall
-// through to the unavailable state instead of rendering the page.
+// useResources.ts: shown on application-based flows (applicant or
+// companion) once the application is accepted and the events module is
+// enabled at the popup level. Direct-sale flows never expose these
+// subsections, so navigating to /portal/api-keys or /portal/docs by URL
+// must fall through to the unavailable state instead of rendering the
+// page.
 export function useEventsApiAccess(): { allowed: boolean } {
   const { getCity } = useCityProvider()
   const { getRelevantApplication, participation } = useApplication()
@@ -21,10 +22,12 @@ export function useEventsApiAccess(): { allowed: boolean } {
   const isDirectSale = city?.sale_type === "direct"
   const isCompanion = participation?.type === "companion"
   const eventsEnabled = city?.events_enabled ?? true
-  const canSeeAttendees = application?.status === "accepted"
+  const applicationAccepted = isCompanion
+    ? participation?.application_status === "accepted"
+    : application?.status === "accepted"
 
   return {
-    allowed: !isDirectSale && !isCompanion && eventsEnabled && canSeeAttendees,
+    allowed: !isDirectSale && eventsEnabled && applicationAccepted,
   }
 }
 

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -531,6 +531,28 @@ function PassRow({
   const currentQuantity = product.quantity ?? 0
   const maxQuantity = resolveMaxQuantity(product)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure on description and collapse state changes
+  useLayoutEffect(() => {
+    if (summaryOpen) return
+    const el = descriptionRef.current
+    if (!el) return
+    setIsDescriptionOverflowing(el.scrollWidth > el.clientWidth + 1)
+  }, [product.description, summaryOpen])
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return
+    if (summaryOpen) return
+    const el = descriptionRef.current
+    if (!el) return
+    const observer = new ResizeObserver(() => {
+      const node = descriptionRef.current
+      if (!node) return
+      setIsDescriptionOverflowing(node.scrollWidth > node.clientWidth + 1)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [summaryOpen])
+
   if (purchased && !isEditing) {
     return (
       <div
@@ -708,28 +730,6 @@ function PassRow({
   )
 
   const hasDescription = !!product.description
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure on description and collapse state changes
-  useLayoutEffect(() => {
-    if (summaryOpen) return
-    const el = descriptionRef.current
-    if (!el) return
-    setIsDescriptionOverflowing(el.scrollWidth > el.clientWidth + 1)
-  }, [product.description, summaryOpen])
-
-  useEffect(() => {
-    if (typeof ResizeObserver === "undefined") return
-    if (summaryOpen) return
-    const el = descriptionRef.current
-    if (!el) return
-    const observer = new ResizeObserver(() => {
-      const node = descriptionRef.current
-      if (!node) return
-      setIsDescriptionOverflowing(node.scrollWidth > node.clientWidth + 1)
-    })
-    observer.observe(el)
-    return () => observer.disconnect()
-  }, [summaryOpen])
 
   if (hasDescription) {
     return (

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -2,7 +2,7 @@
 
 import { Check, ChevronDown, Plus, ShoppingBag, Ticket } from "lucide-react"
 import Image from "next/image"
-import { useEffect, useState } from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import AddAttendeeButtons from "@/components/checkout-flow/shared/AddAttendeeButtons"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
@@ -519,6 +519,9 @@ function PassRow({
   const effectiveDisabled = disabled || stateBlocked
   const isClickable = !effectiveDisabled && (!purchased || isEditing)
   const [summaryOpen, setSummaryOpen] = useState(false)
+  const descriptionRef = useRef<HTMLParagraphElement>(null)
+  const [isDescriptionOverflowing, setIsDescriptionOverflowing] =
+    useState(false)
   // Multi-unit stepper mode — editing of purchased multi-unit passes is out
   // of scope (plan decision), so we only show the stepper for non-purchased rows.
   const showStepper =
@@ -706,6 +709,28 @@ function PassRow({
 
   const hasDescription = !!product.description
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure on description and collapse state changes
+  useLayoutEffect(() => {
+    if (summaryOpen) return
+    const el = descriptionRef.current
+    if (!el) return
+    setIsDescriptionOverflowing(el.scrollWidth > el.clientWidth + 1)
+  }, [product.description, summaryOpen])
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") return
+    if (summaryOpen) return
+    const el = descriptionRef.current
+    if (!el) return
+    const observer = new ResizeObserver(() => {
+      const node = descriptionRef.current
+      if (!node) return
+      setIsDescriptionOverflowing(node.scrollWidth > node.clientWidth + 1)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [summaryOpen])
+
   if (hasDescription) {
     return (
       <div>
@@ -719,23 +744,28 @@ function PassRow({
                 onClick={() => setSummaryOpen(false)}
                 className="inline-flex items-center gap-0.5 font-medium text-primary underline underline-offset-2 hover:opacity-80 align-baseline"
               >
-                Ver menos
+                {t("common.see_less")}
                 <ChevronDown className="w-3 h-3 rotate-180" />
               </button>
             </p>
           ) : (
             <div className="flex items-baseline gap-1.5">
-              <p className="text-xs text-muted-foreground truncate flex-1 min-w-0">
+              <p
+                ref={descriptionRef}
+                className="text-xs text-muted-foreground truncate flex-1 min-w-0"
+              >
                 {product.description}
               </p>
-              <button
-                type="button"
-                onClick={() => setSummaryOpen(true)}
-                className="inline-flex items-center gap-0.5 text-xs font-medium text-primary underline underline-offset-2 hover:opacity-80 shrink-0"
-              >
-                Ver más
-                <ChevronDown className="w-3 h-3" />
-              </button>
+              {isDescriptionOverflowing && (
+                <button
+                  type="button"
+                  onClick={() => setSummaryOpen(true)}
+                  className="inline-flex items-center gap-0.5 text-xs font-medium text-primary underline underline-offset-2 hover:opacity-80 shrink-0"
+                >
+                  {t("common.see_more")}
+                  <ChevronDown className="w-3 h-3" />
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/portal/src/hooks/useResources.ts
+++ b/portal/src/hooks/useResources.ts
@@ -58,8 +58,7 @@ const useResources = () => {
   }
 
   if (isCompanion) {
-    const companionEventsVisible =
-      companionApplicationAccepted && eventsEnabled
+    const companionEventsVisible = companionApplicationAccepted && eventsEnabled
     const resources: Resource[] = [
       {
         name: t("sidebar.companion"),

--- a/portal/src/hooks/useResources.ts
+++ b/portal/src/hooks/useResources.ts
@@ -30,6 +30,9 @@ const useResources = () => {
   const isCompanion = participation?.type === "companion"
   const canSeeAttendees = application?.status === "accepted"
   const companionCanSeePasses = isCompanion
+  const companionApplicationAccepted =
+    participation?.type === "companion" &&
+    participation?.application_status === "accepted"
 
   // Direct-sale popups have no application and no reviewer-controlled
   // attendees — just an event overview that links to checkout, plus a
@@ -55,6 +58,8 @@ const useResources = () => {
   }
 
   if (isCompanion) {
+    const companionEventsVisible =
+      companionApplicationAccepted && eventsEnabled
     const resources: Resource[] = [
       {
         name: t("sidebar.companion"),
@@ -74,6 +79,32 @@ const useResources = () => {
         icon: Ticket,
         status: companionCanSeePasses ? "active" : "hidden",
         path: `/portal/${city?.slug}/passes`,
+      },
+      {
+        name: t("sidebar.events"),
+        icon: CalendarDays,
+        status: companionEventsVisible ? "active" : "hidden",
+        path: `/portal/${city?.slug}/events`,
+        children: [
+          {
+            name: t("sidebar.venues"),
+            icon: MapPin,
+            status: companionEventsVisible ? "active" : "hidden",
+            path: `/portal/${city?.slug}/events/venues`,
+          },
+          {
+            name: t("sidebar.api_keys", { defaultValue: "API Keys" }),
+            icon: Key,
+            status: companionEventsVisible ? "active" : "hidden",
+            path: "/portal/api-keys",
+          },
+          {
+            name: t("sidebar.api_docs", { defaultValue: "API Docs" }),
+            icon: BookOpen,
+            status: companionEventsVisible ? "active" : "hidden",
+            path: "/portal/docs",
+          },
+        ],
       },
     ]
 

--- a/portal/src/providers/cityProvider.tsx
+++ b/portal/src/providers/cityProvider.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { useParams } from "next/navigation"
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation"
 import {
   createContext,
   type ReactNode,
@@ -38,12 +43,17 @@ const CityProvider = ({
   const [cityPreselected, setCityPreselected] = useState<string | null>(null)
   const [lastValidCity, setLastValidCity] = useState<PopupPublic | null>(null)
   const params = useParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const rawSlug = params.popupSlug
+  const currentSlug = Array.isArray(rawSlug) ? rawSlug[0] : rawSlug
 
   const popupsLoaded = isFetched
 
   const getValidCity = useCallback((): PopupPublic | null => {
-    return popups.find((popup) => popup.slug === params.popupSlug) ?? null
-  }, [popups, params.popupSlug])
+    return popups.find((popup) => popup.slug === currentSlug) ?? null
+  }, [popups, currentSlug])
 
   const cityFromUrl = getValidCity()
 
@@ -52,6 +62,29 @@ const CityProvider = ({
       setLastValidCity(cityFromUrl)
     }
   }, [cityFromUrl])
+
+  useEffect(() => {
+    if (!popupsLoaded) return
+    if (!currentSlug) return
+    if (cityFromUrl) return
+    const fallback = lastValidCity ?? popups[0]
+    if (!fallback?.slug) return
+    const segments = pathname.split("/")
+    const slugIndex = segments.indexOf(currentSlug)
+    if (slugIndex === -1) return
+    segments[slugIndex] = fallback.slug
+    const query = searchParams.toString()
+    router.replace(`${segments.join("/")}${query ? `?${query}` : ""}`)
+  }, [
+    popupsLoaded,
+    currentSlug,
+    cityFromUrl,
+    lastValidCity,
+    popups,
+    pathname,
+    router,
+    searchParams,
+  ])
 
   const activePopup = cityFromUrl ?? lastValidCity ?? popups[0] ?? null
   setActiveCurrency(activePopup?.currency ?? "USD")

--- a/portal/src/providers/themeProvider.tsx
+++ b/portal/src/providers/themeProvider.tsx
@@ -34,6 +34,8 @@ interface ThemeColors {
   accent_color?: string
   checkout_navbar_bg?: string
   checkout_subtitle_color?: string
+  checkout_bottom_bar_bg_color?: string
+  checkout_bottom_bar_text_color?: string
 }
 
 interface ThemeConfig {
@@ -95,6 +97,12 @@ function computeThemeVars(
   if (colors.checkout_subtitle_color) {
     vars["--checkout-subtitle"] = colors.checkout_subtitle_color
   }
+  if (colors.checkout_bottom_bar_bg_color) {
+    vars["--checkout-bottom-bar-bg"] = colors.checkout_bottom_bar_bg_color
+  }
+  if (colors.checkout_bottom_bar_text_color) {
+    vars["--checkout-bottom-bar-text"] = colors.checkout_bottom_bar_text_color
+  }
 
   // If no mode/primary is set, stop here — rest of the palette stays on the
   // globals.css defaults.
@@ -146,9 +154,12 @@ function computeThemeVars(
       colors.checkout_navbar_bg || mix(palette.background, "transparent", 85),
     "--checkout-footer-bg": mix(palette.background, "transparent", 85),
     "--checkout-card-bg": palette.card,
-    "--checkout-bottom-bar-bg": palette.sidebar,
-    "--checkout-bottom-bar-text": palette.foreground,
   })
+
+  // --checkout-bottom-bar-bg / -text are deliberately NOT derived from the
+  // palette. Keeping them on the globals.css defaults (or the per-surface
+  // override above) avoids blending the floating footer into the page bg
+  // when the admin has only chosen mode/primary.
 
   // Brand-dependent tokens only fill in once the admin picked a primary —
   // otherwise we'd overwrite the nice shadcn default with nothing usable.


### PR DESCRIPTION
## Summary

Promotes the following changes from `dev` to `main`:

### Features
- **portal**: expose events sidebar and API access for accepted companions

### Fixes
- **portal**: restore change email button and populate field on express checkout
- **backend**: scope required field validation to express checkout subset for group applications
- **portal**: respect checkout bottom bar color overrides from popup theme
- **portal**: redirect to fallback slug when popup URL slug is invalid
- **portal**: gate `VariantTicketSelect` description expander on overflow
- **portal**: use popup primary category for `/passes` 'Starting at' min price

## Test plan
- [ ] Verify express checkout flow (change email button + required field validation for group applications)
- [ ] Verify accepted companions see events sidebar and API access
- [ ] Verify checkout bottom bar respects popup theme overrides
- [ ] Verify invalid popup slug redirects to fallback
- [ ] Verify `VariantTicketSelect` description expander only shows on overflow
- [ ] Verify `/passes` 'Starting at' uses popup primary category min price