### PR TITLE
feat(checkout): form-gated section visibility + scope-aware week→month auto-promote

### DIFF
--- a/backend/app/api/group/router.py
+++ b/backend/app/api/group/router.py
@@ -336,8 +336,6 @@ async def add_group_member(
     # Check for existing application
     application = applications_crud.get_by_human_popup(db, human.id, group.popup_id)
 
-    existing_app_status: str | None = application.status if application else None
-
     if not application:
         # Create new application with ACCEPTED status
         # Note: local_resident and created_by_leader are not on ApplicationAdminCreate
@@ -382,29 +380,6 @@ async def add_group_member(
     db.commit()
     db.refresh(application)
     db.refresh(human)
-
-    # Send accepted email if an existing application just got accepted via group
-    if (
-        existing_app_status is not None
-        and existing_app_status != ApplicationStatus.ACCEPTED.value
-        and application.popup
-    ):
-        from app.services.email import ApplicationAcceptedContext, get_email_service
-
-        email_service = get_email_service()
-        await email_service.send_application_accepted(
-            to=human.email,
-            subject=f"Application Accepted for {application.popup.name}",
-            context=ApplicationAcceptedContext(
-                first_name=human.first_name or "",
-                last_name=human.last_name or "",
-                popup_name=application.popup.name,
-            ),
-            from_address=application.popup.tenant.sender_email,
-            from_name=application.popup.tenant.sender_name,
-            popup_id=application.popup_id,
-            db_session=db,
-        )
 
     # Get products
     products = []

--- a/backoffice/src/components/forms/ThemeConfigForm.tsx
+++ b/backoffice/src/components/forms/ThemeConfigForm.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react"
 import { RgbaColorPicker } from "react-colorful"
 import { PopupsService, type PopupUpdate } from "@/client"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { InlineSection } from "@/components/ui/inline-form"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -23,6 +24,7 @@ import useCustomToast from "@/hooks/useCustomToast"
 import { cn } from "@/lib/utils"
 import { createErrorHandler } from "@/utils"
 import {
+  type CheckoutBackgroundContext,
   type PreviewEvent,
   type PreviewTab,
   ThemePreview,
@@ -37,6 +39,37 @@ interface ThemeConfig {
   }
   radius?: string
   border_radius?: string
+  checkout_background_contexts?: CheckoutBackgroundContext[]
+}
+
+const BACKGROUND_CONTEXT_OPTIONS: {
+  value: CheckoutBackgroundContext
+  label: string
+  description: string
+}[] = [
+  {
+    value: "checkout",
+    label: "Checkout",
+    description: "Open checkout flow (/checkout/[slug]).",
+  },
+  {
+    value: "groups",
+    label: "Groups",
+    description: "Group checkout pages (/groups/[slug]).",
+  },
+  {
+    value: "passes",
+    label: "Passes",
+    description: "Buy passes flow inside the portal (/portal/.../passes/buy).",
+  },
+]
+
+function sanitizeContexts(
+  values: readonly string[] | undefined,
+): CheckoutBackgroundContext[] {
+  if (!values) return []
+  const order: CheckoutBackgroundContext[] = ["checkout", "groups", "passes"]
+  return order.filter((c) => values.includes(c))
 }
 
 interface ThemeConfigFormProps {
@@ -53,6 +86,7 @@ const EMPTY_PREVIEW_EVENT: PreviewEvent = {
   start_date: null,
   end_date: null,
   express_checkout_background: null,
+  checkout_background_contexts: [],
 }
 
 export function ThemeConfigForm({
@@ -76,6 +110,9 @@ export function ThemeConfigForm({
   const [borderRadius, setBorderRadius] = useState(
     themeConfig?.border_radius ?? "",
   )
+  const [backgroundContexts, setBackgroundContexts] = useState<
+    CheckoutBackgroundContext[]
+  >(() => sanitizeContexts(themeConfig?.checkout_background_contexts))
   const [typographyExpanded, setTypographyExpanded] = useState(false)
   const [highlightedKeys, setHighlightedKeys] = useState<Set<string>>(
     () => new Set(),
@@ -112,12 +149,28 @@ export function ThemeConfigForm({
     setHighlightedKeys(keys ? new Set(keys) : new Set())
   }, [])
 
+  const toggleBackgroundContext = useCallback(
+    (context: CheckoutBackgroundContext, enabled: boolean) => {
+      setBackgroundContexts((prev) => {
+        const set = new Set(prev)
+        if (enabled) {
+          set.add(context)
+        } else {
+          set.delete(context)
+        }
+        return sanitizeContexts([...set])
+      })
+    },
+    [],
+  )
+
   const handleResetAll = () => {
     setColors({})
     setFontBaseSize("")
     setFontHeadingScale("")
     setRadius("")
     setBorderRadius("")
+    setBackgroundContexts([])
   }
 
   const handleSave = () => {
@@ -125,9 +178,14 @@ export function ThemeConfigForm({
     const hasTypography = fontBaseSize || fontHeadingScale
     const hasRadius = !!radius
     const hasBorderRadius = !!borderRadius
+    const hasBackgroundContexts = backgroundContexts.length > 0
 
     const config: ThemeConfig | null =
-      hasColors || hasTypography || hasRadius || hasBorderRadius
+      hasColors ||
+      hasTypography ||
+      hasRadius ||
+      hasBorderRadius ||
+      hasBackgroundContexts
         ? {
             ...(hasColors && { colors }),
             ...(hasTypography && {
@@ -140,6 +198,9 @@ export function ThemeConfigForm({
             }),
             ...(hasRadius && { radius }),
             ...(hasBorderRadius && { border_radius: borderRadius }),
+            ...(hasBackgroundContexts && {
+              checkout_background_contexts: backgroundContexts,
+            }),
           }
         : null
 
@@ -148,13 +209,19 @@ export function ThemeConfigForm({
     })
   }
 
+  const savedContexts = useMemo(
+    () => sanitizeContexts(themeConfig?.checkout_background_contexts),
+    [themeConfig?.checkout_background_contexts],
+  )
+
   const hasChanges =
     JSON.stringify(colors) !== JSON.stringify(themeConfig?.colors ?? {}) ||
     fontBaseSize !== (themeConfig?.typography?.font_base_size ?? "") ||
     fontHeadingScale !==
       (themeConfig?.typography?.font_heading_scale?.toString() ?? "") ||
     radius !== (themeConfig?.radius ?? "") ||
-    borderRadius !== (themeConfig?.border_radius ?? "")
+    borderRadius !== (themeConfig?.border_radius ?? "") ||
+    JSON.stringify(backgroundContexts) !== JSON.stringify(savedContexts)
 
   // Effective values = user override OR default.
   const effectiveColors = useMemo(() => {
@@ -303,6 +370,13 @@ export function ThemeConfigForm({
             disabled={readOnly}
           />
 
+          {/* Checkout background visibility */}
+          <BackgroundContextsSection
+            value={backgroundContexts}
+            onToggle={toggleBackgroundContext}
+            disabled={readOnly}
+          />
+
           <Separator />
 
           {!readOnly && (
@@ -341,12 +415,68 @@ export function ThemeConfigForm({
               highlightedKeys={highlightedKeys}
               activeTab={previewTab}
               onTabChange={setPreviewTab}
-              previewEvent={previewEvent ?? EMPTY_PREVIEW_EVENT}
+              previewEvent={{
+                ...(previewEvent ?? EMPTY_PREVIEW_EVENT),
+                checkout_background_contexts: backgroundContexts,
+              }}
             />
           </div>
         </div>
       </div>
     </InlineSection>
+  )
+}
+
+interface BackgroundContextsSectionProps {
+  value: CheckoutBackgroundContext[]
+  onToggle: (context: CheckoutBackgroundContext, enabled: boolean) => void
+  disabled?: boolean
+}
+
+function BackgroundContextsSection({
+  value,
+  onToggle,
+  disabled,
+}: BackgroundContextsSectionProps) {
+  return (
+    <div className="rounded-lg border bg-background">
+      <div className="flex items-center gap-2 px-3 py-2.5">
+        <div className="flex flex-col">
+          <span className="text-sm font-medium">
+            Checkout background visibility
+          </span>
+          <span className="text-[11px] text-muted-foreground">
+            Choose where the checkout background image is shown. If none are
+            selected, the image is hidden everywhere.
+          </span>
+        </div>
+      </div>
+      <div className="space-y-2 border-t px-3 pb-3 pt-3">
+        {BACKGROUND_CONTEXT_OPTIONS.map((option) => {
+          const id = `checkout-bg-${option.value}`
+          const checked = value.includes(option.value)
+          return (
+            <div key={option.value} className="flex items-start gap-2">
+              <Checkbox
+                id={id}
+                checked={checked}
+                disabled={disabled}
+                onCheckedChange={(state) => onToggle(option.value, !!state)}
+                className="mt-0.5"
+              />
+              <div className="flex flex-col">
+                <Label htmlFor={id} className="text-xs font-medium">
+                  {option.label}
+                </Label>
+                <span className="text-[11px] text-muted-foreground">
+                  {option.description}
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 

--- a/backoffice/src/components/forms/ThemePreview/index.tsx
+++ b/backoffice/src/components/forms/ThemePreview/index.tsx
@@ -38,7 +38,11 @@ import { HomeView } from "./tabs/HomeView"
 import type { ThemePreviewProps } from "./types"
 import { useCssVars } from "./useCssVars"
 
-export type { PreviewEvent, PreviewTab } from "./types"
+export type {
+  CheckoutBackgroundContext,
+  PreviewEvent,
+  PreviewTab,
+} from "./types"
 
 export function ThemePreview({
   colors,

--- a/backoffice/src/components/forms/ThemePreview/tabs/CheckoutView.tsx
+++ b/backoffice/src/components/forms/ThemePreview/tabs/CheckoutView.tsx
@@ -19,9 +19,12 @@ export function CheckoutView() {
   const display = useDisplayEvent()
   const isHl = makeIsHl(highlightedKeys)
 
-  const backgroundImage = event.express_checkout_background
-    ? `url(${event.express_checkout_background})`
-    : FALLBACK_BG
+  const checkoutEnabled =
+    event.checkout_background_contexts?.includes("checkout") ?? false
+  const backgroundImage =
+    checkoutEnabled && event.express_checkout_background
+      ? `url(${event.express_checkout_background})`
+      : FALLBACK_BG
 
   return (
     <div

--- a/backoffice/src/components/forms/ThemePreview/types.ts
+++ b/backoffice/src/components/forms/ThemePreview/types.ts
@@ -1,5 +1,7 @@
 export type PreviewTab = "home" | "checkout"
 
+export type CheckoutBackgroundContext = "checkout" | "groups" | "passes"
+
 export interface PreviewEvent {
   name: string
   tagline: string | null
@@ -7,6 +9,7 @@ export interface PreviewEvent {
   start_date: string | null
   end_date: string | null
   express_checkout_background?: string | null
+  checkout_background_contexts?: CheckoutBackgroundContext[]
 }
 
 export interface ThemePreviewProps {

--- a/backoffice/src/components/ticketing-step-builder/template-configs/SortableSectionCard.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/SortableSectionCard.tsx
@@ -8,9 +8,21 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { ImageUpload } from "@/components/ui/image-upload"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
+
+export interface SectionVisibilityCondition {
+  field_id: string
+  value: string | string[]
+}
 
 export interface ProductSection {
   key: string
@@ -20,6 +32,16 @@ export interface ProductSection {
   description?: string
   image_url?: string
   attendee_categories?: string[] | null
+  visible_if?: SectionVisibilityCondition | null
+}
+
+export interface VisibilityFormFieldOption {
+  /** FormField.name — stable key persisted in custom_fields */
+  name: string
+  /** Human-readable label for the dropdown */
+  label: string
+  /** Discrete options to choose from */
+  options: string[]
 }
 
 export function parseConfigSections(config: Record<string, unknown> | null): {
@@ -61,6 +83,9 @@ interface SortableSectionCardProps {
   showMediaFields?: boolean
   showAttendeeCategories?: boolean
   attendeeCategories?: AttendeeCategoryOption[]
+  /** When provided and non-empty, renders the "Visibility condition" picker
+   *  so admins can gate the section against a form answer. */
+  visibilityFormFields?: VisibilityFormFieldOption[]
 }
 
 export function SortableSectionCard({
@@ -72,6 +97,7 @@ export function SortableSectionCard({
   showMediaFields = true,
   showAttendeeCategories = false,
   attendeeCategories = [],
+  visibilityFormFields = [],
 }: SortableSectionCardProps) {
   const {
     attributes,
@@ -109,6 +135,40 @@ export function SortableSectionCard({
         ? null
         : next
     onUpdate(section.key, { attendee_categories: resolved })
+  }
+
+  const NO_FIELD = "__no_field__"
+  const visibilityField = section.visible_if?.field_id
+    ? visibilityFormFields.find((f) => f.name === section.visible_if?.field_id)
+    : undefined
+  // Stored value can be string or string[]; the picker only handles a single
+  // value today. Array form is preserved untouched on read but the dropdown
+  // shows the first match if present.
+  const visibilityValue =
+    typeof section.visible_if?.value === "string"
+      ? section.visible_if?.value
+      : Array.isArray(section.visible_if?.value)
+        ? section.visible_if?.value[0]
+        : undefined
+
+  const handleVisibilityFieldChange = (nextFieldName: string) => {
+    if (nextFieldName === NO_FIELD) {
+      onUpdate(section.key, { visible_if: null })
+      return
+    }
+    const field = visibilityFormFields.find((f) => f.name === nextFieldName)
+    if (!field) return
+    // Reset value when the field changes — options differ between fields.
+    onUpdate(section.key, {
+      visible_if: { field_id: field.name, value: field.options[0] ?? "" },
+    })
+  }
+
+  const handleVisibilityValueChange = (nextValue: string) => {
+    if (!section.visible_if?.field_id) return
+    onUpdate(section.key, {
+      visible_if: { field_id: section.visible_if.field_id, value: nextValue },
+    })
   }
 
   return (
@@ -210,6 +270,59 @@ export function SortableSectionCard({
             {section.attendee_categories == null && (
               <span className="text-xs text-muted-foreground">
                 Visible to all attendees
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {visibilityFormFields.length > 0 && (
+        <div className="px-3 pb-3">
+          <div className="flex flex-col gap-1.5">
+            <Label className="text-xs font-medium text-muted-foreground">
+              Visibility condition
+            </Label>
+            <div className="flex flex-wrap items-center gap-2">
+              <Select
+                value={section.visible_if?.field_id ?? NO_FIELD}
+                onValueChange={handleVisibilityFieldChange}
+              >
+                <SelectTrigger className="h-7 text-xs w-[200px]">
+                  <SelectValue placeholder="No condition" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_FIELD}>No condition</SelectItem>
+                  {visibilityFormFields.map((f) => (
+                    <SelectItem key={f.name} value={f.name}>
+                      {f.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {visibilityField && visibilityField.options.length > 0 && (
+                <>
+                  <span className="text-xs text-muted-foreground">equals</span>
+                  <Select
+                    value={visibilityValue ?? ""}
+                    onValueChange={handleVisibilityValueChange}
+                  >
+                    <SelectTrigger className="h-7 text-xs w-[140px]">
+                      <SelectValue placeholder="Select value" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {visibilityField.options.map((opt) => (
+                        <SelectItem key={opt} value={opt}>
+                          {opt}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </>
+              )}
+            </div>
+            {!section.visible_if?.field_id && (
+              <span className="text-xs text-muted-foreground">
+                Always visible
               </span>
             )}
           </div>

--- a/backoffice/src/components/ticketing-step-builder/template-configs/TicketSelectConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/TicketSelectConfig.tsx
@@ -14,7 +14,11 @@ import {
 import { useQuery } from "@tanstack/react-query"
 import { Check, Plus } from "lucide-react"
 
-import { AttendeeCategoriesService, ProductsService } from "@/client"
+import {
+  AttendeeCategoriesService,
+  FormFieldsService,
+  ProductsService,
+} from "@/client"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
@@ -24,8 +28,13 @@ import {
   parseConfigSections,
   SortableSectionCard,
   toKey,
+  type VisibilityFormFieldOption,
 } from "./SortableSectionCard"
 import type { TemplateConfigProps } from "./types"
+
+// Only fields with a fixed set of answers can drive section visibility.
+// Free-text or date fields don't yield a stable dropdown of values.
+const DISCRETE_FIELD_TYPES = new Set(["select", "checkbox", "radio"])
 
 const TICKET_SELECT_VARIANTS = [
   {
@@ -159,6 +168,12 @@ export function TicketSelectConfig({
     refetchOnMount: "always",
   })
 
+  const { data: formFieldsData } = useQuery({
+    queryKey: ["form-fields", popupId],
+    queryFn: () => FormFieldsService.listFormFields({ popupId, limit: 200 }),
+    enabled: !!popupId,
+  })
+
   const productsResults = Array.isArray(productsData?.results)
     ? productsData.results
     : []
@@ -169,6 +184,22 @@ export function TicketSelectConfig({
     slug: p.slug,
     is_active: p.is_active,
   }))
+
+  const formFieldsResults = Array.isArray(formFieldsData?.results)
+    ? formFieldsData.results
+    : []
+  const visibilityFormFields: VisibilityFormFieldOption[] = formFieldsResults
+    .filter(
+      (f) =>
+        DISCRETE_FIELD_TYPES.has(f.field_type) &&
+        Array.isArray(f.options) &&
+        f.options.length > 0,
+    )
+    .map((f) => ({
+      name: f.name,
+      label: f.label || f.name,
+      options: f.options ?? [],
+    }))
 
   const categoriesResults = Array.isArray(categoriesData?.results)
     ? categoriesData.results
@@ -332,6 +363,7 @@ export function TicketSelectConfig({
                     showMediaFields={false}
                     showAttendeeCategories={true}
                     attendeeCategories={attendeeCategories}
+                    visibilityFormFields={visibilityFormFields}
                   />
                 ))}
             </div>

--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -62,7 +62,7 @@ export default function OpenTicketingCheckoutPage() {
       }
     >
       <main
-        className={`h-svh overflow-y-auto ${background.className}`.trim()}
+        className={`h-svh overflow-y-auto no-scrollbar ${background.className}`.trim()}
         style={background.style}
       >
         <OpenCheckoutRuntime

--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -48,7 +48,7 @@ export default function OpenTicketingCheckoutPage() {
     )
   }
 
-  const background = getBackgroundProps(runtime.popup)
+  const background = getBackgroundProps(runtime.popup, "checkout")
 
   return (
     <SidebarProvider

--- a/portal/src/app/checkout/components/PopupCheckoutContent.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.tsx
@@ -224,7 +224,7 @@ export const PopupCheckoutContent = ({
         <PassesProvider attendees={attendees} restoreFromCart>
           <CheckoutProvider initialStep="passes">
             <div
-              className={`h-dvh overflow-y-auto ${background.className}`}
+              className={`h-dvh overflow-y-auto no-scrollbar ${background.className}`}
               style={background.style}
             >
               <ScrollyCheckoutFlow

--- a/portal/src/app/groups/[groupSlug]/page.tsx
+++ b/portal/src/app/groups/[groupSlug]/page.tsx
@@ -38,7 +38,7 @@ const GroupCheckoutPage = () => {
     )
   }
 
-  const background = getBackgroundProps(popup)
+  const background = getBackgroundProps(popup, "groups")
 
   return (
     <PopupCheckoutContent

--- a/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
@@ -13,7 +13,7 @@ export default function BuyPassesContent() {
   const router = useRouter()
   const { attendeePasses: attendees, products } = usePassesProvider()
   const { getCity } = useCityProvider()
-  const background = getBackgroundProps(getCity())
+  const background = getBackgroundProps(getCity(), "passes")
 
   const handleBack = () => {
     router.push(`/portal/${params.popupSlug}/passes`)

--- a/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useParams, useRouter } from "next/navigation"
+import { useEffect } from "react"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
 import { Loader } from "@/components/ui/Loader"
 import { getBackgroundProps } from "@/lib/background-image"
@@ -14,6 +15,18 @@ export default function BuyPassesContent() {
   const { attendeePasses: attendees, products } = usePassesProvider()
   const { getCity } = useCityProvider()
   const background = getBackgroundProps(getCity(), "passes")
+
+  // The portal layout owns the scroll container (<main id="portal-scroll">),
+  // and the SnapDotNav indicator sits on the right edge of the viewport. The
+  // native scrollbar overlaps it, so hide the scrollbar only while this view
+  // is mounted.
+  useEffect(() => {
+    const main = document.getElementById("portal-scroll")
+    main?.classList.add("no-scrollbar")
+    return () => {
+      main?.classList.remove("no-scrollbar")
+    }
+  }, [])
 
   const handleBack = () => {
     router.push(`/portal/${params.popupSlug}/passes`)

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -164,12 +164,9 @@ function ScrollyCheckoutFlowInner({
     // intermediate section as they pass under the viewport.
     let scrollTargetId: string | null = null
     let scrollTargetTimeout: number | null = null
-    // Whether to clear the pending snap-restore timeout when releasing.
-    // Observer-driven release (target reached during animation) must NOT
-    // clear it, otherwise snap-type stays "none" forever after a scroll.
-    const releaseScrollTarget = (clearTimer = false) => {
+    const releaseScrollTarget = () => {
       scrollTargetId = null
-      if (clearTimer && scrollTargetTimeout !== null) {
+      if (scrollTargetTimeout !== null) {
         window.clearTimeout(scrollTargetTimeout)
         scrollTargetTimeout = null
       }
@@ -207,23 +204,20 @@ function ScrollyCheckoutFlowInner({
       if (scrollTargetTimeout !== null) {
         window.clearTimeout(scrollTargetTimeout)
       }
-      // Why: mandatory snap pinned to a section makes Chrome ignore
-      // programmatic scrolls. Disable snap during the animation; the
-      // timeout below restores it once the destination is reached.
-      mainEl.style.scrollSnapType = "none"
-      scrollTargetTimeout = window.setTimeout(() => {
-        mainEl.style.scrollSnapType = "y mandatory"
-        releaseScrollTarget()
-      }, 1500)
-      const targetTop = el.offsetTop
-      // Why: when the click originates inside a `position: fixed` element
-      // (e.g. the footer button), Chrome silently swallows scrollTo issued
-      // in the same tick. Deferring to the next macrotask lets the browser
-      // finish its focus/tap handling first, then the scroll runs.
+      // Safety net: if the IntersectionObserver doesn't fire (e.g. target
+      // already in view), free up scrollTargetId so future scrolls work.
+      scrollTargetTimeout = window.setTimeout(releaseScrollTarget, 1500)
+      // Why scrollIntoView over scrollTo + manual snap toggling: keeping
+      // scroll-snap-type: y mandatory during the animation lets the browser
+      // land precisely on the snap point without the post-animation "settle"
+      // jump that happened when snap was re-enabled after the scrollTo.
+      // Why the deferred setTimeout: when the click originates inside a
+      // position: fixed element (e.g. footer button), Chrome can swallow a
+      // scroll issued in the same tick.
       window.setTimeout(() => {
-        mainEl.scrollTo({
-          top: targetTop,
+        el.scrollIntoView({
           behavior: reduceMotion ? "auto" : "smooth",
+          block: "start",
         })
       }, 0)
       setActiveSection(targetId)
@@ -241,7 +235,7 @@ function ScrollyCheckoutFlowInner({
       observer.disconnect()
       ro.disconnect()
       navRo.disconnect()
-      releaseScrollTarget(true)
+      releaseScrollTarget()
       scrollToIndexRef.current = null
     }
   }, [allSections, isInitialLoading])

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -98,10 +98,10 @@ export default function ScrollySectionNav({
                     onClick={() => onSectionClick(section.id)}
                     aria-current={isActive ? "step" : undefined}
                     className={cn(
-                      "relative z-10 flex h-7 min-w-0 items-center justify-center gap-1 px-1.5 text-xs font-semibold transition-colors duration-200",
+                      "relative z-10 flex h-7 min-w-0 items-center justify-center gap-1 px-1.5 text-xs font-semibold transition-[color,opacity] duration-200",
                       isActive
                         ? "text-checkout-badge-title"
-                        : "text-checkout-badge-title-disabled hover:text-checkout-badge-title/80",
+                        : "text-checkout-badge-title-disabled hover:opacity-70",
                     )}
                   >
                     <Icon className="size-3.5 shrink-0" />

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.test.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest"
 import type { AttendeePassState } from "@/types/Attendee"
 import type { ProductsPass } from "@/types/Products"
-import { buildSectionGroups } from "./VariantTicketSelect"
+import {
+  buildSectionGroups,
+  isSectionVisibleForApp,
+} from "./VariantTicketSelect"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -162,6 +165,20 @@ describe("buildSectionGroups — attendee_categories filtering", () => {
     }
   })
 
+  it("section without visible_if passes through pre-filter regardless of customFields", () => {
+    // Pre-filter consumers (`VariantTicketSelect`, `LegacySectionLayout`) call
+    // isSectionVisibleForApp first. Sections without a condition are always kept.
+    const section = {
+      key: "no-cond",
+      label: "Always",
+      order: 0,
+      product_ids: [],
+    }
+    expect(isSectionVisibleForApp(section, null)).toBe(true)
+    expect(isSectionVisibleForApp(section, {})).toBe(true)
+    expect(isSectionVisibleForApp(section, { foo: "bar" })).toBe(true)
+  })
+
   it("all four layouts share the filter via buildSectionGroups as single chokepoint", () => {
     // This test verifies the structural assumption: buildSectionGroups is the
     // single filter chokepoint. All four layout variants (stacked, tabs, compact,
@@ -190,5 +207,66 @@ describe("buildSectionGroups — attendee_categories filtering", () => {
     // main attendee sees only the ungated section
     expect(result).toHaveLength(1)
     expect(result[0].section.key).toBe("all")
+  })
+})
+
+describe("isSectionVisibleForApp — visible_if gating", () => {
+  const baseSection = {
+    key: "locals",
+    label: "Locals",
+    order: 0,
+    product_ids: ["p1"],
+  }
+
+  it("matches single string value", () => {
+    const section = {
+      ...baseSection,
+      visible_if: { field_id: "local_resident", value: "Yes" },
+    }
+    expect(
+      isSectionVisibleForApp(section, { local_resident: "Yes" }),
+    ).toBe(true)
+    expect(
+      isSectionVisibleForApp(section, { local_resident: "No" }),
+    ).toBe(false)
+  })
+
+  it("matches when answer is in an array of accepted values", () => {
+    const section = {
+      ...baseSection,
+      visible_if: { field_id: "tier", value: ["Yes", "Maybe"] },
+    }
+    expect(isSectionVisibleForApp(section, { tier: "Yes" })).toBe(true)
+    expect(isSectionVisibleForApp(section, { tier: "Maybe" })).toBe(true)
+    expect(isSectionVisibleForApp(section, { tier: "No" })).toBe(false)
+  })
+
+  it("hides section when the field has no answer for the application", () => {
+    const section = {
+      ...baseSection,
+      visible_if: { field_id: "local_resident", value: "Yes" },
+    }
+    expect(isSectionVisibleForApp(section, { unrelated: "x" })).toBe(false)
+  })
+
+  it("treats missing custom_fields as no-gate (open-ticketing fallback)", () => {
+    // Before the application form is filled (open-ticketing flow), the gate
+    // is short-circuited so sections still render.
+    const section = {
+      ...baseSection,
+      visible_if: { field_id: "local_resident", value: "Yes" },
+    }
+    expect(isSectionVisibleForApp(section, null)).toBe(true)
+    expect(isSectionVisibleForApp(section, undefined)).toBe(true)
+  })
+
+  it("ignores malformed visible_if (no field_id) and shows section", () => {
+    const section = {
+      ...baseSection,
+      visible_if: { field_id: "", value: "Yes" },
+    }
+    expect(isSectionVisibleForApp(section, { local_resident: "Yes" })).toBe(
+      true,
+    )
   })
 })

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.test.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.test.tsx
@@ -223,12 +223,12 @@ describe("isSectionVisibleForApp — visible_if gating", () => {
       ...baseSection,
       visible_if: { field_id: "local_resident", value: "Yes" },
     }
-    expect(
-      isSectionVisibleForApp(section, { local_resident: "Yes" }),
-    ).toBe(true)
-    expect(
-      isSectionVisibleForApp(section, { local_resident: "No" }),
-    ).toBe(false)
+    expect(isSectionVisibleForApp(section, { local_resident: "Yes" })).toBe(
+      true,
+    )
+    expect(isSectionVisibleForApp(section, { local_resident: "No" })).toBe(
+      false,
+    )
   })
 
   it("matches when answer is in an array of accepted values", () => {

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -13,6 +13,7 @@ import QuantitySelector, {
 import { useAttendeeCategories } from "@/hooks/useAttendeeCategories"
 import { deriveProductState, type ProductSaleState } from "@/lib/product-state"
 import { cn } from "@/lib/utils"
+import { useApplication } from "@/providers/applicationProvider"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 import { usePassesProvider } from "@/providers/passesProvider"
@@ -25,12 +26,33 @@ import type { VariantProps } from "../registries/variantRegistry"
 // Types & constants
 // ---------------------------------------------------------------------------
 
+interface SectionVisibilityCondition {
+  field_id: string
+  value: string | string[]
+}
+
 interface TemplateSection {
   key: string
   label: string
   order: number
   product_ids: string[]
   attendee_categories?: string[] | null
+  visible_if?: SectionVisibilityCondition | null
+}
+
+/** True when the section's visible_if matches the application's form answers.
+ *  No visible_if → always visible. Missing custom_fields → visible (open-ticketing
+ *  fallback: the form hasn't been answered yet, treat as no-gate). */
+export function isSectionVisibleForApp(
+  section: TemplateSection,
+  customFields: Record<string, unknown> | null | undefined,
+): boolean {
+  const cond = section.visible_if
+  if (!cond?.field_id) return true
+  if (!customFields) return true
+  const answer = customFields[cond.field_id]
+  const expected = Array.isArray(cond.value) ? cond.value : [cond.value]
+  return expected.includes(answer as string)
 }
 
 const getCategoryMeta = (cat: string) => {
@@ -195,7 +217,14 @@ export default function VariantTicketSelect({
     null,
   )
 
-  const sections = parseSections(templateConfig)
+  // Apply per-application visibility (visible_if) once: it depends on the
+  // application's form answers, not on individual attendees. Layouts and
+  // helpers downstream consume the already-filtered list.
+  const { getRelevantApplication } = useApplication()
+  const customFields = getRelevantApplication()?.custom_fields ?? null
+  const sections = parseSections(templateConfig).filter((s) =>
+    isSectionVisibleForApp(s, customFields),
+  )
 
   // Build category_id → sort_order map for attendee ordering.
   const { getCity } = useCityProvider()
@@ -290,7 +319,10 @@ function parseSections(
 
 /** Returns groups of products for an attendee based on configured sections.
  *  Products not in any section are excluded.
- *  Sections gated by attendee_categories are filtered to the current attendee. */
+ *  Sections gated by attendee_categories are filtered to the current attendee.
+ *  Note: visible_if (per-application gating) is evaluated upstream in the
+ *  main component, so by the time sections reach this function they are
+ *  already filtered by form responses. */
 export function buildSectionGroups(
   attendee: AttendeePassState,
   sections: TemplateSection[],
@@ -1477,9 +1509,16 @@ function LegacySectionLayout({
     updateDynamicQuantity(stepType, p.id, qty)
   }
 
-  const sections = (templateConfig?.sections ?? null) as
+  // Open-ticketing fallback path: no authenticated application, so visible_if
+  // can't be resolved against form answers. Treat as no-gate (return true).
+  const { getRelevantApplication } = useApplication()
+  const customFields = getRelevantApplication()?.custom_fields ?? null
+  const rawSections = (templateConfig?.sections ?? null) as
     | TemplateSection[]
     | null
+  const sections = rawSections
+    ? rawSections.filter((s) => isSectionVisibleForApp(s, customFields))
+    : null
   const hasSections = Array.isArray(sections) && sections.length > 0
   const groups = hasSections ? groupBySection(products, sections) : null
 

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -150,6 +150,8 @@ const stripedStyle = {
 
 type TicketSelectVariant = "stacked" | "tabs" | "compact" | "accordion"
 
+const SELECTED_ROW_CLASSES = "bg-primary/10 border-l-primary"
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -718,7 +720,7 @@ function PassRow({
         effectiveDisabled
           ? "opacity-40 cursor-not-allowed bg-muted border-l-transparent"
           : rowIsActive
-            ? "bg-gradient-to-r from-primary/25 via-primary/[0.08] to-transparent border-l-primary"
+            ? SELECTED_ROW_CLASSES
             : "hover:bg-muted border-l-transparent",
       )}
     >
@@ -758,6 +760,14 @@ function PassRow({
             </span>
             <SaleStateBadge state={saleState} />
           </div>
+          {product.description && (
+            <p
+              ref={descriptionRef}
+              className="text-xs text-muted-foreground truncate mt-0.5"
+            >
+              {product.description}
+            </p>
+          )}
         </div>
       </div>
       <div className="text-right shrink-0">
@@ -779,12 +789,14 @@ function PassRow({
   )
 
   const hasDescription = !!product.description
+  const showExpandControls =
+    hasDescription && (summaryOpen || isDescriptionOverflowing)
 
-  if (hasDescription) {
+  if (showExpandControls) {
     return (
       <div>
         {mainButton}
-        <div className="px-5 pb-3 pt-2">
+        <div className="px-5 pb-2 pt-0">
           {summaryOpen ? (
             <p className="text-xs text-muted-foreground leading-relaxed whitespace-pre-line">
               {product.description}{" "}
@@ -798,23 +810,15 @@ function PassRow({
               </button>
             </p>
           ) : (
-            <div className="flex items-baseline gap-1.5">
-              <p
-                ref={descriptionRef}
-                className="text-xs text-muted-foreground truncate flex-1 min-w-0"
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setSummaryOpen(true)}
+                className="inline-flex items-center gap-0.5 text-xs font-medium text-primary underline underline-offset-2 hover:opacity-80"
               >
-                {product.description}
-              </p>
-              {isDescriptionOverflowing && (
-                <button
-                  type="button"
-                  onClick={() => setSummaryOpen(true)}
-                  className="inline-flex items-center gap-0.5 text-xs font-medium text-primary underline underline-offset-2 hover:opacity-80 shrink-0"
-                >
-                  {t("common.see_more")}
-                  <ChevronDown className="w-3 h-3" />
-                </button>
-              )}
+                {t("common.see_more")}
+                <ChevronDown className="w-3 h-3" />
+              </button>
             </div>
           )}
         </div>
@@ -915,7 +919,7 @@ function DayPassRow({
         effectiveDisabled
           ? "opacity-40 border-l-transparent"
           : hasQuantity
-            ? "bg-gradient-to-r from-primary/25 via-primary/[0.08] to-transparent border-l-primary"
+            ? SELECTED_ROW_CLASSES
             : "border-l-transparent",
       )}
     >

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -404,11 +404,19 @@ function AttendeePassRows({
     id: string,
     p: ProductsPass,
     exclusivityScopeIds?: string[],
+    attendeeVisibleProductIds?: string[],
   ) => void
   isEditing: boolean
   sections: TemplateSection[]
 }) {
   const groups = buildSectionGroups(attendee, sections)
+
+  // Wide scope passed to the strategy: every product id visible to this
+  // attendee across ALL rendered sections. Enables cross-section auto-promote
+  // (Week → Month) while keeping the cart honest about what the user can see.
+  const attendeeVisibleProductIds = groups.flatMap((g) =>
+    g.products.map((p) => p.id),
+  )
 
   const hasFullOrMonthSelected = attendee.products.some(
     (p) =>
@@ -440,6 +448,7 @@ function AttendeePassRows({
                       attendee.id,
                       { ...p, quantity: qty },
                       scopeIds,
+                      attendeeVisibleProductIds,
                     )
                   }
                   disabled={hasFullOrMonthSelected}
@@ -449,12 +458,20 @@ function AttendeePassRows({
                 <PassRow
                   key={p.id}
                   product={p}
-                  onClick={() => toggleProduct(attendee.id, p, scopeIds)}
+                  onClick={() =>
+                    toggleProduct(
+                      attendee.id,
+                      p,
+                      scopeIds,
+                      attendeeVisibleProductIds,
+                    )
+                  }
                   onQuantityChange={(qty) =>
                     toggleProduct(
                       attendee.id,
                       { ...p, quantity: qty },
                       scopeIds,
+                      attendeeVisibleProductIds,
                     )
                   }
                   disabled={
@@ -933,6 +950,7 @@ function CompactAttendeeCard({
     id: string,
     p: ProductsPass,
     exclusivityScopeIds?: string[],
+    attendeeVisibleProductIds?: string[],
   ) => void
   isEditing: boolean
   sections: TemplateSection[]
@@ -941,6 +959,7 @@ function CompactAttendeeCard({
   const meta = getCategoryMeta(attendee.category ?? "")
   const groups = buildSectionGroups(attendee, sections)
   const visibleProducts = groups.flatMap((g) => g.products)
+  const attendeeVisibleProductIds = visibleProducts.map((p) => p.id)
   // Lookup: product.id → ids of peers in the same section, for exclusivity scope.
   const scopeIdsByProductId = new Map<string, string[]>()
   for (const g of groups) {
@@ -1032,6 +1051,7 @@ function CompactAttendeeCard({
                         attendee.id,
                         { ...p, quantity: qty + 1 },
                         scopeIdsByProductId.get(p.id),
+                        attendeeVisibleProductIds,
                       )
                     }
                     onDecrement={() =>
@@ -1039,6 +1059,7 @@ function CompactAttendeeCard({
                         attendee.id,
                         { ...p, quantity: qty - 1 },
                         scopeIdsByProductId.get(p.id),
+                        attendeeVisibleProductIds,
                       )
                     }
                     onAdd={() =>
@@ -1046,6 +1067,7 @@ function CompactAttendeeCard({
                         attendee.id,
                         { ...p, quantity: 1 },
                         scopeIdsByProductId.get(p.id),
+                        attendeeVisibleProductIds,
                       )
                     }
                   />
@@ -1101,6 +1123,7 @@ function CompactAttendeeCard({
                           attendee.id,
                           p,
                           scopeIdsByProductId.get(p.id),
+                          attendeeVisibleProductIds,
                         )
                 }
                 disabled={isDisabled}

--- a/portal/src/lib/background-image.ts
+++ b/portal/src/lib/background-image.ts
@@ -1,16 +1,34 @@
 import type { PopupPublic } from "@/client"
 
+export type CheckoutBackgroundContext = "checkout" | "groups" | "passes"
+
+function getEnabledContexts(
+  popup: PopupPublic | null | undefined,
+): CheckoutBackgroundContext[] {
+  const raw = popup?.theme_config?.checkout_background_contexts
+  if (!Array.isArray(raw)) return []
+  return raw.filter(
+    (value): value is CheckoutBackgroundContext =>
+      value === "checkout" || value === "groups" || value === "passes",
+  )
+}
+
 export function resolveCheckoutBackgroundUrl(
   popup: PopupPublic | null | undefined,
+  context: CheckoutBackgroundContext,
 ): string | null {
+  if (!getEnabledContexts(popup).includes(context)) return null
   return popup?.express_checkout_background || null
 }
 
-export function getBackgroundProps(popup: PopupPublic | null | undefined): {
+export function getBackgroundProps(
+  popup: PopupPublic | null | undefined,
+  context: CheckoutBackgroundContext,
+): {
   className: string
   style: React.CSSProperties | undefined
 } {
-  const imageUrl = resolveCheckoutBackgroundUrl(popup)
+  const imageUrl = resolveCheckoutBackgroundUrl(popup, context)
 
   if (imageUrl) {
     return {

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -147,8 +147,13 @@ export function CheckoutProvider({
   cartUiEnabled = true,
 }: CheckoutProviderProps) {
   const { t } = useTranslation()
-  const { attendeePasses, toggleProduct, isEditing, toggleEditing } =
-    usePassesProvider()
+  const {
+    attendeePasses,
+    toggleProduct,
+    isEditing,
+    toggleEditing,
+    clearSelections,
+  } = usePassesProvider()
   const { discountApplied, setDiscount, resetDiscount } = useDiscount()
   const { getRelevantApplication } = useApplication()
   const { getCity } = useCityProvider()
@@ -694,13 +699,21 @@ export function CheckoutProvider({
   // Cart management
   const clearCart = useCallback(() => {
     clearPersistedCart()
+    clearSelections()
     clearHousing()
     setMerch([])
     clearPatron()
     clearPromoCode()
     setInsurance(false)
     setDynamicItems({})
-  }, [clearPersistedCart, clearHousing, setMerch, clearPatron, clearPromoCode])
+  }, [
+    clearPersistedCart,
+    clearSelections,
+    clearHousing,
+    setMerch,
+    clearPatron,
+    clearPromoCode,
+  ])
 
   // Submit payment (consolidated via usePaymentSubmit)
   const { submitPayment, isSubmitting } = usePaymentSubmit({

--- a/portal/src/providers/passesProvider.tsx
+++ b/portal/src/providers/passesProvider.tsx
@@ -32,10 +32,12 @@ interface PassesContext_interface {
     attendeeId: string,
     product: ProductsPass,
     exclusivityScopeIds?: string[],
+    attendeeVisibleProductIds?: string[],
   ) => void
   products: ProductsPass[]
   isEditing: boolean
   toggleEditing: (editing?: boolean) => void
+  clearSelections: () => void
 }
 
 export const PassesContext = createContext<PassesContext_interface | null>(null)
@@ -296,6 +298,7 @@ const PassesProvider = ({
       attendeeId: string,
       product: ProductsPass,
       exclusivityScopeIds?: string[],
+      attendeeVisibleProductIds?: string[],
     ) => {
       if (!product) return
       const strategy = getProductStrategy(
@@ -310,6 +313,7 @@ const PassesProvider = ({
           product,
           discountRef.current,
           exclusivityScopeIds,
+          attendeeVisibleProductIds,
         ),
       )
     },
@@ -437,6 +441,38 @@ const PassesProvider = ({
     setIsEditing((prev) => (editing !== undefined ? editing : !prev))
   }, [])
 
+  // Reset every product's selection state without rebuilding the structure.
+  // Purchased rows keep their server-side quantity (e.g. day passes already
+  // owned). New selections drop back to their initial quantity per
+  // `buildBaseAttendeePasses`: 0 for multi-unit non-day, 1 otherwise.
+  const clearSelections = useCallback(() => {
+    setAttendeePasses((current) =>
+      current.map((attendee) => ({
+        ...attendee,
+        products: attendee.products.map((p) => {
+          if (p.purchased) {
+            return { ...p, selected: false, edit: false, disabled: false }
+          }
+          const isMultiUnit =
+            p.duration_type !== "day" && supportsQuantitySelector(p.max_per_order)
+          const initialQuantity =
+            p.duration_type === "day"
+              ? (p.original_quantity ?? 0)
+              : isMultiUnit
+                ? 0
+                : 1
+          return {
+            ...p,
+            selected: false,
+            edit: false,
+            disabled: false,
+            quantity: initialQuantity,
+          }
+        }),
+      })),
+    )
+  }, [])
+
   const contextValue = useMemo(
     () => ({
       attendeePasses,
@@ -444,8 +480,16 @@ const PassesProvider = ({
       products,
       isEditing,
       toggleEditing,
+      clearSelections,
     }),
-    [attendeePasses, toggleProduct, products, isEditing, toggleEditing],
+    [
+      attendeePasses,
+      toggleProduct,
+      products,
+      isEditing,
+      toggleEditing,
+      clearSelections,
+    ],
   )
 
   return (

--- a/portal/src/providers/passesProvider.tsx
+++ b/portal/src/providers/passesProvider.tsx
@@ -454,7 +454,8 @@ const PassesProvider = ({
             return { ...p, selected: false, edit: false, disabled: false }
           }
           const isMultiUnit =
-            p.duration_type !== "day" && supportsQuantitySelector(p.max_per_order)
+            p.duration_type !== "day" &&
+            supportsQuantitySelector(p.max_per_order)
           const initialQuantity =
             p.duration_type === "day"
               ? (p.original_quantity ?? 0)

--- a/portal/src/strategies/ProductStrategies.test.ts
+++ b/portal/src/strategies/ProductStrategies.test.ts
@@ -272,6 +272,137 @@ describe("getProductStrategy — category-scoped selection", () => {
   })
 })
 
+describe("WeekProductStrategy — attendeeVisibleProductIds (wide scope)", () => {
+  // Reproduces the Sonoma layout: Month sits in one section, Weeks in another.
+  // Strict scope alone wouldn't promote (Month not in week scope), but the
+  // attendee-wide visible set crosses sections, so 4 weeks → Month locals.
+  it("promotes Month in a different section when both share the attendee-visible set", () => {
+    const w1 = createProduct({
+      id: "w1-locals",
+      category: "ticket",
+      selected: true,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const w2 = createProduct({
+      id: "w2-locals",
+      category: "ticket",
+      selected: true,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const w3 = createProduct({
+      id: "w3-locals",
+      category: "ticket",
+      selected: true,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const w4 = createProduct({
+      id: "w4-locals",
+      category: "ticket",
+      selected: false,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const monthLocals = createProduct({
+      id: "month-locals",
+      category: "ticket",
+      selected: false,
+      duration_type: "month",
+      max_per_order: 1,
+    })
+    // Decoy: a Month from the OTHER tier (regular). Must NOT be promoted.
+    const monthRegular = createProduct({
+      id: "month-regular",
+      category: "ticket",
+      selected: false,
+      duration_type: "month",
+      max_per_order: 1,
+    })
+    const attendees = [
+      createAttendee([w1, w2, w3, w4, monthLocals, monthRegular]),
+    ]
+    const strategy = getProductStrategy(w4, false, CHECKOUT_MODE.PASS_SYSTEM)
+
+    // Strict scope = "WEEKLY PASSES (Locals)" section (only weeks).
+    // Wide scope = visible products across both sections (weeks + month locals).
+    const strictScope = ["w1-locals", "w2-locals", "w3-locals", "w4-locals"]
+    const wideScope = [
+      "w1-locals",
+      "w2-locals",
+      "w3-locals",
+      "w4-locals",
+      "month-locals",
+    ]
+
+    const result = strategy.handleSelection(
+      attendees,
+      "attendee-1",
+      w4,
+      undefined,
+      strictScope,
+      wideScope,
+    )
+
+    const monthL = result[0]?.products.find((p) => p.id === "month-locals")
+    const monthR = result[0]?.products.find((p) => p.id === "month-regular")
+    expect(monthL?.selected).toBe(true)
+    // Regular month was outside the wide scope — never touched.
+    expect(monthR?.selected).toBe(false)
+    // The 4 weeks should be cleared (promoted to month).
+    for (const id of strictScope) {
+      expect(result[0]?.products.find((p) => p.id === id)?.selected).toBe(false)
+    }
+  })
+
+  it("falls back to legacy (no scope) when neither scope is provided", () => {
+    // Sanity: existing legacy test in this file passes with no scope arg.
+    // This test re-asserts that wide scope is optional and not required.
+    const t1 = createProduct({
+      id: "t1",
+      category: "ticket",
+      selected: true,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const t2 = createProduct({
+      id: "t2",
+      category: "ticket",
+      selected: true,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const t3 = createProduct({
+      id: "t3",
+      category: "ticket",
+      selected: true,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const t4 = createProduct({
+      id: "t4",
+      category: "ticket",
+      selected: false,
+      duration_type: "week",
+      max_per_order: 1,
+    })
+    const month = createProduct({
+      id: "t-month",
+      category: "ticket",
+      selected: false,
+      duration_type: "month",
+      max_per_order: 1,
+    })
+    const attendees = [createAttendee([t1, t2, t3, t4, month])]
+    const strategy = getProductStrategy(t4, false, CHECKOUT_MODE.PASS_SYSTEM)
+    const result = strategy.handleSelection(attendees, "attendee-1", t4)
+    expect(result[0]?.products.find((p) => p.id === "t-month")?.selected).toBe(
+      true,
+    )
+  })
+})
+
 describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => {
   // Reproduces: GA + VIP both exclusive, multi-unit (max_per_order=null), duration_type=full.
   // Pre-state: GA quantity=1 selected, VIP quantity=0 not selected.

--- a/portal/src/strategies/ProductStrategies.ts
+++ b/portal/src/strategies/ProductStrategies.ts
@@ -18,7 +18,14 @@ interface ProductStrategy {
     attendeeId: string,
     product: ProductsPass,
     discount?: DiscountProps,
+    // Strict scope: products in the SAME visual section as the clicked one.
+    // Drives exclusivity (e.g. clicking a VIP clears a GA in the same section).
     exclusivityScopeIds?: string[],
+    // Wide scope: every product visible to this attendee across ALL sections
+    // currently rendered (post visible_if + attendee_categories filtering).
+    // Drives auto-promotion (week → month) without leaking into products the
+    // user can't see (e.g. Caregiver vs Nanny, opposite-tier locals).
+    attendeeVisibleProductIds?: string[],
   ) => AttendeePassState[]
 }
 
@@ -107,33 +114,94 @@ class MonthProductStrategy implements ProductStrategy {
 }
 
 class WeekProductStrategy implements ProductStrategy {
-  protected countActiveWeeks(products: ProductsPass[]): number {
+  protected inScope(p: ProductsPass, scopeIds: string[] | undefined): boolean {
+    if (!scopeIds || scopeIds.length === 0) return true
+    return scopeIds.includes(p.id)
+  }
+
+  protected countActiveWeeks(
+    products: ProductsPass[],
+    scopeIds: string[] | undefined,
+  ): number {
     return products.filter(
-      (p) => p.duration_type === "week" && (p.purchased || p.selected),
+      (p) =>
+        p.duration_type === "week" &&
+        (p.purchased || p.selected) &&
+        this.inScope(p, scopeIds),
     ).length
   }
 
-  protected hasEditedWeeks(products: ProductsPass[]): boolean {
-    return products.some((p) => p.duration_type === "week" && p.edit)
+  protected hasEditedWeeks(
+    products: ProductsPass[],
+    scopeIds: string[] | undefined,
+  ): boolean {
+    return products.some(
+      (p) =>
+        p.duration_type === "week" && p.edit && this.inScope(p, scopeIds),
+    )
+  }
+
+  // The Month target to auto-promote. With a section scope the target MUST
+  // live inside the same section as the weeks — otherwise we'd promote a Month
+  // the user can't see (e.g. Month Locals when only regular weeks are visible).
+  // Without scope, fall back to the first Month in the attendee (legacy).
+  protected resolveMonthTarget(
+    products: ProductsPass[],
+    scopeIds: string[] | undefined,
+  ): ProductsPass | undefined {
+    if (scopeIds && scopeIds.length > 0) {
+      return products.find(
+        (p) => p.duration_type === "month" && scopeIds.includes(p.id),
+      )
+    }
+    return products.find((p) => p.duration_type === "month")
+  }
+
+  // Threshold: with scope, all weeks in that scope; without, legacy "4 weeks".
+  protected weeksInScopeCount(
+    products: ProductsPass[],
+    scopeIds: string[] | undefined,
+  ): number {
+    if (scopeIds && scopeIds.length > 0) {
+      return products.filter(
+        (p) => p.duration_type === "week" && scopeIds.includes(p.id),
+      ).length
+    }
+    return 4
   }
 
   protected shouldSelectMonth(
     activeWeeks: number,
+    weeksThreshold: number,
     hasEditedWeeks: boolean,
+    monthTargetExists: boolean,
     monthPurchased: boolean,
   ): boolean {
-    if (monthPurchased) {
-      return false
-    }
-    return activeWeeks >= 4 && !hasEditedWeeks
+    if (!monthTargetExists) return false
+    if (monthPurchased) return false
+    if (weeksThreshold === 0) return false
+    return activeWeeks >= weeksThreshold && !hasEditedWeeks
   }
 
   handleSelection(
     attendees: AttendeePassState[],
     attendeeId: string,
     product: ProductsPass,
+    _discount?: DiscountProps,
+    exclusivityScopeIds?: string[],
+    attendeeVisibleProductIds?: string[],
   ): AttendeePassState[] {
     const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+
+    // Promotion scope: prefer the WIDE scope (all attendee-visible products
+    // across sections) so a week-in-section-A can promote a month-in-section-B
+    // when both belong to the same coherent set the user actually sees.
+    // Fall back to the strict section scope to keep behaviour stable for
+    // configs that don't provide visibility hints.
+    const promotionScope =
+      attendeeVisibleProductIds && attendeeVisibleProductIds.length > 0
+        ? attendeeVisibleProductIds
+        : exclusivityScopeIds
 
     return attendees.map((attendee) => {
       if (attendee.id !== attendeeId) return attendee
@@ -141,9 +209,6 @@ class WeekProductStrategy implements ProductStrategy {
       const willBeSelected = isMultiUnit
         ? (product.quantity ?? 0) > 0
         : !product.selected
-      const monthProduct = attendee.products.find(
-        (p) => p.duration_type === "month",
-      )
 
       const updatedProducts = attendee.products.map((p) => {
         if (p.id !== product.id) return p
@@ -162,32 +227,52 @@ class WeekProductStrategy implements ProductStrategy {
         }
       })
 
-      const activeWeeks = this.countActiveWeeks(updatedProducts)
-      const hasEdited = this.hasEditedWeeks(updatedProducts)
+      const monthTarget = this.resolveMonthTarget(
+        updatedProducts,
+        promotionScope,
+      )
+      const activeWeeks = this.countActiveWeeks(
+        updatedProducts,
+        promotionScope,
+      )
+      const hasEdited = this.hasEditedWeeks(updatedProducts, promotionScope)
+      const weeksThreshold = this.weeksInScopeCount(
+        updatedProducts,
+        promotionScope,
+      )
       const shouldSelectMonth = this.shouldSelectMonth(
         activeWeeks,
+        weeksThreshold,
         hasEdited,
-        monthProduct?.purchased || false,
+        !!monthTarget,
+        monthTarget?.purchased || false,
       )
 
-      const isClearedByMonth = (p: ProductsPass): boolean =>
-        shouldSelectMonth &&
-        !p.purchased &&
-        (p.duration_type === "day" || p.duration_type === "week")
+      const isClearedByMonth = (p: ProductsPass): boolean => {
+        if (!shouldSelectMonth) return false
+        if (p.purchased) return false
+        if (p.duration_type !== "day" && p.duration_type !== "week") return false
+        // Use the same scope used to decide the promotion so we only clear
+        // products that belong to the same "visible set". Without scope hints,
+        // legacy behaviour clears all week/day products of the attendee.
+        return this.inScope(p, promotionScope)
+      }
 
       return {
         ...attendee,
-        products: updatedProducts.map((p) => ({
-          ...p,
-          quantity: isClearedByMonth(p) ? 0 : p.quantity,
-          selected:
-            p.duration_type === "month"
+        products: updatedProducts.map((p) => {
+          const isTargetMonth = !!monthTarget && p.id === monthTarget.id
+          return {
+            ...p,
+            quantity: isClearedByMonth(p) ? 0 : p.quantity,
+            selected: isTargetMonth
               ? shouldSelectMonth
               : isClearedByMonth(p)
                 ? false
                 : p.selected,
-          edit: p.duration_type === "month" ? hasEdited : p.edit,
-        })),
+            edit: isTargetMonth ? hasEdited : p.edit,
+          }
+        }),
       }
     })
   }
@@ -283,6 +368,7 @@ class ExclusivityGuard implements ProductStrategy {
     product: ProductsPass,
     discount?: DiscountProps,
     exclusivityScopeIds?: string[],
+    attendeeVisibleProductIds?: string[],
   ): AttendeePassState[] {
     const result = this.inner.handleSelection(
       attendees,
@@ -290,6 +376,7 @@ class ExclusivityGuard implements ProductStrategy {
       product,
       discount,
       exclusivityScopeIds,
+      attendeeVisibleProductIds,
     )
 
     // Scope: explicit ids from the caller (ticketing-step section) when provided,

--- a/portal/src/strategies/ProductStrategies.ts
+++ b/portal/src/strategies/ProductStrategies.ts
@@ -136,8 +136,7 @@ class WeekProductStrategy implements ProductStrategy {
     scopeIds: string[] | undefined,
   ): boolean {
     return products.some(
-      (p) =>
-        p.duration_type === "week" && p.edit && this.inScope(p, scopeIds),
+      (p) => p.duration_type === "week" && p.edit && this.inScope(p, scopeIds),
     )
   }
 
@@ -231,10 +230,7 @@ class WeekProductStrategy implements ProductStrategy {
         updatedProducts,
         promotionScope,
       )
-      const activeWeeks = this.countActiveWeeks(
-        updatedProducts,
-        promotionScope,
-      )
+      const activeWeeks = this.countActiveWeeks(updatedProducts, promotionScope)
       const hasEdited = this.hasEditedWeeks(updatedProducts, promotionScope)
       const weeksThreshold = this.weeksInScopeCount(
         updatedProducts,
@@ -251,7 +247,8 @@ class WeekProductStrategy implements ProductStrategy {
       const isClearedByMonth = (p: ProductsPass): boolean => {
         if (!shouldSelectMonth) return false
         if (p.purchased) return false
-        if (p.duration_type !== "day" && p.duration_type !== "week") return false
+        if (p.duration_type !== "day" && p.duration_type !== "week")
+          return false
         // Use the same scope used to decide the promotion so we only clear
         // products that belong to the same "visible set". Without scope hints,
         // legacy behaviour clears all week/day products of the attendee.


### PR DESCRIPTION
## Summary

- **Fix cross-section bleed in `WeekProductStrategy`**: counting, month-target lookup, and clearing now respect the products visible to the attendee. Selecting weeks no longer auto-selects unrelated months (Caregiver vs Nanny, opposite-tier locals, etc.). `clearCart` also resets `attendeePasses` so removing every entry no longer locks weeks/days behind a phantom Month.
- **Section visibility gated by form answer**: admins attach a `visible_if = { field_id, value }` condition to any ticket-step section. The portal evaluates it against `application.custom_fields` (open-ticketing → no-gate fallback). Backoffice exposes the picker over the popup's discrete form fields (select / checkbox / radio).
- **UI polish**: snap-scroll uses `scrollIntoView` with mandatory snap kept active (no settle jump), portal scrollbar hidden while the flow is mounted so `SnapDotNav` doesn't collide, `PassRow` description toggle measures real overflow before showing "Ver más", and a `SELECTED_ROW_CLASSES` constant replaces duplicated gradient.

## Test plan

- [x] `pnpm tsc --noEmit` in portal — clean
- [x] `pnpm vitest run` for strategies + provider + variant tests — 10/10 strategy (incl. 2 new cross-section), 4/4 passesProvider, 6 new visibility tests pass. The 4 pre-existing `attendee_categories` kid-normalisation failures are unchanged.
- [ ] Sonoma popup: configure both `(Locals)` sections with `visible_if = { local_resident, "Yes" }` and the regular sections with `"No"`. Verify local buyer sees only locals sections, non-local sees only regulars.
- [ ] Select every weekly pass in either section → auto-promotes to the matching Month and clears the weeks. Caregiver / opposite-tier / Kid months never sneak into the cart.
- [ ] Press the cart "Remove all" affordance → all weeks/days re-enable for selection.