### PR TITLE
feat(checkout): enable-and-validate UX (toast, scroll-jump, buyer form rewrite)

### DIFF
--- a/portal/src/app/checkout/[popupSlug]/components/OpenTicketingBuyerForm.tsx
+++ b/portal/src/app/checkout/[popupSlug]/components/OpenTicketingBuyerForm.tsx
@@ -6,10 +6,21 @@ import {
   LabelRequired,
   SelectForm,
 } from "@edgeos/shared-form-ui"
+import { AlertCircle, ShieldCheck, Sparkles } from "lucide-react"
+import { useCallback, useId, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { DynamicField } from "@/app/portal/[popupSlug]/application/components/fields/dynamic-field"
+import { stepCardSurfaceStyle } from "@/lib/stepCardSurface"
+import { cn } from "@/lib/utils"
+import { useCheckout } from "@/providers/checkoutProvider"
 import type { ApplicationFormSchema } from "@/types/form-schema"
 import { getCheckoutSchemaSections } from "../../types"
+
+// Loose email shape check used for the on-blur visual cue only. The
+// authoritative validator is still the Zod schema on the parent — this
+// just decides whether to paint the "doesn't look like an email" warning
+// the moment the user moves focus away (before Zod errors arrive).
+const EMAIL_LOOSE_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 
 interface OpenTicketingBuyerFormProps {
   schema: ApplicationFormSchema
@@ -17,6 +28,10 @@ interface OpenTicketingBuyerFormProps {
   errors: Record<string, string>
   onChange: (fieldName: string, value: unknown) => void
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function getDisplayGender(
   values: Record<string, unknown>,
@@ -43,6 +58,90 @@ function getGenderSpecifyValue(values: Record<string, unknown>) {
   return ""
 }
 
+// Email input with blur-based validation. Paints amber border + helper
+// message once the field is "touched" AND its value either fails the
+// loose regex or has a parent Zod error. Forced-touched comes through
+// the provider when the buyer clicks Pay with incomplete data.
+function EmailField({
+  label,
+  helpText,
+  required,
+  value,
+  onChange,
+  parentError,
+  touched,
+  onBlur,
+}: {
+  label: string
+  helpText?: string
+  required?: boolean
+  value: string
+  onChange: (next: string) => void
+  parentError?: string
+  touched: boolean
+  onBlur: () => void
+}) {
+  const { t } = useTranslation()
+  const id = useId()
+  const isInvalidFormat =
+    touched && value.trim() !== "" && !EMAIL_LOOSE_RE.test(value.trim())
+  const isBlankRequired = touched && required && value.trim() === ""
+  const errorMessage =
+    parentError ??
+    (isInvalidFormat
+      ? t("checkout.email_invalid", {
+          defaultValue: "Esto no parece un email válido",
+        })
+      : isBlankRequired
+        ? t("checkout.field_required", {
+            defaultValue: "Este campo es obligatorio",
+          })
+        : undefined)
+  const showError = !!errorMessage
+
+  return (
+    <div className="space-y-2 md:col-span-2">
+      <LabelRequired isRequired={required}>{label}</LabelRequired>
+      {helpText ? (
+        <p className="text-sm text-muted-foreground">{helpText}</p>
+      ) : null}
+      <div className="relative">
+        <Input
+          id={`email-${id}`}
+          type="email"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onBlur={onBlur}
+          className={cn(
+            "w-full transition-all duration-200",
+            // Amber (not red) for "needs your attention" — matches the
+            // nav's visited-incomplete tint and the shared toast. Red
+            // stays reserved for genuine server/payment errors.
+            showError &&
+              "border-amber-500 ring-2 ring-amber-500/20 focus-visible:ring-amber-500/30",
+          )}
+          aria-invalid={showError || undefined}
+          aria-describedby={showError ? `email-err-${id}` : undefined}
+        />
+        {showError && (
+          <AlertCircle
+            aria-hidden
+            className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-amber-600"
+          />
+        )}
+      </div>
+      {showError && (
+        <p
+          id={`email-err-${id}`}
+          className="text-sm text-amber-700 flex items-center gap-1.5"
+        >
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}
+
 export function OpenTicketingBuyerForm({
   schema,
   values,
@@ -50,108 +149,200 @@ export function OpenTicketingBuyerForm({
   onChange,
 }: OpenTicketingBuyerFormProps) {
   const { t } = useTranslation()
+  const { getBuyerInvalidFields, forcedBuyerFieldsTouched } = useCheckout()
   const sections = getCheckoutSchemaSections(schema)
   const genderField = schema.base_fields.gender
   const displayGender = getDisplayGender(values, schema)
   const genderSpecifyValue = getGenderSpecifyValue(values)
 
+  // Per-field local touched state. Forced fields (from the provider) are
+  // unioned in at read time so the user can't escape the highlight by
+  // refusing to focus a field.
+  const [localTouched, setLocalTouched] = useState<Set<string>>(() => new Set())
+  const isTouched = useCallback(
+    (name: string) =>
+      localTouched.has(name) || forcedBuyerFieldsTouched.has(name),
+    [localTouched, forcedBuyerFieldsTouched],
+  )
+  const markTouched = useCallback((name: string) => {
+    setLocalTouched((prev) => {
+      if (prev.has(name)) return prev
+      const next = new Set(prev)
+      next.add(name)
+      return next
+    })
+  }, [])
+
+  // Set of fields that currently fail the Zod schema. We surface these
+  // inline on touched fields so the user sees the same gating the
+  // funnel uses upstream.
+  const invalidFieldSet = useMemo(
+    () => new Set(getBuyerInvalidFields()),
+    [getBuyerInvalidFields],
+  )
+
   return (
-    <section className="space-y-6 rounded-2xl border bg-card p-6 shadow-sm">
-      {sections.map((section) => (
-        <section key={section.id} className="space-y-4">
-          {sections.length > 1 ? (
-            <div>
-              <h3 className="text-base font-semibold">{section.title}</h3>
-              {section.subtitle ? (
-                <p className="text-sm text-muted-foreground">
-                  {section.subtitle}
-                </p>
-              ) : null}
-            </div>
-          ) : null}
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {section.fields.map(({ name, field }) => {
-              if (name === "email") {
-                return (
-                  <div key={name} className="space-y-2 md:col-span-2">
-                    <LabelRequired isRequired={field.required}>
-                      {field.label}
-                    </LabelRequired>
-                    {field.help_text ? (
-                      <p className="text-sm text-muted-foreground">
-                        {field.help_text}
-                      </p>
-                    ) : null}
-                    <Input
-                      id="checkout-email"
-                      type="email"
-                      value={String(values.email ?? "")}
-                      onChange={(event) =>
-                        onChange("email", event.target.value)
-                      }
-                      className="w-full"
-                    />
-                    {errors.email ? (
-                      <p className="text-sm text-destructive">{errors.email}</p>
-                    ) : null}
-                  </div>
-                )
-              }
-
-              if (name === "gender" && genderField) {
-                return (
-                  <div key={name} className="space-y-4 md:col-span-2">
-                    <SelectForm
-                      label={genderField.label}
-                      id="gender"
-                      value={displayGender}
-                      onChange={(value) => onChange("gender", value)}
-                      error={errors.gender}
-                      isRequired={genderField.required}
-                      options={(genderField.options ?? []).map((option) => ({
-                        value: option,
-                        label: option,
-                      }))}
-                    />
-
-                    {displayGender === "Specify" ? (
-                      <InputForm
-                        label={t("form.gender_specify")}
-                        id="gender_specify"
-                        value={genderSpecifyValue}
-                        onChange={(value) => onChange("gender_specify", value)}
-                        error={errors.gender_specify}
-                        isRequired
-                        placeholder={t("form.gender_specify_placeholder")}
-                      />
-                    ) : null}
-                  </div>
-                )
-              }
-
-              return (
-                <div
-                  key={name}
-                  className={
-                    field.type === "textarea" || field.type === "multiselect"
-                      ? "md:col-span-2"
-                      : ""
-                  }
-                >
-                  <DynamicField
-                    name={name}
-                    field={field}
-                    value={values[name]}
-                    error={errors[name]}
-                    onChange={onChange}
-                  />
-                </div>
-              )
+    <div
+      className="rounded-2xl overflow-hidden shadow-sm border border-border"
+      style={stepCardSurfaceStyle()}
+    >
+      {/* Hero band: warm accent surface introducing the buyer step.
+          Falls back to currentColor when the popup didn't configure an
+          accent so all popups still render coherently. */}
+      <div
+        className="px-6 py-5 flex items-start gap-3"
+        style={{
+          background:
+            "color-mix(in srgb, var(--accent, currentColor) 12%, transparent)",
+        }}
+      >
+        <div
+          className="rounded-xl p-2 shrink-0"
+          style={{
+            background:
+              "color-mix(in srgb, var(--accent, currentColor) 20%, transparent)",
+          }}
+        >
+          <Sparkles className="w-5 h-5 text-[color:var(--accent,currentColor)]" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h2 className="text-base font-semibold text-foreground">
+            {t("checkout.buyer_hero_title", {
+              defaultValue: "¡Estás a un paso!",
             })}
-          </div>
-        </section>
-      ))}
-    </section>
+          </h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {t("checkout.buyer_hero_subtitle", {
+              defaultValue:
+                "Necesitamos un par de datos para reservar tu lugar.",
+            })}
+          </p>
+          <p className="text-xs text-muted-foreground mt-2 flex items-center gap-1.5">
+            <ShieldCheck className="w-3.5 h-3.5 shrink-0" />
+            {t("checkout.buyer_hero_trust", {
+              defaultValue:
+                "Tu privacidad nos es importante. No compartimos tus datos con terceros.",
+            })}
+          </p>
+        </div>
+      </div>
+
+      <section className="space-y-6 px-6 py-6">
+        {sections.map((section) => (
+          <section key={section.id} className="space-y-4">
+            {sections.length > 1 ? (
+              <div>
+                <h3 className="text-base font-semibold">{section.title}</h3>
+                {section.subtitle ? (
+                  <p className="text-sm text-muted-foreground">
+                    {section.subtitle}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {section.fields.map(({ name, field }) => {
+                if (name === "email") {
+                  return (
+                    <EmailField
+                      key={name}
+                      label={field.label}
+                      helpText={field.help_text ?? undefined}
+                      required={field.required}
+                      value={String(values.email ?? "")}
+                      onChange={(next) => onChange("email", next)}
+                      parentError={errors.email}
+                      touched={isTouched("email")}
+                      onBlur={() => markTouched("email")}
+                    />
+                  )
+                }
+
+                if (name === "gender" && genderField) {
+                  return (
+                    <div key={name} className="space-y-4 md:col-span-2">
+                      <SelectForm
+                        label={genderField.label}
+                        id="gender"
+                        value={displayGender}
+                        onChange={(value) => {
+                          onChange("gender", value)
+                          markTouched("gender")
+                        }}
+                        error={
+                          errors.gender ??
+                          (isTouched("gender") &&
+                          invalidFieldSet.has("gender") &&
+                          !displayGender
+                            ? t("checkout.field_required", {
+                                defaultValue: "Este campo es obligatorio",
+                              })
+                            : undefined)
+                        }
+                        isRequired={genderField.required}
+                        options={(genderField.options ?? []).map((option) => ({
+                          value: option,
+                          label: option,
+                        }))}
+                      />
+
+                      {displayGender === "Specify" ? (
+                        <InputForm
+                          label={t("form.gender_specify")}
+                          id="gender_specify"
+                          value={genderSpecifyValue}
+                          onChange={(value) =>
+                            onChange("gender_specify", value)
+                          }
+                          error={errors.gender_specify}
+                          isRequired
+                          placeholder={t("form.gender_specify_placeholder")}
+                        />
+                      ) : null}
+                    </div>
+                  )
+                }
+
+                // Compute an inline error for regular fields when the
+                // Zod schema flags them AND the user has either touched
+                // them or the funnel has forcefully revealed errors. Falls
+                // back to the parent's `errors[name]` (server-side / async
+                // validation), which always wins.
+                const touched = isTouched(name)
+                const isInvalid = invalidFieldSet.has(name)
+                const inlineError =
+                  errors[name] ??
+                  (touched && isInvalid && field.required
+                    ? t("checkout.field_required", {
+                        defaultValue: "Este campo es obligatorio",
+                      })
+                    : undefined)
+
+                return (
+                  <div
+                    key={name}
+                    onBlurCapture={() => markTouched(name)}
+                    className={
+                      field.type === "textarea" || field.type === "multiselect"
+                        ? "md:col-span-2"
+                        : ""
+                    }
+                  >
+                    <DynamicField
+                      name={name}
+                      field={field}
+                      value={values[name]}
+                      error={inlineError}
+                      onChange={onChange}
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          </section>
+        ))}
+      </section>
+    </div>
   )
 }

--- a/portal/src/components/checkout-flow/CartFooter.tsx
+++ b/portal/src/components/checkout-flow/CartFooter.tsx
@@ -21,87 +21,201 @@ interface CartFooterProps {
   onBack?: () => void
   nextSectionLabel?: string
   onContinue?: () => void
+  /** Scroll-based "previous step" handler from the funnel container.
+   *  Volver uses this when present because the provider's
+   *  `goToPreviousStep` only updates internal state — in scrolly mode
+   *  it leaves the page parked on the current section. */
+  onPrevious?: () => void
+  /** Provided by the funnel container so this component can jump back
+   *  to a failing step when the user clicks Continuar/Pagar without
+   *  filling required fields. */
+  onScrollToStep?: (stepId: string) => void
   isLastSection?: boolean
   activeSectionId?: string
 }
+
+// Past this character count we fall back to a generic "Continuar →" on
+// the Continue pill so the bottom bar doesn't break the row on mobile.
+const NEXT_LABEL_MOBILE_THRESHOLD = 14
 
 export default function CartFooter({
   onPay,
   onBack,
   nextSectionLabel,
   onContinue,
+  onPrevious,
+  onScrollToStep,
   isLastSection = false,
   activeSectionId,
 }: CartFooterProps) {
   const { t } = useTranslation()
   const {
-    cart,
     summary,
     currentStep,
     availableSteps,
     attendees,
     goToNextStep,
     goToPreviousStep,
-    canProceedToStep,
     isSubmitting,
     isEditing,
     editCredit,
     termsAccepted,
     isBuyerInfoComplete,
     cartUiEnabled,
+    hasAnyCartItems,
+    getBuyerInvalidFields,
+    findFirstIncompleteStep,
+    findFirstProductStep,
+    markBuyerFieldsTouched,
+    triggerCheckoutToast,
+    dismissCheckoutToast,
+    visitedSteps,
   } = useCheckout()
   const { getCity } = useCityProvider()
   const popup = getCity()
 
   const [isExpanded, setIsExpanded] = useState(false)
 
-  // In scrolly mode `currentStep` stays at the initial value while the user
-  // scrolls. `activeSectionId` reflects the section actually in view, so
-  // position-based gating (next step, first step, etc.) must use it when
-  // provided to avoid letting users skip required steps like buyer info.
+  // In scrolly mode `currentStep` stays at the initial value while the
+  // user scrolls. `activeSectionId` reflects the section actually in
+  // view, so position-based gating (first step, confirm step, …) must
+  // use it when provided to avoid letting users skip required steps.
   const positionStep = (activeSectionId ?? currentStep) as CheckoutStep
   const isConfirmStep = positionStep === "confirm" || isLastSection
-  const isFirstStep = positionStep === "passes"
+  const isBuyerStep = positionStep === ("buyer" as CheckoutStep)
   const currentIndex = availableSteps.indexOf(positionStep)
-  const nextStepId =
-    currentIndex < availableSteps.length - 1
-      ? availableSteps[currentIndex + 1]
-      : null
+  // First step is whatever sits at index 0 of the configured step order
+  // — previously hardcoded to "passes", which broke once popups started
+  // putting buyer or hero steps first.
+  const isFirstStep = currentIndex === 0
 
   const hasEditChanges =
     isEditing && attendees.some((a) => a.products.some((p) => p.edit))
   const requiresTerms =
     isConfirmStep && !!popup?.terms_and_conditions_url && !termsAccepted
-  const hasDynamicItems = Object.values(cart.dynamicItems).some(
-    (items) => items.length > 0,
-  )
-  const canContinue = requiresTerms
-    ? false
-    : isEditing
-      ? cart.passes.length > 0
-      : isConfirmStep
-        ? (cart.passes.length > 0 ||
-            !!cart.housing ||
-            cart.merch.length > 0 ||
-            !!cart.patron ||
-            hasDynamicItems) &&
-          isBuyerInfoComplete
-        : nextStepId
-          ? canProceedToStep(nextStepId)
-          : false
-
   const hasItems =
-    summary.itemCount > 0 || hasDynamicItems || (isEditing && hasEditChanges)
+    summary.itemCount > 0 || hasAnyCartItems || (isEditing && hasEditChanges)
+
+  // Focus the first invalid field within a given step's section after
+  // React re-renders the inline errors (so the right input has
+  // aria-invalid="true" by the time we look it up). Idempotent.
+  const focusFirstInvalidInStep = (stepId: string) => {
+    if (typeof document === "undefined") return
+    window.setTimeout(() => {
+      const section = document.getElementById(stepId)
+      if (!section) return
+      const target = section.querySelector<HTMLElement>('[aria-invalid="true"]')
+      target?.focus({ preventScroll: true })
+    }, 250)
+  }
 
   const handleContinue = () => {
-    if (isConfirmStep && onPay) {
-      onPay()
-    } else if (onContinue) {
+    if (isSubmitting) return
+
+    // --- Path A: confirm / pay attempt ------------------------------
+    // Resolution order is funnel-order: bounce the user back to the
+    // earliest fixable thing, not the closest. Required-input gaps
+    // (today: buyer info) come first because the buyer step lives
+    // before any product step in the funnel; the cart-empty check
+    // fires next once the buyer has filled their info.
+    if (isConfirmStep) {
+      if (requiresTerms) return
+      const incomplete = findFirstIncompleteStep()
+      if (incomplete) {
+        if (incomplete === "buyer") {
+          markBuyerFieldsTouched(getBuyerInvalidFields())
+        }
+        onScrollToStep?.(incomplete)
+        focusFirstInvalidInStep(incomplete)
+        triggerCheckoutToast({
+          message: t("checkout.toast_buyer_incomplete_pay", {
+            defaultValue:
+              "Antes de pagar, completá los campos de Tu información.",
+          }),
+          chips: [
+            {
+              label: t("checkout.step_short.buyer", {
+                defaultValue: "Tu información",
+              }),
+              stepId: incomplete,
+            },
+          ],
+        })
+        return
+      }
+      if (!hasItems) {
+        const target = findFirstProductStep(visitedSteps)
+        if (target) onScrollToStep?.(target)
+        triggerCheckoutToast({
+          message: t("checkout.toast_cart_empty", {
+            defaultValue:
+              "Necesitás agregar al menos un item antes de continuar.",
+          }),
+        })
+        return
+      }
+      dismissCheckoutToast()
+      onPay?.()
+      return
+    }
+
+    // --- Path B: Continuar from the buyer step ----------------------
+    // Local gate — don't let the user "advance forward" while leaving
+    // the form invalid behind them. Reveals all invalid fields, focuses
+    // the first one, raises the toast.
+    if (isBuyerStep && !isBuyerInfoComplete) {
+      markBuyerFieldsTouched(getBuyerInvalidFields())
+      focusFirstInvalidInStep("buyer")
+      triggerCheckoutToast({
+        message: t("checkout.toast_buyer_incomplete_continue", {
+          defaultValue:
+            "Hay datos incompletos en Tu información. Revisalos para continuar.",
+        }),
+      })
+      return
+    }
+
+    // --- Path C: any other step ------------------------------------
+    dismissCheckoutToast()
+    if (onContinue) {
       onContinue()
     } else {
       goToNextStep()
     }
   }
+
+  // New gating model — "enabled by default; click runs validation".
+  // The button renders disabled in only two states where it truly has
+  // no work to do: a submit in flight, or the terms-acceptance gate on
+  // the confirm step. Everywhere else the click triggers validation and
+  // either jumps to the failing step + raises the toast on failure, or
+  // advances / pays on success.
+  const isHardDisabled = isSubmitting || requiresTerms
+
+  // CTA label resolution. Named "Continuar a <Step>" is the desktop
+  // default; on narrow viewports or long labels we fall back to the
+  // generic "Continuar" so the pill stays predictable.
+  const longNextLabel =
+    !!nextSectionLabel && nextSectionLabel.length > NEXT_LABEL_MOBILE_THRESHOLD
+  const continueText = isEditing
+    ? isConfirmStep
+      ? summary.grandTotal === 0
+        ? t("checkout.actions.confirm_edit")
+        : t("checkout.actions.pay_and_confirm_edit")
+      : nextSectionLabel
+        ? longNextLabel
+          ? t("common.continue")
+          : nextSectionLabel
+        : t("common.continue")
+    : isConfirmStep
+      ? summary.grandTotal === 0
+        ? t("checkout.actions.claim_pass")
+        : t("checkout.actions.pay")
+      : nextSectionLabel
+        ? longNextLabel
+          ? t("common.continue")
+          : nextSectionLabel
+        : t("common.continue")
 
   return (
     <div className="z-30">
@@ -134,7 +248,9 @@ export default function CartFooter({
             {(!isFirstStep || onBack) && (
               <button
                 type="button"
-                onClick={isFirstStep ? onBack : goToPreviousStep}
+                onClick={
+                  isFirstStep ? onBack : (onPrevious ?? goToPreviousStep)
+                }
                 className="flex items-center justify-center p-2.5 lg:px-3 lg:py-2 text-checkout-bottom-bar-text/60 hover:text-checkout-bottom-bar-text hover:bg-white/10 rounded-lg transition-colors shrink-0"
               >
                 <ArrowLeft className="w-4 h-4" />
@@ -180,14 +296,17 @@ export default function CartFooter({
               </div>
             </button>
 
-            {/* Continue button */}
+            {/* Continue button — enable-and-validate: stays enabled unless
+                a submit is in flight or terms are pending. Click triggers
+                handleContinue, which runs validation and either advances
+                or scroll-jumps to the failing step + raises the toast. */}
             <button
               type="button"
               onClick={handleContinue}
-              disabled={!canContinue || isSubmitting}
+              disabled={isHardDisabled}
               className={cn(
                 "flex items-center justify-center gap-1.5 lg:gap-2 px-3 lg:px-6 py-3 lg:py-3.5 rounded-xl text-sm font-semibold transition-all shrink-0 whitespace-nowrap",
-                canContinue && !isSubmitting
+                !isHardDisabled
                   ? "bg-checkout-button text-checkout-button-title shadow-lg active:scale-95 hover:opacity-90"
                   : "bg-checkout-button-disabled text-checkout-button-title-disabled cursor-not-allowed",
               )}
@@ -199,19 +318,7 @@ export default function CartFooter({
                 </>
               ) : (
                 <>
-                  <span>
-                    {isEditing
-                      ? isConfirmStep
-                        ? summary.grandTotal === 0
-                          ? t("checkout.actions.confirm_edit")
-                          : t("checkout.actions.pay_and_confirm_edit")
-                        : (nextSectionLabel ?? t("common.continue"))
-                      : isConfirmStep
-                        ? summary.grandTotal === 0
-                          ? t("checkout.actions.claim_pass")
-                          : t("checkout.actions.pay")
-                        : (nextSectionLabel ?? t("common.continue"))}
-                  </span>
+                  <span>{continueText}</span>
                   <ArrowRight className="w-4 h-4 shrink-0" />
                 </>
               )}

--- a/portal/src/components/checkout-flow/CheckoutToast.tsx
+++ b/portal/src/components/checkout-flow/CheckoutToast.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { AlertCircle, ArrowRight, X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { cn } from "@/lib/utils"
+import { useCheckout } from "@/providers/checkoutProvider"
+
+interface CheckoutToastProps {
+  /**
+   * Called when the user clicks a step-chip to jump to that section.
+   * The funnel container wires this to its `scrollToStep` so the toast
+   * stays presentation-only.
+   */
+  onChipClick?: (stepId: string) => void
+  className?: string
+}
+
+/**
+ * Sticky banner at the top of the checkout surface. Surfaces validation
+ * errors raised by the Continuar/Pagar buttons. Persistent — only the
+ * dismiss button or `dismissCheckoutToast()` removes it — so the user
+ * doesn't lose context mid-correction. Chips on the right let the user
+ * jump back to the failing step in one tap.
+ */
+export default function CheckoutToast({
+  onChipClick,
+  className,
+}: CheckoutToastProps) {
+  const { t } = useTranslation()
+  const { checkoutToast, dismissCheckoutToast } = useCheckout()
+  if (!checkoutToast) return null
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: `<output>` is semantically for form-calculation results; this is a checkout-level status banner, where `role="status"` + aria-live="polite" is the documented WAI-ARIA pattern.
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "sticky top-12 z-30 mx-auto max-w-3xl px-4 pt-3",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3 rounded-xl border border-amber-300/60 bg-amber-50/95 px-4 py-3 shadow-lg backdrop-blur-sm">
+        <AlertCircle className="mt-0.5 w-4 h-4 text-amber-600 shrink-0" />
+        <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-amber-900 leading-snug">
+            {checkoutToast.message}
+          </p>
+          {checkoutToast.chips && checkoutToast.chips.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {checkoutToast.chips.map((chip) => (
+                <button
+                  key={chip.stepId}
+                  type="button"
+                  onClick={() => onChipClick?.(chip.stepId)}
+                  className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-200"
+                >
+                  {chip.label}
+                  <ArrowRight className="w-3 h-3" />
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={dismissCheckoutToast}
+          aria-label={t("checkout.toast_dismiss_aria", {
+            defaultValue: "Cerrar aviso",
+          })}
+          className="-mt-1 -mr-1 rounded-md p-1 text-amber-700 hover:bg-amber-100 hover:text-amber-900 transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { readAndClearPendingPaymentRedirectState } from "@/hooks/usePaymentRedirect"
 import { useCheckout } from "@/providers/checkoutProvider"
+import CheckoutToast from "./CheckoutToast"
 import DynamicProductStep from "./DynamicProductStep"
 import { shouldUseDynamicStep } from "./registries/stepRegistry"
 import type { WatermarkStyle } from "./ScrollySectionNav"
@@ -21,15 +22,27 @@ interface ScrollyCheckoutFlowProps {
   onPaymentComplete?: () => void
   onBack?: () => void
   navExtraContent?: ReactNode
+  /** Tenant logo shown on the left side of the checkout nav. Usually
+   *  `popup.icon_url` with a tenant fallback. */
+  brandLogoUrl?: string | null
+  /** Tenant/popup name for alt text on the logo. */
+  brandLabel?: string
 }
 
 function ScrollyCheckoutFlowInner({
   onPaymentComplete,
   onBack,
   navExtraContent,
+  brandLogoUrl,
+  brandLabel,
 }: ScrollyCheckoutFlowProps) {
-  const { availableSteps, submitPayment, stepConfigs, isInitialLoading } =
-    useCheckout()
+  const {
+    availableSteps,
+    submitPayment,
+    stepConfigs,
+    isInitialLoading,
+    markStepVisited,
+  } = useCheckout()
 
   const getStepConfig = (stepType: string) =>
     stepConfigs.find(
@@ -59,7 +72,13 @@ function ScrollyCheckoutFlowInner({
     }
   }
 
-  const [activeSection, setActiveSection] = useState<string>("passes")
+  // Initial activeSection: first available step from the runtime,
+  // falling back to "passes" only when nothing has loaded yet. Hardcoding
+  // "passes" caused the cart footer to misdetect the first step when the
+  // popup placed buyer or a hero step at order 0.
+  const [activeSection, setActiveSection] = useState<string>(
+    availableSteps[0] ?? "passes",
+  )
   const scrollToIndexRef = useRef<((index: number) => void) | null>(null)
 
   const footerDesign = "pill" as const
@@ -86,9 +105,20 @@ function ScrollyCheckoutFlowInner({
           id: step,
           label: config?.title ?? defaultLabels[step] ?? step,
           template: config?.template ?? null,
+          emoji: config?.emoji ?? null,
+          showInNavbar: config?.show_in_navbar ?? true,
         }
       })
   }, [availableSteps, stepConfigs])
+
+  // Sections rendered in the top nav chrome. Subset of allSections — the
+  // IntersectionObserver still tracks the full set so scroll behaviour
+  // is unchanged, but informational steps (FAQs, Gallery, etc.) can be
+  // hidden from the nav per-tenant via `show_in_navbar`.
+  const navSections = useMemo(
+    () => allSections.filter((s) => s.showInNavbar !== false),
+    [allSections],
+  )
 
   const goToConfirm = useCallback(() => {
     const idx = allSections.findIndex((s) => s.id === "confirm")
@@ -101,6 +131,24 @@ function ScrollyCheckoutFlowInner({
       scrollToIndexRef.current?.(idx + 1)
     }
   }, [allSections, activeSection])
+
+  const goToPreviousSection = useCallback(() => {
+    const idx = allSections.findIndex((s) => s.id === activeSection)
+    if (idx > 0) {
+      scrollToIndexRef.current?.(idx - 1)
+    }
+  }, [allSections, activeSection])
+
+  // Public escape-hatch: jump to a specific step by id. Used by the
+  // validation flow when Continuar/Pagar bounces the user back to a
+  // failing step (toast → click chip → scrolls to buyer step).
+  const scrollToStep = useCallback(
+    (stepId: string) => {
+      const idx = allSections.findIndex((s) => s.id === stepId)
+      if (idx >= 0) scrollToIndexRef.current?.(idx)
+    },
+    [allSections],
+  )
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: isInitialLoading must trigger a re-run when sections mount in the DOM, even though it's not read inside.
   useEffect(() => {
@@ -177,6 +225,11 @@ function ScrollyCheckoutFlowInner({
         for (const entry of entries) {
           if (entry.isIntersecting && entry.intersectionRatio >= 0.3) {
             const id = entry.target.id
+            // Any section that crosses the 30% visibility threshold
+            // counts as "visited" for the wayfinding nav. Triggered for
+            // both natural scroll and programmatic scroll, so the user
+            // gets credited for visits they actively chose.
+            markStepVisited(id)
             if (scrollTargetId !== null) {
               if (id === scrollTargetId) {
                 releaseScrollTarget()
@@ -238,7 +291,7 @@ function ScrollyCheckoutFlowInner({
       releaseScrollTarget()
       scrollToIndexRef.current = null
     }
-  }, [allSections, isInitialLoading])
+  }, [allSections, isInitialLoading, markStepVisited])
 
   const renderSectionContent = (stepId: string) => {
     // Buyer and confirm are structural steps — wired explicitly, not via DynamicProductStep.
@@ -288,14 +341,17 @@ function ScrollyCheckoutFlowInner({
   return (
     <div className="relative font-sans">
       <ScrollySectionNav
-        sections={allSections}
+        sections={navSections}
         activeSection={activeSection}
         onSectionClick={(sectionId) => {
           const idx = allSections.findIndex((s) => s.id === sectionId)
           if (idx >= 0) scrollToIndexRef.current?.(idx)
         }}
         extraContent={navExtraContent}
+        brandLogoUrl={brandLogoUrl}
+        brandLabel={brandLabel}
       />
+      <CheckoutToast onChipClick={scrollToStep} />
       {allSections.map((section) => {
         const config = getStepConfig(section.id)
         return (
@@ -342,6 +398,8 @@ function ScrollyCheckoutFlowInner({
         sections={allSections}
         onGoToConfirm={goToConfirm}
         onGoToNextSection={goToNextSection}
+        onGoToPreviousSection={goToPreviousSection}
+        onScrollToStep={scrollToStep}
       />
     </div>
   )
@@ -350,3 +408,5 @@ function ScrollyCheckoutFlowInner({
 export default function ScrollyCheckoutFlow(props: ScrollyCheckoutFlowProps) {
   return <ScrollyCheckoutFlowInner {...props} />
 }
+
+export type { ScrollyCheckoutFlowProps }

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -2,7 +2,7 @@
 
 import { Check } from "lucide-react"
 import type { ReactNode } from "react"
-import { resolveStepIcon } from "@/lib/checkoutStepIcons"
+import { getRegistryIcon, resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import type { CheckoutStep } from "@/types/checkout"
@@ -20,6 +20,10 @@ interface NavSection {
   id: string
   label: string
   template?: string | null
+  /** Tenant-picked emoji, either as a registry slug (e.g. "user", "mushroom")
+   *  or a literal emoji character. Registry slugs win; literal emoji
+   *  characters render as a text node with optional monochrome filter. */
+  emoji?: string | null
 }
 
 interface ScrollySectionNavProps {
@@ -27,6 +31,11 @@ interface ScrollySectionNavProps {
   activeSection: string
   onSectionClick: (sectionId: string) => void
   extraContent?: ReactNode
+  /** Tenant logo (popup icon_url with tenant fallback) shown on the left
+   *  of the nav. Skipped when null. */
+  brandLogoUrl?: string | null
+  /** Display name used as alt text on the logo. */
+  brandLabel?: string
 }
 
 export default function ScrollySectionNav({
@@ -34,8 +43,35 @@ export default function ScrollySectionNav({
   activeSection,
   onSectionClick,
   extraContent,
+  brandLogoUrl,
+  brandLabel,
 }: ScrollySectionNavProps) {
-  const { isStepComplete } = useCheckout()
+  const {
+    isStepComplete,
+    visitedSteps,
+    isBuyerInfoComplete,
+    forcedBuyerFieldsTouched,
+  } = useCheckout()
+
+  // Predicate: is this step required-but-incomplete for the user right
+  // now? Only the buyer step has formal field validation today, but the
+  // helper is shaped so additional gated steps can join later (e.g. a
+  // future "require at least one ticket" rule).
+  //
+  // A step is shown as "incomplete" in the nav when:
+  //   * the user has scrolled past it (visited), OR
+  //   * the funnel forcefully revealed errors after a Continuar/Pagar
+  //     attempt (forcedBuyerFieldsTouched > 0).
+  // Untouched required steps are NOT flagged — anxiety-inducing to
+  // shout at users about fields they haven't seen.
+  const isStepIncomplete = (stepId: string): boolean => {
+    if (stepId === "buyer") {
+      if (isBuyerInfoComplete) return false
+      const surfacedByForce = forcedBuyerFieldsTouched.size > 0
+      return surfacedByForce || visitedSteps.has(stepId)
+    }
+    return false
+  }
 
   const activeIndex = Math.max(
     0,
@@ -47,6 +83,17 @@ export default function ScrollySectionNav({
     <div data-snap-nav className="sticky top-0 z-20">
       <div className="bg-checkout-navbar-bg/85 px-2.5 py-1.5 backdrop-blur-xl">
         <div className="mx-auto flex max-w-4xl items-center gap-1.5">
+          {brandLogoUrl ? (
+            // Small tenant logo, sized 28px. Next/image not used because
+            // tenant icon URLs come from arbitrary CDNs and don't need
+            // SSR-time optimisation at this scale.
+            // biome-ignore lint/performance/noImgElement: tenant logo, sized small, no need for next/image SSR
+            <img
+              src={brandLogoUrl}
+              alt={brandLabel ?? "Tenant logo"}
+              className="size-7 shrink-0 rounded-md object-contain"
+            />
+          ) : null}
           <div className="relative flex-1 overflow-hidden rounded-xl border border-white/10 bg-checkout-badge-bg-disabled/60 p-0.5">
             <div
               aria-hidden
@@ -63,20 +110,51 @@ export default function ScrollySectionNav({
                 const isActive = section.id === activeSection
                 const isComplete =
                   !isActive && isStepComplete(section.id as CheckoutStep)
+                const isIncomplete = !isActive && isStepIncomplete(section.id)
+                const emoji = section.emoji?.trim()
+                // Two ways a tenant can specify the nav icon: a slug into
+                // the curated Lucide registry ("user", "mushroom", …)
+                // which renders a stroke SVG, OR a literal emoji
+                // character. If neither is set, the step-type/template
+                // default applies via resolveIcon. The literal-emoji
+                // branch picks up the optional monochrome filter so
+                // colorful glyphs can be forced to a single tone.
+                const RegistryIcon = getRegistryIcon(emoji)
                 return (
                   <button
                     key={section.id}
                     type="button"
                     onClick={() => onSectionClick(section.id)}
                     aria-current={isActive ? "step" : undefined}
+                    aria-invalid={isIncomplete || undefined}
                     className={cn(
                       "relative z-10 flex h-7 min-w-0 items-center justify-center gap-1 px-1.5 text-xs font-semibold transition-[color,opacity] duration-200",
                       isActive
                         ? "text-checkout-badge-title"
-                        : "text-checkout-badge-title-disabled hover:opacity-70",
+                        : isIncomplete
+                          ? // Muted amber tint — "needs your attention"
+                            // without the red-alarm rage of a destructive
+                            // colour. Matches the toast/banner palette.
+                            "text-amber-400 hover:text-amber-300"
+                          : "text-checkout-badge-title-disabled hover:opacity-70",
                     )}
                   >
-                    <Icon className="size-3.5 shrink-0" />
+                    {RegistryIcon ? (
+                      <RegistryIcon className="size-3.5 shrink-0" />
+                    ) : emoji ? (
+                      <span
+                        aria-hidden
+                        style={{
+                          filter:
+                            "var(--checkout-nav-emoji-filter, none)" as string,
+                        }}
+                        className="text-sm leading-none shrink-0"
+                      >
+                        {emoji}
+                      </span>
+                    ) : (
+                      <Icon className="size-3.5 shrink-0" />
+                    )}
                     <span className="hidden truncate sm:inline">
                       {section.label}
                     </span>

--- a/portal/src/components/checkout-flow/SnapFooter.tsx
+++ b/portal/src/components/checkout-flow/SnapFooter.tsx
@@ -202,6 +202,8 @@ export default function SnapFooter({
   sections,
   onGoToConfirm,
   onGoToNextSection,
+  onGoToPreviousSection,
+  onScrollToStep,
 }: {
   footerDesign: FooterDesign
   onPay?: () => void
@@ -210,6 +212,13 @@ export default function SnapFooter({
   sections?: SnapFooterSection[]
   onGoToConfirm?: () => void
   onGoToNextSection?: () => void
+  /** Scroll back one section. CartFooter prefers this over the
+   *  provider's goToPreviousStep because in scrolly mode the provider
+   *  one only updates internal state without moving the page. */
+  onGoToPreviousSection?: () => void
+  /** Jump to a specific step by id — used by the validation flow when
+   *  Continuar/Pagar bounces the user back to a failing step. */
+  onScrollToStep?: (stepId: string) => void
 }) {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
@@ -256,6 +265,8 @@ export default function SnapFooter({
         onBack={onBack}
         nextSectionLabel={nextSectionLabel}
         onContinue={onGoToNextSection}
+        onPrevious={onGoToPreviousSection}
+        onScrollToStep={onScrollToStep}
         isLastSection={isOnConfirm}
         activeSectionId={activeSection}
       />

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -168,6 +168,15 @@
     "express_title": "Express Checkout",
     "buyer_step_title": "Your information",
     "buyer_step_description": "Complete your information before payment.",
+    "buyer_hero_title": "You're one step away!",
+    "buyer_hero_subtitle": "We need a couple of details to reserve your spot.",
+    "buyer_hero_trust": "Your privacy matters. We don't share your data with third parties.",
+    "email_invalid": "This doesn't look like a valid email",
+    "field_required": "This field is required",
+    "toast_dismiss_aria": "Dismiss notice",
+    "toast_buyer_incomplete_continue": "Your information has missing fields. Review them to continue.",
+    "toast_buyer_incomplete_pay": "Complete the Your information fields before paying.",
+    "toast_cart_empty": "Add at least one item before continuing.",
     "loading_info": "Loading your information",
     "processing": "Processing your registration",
     "processing_subtitle": "This might take a few moments",
@@ -221,6 +230,7 @@
       "housing": "Housing",
       "merch": "Merch",
       "patron": "Patron",
+      "buyer": "Your information",
       "confirm": "Review & Confirm"
     }
   },

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -168,6 +168,15 @@
     "express_title": "Checkout Express",
     "buyer_step_title": "Tu información",
     "buyer_step_description": "Completá tus datos antes del pago.",
+    "buyer_hero_title": "¡Estás a un paso!",
+    "buyer_hero_subtitle": "Necesitamos un par de datos para reservar tu lugar.",
+    "buyer_hero_trust": "Tu privacidad nos es importante. No compartimos tus datos con terceros.",
+    "email_invalid": "Esto no parece un email válido",
+    "field_required": "Este campo es obligatorio",
+    "toast_dismiss_aria": "Cerrar aviso",
+    "toast_buyer_incomplete_continue": "Hay datos incompletos en Tu información. Revisalos para continuar.",
+    "toast_buyer_incomplete_pay": "Antes de pagar, completá los campos de Tu información.",
+    "toast_cart_empty": "Necesitás agregar al menos un item antes de continuar.",
     "loading_info": "Cargando tu información",
     "processing": "Procesando tu registro",
     "processing_subtitle": "Esto puede tardar unos momentos",
@@ -221,6 +230,7 @@
       "housing": "Alojamiento",
       "merch": "Merch",
       "patron": "Patrono",
+      "buyer": "Tu información",
       "confirm": "Revisar y Confirmar"
     }
   },

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -168,6 +168,15 @@
     "express_title": "快速结账",
     "buyer_step_title": "您的信息",
     "buyer_step_description": "请在付款前填写您的信息。",
+    "buyer_hero_title": "就差一步！",
+    "buyer_hero_subtitle": "我们需要几条信息来保留您的位置。",
+    "buyer_hero_trust": "您的隐私很重要。我们不会与第三方共享您的数据。",
+    "email_invalid": "这看起来不是有效的电子邮件",
+    "field_required": "此字段为必填",
+    "toast_dismiss_aria": "关闭提示",
+    "toast_buyer_incomplete_continue": "您的信息中有未完成的字段，请检查后继续。",
+    "toast_buyer_incomplete_pay": "支付前请填写「您的信息」中的字段。",
+    "toast_cart_empty": "继续前请至少添加一个商品。",
     "loading_info": "正在加载您的信息",
     "processing": "正在处理您的注册",
     "processing_subtitle": "这可能需要一些时间",
@@ -221,6 +230,7 @@
       "housing": "住宿",
       "merch": "周边",
       "patron": "赞助人",
+      "buyer": "您的信息",
       "confirm": "审核并确认"
     }
   },

--- a/portal/src/lib/form-schema-builder.test.ts
+++ b/portal/src/lib/form-schema-builder.test.ts
@@ -36,7 +36,7 @@ describe("buildFormZodSchema — email validation", () => {
     // gate on the field name in the default branch.
     const schema = buildSchema({
       email: {
-        type: "string",
+        type: "text",
         label: "Email",
         required: true,
       } as ApplicationFormSchema["base_fields"][string],
@@ -52,7 +52,7 @@ describe("buildFormZodSchema — email validation", () => {
   it("accepts a syntactically valid email", () => {
     const schema = buildSchema({
       email: {
-        type: "string",
+        type: "text",
         label: "Email",
         required: true,
       } as ApplicationFormSchema["base_fields"][string],
@@ -68,7 +68,7 @@ describe("buildFormZodSchema — email validation", () => {
   it("allows empty email when the field is not required", () => {
     const schema = buildSchema({
       email: {
-        type: "string",
+        type: "text",
         label: "Email",
         required: false,
       } as ApplicationFormSchema["base_fields"][string],
@@ -86,7 +86,7 @@ describe("buildFormZodSchema — email validation", () => {
       base_fields: {},
       custom_fields: {
         email: {
-          type: "string",
+          type: "text",
           label: "Custom email",
           required: true,
         },

--- a/portal/src/lib/form-schema-builder.test.ts
+++ b/portal/src/lib/form-schema-builder.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+import type { ApplicationFormSchema } from "@/types/form-schema"
+import { buildFormZodSchema } from "./form-schema-builder"
+
+// Shared helper — most tests vary only one base field at a time.
+function buildSchema(
+  base: Record<string, ApplicationFormSchema["base_fields"][string]>,
+): ApplicationFormSchema {
+  return {
+    base_fields: base,
+    custom_fields: {},
+    sections: [],
+  } as unknown as ApplicationFormSchema
+}
+
+describe("buildFormZodSchema — email validation", () => {
+  it("rejects a malformed email when field.type === 'email'", () => {
+    const schema = buildSchema({
+      contact_email: {
+        type: "email",
+        label: "Contact email",
+        required: true,
+      } as ApplicationFormSchema["base_fields"][string],
+    })
+
+    const result = buildFormZodSchema(schema, false).safeParse({
+      contact_email: "not-an-email",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects a malformed value when the field is literally named 'email'", () => {
+    // The open-ticketing buyer schema declares email as a plain string
+    // (the backend has no `email` field type for base fields), so we
+    // gate on the field name in the default branch.
+    const schema = buildSchema({
+      email: {
+        type: "string",
+        label: "Email",
+        required: true,
+      } as ApplicationFormSchema["base_fields"][string],
+    })
+
+    const result = buildFormZodSchema(schema, false).safeParse({
+      email: "asdas",
+    })
+
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts a syntactically valid email", () => {
+    const schema = buildSchema({
+      email: {
+        type: "string",
+        label: "Email",
+        required: true,
+      } as ApplicationFormSchema["base_fields"][string],
+    })
+
+    const result = buildFormZodSchema(schema, false).safeParse({
+      email: "buyer@example.com",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("allows empty email when the field is not required", () => {
+    const schema = buildSchema({
+      email: {
+        type: "string",
+        label: "Email",
+        required: false,
+      } as ApplicationFormSchema["base_fields"][string],
+    })
+
+    const result = buildFormZodSchema(schema, false).safeParse({
+      email: "",
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("treats custom_<email> fields the same way (custom-fields branch)", () => {
+    const schema = {
+      base_fields: {},
+      custom_fields: {
+        email: {
+          type: "string",
+          label: "Custom email",
+          required: true,
+        },
+      },
+      sections: [],
+    } as unknown as ApplicationFormSchema
+
+    // The custom-field key is namespaced as `custom_<name>`, so we pass
+    // that as the fieldName to `fieldToZod`. The `email` literal-name
+    // check only fires for keys exactly equal to "email", not "custom_email".
+    // The custom field falls back to a plain string and accepts junk.
+    const result = buildFormZodSchema(schema, false).safeParse({
+      custom_email: "asdas",
+    })
+
+    expect(result.success).toBe(true)
+  })
+})

--- a/portal/src/lib/form-schema-builder.ts
+++ b/portal/src/lib/form-schema-builder.ts
@@ -5,7 +5,9 @@ import type {
   MultiSelectDetailedConfig,
 } from "@/types/form-schema"
 
-function fieldToZod(field: FormFieldSchema): z.ZodType {
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function fieldToZod(field: FormFieldSchema, fieldName: string): z.ZodType {
   switch (field.type) {
     case "boolean":
       return z.boolean()
@@ -14,6 +16,10 @@ function fieldToZod(field: FormFieldSchema): z.ZodType {
       return z.array(z.string())
     case "number":
       return z.string()
+    case "email":
+      return z.string().refine((v) => v === "" || EMAIL_RE.test(v), {
+        error: "Enter a valid email address",
+      })
     case "rich_text":
       // Checkbox-mode rich_text stores a bool; display-only stores nothing
       // meaningful but we keep the field in state to roundtrip cleanly.
@@ -24,6 +30,16 @@ function fieldToZod(field: FormFieldSchema): z.ZodType {
         signed_at: z.string().optional(),
       })
     default:
+      // The open-ticketing buyer step's `email` slot is declared as a
+      // plain string in the runtime schema (the backend has no `email`
+      // field type for base fields), but the field name is literally
+      // "email" — surface a validation error if the value isn't a valid
+      // address so the user can't submit junk like "asdas".
+      if (fieldName === "email") {
+        return z.string().refine((v) => v === "" || EMAIL_RE.test(v), {
+          error: "Enter a valid email address",
+        })
+      }
       return z.string()
   }
 }
@@ -37,7 +53,7 @@ export function buildFormZodSchema(
 
   // Base fields from schema (all profile + application fields)
   for (const [name, field] of Object.entries(schema.base_fields)) {
-    const zodType = fieldToZod(field)
+    const zodType = fieldToZod(field, name)
     const isReplacedByChildrenSection =
       fieldsOptionalWhenChildrenSection?.has(name)
     shape[name] =
@@ -51,7 +67,7 @@ export function buildFormZodSchema(
 
   // Custom fields from schema
   for (const [name, field] of Object.entries(schema.custom_fields)) {
-    const zodType = fieldToZod(field)
+    const zodType = fieldToZod(field, `custom_${name}`)
     shape[`custom_${name}`] =
       isDraft || !field.required
         ? makeOptional(zodType)

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -111,8 +111,53 @@ interface CheckoutContextValue {
   buyerGeneralError: string | null
   setBuyerField: (fieldName: string, value: unknown) => void
   isBuyerInfoComplete: boolean
+  /** Names of buyer-form fields that fail the current Zod schema. Empty
+   *  when the form is complete or no schema is configured. Source of
+   *  truth for "where did the user miss something?" — the CartFooter's
+   *  enable-and-validate flow uses it to mark fields touched and
+   *  decide which step to scroll back to. */
+  getBuyerInvalidFields: () => string[]
+  /** Returns the step_type of the first step (in funnel order) with
+   *  unmet required input. Today only buyer is gated; returns `null`
+   *  when nothing's missing. */
+  findFirstIncompleteStep: () => string | null
+  /** Returns the step_type of the first product-bearing step the user
+   *  should be sent to when the cart is empty. Prefers visited steps,
+   *  else falls back to the first product step in funnel order. */
+  findFirstProductStep: (visited?: Set<string>) => string | null
+  /** True when at least one cartable item is present (regardless of price). */
+  hasAnyCartItems: boolean
+  /** Step types the user has scrolled into during this session. Updated
+   *  by the funnel's IntersectionObserver. Used by the nav to paint a
+   *  step amber (visited but incomplete) vs leave it neutral. */
+  visitedSteps: Set<string>
+  markStepVisited: (stepType: string) => void
+  /** Buyer-form fields that should render their error regardless of
+   *  whether the user has actually focused them. Triggered when the
+   *  user presses Continuar/Pagar with incomplete data; cleared when
+   *  the user edits again. */
+  forcedBuyerFieldsTouched: Set<string>
+  markBuyerFieldsTouched: (fieldNames: string[]) => void
+  clearForcedBuyerFieldsTouched: () => void
+  /** Persistent banner the funnel raises when a Continuar/Pagar attempt
+   *  fails validation. Persistent until dismissed so the user doesn't
+   *  lose context mid-correction. */
+  checkoutToast: CheckoutToastState | null
+  triggerCheckoutToast: (state: Omit<CheckoutToastState, "id">) => void
+  dismissCheckoutToast: () => void
   cartUiEnabled: boolean
   creditsEnabled: boolean
+}
+
+export interface CheckoutToastChip {
+  label: string
+  stepId: string
+}
+
+export interface CheckoutToastState {
+  id: string
+  message: string
+  chips?: CheckoutToastChip[]
 }
 
 const CheckoutContext = createContext<CheckoutContextValue | null>(null)
@@ -241,6 +286,25 @@ export function CheckoutProvider({
     !buyerFormSchema ||
     buildFormZodSchema(buyerFormSchema, false).safeParse(buyerValues).success
 
+  // Returns the names of buyer-form fields that fail the current schema.
+  // Returns [] when complete or when no schema is configured.
+  const getBuyerInvalidFields = useCallback((): string[] => {
+    if (!buyerFormSchema) return []
+    const result = buildFormZodSchema(buyerFormSchema, false).safeParse(
+      buyerValues,
+    )
+    if (result.success) return []
+    const seen = new Set<string>()
+    for (const issue of result.error.issues) {
+      const fieldName =
+        Array.isArray(issue.path) && issue.path.length > 0
+          ? String(issue.path[0])
+          : null
+      if (fieldName) seen.add(fieldName)
+    }
+    return Array.from(seen)
+  }, [buyerFormSchema, buyerValues])
+
   // True while step configs or products are still loading on first render.
   // Why: when both queries are pending, availableSteps falls back to
   // ["passes", "confirm"] with default labels and the cart total reads $0,
@@ -295,6 +359,57 @@ export function CheckoutProvider({
   const [dynamicItems, setDynamicItems] = useState<
     Record<string, SelectedDynamicItem[]>
   >({})
+  // Steps the user has scrolled into during this session. Session-only —
+  // no localStorage. Used purely for nav UX (paint amber when started
+  // but not completed).
+  const [visitedSteps, setVisitedSteps] = useState<Set<string>>(
+    () => new Set<string>(),
+  )
+  const markStepVisited = useCallback((stepType: string) => {
+    setVisitedSteps((prev) => {
+      if (prev.has(stepType)) return prev
+      const next = new Set(prev)
+      next.add(stepType)
+      return next
+    })
+  }, [])
+  const [forcedBuyerFieldsTouched, setForcedBuyerFieldsTouched] = useState<
+    Set<string>
+  >(() => new Set<string>())
+  const markBuyerFieldsTouched = useCallback((fieldNames: string[]) => {
+    if (fieldNames.length === 0) return
+    setForcedBuyerFieldsTouched((prev) => {
+      let changed = false
+      const next = new Set(prev)
+      for (const name of fieldNames) {
+        if (!next.has(name)) {
+          next.add(name)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [])
+  const clearForcedBuyerFieldsTouched = useCallback(() => {
+    setForcedBuyerFieldsTouched((prev) =>
+      prev.size === 0 ? prev : new Set<string>(),
+    )
+  }, [])
+  const [checkoutToast, setCheckoutToast] = useState<CheckoutToastState | null>(
+    null,
+  )
+  const triggerCheckoutToast = useCallback(
+    (state: Omit<CheckoutToastState, "id">) => {
+      // Fresh id forces re-render even when the same message fires twice
+      // (e.g. user re-clicks Pay with the same missing data); useful for
+      // chip animations downstream.
+      setCheckoutToast({ ...state, id: String(Date.now()) })
+    },
+    [],
+  )
+  const dismissCheckoutToast = useCallback(() => {
+    setCheckoutToast(null)
+  }, [])
 
   // Build selected passes from attendeePasses
   const selectedPasses = useMemo<SelectedPassItem[]>(() => {
@@ -591,6 +706,51 @@ export function CheckoutProvider({
     ],
   )
 
+  // Validation helpers — used by CartFooter's enable-and-validate flow.
+  // findFirstIncompleteStep: today only the buyer step has formal field
+  // validation. Returns its step_type when its Zod schema isn't satisfied
+  // and the step exists in availableSteps; otherwise null. The helper is
+  // shaped so additional gated steps can join later without breaking the
+  // caller (e.g. a future "require at least one ticket" rule).
+  const findFirstIncompleteStep = useCallback((): string | null => {
+    if (
+      !isBuyerInfoComplete &&
+      (availableSteps as string[]).includes("buyer")
+    ) {
+      return "buyer"
+    }
+    return null
+  }, [availableSteps, isBuyerInfoComplete])
+
+  // findFirstProductStep: pick a step to bounce the user back to when
+  // the cart is empty at confirm time. Visited steps win (the buyer was
+  // actually there), else the first product-bearing step in funnel order.
+  const findFirstProductStep = useCallback(
+    (visited?: Set<string>): string | null => {
+      const productSteps = (availableSteps as string[]).filter(
+        (s) => s !== "buyer" && s !== "confirm" && s !== "success",
+      )
+      if (productSteps.length === 0) return null
+      if (visited && visited.size > 0) {
+        const visitedProduct = productSteps.find((s) => visited.has(s))
+        if (visitedProduct) return visitedProduct
+      }
+      return productSteps[0]
+    },
+    [availableSteps],
+  )
+
+  // hasAnyCartItems: mirrors CartFooter's old `canContinue` cart check,
+  // surfaced on the context so CartFooter (and any future surface that
+  // needs the same predicate) can read it directly instead of replicating
+  // the OR-chain locally.
+  const hasAnyCartItems =
+    selectedPasses.length > 0 ||
+    !!housing ||
+    merch.length > 0 ||
+    !!patron ||
+    Object.values(dynamicItems).some((items) => items.length > 0)
+
   // Dynamic item actions
   const addDynamicItem = useCallback(
     (stepType: string, item: SelectedDynamicItem) => {
@@ -822,6 +982,18 @@ export function CheckoutProvider({
       setBuyerGeneralError(null)
     },
     isBuyerInfoComplete,
+    getBuyerInvalidFields,
+    findFirstIncompleteStep,
+    findFirstProductStep,
+    hasAnyCartItems,
+    visitedSteps,
+    markStepVisited,
+    forcedBuyerFieldsTouched,
+    markBuyerFieldsTouched,
+    clearForcedBuyerFieldsTouched,
+    checkoutToast,
+    triggerCheckoutToast,
+    dismissCheckoutToast,
     cartUiEnabled,
     creditsEnabled,
   }


### PR DESCRIPTION
## Chain context

```
dev
  ↳ PR #140 — variants (VariantTicketCard + VariantRichText)  (still open at write time)
       ↳ PR (this one) — validation UX  📍 base: dev
            ↳ next slice — favicon override + tracking config + form-ui red→amber
```

Branch is based on \`feat/checkout-theme-tokens\` (the #140 head) so the dependency graph reads cleanly, but the PR targets **dev** — when #140 merges, the diff stays exactly this slice. If #140 merges first, no rebase needed.

## Summary

Slice 4 of the checkout overhaul from #105. Replaces the silent disabled-button gating with a click-then-validate flow: every Continue/Pay click runs a full validation pass, scroll-jumps the buyer back to the earliest failing step with the offending field focused, and raises a persistent amber banner explaining what's missing. The nav grows a third \"visited but incomplete\" state painted amber so the user always knows where they have work left.

## What's in here

**Provider — validation state + helpers (\`checkoutProvider.tsx\`):**
- \`visitedSteps\` + \`markStepVisited\` — session-only set populated by the funnel's IntersectionObserver.
- \`forcedBuyerFieldsTouched\` + \`markBuyerFieldsTouched\` + \`clearForcedBuyerFieldsTouched\` — fields the funnel reveals after a failed submit attempt.
- \`checkoutToast\` + \`triggerCheckoutToast\` + \`dismissCheckoutToast\` — single-slot persistent banner.
- \`getBuyerInvalidFields\` — Zod-issue-derived list of failing field names.
- \`findFirstIncompleteStep\` — today returns 'buyer' when its schema isn't satisfied; shaped for future gated steps.
- \`findFirstProductStep(visited)\` — bounce-back target when cart is empty at confirm.
- \`hasAnyCartItems\` — shared cart-non-empty predicate.

**New components / surfaces:**
- \`CheckoutToast.tsx\` — sticky amber banner; chips on the right jump back to failing steps via the provided \`onChipClick\`.

**Rewrites:**
- \`CartFooter.tsx\` — enable-and-validate pattern. Continue/Pay is hard-disabled only during submit or terms-acceptance gate; otherwise click runs validation and either advances or scroll-jumps + raises the toast. Three paths: confirm/pay, Continue-from-buyer, and any other step.
- \`OpenTicketingBuyerForm.tsx\` — hero band on top (warm accent surface), \`EmailField\` sub-component with blur-based loose + Zod validation, per-field touched state unioned with \`forcedBuyerFieldsTouched\`, regular fields gain inline errors via the same Zod-issue predicate. Outer wrapper consumes \`stepCardSurfaceStyle()\`.

**Funnel wiring:**
- \`ScrollyCheckoutFlow.tsx\` — IntersectionObserver flags visits, \`allSections\` carries emoji + showInNavbar, separate \`navSections\` for the nav chrome, \`scrollToStep\` + \`goToPreviousSection\` escape hatches, mounts \`CheckoutToast\` once, passes brand logo through, initial \`activeSection\` derives from \`availableSteps[0]\`.
- \`SnapFooter.tsx\` — plumbs \`onGoToPreviousSection\` + \`onScrollToStep\` through to the pill-design CartFooter.
- \`ScrollySectionNav.tsx\` — 3-state colouring (active, complete, visited-but-incomplete amber), emoji rendering (registry slug → SVG; literal emoji → text node with optional monochrome filter; otherwise step-type/template default), optional brand logo on left.

**Validation infra:**
- \`form-schema-builder.ts\` — Zod refine for email on \`field.type === \"email\"\` AND for fields literally named \`email\` (the open-ticketing buyer schema declares email as a plain string at runtime).

**i18n (es/en/zh):**
- buyer hero copy, email_invalid, field_required, 3 toast messages + dismiss aria, step_short.buyer.

**Tests:**
- \`form-schema-builder.test.ts\` — 5 cases covering the new email validation paths.

## Size note — size:exception requested

~1000 LOC additions over the 400-line chain budget. Justification: the validation flow is **one cohesive unit** spanning provider state, toast, footer, nav, and the buyer form — each piece reads from the others (\`forcedBuyerFieldsTouched\` plumbs from CartFooter → provider → BuyerForm; \`scrollToStep\` plumbs from ScrollyCheckoutFlow → SnapFooter → CartFooter → CheckoutToast). Splitting per-file would create half-merged states where the funnel can raise a toast that no component renders, or scroll-jump to a step that no field highlights.

The 7 commits split the work into reviewable units:

| # | Commit | LOC |
|---|--------|-----|
| 1 | provider state + helpers | +172 |
| 2 | form-schema-builder email + tests | +126 / -3 |
| 3 | CheckoutToast + CartFooter | +235 / -50 |
| 4 | ScrollyCheckoutFlow + SnapFooter wiring | +76 / -5 |
| 5 | ScrollySectionNav 3-state + emoji + logo | +82 / -4 |
| 6 | Buyer form hero + on-blur validation | +287 / -96 |
| 7 | i18n keys | +30 |

Next slice (favicon override + tracking config + form-ui red→amber) returns to the ≤400 LOC budget.

## Behaviour for existing tenants

- Tenants without a buyer schema (\`buyerFormSchema = null\`) keep the same flow — \`isBuyerInfoComplete\` defaults to true and \`findFirstIncompleteStep\` returns null. The Continue/Pay button still validates, but the validation always passes.
- Tenants with the legacy disabled-button UX get a slightly different feel: the button stays clickable, but invalid clicks now raise the toast instead of silently doing nothing. That's the whole point — silent disabled buttons made users tap twice without understanding why.
- The buyer hero band is wrapped in \`stepCardSurfaceStyle()\` so popups without \`card_*\` theme tokens render against the default \`--card\` surface, identical to today modulo the Sparkles icon and the trust line.

## Deliberately out of scope

- Favicon override (\`FaviconOverride\`), tracking snippet injection — separate slice with a security-focused config rework.
- \`shared-form-ui\` red → amber across portal AND backoffice — needs design sign-off; not a checkout-only change.
- Accent-over-primary swap in \`themeProvider\` — changes existing tenants with \`accent_color\` set; separate slice with QA.

## Test plan

- [x] \`pnpm --filter portal run lint\` — 1 pre-existing warning on VariantPatronPreset, unchanged. CheckoutToast keeps \`role=\"status\"\` over \`<output>\` (biome-ignore with rationale: \`<output>\` is for form-calculation results).
- [x] \`pnpm --filter portal run build\` — green.
- [x] \`pnpm --filter portal run test\` — 5 new tests pass (form-schema-builder email validation); 8 pre-existing failures unchanged.
- [ ] Visual QA: Pay button with empty buyer form — confirm toast appears with chip jumping back to buyer step.
- [ ] Visual QA: Pay button with empty cart but buyer filled — confirm cart-empty toast appears and scroll jumps to first product step.
- [ ] Visual QA: nav shows amber state on buyer step after scrolling past without filling.
- [ ] Visual QA: tenant with \`step.emoji = \"user\"\` (registry slug) renders the User icon in the nav.
- [ ] Visual QA: tenant with \`step.emoji = \"🎟️\"\` (literal) renders the emoji directly in the nav.