### PR TITLE
feat(theme): step-card surface tokens + shared icon registry

### DIFF
--- a/portal/src/components/checkout-flow/CartItemList.tsx
+++ b/portal/src/components/checkout-flow/CartItemList.tsx
@@ -2,6 +2,7 @@
 
 import { Heart, Home, Shield, ShoppingBag, Tag, Ticket, X } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { formatCurrency } from "@/types/checkout"
 
@@ -19,11 +20,30 @@ export default function CartItemList() {
     clearPromoCode,
     removeDynamicItem,
     isEditing,
+    stepConfigs,
   } = useCheckout()
 
-  const hasDynamicItems = Object.values(cart.dynamicItems).some(
-    (items) => items.length > 0,
-  )
+  // Group dynamic items by their originating step so the drawer renders one
+  // section per step type ("Housing", "Parking", …) with the matching icon,
+  // instead of dumping every dynamic item under a single "Tickets" heading.
+  const dynamicGroups = Object.entries(cart.dynamicItems)
+    .filter(([, items]) => items.length > 0)
+    .map(([stepType, items]) => {
+      const stepConfig = stepConfigs.find((s) => s.step_type === stepType)
+      const Icon = resolveStepIcon({
+        stepType,
+        template: stepConfig?.template,
+        emoji: stepConfig?.emoji,
+      })
+      return {
+        stepType,
+        label: stepConfig?.title ?? stepType,
+        Icon,
+        items,
+      }
+    })
+
+  const hasDynamicItems = dynamicGroups.length > 0
   const hasEditChanges =
     isEditing && attendees.some((a) => a.products.some((p) => p.edit))
   const hasItems =
@@ -205,52 +225,51 @@ export default function CartItemList() {
         </div>
       )}
 
-      {/* Dynamic Items */}
-      {hasDynamicItems && (
-        <div className="mb-4">
-          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Tickets
+      {/* Dynamic Items — one group per step (Housing, Parking, …) */}
+      {dynamicGroups.map(({ stepType, label, Icon, items }) => (
+        <div key={stepType} className="mb-4">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2 flex items-center gap-1.5">
+            <Icon className="w-3.5 h-3.5" />
+            <span>{label}</span>
           </h4>
           <div className="space-y-2">
-            {Object.values(cart.dynamicItems)
-              .flat()
-              .map((item) => (
-                <div
-                  key={item.productId}
-                  className="flex items-center justify-between py-2 border-b border-border last:border-0"
-                >
-                  <div className="flex items-center gap-3 flex-1 min-w-0">
-                    <Ticket className="w-4 h-4 text-muted-foreground shrink-0" />
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium text-checkout-title truncate">
-                        {item.quantity > 1 && (
-                          <span className="text-muted-foreground">
-                            {item.quantity} ×{" "}
-                          </span>
-                        )}
-                        {item.product.name}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium text-checkout-title">
-                      {formatCurrency(item.price)}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        removeDynamicItem(item.stepType, item.productId)
-                      }
-                      className="p-1 text-muted-foreground hover:text-destructive transition-colors"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
+            {items.map((item) => (
+              <div
+                key={item.productId}
+                className="flex items-center justify-between py-2 border-b border-border last:border-0"
+              >
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <Icon className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-checkout-title truncate">
+                      {item.quantity > 1 && (
+                        <span className="text-muted-foreground">
+                          {item.quantity} ×{" "}
+                        </span>
+                      )}
+                      {item.product.name}
+                    </p>
                   </div>
                 </div>
-              ))}
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium text-checkout-title">
+                    {formatCurrency(item.price)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      removeDynamicItem(item.stepType, item.productId)
+                    }
+                    className="p-1 text-muted-foreground hover:text-destructive transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
           </div>
         </div>
-      )}
+      ))}
 
       {/* Insurance */}
       {cart.insurance && summary.insuranceSubtotal > 0 && (

--- a/portal/src/components/checkout-flow/InsuranceCard.tsx
+++ b/portal/src/components/checkout-flow/InsuranceCard.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion } from "framer-motion"
 import { Check, Umbrella } from "lucide-react"
+import { stepCardSurfaceStyle } from "@/lib/stepCardSurface"
 import { cn } from "@/lib/utils"
 import { formatCurrency, INSURANCE_BENEFITS } from "@/types/checkout"
 
@@ -32,7 +33,8 @@ export default function InsuranceCard({
     <motion.div
       whileHover={{ y: -1 }}
       transition={{ type: "spring", stiffness: 400, damping: 25 }}
-      className="bg-white rounded-2xl border border-gray-100 border-l-4 border-l-amber-400 p-5 shadow-sm"
+      className="rounded-2xl border border-border border-l-4 border-l-amber-400 p-5 shadow-sm"
+      style={stepCardSurfaceStyle()}
     >
       <div className="flex items-start gap-3">
         <motion.div
@@ -45,8 +47,8 @@ export default function InsuranceCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <h3 className="font-semibold text-gray-900">{title}</h3>
-              <p className="text-sm text-gray-500 mt-0.5">
+              <h3 className="font-semibold text-foreground">{title}</h3>
+              <p className="text-sm text-muted-foreground mt-0.5">
                 {formatCurrency(price)} · {subtitle}
               </p>
             </div>
@@ -72,7 +74,7 @@ export default function InsuranceCard({
             </button>
           </div>
 
-          <ul className="text-xs text-gray-500 mt-3 space-y-1">
+          <ul className="text-xs text-muted-foreground mt-3 space-y-1">
             {benefits.map((b) => (
               <li key={b} className="flex items-center gap-2">
                 <AnimatePresence mode="wait" initial={false}>

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -1,17 +1,8 @@
 "use client"
 
-import {
-  Check,
-  Heart,
-  HelpCircle,
-  Home,
-  ImageIcon,
-  Play,
-  Shield,
-  ShoppingBag,
-  Ticket,
-} from "lucide-react"
+import { Check } from "lucide-react"
 import type { ReactNode } from "react"
+import { resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import type { CheckoutStep } from "@/types/checkout"
@@ -19,30 +10,11 @@ import type { CheckoutStep } from "@/types/checkout"
 export type FooterDesign = "pill" | "stripe" | "dock"
 export type WatermarkStyle = "none" | "ghost" | "stroke" | "bold"
 
-const SECTION_ICONS: Record<string, typeof Ticket> = {
-  passes: Ticket,
-  housing: Home,
-  merch: ShoppingBag,
-  patron: Heart,
-  confirm: Shield,
-}
-
-const TEMPLATE_ICONS: Record<string, typeof Ticket> = {
-  "ticket-select": Ticket,
-  "patron-preset": Heart,
-  "housing-date": Home,
-  "merch-image": ShoppingBag,
-  "youtube-video": Play,
-  "image-gallery": ImageIcon,
-  faqs: HelpCircle,
-}
-
-function resolveIcon(section: { id: string; template?: string | null }) {
-  if (section.template && TEMPLATE_ICONS[section.template]) {
-    return TEMPLATE_ICONS[section.template]
-  }
-  return SECTION_ICONS[section.id] ?? Ticket
-}
+// Icon resolution lives in `@/lib/checkoutStepIcons` so the cart drawer
+// (and other surfaces) can render the same registry without duplicating
+// the step-type / template lookup tables.
+const resolveIcon = (section: { id: string; template?: string | null }) =>
+  resolveStepIcon({ stepType: section.id, template: section.template })
 
 interface NavSection {
   id: string

--- a/portal/src/lib/checkoutStepIcons.tsx
+++ b/portal/src/lib/checkoutStepIcons.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import {
+  CheckCircle,
+  CircleUser,
+  Film,
+  Heart,
+  HelpCircle,
+  Home,
+  Image as ImageIcon,
+  ParkingSquare,
+  Play,
+  Shield,
+  ShoppingBag,
+  ShoppingCart,
+  Tent,
+  Ticket,
+  User,
+} from "lucide-react"
+import type { ComponentType, SVGProps } from "react"
+
+export type LucideLikeIcon = ComponentType<SVGProps<SVGSVGElement>>
+
+/**
+ * Curated icon registry. Admins set `step.emoji` to one of these slug
+ * names (`"user"`, `"tent"`, `"parking"`, …) and the nav + cart drawer
+ * render the matching component. Slug values are case-insensitive and
+ * may use dashes for readability.
+ */
+const ICON_REGISTRY: Record<string, LucideLikeIcon> = {
+  user: User,
+  "user-circle": CircleUser,
+  profile: User,
+  ticket: Ticket,
+  tent: Tent,
+  housing: Tent,
+  parking: ParkingSquare,
+  film: Film,
+  movie: Film,
+  image: ImageIcon,
+  photo: ImageIcon,
+  gallery: ImageIcon,
+  help: HelpCircle,
+  faq: HelpCircle,
+  cart: ShoppingCart,
+  checkout: ShoppingCart,
+  bag: ShoppingBag,
+  heart: Heart,
+  play: Play,
+  shield: Shield,
+  home: Home,
+  check: CheckCircle,
+}
+
+/**
+ * Step-type → default icon. Used when the tenant hasn't set an emoji /
+ * registry slug and the template doesn't carry one either. Keeps the
+ * built-in step semantics readable in the nav.
+ */
+const SECTION_ICONS: Record<string, LucideLikeIcon> = {
+  passes: Ticket,
+  housing: Home,
+  merch: ShoppingBag,
+  patron: Heart,
+  confirm: Shield,
+  buyer: User,
+}
+
+/**
+ * Template → default icon. Takes precedence over the step-type fallback
+ * because a step's chosen template usually signals its content more
+ * specifically than the step_type alone (e.g. a "tickets" step with the
+ * housing-date template should still get a Home icon).
+ */
+const TEMPLATE_ICONS: Record<string, LucideLikeIcon> = {
+  "ticket-select": Ticket,
+  "patron-preset": Heart,
+  "housing-date": Home,
+  "merch-image": ShoppingBag,
+  "youtube-video": Play,
+  "image-gallery": ImageIcon,
+  faqs: HelpCircle,
+  "buyer-form": User,
+}
+
+/** Normalise a registry slug — lowercase, hyphen-tolerant, trimmed. */
+function normaliseSlug(value: string | null | undefined): string | null {
+  if (!value) return null
+  const trimmed = value.trim().toLowerCase()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Look up an icon by registry slug. Returns `null` when the input isn't a
+ * known slug — callers use that to decide whether to render the literal
+ * value (emoji) or fall back to the step-type default.
+ */
+export function getRegistryIcon(
+  value: string | null | undefined,
+): LucideLikeIcon | null {
+  const slug = normaliseSlug(value)
+  if (!slug) return null
+  return ICON_REGISTRY[slug] ?? null
+}
+
+interface ResolveIconInput {
+  stepType?: string | null
+  template?: string | null
+  /** Tenant-picked emoji or registry slug. Registry slugs win; literal
+   *  emoji characters fall through to the template/step defaults so a
+   *  separate render path can paint them inline. */
+  emoji?: string | null
+}
+
+/**
+ * Resolve which Lucide icon a step should render in the nav / cart
+ * drawer. Resolution order:
+ *
+ *   1. `emoji` as a registry slug (e.g. `"user"` → User icon)
+ *   2. `template` → TEMPLATE_ICONS
+ *   3. `stepType` → SECTION_ICONS
+ *   4. Ticket (last-resort default)
+ */
+export function resolveStepIcon({
+  stepType,
+  template,
+  emoji,
+}: ResolveIconInput): LucideLikeIcon {
+  const fromRegistry = getRegistryIcon(emoji)
+  if (fromRegistry) return fromRegistry
+  if (template && TEMPLATE_ICONS[template]) return TEMPLATE_ICONS[template]
+  if (stepType && SECTION_ICONS[stepType]) return SECTION_ICONS[stepType]
+  return Ticket
+}

--- a/portal/src/lib/stepCardSurface.ts
+++ b/portal/src/lib/stepCardSurface.ts
@@ -1,0 +1,45 @@
+import type { CSSProperties } from "react"
+
+/**
+ * Inline style for any "step card" surface in the checkout — ticket
+ * sections, buyer form, confirm summary, FAQ items, cart drawer,
+ * insurance card, etc.
+ *
+ * Re-binds the Tailwind palette CSS vars within the element's subtree to
+ * the theme-configured card surface, with a multi-level fallback so
+ * tenants that haven't set card colours still render coherently:
+ *
+ *   --step-card-bg      (theme `card_background_color`, or per-step
+ *                        override applied on a parent wrapper)
+ *     ↳ --checkout-card-bg  (legacy admin-configurable, kept for back-compat)
+ *       ↳ --card             (Tailwind global, mode-driven default)
+ *
+ * Mirroring `--foreground` (and `--muted-foreground`, `--border`) to the
+ * card fg colour means descendants that use `text-foreground` /
+ * `text-muted-foreground` / `border-border` Tailwind classes also recolour
+ * automatically — no per-component class surgery needed.
+ */
+export const stepCardSurfaceStyle = (): CSSProperties =>
+  ({
+    "--card": "var(--step-card-bg, var(--checkout-card-bg, var(--card)))",
+    "--card-foreground": "var(--step-card-fg, var(--card-foreground))",
+    "--foreground": "var(--step-card-fg, var(--card-foreground))",
+    "--muted-foreground":
+      "color-mix(in srgb, var(--step-card-fg, var(--card-foreground)) 75%, transparent)",
+    // `--muted` paints `bg-muted` highlights inside the card (subtotal
+    // row, disabled chips, icon backings). Tinting it with a slice of
+    // the card-fg keeps these surfaces feeling integrated rather than
+    // dropping out as the original grey-on-dark muted token.
+    "--muted":
+      "color-mix(in srgb, var(--step-card-fg, var(--card-foreground)) 8%, transparent)",
+    "--border":
+      "color-mix(in srgb, var(--step-card-fg, var(--card-foreground)) 18%, transparent)",
+    // `--input` is the shadcn token for input-field borders specifically
+    // (distinct from `--border` which covers card/section dividers).
+    // Tie it to the same card-fg mix so inputs feel like part of the
+    // card surface rather than picking up the global slate/black.
+    "--input":
+      "color-mix(in srgb, var(--step-card-fg, var(--card-foreground)) 25%, transparent)",
+    background: "var(--step-card-bg, var(--checkout-card-bg, var(--card)))",
+    color: "var(--step-card-fg, var(--card-foreground))",
+  }) as CSSProperties

--- a/portal/src/providers/themeProvider.tsx
+++ b/portal/src/providers/themeProvider.tsx
@@ -36,6 +36,31 @@ interface ThemeColors {
   checkout_subtitle_color?: string
   checkout_bottom_bar_bg_color?: string
   checkout_bottom_bar_text_color?: string
+  /** Optional override for the watermark (giant section-name text behind
+   *  the snap header). Defaults to a 92% bg-mix of the foreground so it
+   *  sits quietly behind the title, but on dark hero photos that becomes
+   *  invisible — tenants that want it visible can set e.g. an rgba white. */
+  checkout_watermark_color?: string
+  /** Optional override for the step-nav text + icon colour. Required when
+   *  the admin picks a `checkout_navbar_bg` that doesn't match the chosen
+   *  `mode` (e.g. dark-teal navbar in a light-mode popup): without this
+   *  the nav labels default to muted-foreground and disappear against the
+   *  dark fill. Applied to both active and inactive nav items. */
+  checkout_nav_text_color?: string
+  /** When true, native emojis in the nav are forced to a single tone via
+   *  CSS `filter` (the default chain inverts to white, which works on dark
+   *  navbars). Pass a custom filter string to override the default. Useful
+   *  when the admin wants the emoji palette to feel "monochrome iconography"
+   *  rather than OS-coloured pictographs. */
+  checkout_nav_monochrome_emoji?: boolean | string
+  /** Override the universal step-card surface for the whole popup.
+   *  Drives `--step-card-bg` and `--step-card-fg`, consumed by every
+   *  card-like surface in the checkout (ticket sections, buyer form,
+   *  confirm summary, FAQ items, cart drawer, insurance card). Use when
+   *  the popup theme mode and the card surface need to disagree — e.g.
+   *  a dark popup with cream-on-teal cards. */
+  card_background_color?: string
+  card_foreground_color?: string
 }
 
 interface ThemeConfig {
@@ -103,6 +128,36 @@ function computeThemeVars(
   if (colors.checkout_bottom_bar_text_color) {
     vars["--checkout-bottom-bar-text"] = colors.checkout_bottom_bar_text_color
   }
+  if (colors.checkout_nav_text_color) {
+    // Force nav text/icon colour for both active and inactive states. The
+    // disabled token uses a slight opacity so the inactive labels still
+    // recede visually without becoming unreadable.
+    vars["--checkout-badge-title"] = colors.checkout_nav_text_color
+    vars["--checkout-nav-text"] = colors.checkout_nav_text_color
+    vars["--checkout-badge-title-disabled"] =
+      `color-mix(in srgb, ${colors.checkout_nav_text_color} 70%, transparent)`
+  }
+  if (colors.checkout_nav_monochrome_emoji) {
+    // Native emojis ignore CSS `color`, so we use `filter` to force them
+    // to a single tone. Default chain inverts to white (works on dark
+    // navbars); a custom filter string is plumbed through as-is.
+    vars["--checkout-nav-emoji-filter"] =
+      typeof colors.checkout_nav_monochrome_emoji === "string"
+        ? colors.checkout_nav_monochrome_emoji
+        : "brightness(0) saturate(0) invert(1)"
+  }
+  // Universal step-card surface — written outside the `hasTheme` guard so
+  // tenants can opt into card colours without committing to a full
+  // mode/primary theme. Consumed by every card surface in the checkout
+  // via `stepCardSurfaceStyle()` (see `portal/src/lib/stepCardSurface.ts`),
+  // which reads `var(--step-card-bg, …)` and re-binds `--card`,
+  // `--foreground`, `--muted-foreground`, `--border` for its subtree.
+  if (colors.card_background_color) {
+    vars["--step-card-bg"] = colors.card_background_color
+  }
+  if (colors.card_foreground_color) {
+    vars["--step-card-fg"] = colors.card_foreground_color
+  }
 
   // If no mode/primary is set, stop here — rest of the palette stays on the
   // globals.css defaults.
@@ -147,7 +202,9 @@ function computeThemeVars(
     "--checkout-title": palette.foreground,
     "--checkout-subtitle":
       colors.checkout_subtitle_color || palette.foregroundSecondary,
-    "--checkout-watermark": mix(palette.background, palette.foreground, 92),
+    "--checkout-watermark":
+      colors.checkout_watermark_color ||
+      mix(palette.background, palette.foreground, 92),
     "--checkout-navbar-bg":
       colors.checkout_navbar_bg || mix(palette.background, "transparent", 85),
     "--checkout-nav-bg":


### PR DESCRIPTION
## Chain context

```
PR #137 — backend + backoffice step meta  📍 base for this PR
     ↳ PR (this one) — theme tokens + surface helper + icon registry
         ↳ next slice — new variant templates (TicketCard / RichText)
             ↳ later — validation UX (CartFooter enable-and-validate, toast, scroll-jump)
```

Stacked on `feat/checkout-step-meta` (#137). When that merges to `dev`, GitHub will retarget this PR automatically and the diff stays clean.

## Summary

Slice 2 of the checkout overhaul from #105: the visual primitives that the later slices consume. Strictly additive — every change is opt-in via theme tokens or falls through to current behaviour when those tokens are unset.

## What's in here

**New shared libs:**
- `portal/src/lib/stepCardSurface.ts` — \`stepCardSurfaceStyle()\` returns an inline-style record that rebinds Tailwind palette CSS vars (\`--card\`, \`--foreground\`, \`--muted-foreground\`, \`--border\`, \`--input\`, \`--muted\`) inside its subtree to the step-card colours. Multi-level fallback chain: \`--step-card-bg\` → \`--checkout-card-bg\` → \`--card\`. Tenants who haven't set card colours render exactly as today.
- `portal/src/lib/checkoutStepIcons.tsx` — Curated icon registry plus \`getRegistryIcon\` (slug lookup) and \`resolveStepIcon\` (step-type / template / emoji-slug resolution). Replaces inline icon maps duplicated across the nav and elsewhere.

**Theme provider — new opt-in tokens** (no behaviour change when unset):
- \`card_background_color\` / \`card_foreground_color\` — drive \`--step-card-bg\` / \`--step-card-fg\` for the universal card surface.
- \`checkout_watermark_color\` — override the giant section-name watermark when the bg/foreground mix gets lost on dark hero photos.
- \`checkout_nav_text_color\` — force both active and inactive nav label colours when the configured navbar background doesn't match the chosen mode.
- \`checkout_nav_monochrome_emoji\` — expose \`--checkout-nav-emoji-filter\` (boolean → default invert chain, string → custom filter) for tenants that want monochrome nav emojis.

**Consumers:**
- \`ScrollySectionNav.tsx\` — pure refactor; drops the inline \`SECTION_ICONS\` / \`TEMPLATE_ICONS\` tables and delegates to \`resolveStepIcon\`. Same icons, same fallback order.
- \`CartItemList.tsx\` — groups dynamic items by their originating step using \`stepConfigs\` + the icon registry. Each step gets its own labelled section instead of every dynamic item collapsing under one \"Tickets\" heading.
- \`InsuranceCard.tsx\` — drops the hardcoded \`bg-white\` / \`text-gray-*\` palette and consumes \`stepCardSurfaceStyle()\`. Light tenants still render white (helper falls back to \`--card\`); dark-mode popups now get an insurance card that matches the rest of the surface.

## Deliberately out of scope

- The accent-over-primary swap in \`computeThemeVars\` (changes \`--checkout-button\` for tenants who already set \`accent_color\` — needs its own slice with QA).
- \`CartFooter\` enable-and-validate, \`CheckoutToast\`, scroll-jump UX — those live in the next slice.
- The new \`VariantTicketCard\` / \`VariantRichText\` templates — separate slice, depends on this surface helper.
- Per-step emoji rendering in the nav — registry plumbing is in place but the nav still renders the Lucide icon only; the literal-emoji branch lands with the validation-UX slice.

## Test plan

- [x] \`pnpm --filter portal run lint\` — 1 warning, pre-existing on \`VariantPatronPreset.tsx\`, not touched here.
- [x] \`pnpm --filter portal run build\` — green.
- [x] \`pnpm --filter portal run test\` — 8 pre-existing failures (also fail on the branch base without these changes). No new regressions introduced.
- [ ] Visual QA on a tenant without any \`card_*\` / \`checkout_*\` overrides: nav, cart drawer and insurance card render identically to today.
- [ ] Visual QA on a tenant with \`card_background_color\` set: insurance card and step subtree paint the configured surface.

## Notes

- \`stepCardSurfaceStyle()\` only mirrors variables; it does NOT apply itself anywhere outside the InsuranceCard in this PR. Later slices wire it onto the buyer form, ticket sections and cart drawer.
- The icon registry intentionally does not include tenant-specific glyphs (e.g. the mushroom SVG from #105). Anything beyond the Lucide curated set is a separate decision.