### PR TITLE
feat: per-step navbar visibility, emoji, popup favicon

### DIFF
--- a/backend/app/alembic/versions/a3f72c1d9b0e_step_meta_and_popup_favicon.py
+++ b/backend/app/alembic/versions/a3f72c1d9b0e_step_meta_and_popup_favicon.py
@@ -1,0 +1,52 @@
+"""Step meta + popup favicon: ticketingsteps.emoji, ticketingsteps.show_in_navbar, popups.favicon_url.
+
+Three additive columns, all opt-in and backwards-compatible:
+
+* ``ticketingsteps.emoji`` — optional emoji string (max 8 chars) rendered
+  in place of the default Lucide icon in the checkout step nav. ``NULL``
+  keeps the legacy icon.
+* ``ticketingsteps.show_in_navbar`` — whether the step appears in the top
+  section nav. ``True`` (server default) preserves current behaviour for
+  every existing step; tenants opt informational steps out as needed.
+* ``popups.favicon_url`` — URL of the favicon shown on the checkout page.
+  ``NULL`` falls back to the tenant default.
+
+Revision ID: a3f72c1d9b0e
+Revises: f7fa8db4239a
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a3f72c1d9b0e"
+down_revision: str | Sequence[str] | None = "f7fa8db4239a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ticketingsteps",
+        sa.Column("emoji", sa.String(length=8), nullable=True),
+    )
+    op.add_column(
+        "ticketingsteps",
+        sa.Column(
+            "show_in_navbar",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column("favicon_url", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("popups", "favicon_url")
+    op.drop_column("ticketingsteps", "show_in_navbar")
+    op.drop_column("ticketingsteps", "emoji")

--- a/backend/app/alembic/versions/c8d3a5e1f29b_backfill_buyer_step_for_direct_sale.py
+++ b/backend/app/alembic/versions/c8d3a5e1f29b_backfill_buyer_step_for_direct_sale.py
@@ -1,0 +1,154 @@
+"""Backfill the buyer step into every direct-sale popup that doesn't already have one.
+
+Open-ticketing checkouts previously rendered the buyer-info step ("Your
+information") as a synthetic React-only step. We now require a real
+``ticketingsteps`` row so admins can edit its title, description, emoji
+and ordering from the backoffice like any other step.
+
+For every popup where ``sale_type='direct'`` and no row with
+``step_type='buyer'`` exists, this migration inserts one with:
+
+* ``step_type='buyer'``, ``template='buyer-form'``
+* Order placed immediately before the existing ``confirm`` step (shifting
+  ``confirm`` and anything past it up by one). When no confirm step
+  exists the buyer row is appended at the end.
+* ``protected=True`` so the row can't be deleted by accident from the UI.
+
+The row ID is derived from a deterministic UUIDv5 over the popup id
+(plus this migration's revision id as the namespace seed). That way the
+downgrade can target exactly the rows this migration created — admins
+who later recreate the buyer step from the UI will get a different UUID,
+and their work won't be wiped if someone rolls this migration back.
+
+Revision ID: c8d3a5e1f29b
+Revises: a3f72c1d9b0e
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c8d3a5e1f29b"
+down_revision: str | Sequence[str] | None = "a3f72c1d9b0e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# UUIDv5 namespace seeded from this revision. Deterministic so the same
+# popup id always yields the same row id — required for the targeted
+# downgrade to find the row it inserted.
+_NAMESPACE = uuid.UUID("c8d3a5e1-f29b-5000-8000-000000000000")
+
+
+def _buyer_row_id(popup_id: uuid.UUID) -> uuid.UUID:
+    return uuid.uuid5(_NAMESPACE, str(popup_id))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT p.id AS popup_id, p.tenant_id
+            FROM popups p
+            WHERE p.sale_type = 'direct'
+              AND NOT EXISTS (
+                SELECT 1
+                FROM ticketingsteps s
+                WHERE s.popup_id = p.id
+                  AND s.step_type = 'buyer'
+              )
+            """
+        )
+    ).all()
+
+    for row in rows:
+        confirm_order = conn.execute(
+            sa.text(
+                """
+                SELECT "order" FROM ticketingsteps
+                WHERE popup_id = :pid AND step_type = 'confirm'
+                LIMIT 1
+                """
+            ),
+            {"pid": row.popup_id},
+        ).scalar()
+
+        if confirm_order is not None:
+            conn.execute(
+                sa.text(
+                    """
+                    UPDATE ticketingsteps
+                    SET "order" = "order" + 1
+                    WHERE popup_id = :pid AND "order" >= :ord
+                    """
+                ),
+                {"pid": row.popup_id, "ord": confirm_order},
+            )
+            buyer_order = confirm_order
+        else:
+            buyer_order = conn.execute(
+                sa.text(
+                    """
+                    SELECT COALESCE(MAX("order"), -1) + 1
+                    FROM ticketingsteps
+                    WHERE popup_id = :pid
+                    """
+                ),
+                {"pid": row.popup_id},
+            ).scalar()
+
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO ticketingsteps (
+                    id, tenant_id, popup_id, step_type, title,
+                    description, "order", is_enabled, protected,
+                    template, template_config, watermark,
+                    show_title, show_watermark, show_in_navbar
+                ) VALUES (
+                    :id, :tid, :pid, 'buyer', :title,
+                    :description, :ord, true, true,
+                    'buyer-form', NULL, :watermark,
+                    false, true, true
+                )
+                """
+            ),
+            {
+                "id": _buyer_row_id(row.popup_id),
+                "tid": row.tenant_id,
+                "pid": row.popup_id,
+                "ord": buyer_order,
+                "title": "Your information",
+                "description": "Complete your information before payment.",
+                "watermark": "Your info",
+            },
+        )
+
+
+def downgrade() -> None:
+    # Targeted revert: only remove the rows this migration inserted, by
+    # rebuilding the deterministic UUIDv5 ids per direct-sale popup.
+    # Admin-customized buyer steps (different id) are left untouched.
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        sa.text(
+            """
+            SELECT id FROM popups WHERE sale_type = 'direct'
+            """
+        )
+    ).all()
+
+    for row in rows:
+        conn.execute(
+            sa.text(
+                """
+                DELETE FROM ticketingsteps WHERE id = :rid
+                """
+            ),
+            {"rid": _buyer_row_id(row.id)},
+        )

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -113,6 +113,7 @@ class PopupBase(SQLModel):
         default=None,
         sa_column=Column(JSONB, nullable=True),
     )
+    favicon_url: str | None = None
     default_language: str = Field(default="en")
     supported_languages: list[str] = Field(
         default=["en"],
@@ -182,6 +183,7 @@ class PopupCreate(SQLModel):
     requires_application_fee: bool = False
     application_fee_amount: Decimal | None = None
     theme_config: dict | None = None
+    favicon_url: str | None = None
     default_language: str = "en"
     supported_languages: list[str] = ["en"]
     insurance_enabled: bool = False
@@ -245,6 +247,7 @@ class PopupUpdate(SQLModel):
     requires_application_fee: bool | None = None
     application_fee_amount: Decimal | None = None
     theme_config: dict | None = None
+    favicon_url: str | None = None
     default_language: str | None = None
     supported_languages: list[str] | None = None
     insurance_enabled: bool | None = None
@@ -310,6 +313,7 @@ class PopupPublic(SQLModel):
     requires_application_fee: bool = False
     application_fee_amount: Decimal | None = None
     theme_config: dict | None = None
+    favicon_url: str | None = None
     default_language: str = "en"
     supported_languages: list[str] = ["en"]
     insurance_enabled: bool = False

--- a/backend/app/api/ticketing_step/constants.py
+++ b/backend/app/api/ticketing_step/constants.py
@@ -65,12 +65,28 @@ DEFAULT_TICKETING_STEPS = [
         "protected": False,
         "product_category": "patreon",
     },
+    # Buyer step is direct-sale only — see seed_ticketing_steps_for_popup
+    # below for the sale_type gate. We keep it in the canonical list so the
+    # row sits between patron and confirm whenever a direct-sale popup is
+    # seeded; application-mode popups skip it.
+    {
+        "step_type": "buyer",
+        "title": "Your information",
+        "description": "Complete your information before payment.",
+        "watermark": "Your info",
+        "template": "buyer-form",
+        "template_config": None,
+        "order": 4,
+        "is_enabled": True,
+        "protected": True,
+        "_direct_sale_only": True,
+    },
     {
         "step_type": "confirm",
         "title": "Review & Confirm",
         "description": "Review your order before payment",
         "watermark": "Confirm",
-        "order": 4,
+        "order": 5,
         "is_enabled": True,
         "protected": True,
         "template_config": {
@@ -93,10 +109,20 @@ def seed_ticketing_steps_for_popup(
     db: Session,
     popup_id: uuid.UUID,
     tenant_id: uuid.UUID,
+    sale_type: str | None = None,
 ) -> None:
+    """Seed the default ticketing-step set for a popup.
+
+    Steps flagged with ``_direct_sale_only`` (e.g. the buyer step) only get
+    inserted when ``sale_type='direct'``. Application popups collect buyer
+    info via the application form earlier in the funnel, so the open-
+    ticketing buyer step is irrelevant there.
+    """
     from app.api.ticketing_step.models import TicketingSteps
 
     for step_def in DEFAULT_TICKETING_STEPS:
+        if step_def.get("_direct_sale_only") and sale_type != "direct":
+            continue
         step = TicketingSteps(
             tenant_id=tenant_id,
             popup_id=popup_id,

--- a/backend/app/api/ticketing_step/schemas.py
+++ b/backend/app/api/ticketing_step/schemas.py
@@ -63,6 +63,8 @@ class TicketingStepBase(SQLModel):
     watermark: str | None = Field(default=None, nullable=True)
     show_title: bool = Field(default=True)
     show_watermark: bool = Field(default=True)
+    show_in_navbar: bool = Field(default=True)
+    emoji: str | None = Field(default=None, nullable=True, max_length=8)
 
 
 class TicketingStepPublic(BaseModel):
@@ -81,6 +83,8 @@ class TicketingStepPublic(BaseModel):
     watermark: str | None = None
     show_title: bool = True
     show_watermark: bool = True
+    show_in_navbar: bool = True
+    emoji: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -98,6 +102,8 @@ class TicketingStepCreate(BaseModel):
     watermark: str | None = None
     show_title: bool = True
     show_watermark: bool = True
+    show_in_navbar: bool = True
+    emoji: str | None = None
 
     @model_validator(mode="after")
     def _validate_template_config(self) -> "TicketingStepCreate":
@@ -118,6 +124,8 @@ class TicketingStepUpdate(BaseModel):
     watermark: str | None = None
     show_title: bool | None = None
     show_watermark: bool | None = None
+    show_in_navbar: bool | None = None
+    emoji: str | None = None
 
     @model_validator(mode="after")
     def _validate_template_config(self) -> "TicketingStepUpdate":

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -189,7 +189,12 @@ def _seed_ticketing_steps(session: Session, popup_map: dict, tenant_id) -> None:
         if existing:
             continue
 
-        seed_ticketing_steps_for_popup(session, popup_id=popup.id, tenant_id=tenant_id)
+        seed_ticketing_steps_for_popup(
+            session,
+            popup_id=popup.id,
+            tenant_id=tenant_id,
+            sale_type=str(popup.sale_type) if popup.sale_type else None,
+        )
         logger.info(f"Ticketing steps seeded for {popup_key}")
 
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -10664,6 +10664,17 @@ export const PopupAdminSchema = {
             ],
             title: 'Theme Config'
         },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
+        },
         default_language: {
             type: 'string',
             title: 'Default Language',
@@ -11013,6 +11024,17 @@ export const PopupCreateSchema = {
             ],
             title: 'Theme Config'
         },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
+        },
         default_language: {
             type: 'string',
             title: 'Default Language',
@@ -11287,6 +11309,17 @@ export const PopupPublicSchema = {
                 }
             ],
             title: 'Theme Config'
+        },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
         },
         default_language: {
             type: 'string',
@@ -11778,6 +11811,17 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Theme Config'
+        },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
         },
         default_language: {
             anyOf: [
@@ -14446,6 +14490,22 @@ export const TicketingStepCreateSchema = {
             type: 'boolean',
             title: 'Show Watermark',
             default: true
+        },
+        show_in_navbar: {
+            type: 'boolean',
+            title: 'Show In Navbar',
+            default: true
+        },
+        emoji: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Emoji'
         }
     },
     type: 'object',
@@ -14558,6 +14618,22 @@ export const TicketingStepPublicSchema = {
             type: 'boolean',
             title: 'Show Watermark',
             default: true
+        },
+        show_in_navbar: {
+            type: 'boolean',
+            title: 'Show In Navbar',
+            default: true
+        },
+        emoji: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Emoji'
         }
     },
     type: 'object',
@@ -14677,6 +14753,28 @@ export const TicketingStepUpdateSchema = {
                 }
             ],
             title: 'Show Watermark'
+        },
+        show_in_navbar: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Show In Navbar'
+        },
+        emoji: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Emoji'
         }
     },
     type: 'object',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2171,6 +2171,7 @@ export type PopupAdmin = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: string;
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
@@ -2214,6 +2215,7 @@ export type PopupCreate = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: string;
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
@@ -2255,6 +2257,7 @@ export type PopupPublic = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: string;
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
@@ -2329,6 +2332,7 @@ export type PopupUpdate = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: (string | null);
     supported_languages?: (Array<(string)> | null);
     insurance_enabled?: (boolean | null);
@@ -2813,6 +2817,8 @@ export type TicketingStepCreate = {
     watermark?: (string | null);
     show_title?: boolean;
     show_watermark?: boolean;
+    show_in_navbar?: boolean;
+    emoji?: (string | null);
 };
 
 export type TicketingStepPublic = {
@@ -2833,6 +2839,8 @@ export type TicketingStepPublic = {
     watermark?: (string | null);
     show_title?: boolean;
     show_watermark?: boolean;
+    show_in_navbar?: boolean;
+    emoji?: (string | null);
 };
 
 export type TicketingStepUpdate = {
@@ -2848,6 +2856,8 @@ export type TicketingStepUpdate = {
     watermark?: (string | null);
     show_title?: (boolean | null);
     show_watermark?: (boolean | null);
+    show_in_navbar?: (boolean | null);
+    emoji?: (string | null);
 };
 
 /**

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -202,6 +202,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
       application_fee_amount: defaultValues?.application_fee_amount ?? "",
       image_url: defaultValues?.image_url ?? "",
       icon_url: defaultValues?.icon_url ?? "",
+      favicon_url: defaultValues?.favicon_url ?? "",
       express_checkout_background:
         defaultValues?.express_checkout_background ?? "",
       currency: defaultValues?.currency ?? "USD",
@@ -244,6 +245,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
           : null,
         image_url: value.image_url || null,
         icon_url: value.icon_url || null,
+        favicon_url: value.favicon_url || null,
         express_checkout_background: value.express_checkout_background || null,
         currency: value.currency,
         web_url: value.web_url || null,
@@ -783,6 +785,30 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                     <p className="text-sm font-medium">Icon</p>
                     <p className="text-xs text-muted-foreground">
                       Small icon shown in the portal sidebar popup menu
+                    </p>
+                  </div>
+                </div>
+                <ImageUpload
+                  value={field.state.value || null}
+                  onChange={(url) => field.handleChange(url ?? "")}
+                  disabled={readOnly}
+                />
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="favicon_url">
+            {(field) => (
+              <div className="space-y-2 py-3">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                    <Image className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium">Favicon</p>
+                    <p className="text-xs text-muted-foreground">
+                      Browser tab icon shown on the public checkout for this
+                      popup. Overrides the tenant default.
                     </p>
                   </div>
                 </div>

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -107,6 +107,8 @@ function StepConfigContent({ stepId }: { stepId: string }) {
   const [showWatermark, setShowWatermark] = useState(
     step.show_watermark ?? true,
   )
+  const [showInNavbar, setShowInNavbar] = useState(step.show_in_navbar ?? true)
+  const [emoji, setEmoji] = useState(step.emoji ?? "")
 
   const isDirty =
     title !== step.title ||
@@ -117,7 +119,9 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     JSON.stringify(templateConfig) !==
       JSON.stringify(step.template_config ?? null) ||
     showTitle !== (step.show_title ?? true) ||
-    showWatermark !== (step.show_watermark ?? true)
+    showWatermark !== (step.show_watermark ?? true) ||
+    showInNavbar !== (step.show_in_navbar ?? true) ||
+    emoji !== (step.emoji ?? "")
 
   const blocker = useDirtyBlocker(
     isDirty,
@@ -134,6 +138,8 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     setTemplateConfig((step.template_config as Record<string, unknown>) ?? null)
     setShowTitle(step.show_title ?? true)
     setShowWatermark(step.show_watermark ?? true)
+    setShowInNavbar(step.show_in_navbar ?? true)
+    setEmoji(step.emoji ?? "")
   }, [
     step.title,
     step.description,
@@ -143,6 +149,8 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     step.template_config,
     step.show_title,
     step.show_watermark,
+    step.show_in_navbar,
+    step.emoji,
   ])
 
   // Popup data (needed for insurance_enabled gate on confirm step)
@@ -184,6 +192,8 @@ function StepConfigContent({ stepId }: { stepId: string }) {
           template_config: templateConfig,
           show_title: showTitle,
           show_watermark: showWatermark,
+          show_in_navbar: showInNavbar,
+          emoji: emoji.trim() || null,
         },
       })
     },
@@ -235,11 +245,26 @@ function StepConfigContent({ stepId }: { stepId: string }) {
         <CardContent className="flex flex-col gap-4">
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="step-title">Title</Label>
-            <Input
-              id="step-title"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-            />
+            <div className="flex gap-1.5">
+              <Input
+                id="step-emoji"
+                aria-label="Step emoji"
+                value={emoji}
+                onChange={(e) => setEmoji(e.target.value.slice(0, 8))}
+                placeholder="🎟️"
+                className="w-16 text-center text-lg"
+              />
+              <Input
+                id="step-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="flex-1"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Optional emoji replaces the default icon in the checkout step nav.
+              Leave blank to keep the built-in icon.
+            </p>
           </div>
 
           <div className="flex flex-col gap-1.5">
@@ -292,6 +317,22 @@ function StepConfigContent({ stepId }: { stepId: string }) {
               checked={showWatermark}
               onCheckedChange={setShowWatermark}
               aria-label="Toggle watermark visibility"
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
+            <div className="flex flex-col gap-0.5">
+              <Label>Show in Navbar</Label>
+              <p className="text-xs text-muted-foreground">
+                Whether the step appears in the top section nav. Hidden steps
+                still render and are reachable by scroll — useful for
+                informational sections that shouldn't clutter the nav.
+              </p>
+            </div>
+            <Switch
+              checked={showInNavbar}
+              onCheckedChange={setShowInNavbar}
+              aria-label="Toggle navbar visibility"
             />
           </div>
 

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -10664,6 +10664,17 @@ export const PopupAdminSchema = {
             ],
             title: 'Theme Config'
         },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
+        },
         default_language: {
             type: 'string',
             title: 'Default Language',
@@ -11013,6 +11024,17 @@ export const PopupCreateSchema = {
             ],
             title: 'Theme Config'
         },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
+        },
         default_language: {
             type: 'string',
             title: 'Default Language',
@@ -11287,6 +11309,17 @@ export const PopupPublicSchema = {
                 }
             ],
             title: 'Theme Config'
+        },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
         },
         default_language: {
             type: 'string',
@@ -11778,6 +11811,17 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Theme Config'
+        },
+        favicon_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Favicon Url'
         },
         default_language: {
             anyOf: [
@@ -14446,6 +14490,22 @@ export const TicketingStepCreateSchema = {
             type: 'boolean',
             title: 'Show Watermark',
             default: true
+        },
+        show_in_navbar: {
+            type: 'boolean',
+            title: 'Show In Navbar',
+            default: true
+        },
+        emoji: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Emoji'
         }
     },
     type: 'object',
@@ -14558,6 +14618,22 @@ export const TicketingStepPublicSchema = {
             type: 'boolean',
             title: 'Show Watermark',
             default: true
+        },
+        show_in_navbar: {
+            type: 'boolean',
+            title: 'Show In Navbar',
+            default: true
+        },
+        emoji: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Emoji'
         }
     },
     type: 'object',
@@ -14677,6 +14753,28 @@ export const TicketingStepUpdateSchema = {
                 }
             ],
             title: 'Show Watermark'
+        },
+        show_in_navbar: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Show In Navbar'
+        },
+        emoji: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Emoji'
         }
     },
     type: 'object',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2171,6 +2171,7 @@ export type PopupAdmin = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: string;
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
@@ -2214,6 +2215,7 @@ export type PopupCreate = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: string;
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
@@ -2255,6 +2257,7 @@ export type PopupPublic = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: string;
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
@@ -2329,6 +2332,7 @@ export type PopupUpdate = {
     theme_config?: ({
     [key: string]: unknown;
 } | null);
+    favicon_url?: (string | null);
     default_language?: (string | null);
     supported_languages?: (Array<(string)> | null);
     insurance_enabled?: (boolean | null);
@@ -2813,6 +2817,8 @@ export type TicketingStepCreate = {
     watermark?: (string | null);
     show_title?: boolean;
     show_watermark?: boolean;
+    show_in_navbar?: boolean;
+    emoji?: (string | null);
 };
 
 export type TicketingStepPublic = {
@@ -2833,6 +2839,8 @@ export type TicketingStepPublic = {
     watermark?: (string | null);
     show_title?: boolean;
     show_watermark?: boolean;
+    show_in_navbar?: boolean;
+    emoji?: (string | null);
 };
 
 export type TicketingStepUpdate = {
@@ -2848,6 +2856,8 @@ export type TicketingStepUpdate = {
     watermark?: (string | null);
     show_title?: (boolean | null);
     show_watermark?: (boolean | null);
+    show_in_navbar?: (boolean | null);
+    emoji?: (string | null);
 };
 
 /**


### PR DESCRIPTION
## Summary

Slice 1 of the broader checkout overhaul from #105, isolated as a small reviewable unit: adds the tenant-configurable step metadata (emoji, `show_in_navbar`) and popup favicon, plus the real `ticketingsteps` row for the open-ticketing buyer step.

Deliberately **does not** include the larger overhaul: tracking snippets, theme tokens, new variant templates, validation UX, and form-ui red→amber are out of scope here and follow in later PRs.

## What's in here

**Backend (two migrations, chained off `f7fa8db4239a`):**
- `a3f72c1d9b0e_step_meta_and_popup_favicon` — adds `ticketingsteps.emoji` (varchar 8, nullable), `ticketingsteps.show_in_navbar` (bool, default `true`), `popups.favicon_url` (varchar, nullable). All additive and backwards-compatible.
- `c8d3a5e1f29b_backfill_buyer_step_for_direct_sale` — inserts a `step_type='buyer'` / `template='buyer-form'` row into every direct-sale popup that doesn't already have one. Slot is placed immediately before `confirm`, shifting confirm and anything past it up by one. Row id is a deterministic UUIDv5 over the popup id so the downgrade only removes rows this migration inserted; admin-customized buyer steps (different id) are untouched.

**Schemas + seed:**
- `popup/schemas.py` — `favicon_url` on Base / Create / Update / Public.
- `ticketing_step/schemas.py` — `show_in_navbar` (bool default `True`) and `emoji` (str, max 8) on Base / Public / Create / Update.
- `ticketing_step/constants.py` — `DEFAULT_TICKETING_STEPS` now carries the buyer step with `_direct_sale_only: True`. `seed_ticketing_steps_for_popup` accepts an optional `sale_type` and skips direct-sale-only steps when the popup is application-mode.
- `core/db.py` — passes `popup.sale_type` through to the seeder.

**Backoffice:**
- `PopupForm.tsx` — favicon `ImageUpload` field in the Branding section, alongside Icon and Cover.
- `_layout/ticketing-steps/$stepId.tsx` — \"Show in Navbar\" switch and an inline 8-char emoji input that prefixes the title field. Both fields participate in the dirty-state check and PATCH payload.

**Generated clients:**
- `portal/src/client/{schemas,types}.gen.ts` and `backoffice/src/client/{schemas,types}.gen.ts` regenerated via `bash scripts/generate-client.sh`.

## Behaviour for existing tenants

- Existing application-mode popups: no change. The buyer step gate filters them out at seed time and no migration touches their rows.
- Existing direct-sale popups: get a buyer-step row inserted at order = (current confirm.order), with the confirm step shifted up. The portal continues to render the buyer step via its existing synthetic fallback path until the next slice of #105 wires the real row in — so this PR is **safe to land on its own** even though the portal doesn't yet consume `show_in_navbar` / `emoji`.
- Default `show_in_navbar = true` and `emoji = NULL` preserve current portal behaviour for every existing step.

## Test plan

- [x] `alembic upgrade head` clean on a fresh DB.
- [x] `alembic downgrade -2` + `alembic upgrade head` round-trip clean.
- [x] Manual: create a direct-sale popup with a `confirm` step at order 5, run the backfill. Buyer step inserted at order 5, confirm shifted to order 6. Downgrade removes only the buyer row created by the migration.
- [x] `pnpm --filter backoffice run build` — green.
- [x] `pnpm --filter portal run build` — green.
- [x] `bash backend/scripts/lint.sh` — 323 diagnostics, identical to main (no new warnings introduced).
- [x] OpenAPI clients regenerated via `bash scripts/generate-client.sh`.
- [ ] QA on a real direct-sale popup in staging (set favicon + emoji in backoffice, confirm round-trips).

## Notes

- Migrations follow the hash-filename convention (no `00NN_*` enumerated filenames).
- No Amanita seed / public assets / tracking-snippet config — those follow in their own PRs per the review plan.