### PR TITLE
feat(portal): scholarship discount + allows_coupons gating

### DIFF
--- a/backoffice/src/components/ApplicationDetail.tsx
+++ b/backoffice/src/components/ApplicationDetail.tsx
@@ -44,6 +44,7 @@ import { LoadingButton } from "@/components/ui/loading-button"
 import { Separator } from "@/components/ui/separator"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import { cn } from "@/lib/utils"
 import { createErrorHandler } from "@/utils"
 
 // ========================
@@ -791,10 +792,17 @@ export function ApplicationDetail({
         </div>
       )
     }
+    const formatted = formatFieldValue(key, value)
+    const hasUnbreakableWord = formatted
+      .split(/\s+/)
+      .some((word) => word.length > 24)
+    const fullRow = hasUnbreakableWord
     return (
-      <div key={key}>
-        <p className="text-xs text-muted-foreground">{getFieldLabel(key)}</p>
-        <p className="text-sm">{formatFieldValue(key, value)}</p>
+      <div key={key} className={cn("min-w-0", fullRow && "sm:col-span-2")}>
+        <p className="text-xs text-muted-foreground break-words">
+          {getFieldLabel(key)}
+        </p>
+        <p className="text-sm break-words">{formatted}</p>
       </div>
     )
   }

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx
@@ -26,13 +26,8 @@ const TotalPurchase = ({
   const { t } = useTranslation()
   const { getCity } = useCityProvider()
   const creditsEnabled = getCity()?.credits_enabled ?? false
-  const {
-    originalTotal,
-    total,
-    discountAmount,
-    appliedDiscount,
-    groupName,
-  } = useCalculateTotal()
+  const { originalTotal, total, discountAmount, appliedDiscount, groupName } =
+    useCalculateTotal()
 
   // Detectar si hay productos month seleccionados
   const hasMonthSelected = attendees.some((attendee) =>

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx
@@ -8,10 +8,8 @@ import {
 import { useCalculateTotal } from "@/hooks/useCalculateTotal"
 import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
+import type { AppliedDiscount } from "@/strategies/TotalStrategy"
 import type { AttendeePassState } from "@/types/Attendee"
-import type { DiscountProps } from "@/types/discounts"
-import type { ProductsPass } from "@/types/Products"
-import useDiscountCode from "../../hooks/useDiscountCode"
 import ProductCart from "./Products/ProductCart"
 
 const TotalPurchase = ({
@@ -26,14 +24,13 @@ const TotalPurchase = ({
   setIsOpen: (prev: boolean) => void
 }) => {
   const { t } = useTranslation()
-  const { discountApplied } = useDiscountCode()
   const { getCity } = useCityProvider()
   const creditsEnabled = getCity()?.credits_enabled ?? false
   const {
     originalTotal,
     total,
     discountAmount,
-    groupDiscountPercentage,
+    appliedDiscount,
     groupName,
   } = useCalculateTotal()
 
@@ -116,19 +113,12 @@ const TotalPurchase = ({
               />
             )}
 
-            {groupDiscountPercentage >= discountApplied.discount_value ? (
-              <GroupDiscountDisplay
-                groupDiscountPercentage={groupDiscountPercentage}
-                groupName={groupName}
-              />
-            ) : (
-              <DiscountCouponTotal
-                products={productsCart}
-                discountAmount={discountAmount}
-                discountApplied={discountApplied}
-                patreonSelected={patreonSelected}
-              />
-            )}
+            <AppliedDiscountDisplay
+              appliedDiscount={appliedDiscount}
+              discountAmount={discountAmount}
+              groupName={groupName}
+              patreonSelected={patreonSelected}
+            />
 
             {/* LEGACY: application.credit was removed from API */}
           </div>
@@ -142,53 +132,79 @@ const TotalPurchase = ({
   )
 }
 
-const DiscountCouponTotal = ({
+const AppliedDiscountDisplay = ({
+  appliedDiscount,
   discountAmount,
-  discountApplied,
+  groupName,
   patreonSelected,
-  products: _products,
 }: {
+  appliedDiscount: AppliedDiscount
   discountAmount: number
-  discountApplied: DiscountProps
+  groupName: string | null
   patreonSelected: boolean
-  products: ProductsPass[]
 }) => {
   const { t } = useTranslation()
-  if (!discountApplied.discount_value || discountAmount === 0) return null
 
-  const getLabelDiscount = () => {
-    if (patreonSelected) {
-      return t("passes.discounts.patron_free")
-    }
-    if (discountApplied.discount_code) {
-      return t("passes.discounts.code", {
-        code: discountApplied.discount_code,
-        percent: discountApplied.discount_value,
-      })
-    }
-    return t("passes.discounts.generic", {
-      percent: discountApplied.discount_value,
-    })
-  }
+  if (appliedDiscount.type === "none") return null
 
-  if (discountAmount > 0) {
+  if (appliedDiscount.type === "group") {
+    if (!appliedDiscount.percentage) return null
     return (
       <div className="flex justify-between text-sm text-muted-foreground">
         <div className="flex items-center gap-2">
           <Tag className="w-4 h-4" />
           <span className="text-sm text-muted-foreground">
-            {getLabelDiscount()}
+            {groupName
+              ? t("passes.discounts.group_named", {
+                  name: groupName,
+                  percent: appliedDiscount.percentage,
+                })
+              : t("passes.discounts.group_generic", {
+                  percent: appliedDiscount.percentage,
+                })}
           </span>
         </div>
-        <span data-discount-amount={discountAmount.toFixed(0)}>
-          {" "}
-          - ${discountAmount.toFixed(0)}
+        <span className="text-green-600 font-medium">
+          {t("passes.discounts.applied")}
         </span>
       </div>
     )
   }
 
-  return null
+  if (discountAmount <= 0) return null
+
+  const getLabel = () => {
+    if (appliedDiscount.type === "scholarship") {
+      return t("passes.discounts.scholarship", {
+        percent: appliedDiscount.percentage,
+      })
+    }
+    if (patreonSelected) {
+      return t("passes.discounts.patron_free")
+    }
+    if (appliedDiscount.code) {
+      return t("passes.discounts.code", {
+        code: appliedDiscount.code,
+        percent: appliedDiscount.percentage,
+      })
+    }
+    return t("passes.discounts.generic", {
+      percent: appliedDiscount.percentage,
+    })
+  }
+
+  return (
+    <div className="flex justify-between text-sm text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <Tag className="w-4 h-4" />
+        <span className="text-sm text-muted-foreground">{getLabel()}</span>
+      </div>
+      <span data-discount-amount={discountAmount.toFixed(0)}>
+        {" "}
+        - ${discountAmount.toFixed(0)}
+      </span>
+    </div>
+  )
 }
 
 const _DiscountMonth = ({
@@ -284,38 +300,6 @@ const DiscountWeekPurchased = ({
       <span data-week-discount={weekDiscount.toFixed(0)}>
         {" "}
         - ${weekDiscount.toFixed(0)}
-      </span>
-    </div>
-  )
-}
-
-const GroupDiscountDisplay = ({
-  groupDiscountPercentage,
-  groupName,
-}: {
-  groupDiscountPercentage: number
-  groupName: string | null
-}) => {
-  const { t } = useTranslation()
-  if (!groupDiscountPercentage || groupDiscountPercentage === 0) return null
-
-  return (
-    <div className="flex justify-between text-sm text-muted-foreground">
-      <div className="flex items-center gap-2">
-        <Tag className="w-4 h-4" />
-        <span className="text-sm text-muted-foreground">
-          {groupName
-            ? t("passes.discounts.group_named", {
-                name: groupName,
-                percent: groupDiscountPercentage,
-              })
-            : t("passes.discounts.group_generic", {
-                percent: groupDiscountPercentage,
-              })}
-        </span>
-      </div>
-      <span className="text-green-600 font-medium">
-        {t("passes.discounts.applied")}
       </span>
     </div>
   )

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -385,72 +385,76 @@ export default function ConfirmStep() {
         )}
 
         {/* Promo Code Section */}
-        <div className="border-t border-border" />
-        <div className="px-4 sm:px-5 py-4">
-          <div className="flex items-center gap-2 sm:gap-3">
-            <input
-              type="text"
-              value={promoInput}
-              onChange={(e) => {
-                setPromoInput(e.target.value.toUpperCase())
-                setPromoError("")
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault()
-                  handleApplyPromo()
-                }
-              }}
-              placeholder="Promo code"
-              disabled={cart.promoCodeValid}
-              className={cn(
-                "flex-1 px-3 py-2 border rounded-lg text-sm transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
-                promoError
-                  ? "border-destructive bg-destructive/10"
-                  : cart.promoCodeValid
-                    ? "border-green-300 bg-green-50"
-                    : "border-border",
-              )}
-            />
-            {cart.promoCodeValid ? (
-              <button
-                type="button"
-                onClick={handleClearPromo}
-                aria-label="Remove promo code"
-                className="px-3 py-2 rounded-lg text-sm font-medium bg-slate-100 text-muted-foreground hover:bg-destructive/20 hover:text-destructive transition-colors duration-200 shrink-0"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={handleApplyPromo}
-                disabled={promoLoading || isLoading || !promoInput.trim()}
-                className={cn(
-                  "px-3 sm:px-4 py-2 rounded-lg text-sm font-medium transition-colors shrink-0",
-                  !promoInput.trim()
-                    ? "bg-muted text-muted-foreground cursor-not-allowed"
-                    : "bg-foreground text-background hover:bg-foreground/90",
-                )}
-              >
-                {promoLoading || isLoading ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
+        {popup?.allows_coupons && (
+          <>
+            <div className="border-t border-border" />
+            <div className="px-4 sm:px-5 py-4">
+              <div className="flex items-center gap-2 sm:gap-3">
+                <input
+                  type="text"
+                  value={promoInput}
+                  onChange={(e) => {
+                    setPromoInput(e.target.value.toUpperCase())
+                    setPromoError("")
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      handleApplyPromo()
+                    }
+                  }}
+                  placeholder="Promo code"
+                  disabled={cart.promoCodeValid}
+                  className={cn(
+                    "flex-1 px-3 py-2 border rounded-lg text-sm transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent",
+                    promoError
+                      ? "border-destructive bg-destructive/10"
+                      : cart.promoCodeValid
+                        ? "border-green-300 bg-green-50"
+                        : "border-border",
+                  )}
+                />
+                {cart.promoCodeValid ? (
+                  <button
+                    type="button"
+                    onClick={handleClearPromo}
+                    aria-label="Remove promo code"
+                    className="px-3 py-2 rounded-lg text-sm font-medium bg-slate-100 text-muted-foreground hover:bg-destructive/20 hover:text-destructive transition-colors duration-200 shrink-0"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
                 ) : (
-                  "Apply"
+                  <button
+                    type="button"
+                    onClick={handleApplyPromo}
+                    disabled={promoLoading || isLoading || !promoInput.trim()}
+                    className={cn(
+                      "px-3 sm:px-4 py-2 rounded-lg text-sm font-medium transition-colors shrink-0",
+                      !promoInput.trim()
+                        ? "bg-muted text-muted-foreground cursor-not-allowed"
+                        : "bg-foreground text-background hover:bg-foreground/90",
+                    )}
+                  >
+                    {promoLoading || isLoading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      "Apply"
+                    )}
+                  </button>
                 )}
-              </button>
-            )}
-          </div>
-          {promoError && (
-            <div className="flex items-center gap-1.5 text-destructive text-xs mt-2">
-              <AlertCircle className="w-3 h-3" />
-              <span>{promoError}</span>
+              </div>
+              {promoError && (
+                <div className="flex items-center gap-1.5 text-destructive text-xs mt-2">
+                  <AlertCircle className="w-3 h-3" />
+                  <span>{promoError}</span>
+                </div>
+              )}
+              {cart.promoCodeValid && (
+                <p className="text-green-600 text-xs mt-2">Code applied!</p>
+              )}
             </div>
-          )}
-          {cart.promoCodeValid && (
-            <p className="text-green-600 text-xs mt-2">Code applied!</p>
-          )}
-        </div>
+          </>
+        )}
 
         {/* Terms and Conditions */}
         {popup?.terms_and_conditions_url && (

--- a/portal/src/hooks/useCalculateTotal.ts
+++ b/portal/src/hooks/useCalculateTotal.ts
@@ -32,6 +32,17 @@ export function useCalculateTotal() {
       }
     }
 
+    let scholarshipDiscountValue = 0
+    if (
+      application?.scholarship_status === "approved" &&
+      application.discount_percentage != null
+    ) {
+      const parsed = Number(application.discount_percentage)
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        scholarshipDiscountValue = parsed
+      }
+    }
+
     const calculator = new TotalCalculator(
       checkoutPolicy.checkoutMode,
       creditsEnabled,
@@ -40,6 +51,7 @@ export function useCalculateTotal() {
       attendeePasses,
       discountApplied,
       groupDiscountValue,
+      scholarshipDiscountValue,
     )
     const balance = result.total
 
@@ -48,8 +60,10 @@ export function useCalculateTotal() {
       originalTotal: result.originalTotal,
       discountAmount: result.discountAmount,
       balance,
+      appliedDiscount: result.appliedDiscount,
       groupDiscountPercentage: groupDiscountValue,
       groupName: groupNameValue,
+      scholarshipDiscountPercentage: scholarshipDiscountValue,
     }
   }, [
     application,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -322,7 +322,8 @@
       "group_named": "{{name}} Group ({{percent}}% OFF)",
       "group_generic": "Group Discount ({{percent}}% OFF)",
       "code": "{{code}} ({{percent}}% OFF)",
-      "generic": "Discount {{percent}}% OFF"
+      "generic": "Discount {{percent}}% OFF",
+      "scholarship": "Scholarship ({{percent}}% OFF)"
     }
   },
   "attendees": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -322,7 +322,8 @@
       "group_named": "Grupo {{name}} ({{percent}}% OFF)",
       "group_generic": "Descuento de grupo ({{percent}}% OFF)",
       "code": "{{code}} ({{percent}}% OFF)",
-      "generic": "Descuento {{percent}}% OFF"
+      "generic": "Descuento {{percent}}% OFF",
+      "scholarship": "Beca ({{percent}}% OFF)"
     }
   },
   "attendees": {

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -312,7 +312,8 @@
       "group_named": "{{name}} hópur ({{percent}}% AFSLÁTTUR)",
       "group_generic": "Hópafsláttur ({{percent}}% AFSLÁTTUR)",
       "code": "{{code}} ({{percent}}% AFSLÁTTUR)",
-      "generic": "Afsláttur {{percent}}% AFSLÁTTUR"
+      "generic": "Afsláttur {{percent}}% AFSLÁTTUR",
+      "scholarship": "Námsstyrkur ({{percent}}% AFSLÁTTUR)"
     }
   },
   "attendees": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -322,7 +322,8 @@
       "group_named": "{{name}} 团体 ({{percent}}% 折扣)",
       "group_generic": "团体折扣 ({{percent}}% 折扣)",
       "code": "{{code}} ({{percent}}% 折扣)",
-      "generic": "折扣 {{percent}}% OFF"
+      "generic": "折扣 {{percent}}% OFF",
+      "scholarship": "奖学金 ({{percent}}% 折扣)"
     }
   },
   "attendees": {

--- a/portal/src/strategies/TotalStrategy.ts
+++ b/portal/src/strategies/TotalStrategy.ts
@@ -7,11 +7,22 @@ import type { AttendeePassState } from "@/types/Attendee"
 import type { DiscountProps } from "@/types/discounts"
 import type { ProductsPass } from "@/types/Products"
 
+export type AppliedDiscount =
+  | { type: "none" }
+  | { type: "coupon"; percentage: number; code: string | null }
+  | { type: "group"; percentage: number }
+  | { type: "scholarship"; percentage: number }
+
 interface TotalResult {
   total: number
   originalTotal: number
   discountAmount: number
 }
+
+interface FinalTotalResult extends TotalResult {
+  appliedDiscount: AppliedDiscount
+}
+
 interface PriceCalculationStrategy {
   calculate(products: ProductsPass[], discount: DiscountProps): TotalResult
 }
@@ -224,7 +235,8 @@ export class TotalCalculator {
     attendees: AttendeePassState[],
     discount: DiscountProps,
     groupDiscountPercentage?: number,
-  ): TotalResult {
+    scholarshipDiscountPercentage?: number,
+  ): FinalTotalResult {
     const baseResult = attendees.reduce(
       (total, attendee) => {
         const ticketProducts = attendee.products.filter(
@@ -260,21 +272,57 @@ export class TotalCalculator {
       { total: 0, originalTotal: 0, discountAmount: 0 },
     )
 
-    if (groupDiscountPercentage && groupDiscountPercentage > 0) {
-      const groupDiscountAmount =
-        baseResult.originalTotal * (groupDiscountPercentage / 100)
-      const individualDiscountAmount = baseResult.discountAmount
+    const couponAmount = baseResult.discountAmount
+    const couponPercentage = discount.discount_value ?? 0
+    const groupAmount =
+      groupDiscountPercentage && groupDiscountPercentage > 0
+        ? baseResult.originalTotal * (groupDiscountPercentage / 100)
+        : 0
+    const scholarshipAmount =
+      scholarshipDiscountPercentage && scholarshipDiscountPercentage > 0
+        ? baseResult.originalTotal * (scholarshipDiscountPercentage / 100)
+        : 0
 
-      if (groupDiscountAmount > individualDiscountAmount) {
-        return {
-          total: baseResult.originalTotal - groupDiscountAmount,
-          originalTotal: baseResult.originalTotal,
-          discountAmount: groupDiscountAmount,
-        }
+    // Priority on ties mirrors backend: scholarship >= coupon >= group > none.
+    let appliedDiscount: AppliedDiscount = { type: "none" }
+    let winningAmount = 0
+
+    if (groupAmount > winningAmount) {
+      appliedDiscount = {
+        type: "group",
+        percentage: groupDiscountPercentage ?? 0,
       }
+      winningAmount = groupAmount
+    }
+    if (couponAmount >= winningAmount && couponAmount > 0) {
+      appliedDiscount = {
+        type: "coupon",
+        percentage: couponPercentage,
+        code: discount.discount_code ?? null,
+      }
+      winningAmount = couponAmount
+    }
+    if (scholarshipAmount >= winningAmount && scholarshipAmount > 0) {
+      appliedDiscount = {
+        type: "scholarship",
+        percentage: scholarshipDiscountPercentage ?? 0,
+      }
+      winningAmount = scholarshipAmount
     }
 
-    return baseResult
+    if (
+      appliedDiscount.type === "coupon" ||
+      appliedDiscount.type === "none"
+    ) {
+      return { ...baseResult, appliedDiscount }
+    }
+
+    return {
+      total: baseResult.originalTotal - winningAmount,
+      originalTotal: baseResult.originalTotal,
+      discountAmount: winningAmount,
+      appliedDiscount,
+    }
   }
 
   private getStrategy(products: ProductsPass[]): PriceCalculationStrategy {

--- a/portal/src/strategies/TotalStrategy.ts
+++ b/portal/src/strategies/TotalStrategy.ts
@@ -310,10 +310,7 @@ export class TotalCalculator {
       winningAmount = scholarshipAmount
     }
 
-    if (
-      appliedDiscount.type === "coupon" ||
-      appliedDiscount.type === "none"
-    ) {
+    if (appliedDiscount.type === "coupon" || appliedDiscount.type === "none") {
       return { ...baseResult, appliedDiscount }
     }
 


### PR DESCRIPTION
## Summary
- Apply approved-scholarship `discount_percentage` in `/passes/buy` and `/checkout` totals, mirroring the backend best-of-three (priority on ties: scholarship > coupon > group) already in `backend/app/api/payment/crud.py:1247-1267`.
- `TotalPurchase` now shows only the winning discount; when scholarship wins, render a "Scholarship (X% OFF)" line in all four locales.
- Hide the open-ticketing promo section in `ConfirmStep` when popup `allows_coupons` is false (was unconditionally rendered).

## Changes
| File | Change |
|------|--------|
| `portal/src/strategies/TotalStrategy.ts` | `TotalCalculator.calculate()` takes `scholarshipDiscountPercentage`, returns `appliedDiscount` (discriminated union) |
| `portal/src/hooks/useCalculateTotal.ts` | Reads scholarship from active application, surfaces `appliedDiscount` |
| `portal/src/app/portal/[popupSlug]/passes/components/common/TotalPurchase.tsx` | Unified `AppliedDiscountDisplay` switching on `appliedDiscount.type` |
| `portal/src/i18n/locales/{en,es,zh,is}.json` | Added `passes.discounts.scholarship` key |
| `portal/src/components/checkout-flow/steps/ConfirmStep.tsx` | Wrapped Promo Code section in `popup?.allows_coupons` gate |

## Test plan
- [ ] `pnpm --filter portal run build`
- [ ] Approved scholarship, no coupon/group: line shows "Scholarship (X% OFF)", total = originalTotal - X%
- [ ] Approved scholarship + a better coupon code applied: coupon wins, scholarship line hidden, total reflects coupon
- [ ] Approved scholarship + worse coupon code applied: scholarship wins (ties go to scholarship, matching backend)
- [ ] Group with bigger discount than scholarship: group wins
- [ ] Open-ticketing checkout with popup `allows_coupons=false`: promo input + separator hidden in ConfirmStep
- [ ] Open-ticketing checkout with popup `allows_coupons=true`: promo input visible and functional

## Notes
- The backend already computes the scholarship discount on the actual charge — this PR makes the displayed total match what the user is charged. Before this change, users with an approved scholarship saw full price on screen but were charged the discounted amount.
- `/checkout/[popupSlug]` (open-ticketing) intentionally has no application context, so scholarship is N/A there. Only the coupon gate applies in that flow.