### PR TITLE
feat(backoffice): table pagination default and back-nav filter persistence

### DIFF
--- a/backoffice/src/components/Common/FormPageLayout.tsx
+++ b/backoffice/src/components/Common/FormPageLayout.tsx
@@ -1,7 +1,7 @@
-import { useNavigate } from "@tanstack/react-router"
 import { ArrowLeft } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
+import { useGoBack } from "@/hooks/useGoBack"
 
 interface FormPageLayoutProps {
   title: string
@@ -18,7 +18,7 @@ export function FormPageLayout({
   onBack,
   children,
 }: FormPageLayoutProps) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: backTo })
 
   return (
     <div className="flex flex-col gap-6">
@@ -27,7 +27,7 @@ export function FormPageLayout({
           variant="ghost"
           size="icon"
           aria-label="Go back"
-          onClick={onBack ?? (() => navigate({ to: backTo }))}
+          onClick={onBack ?? goBack}
         >
           <ArrowLeft className="h-4 w-4" />
         </Button>

--- a/backoffice/src/hooks/useGoBack.ts
+++ b/backoffice/src/hooks/useGoBack.ts
@@ -1,0 +1,18 @@
+import { useNavigate, useRouter } from "@tanstack/react-router"
+import { useCallback } from "react"
+
+type NavigateFn = ReturnType<typeof useNavigate>
+type NavigateFallback = Parameters<NavigateFn>[0]
+
+export function useGoBack(fallback: NavigateFallback) {
+  const router = useRouter()
+  const navigate = useNavigate()
+
+  return useCallback(() => {
+    if (router.history.canGoBack()) {
+      router.history.back()
+    } else {
+      navigate(fallback)
+    }
+  }, [router, navigate, fallback])
+}

--- a/backoffice/src/hooks/useGoBack.ts
+++ b/backoffice/src/hooks/useGoBack.ts
@@ -1,18 +1,19 @@
 import { useNavigate, useRouter } from "@tanstack/react-router"
 import { useCallback } from "react"
 
-type NavigateFn = ReturnType<typeof useNavigate>
-type NavigateFallback = Parameters<NavigateFn>[0]
+type Fallback = { to: string } | (() => void)
 
-export function useGoBack(fallback: NavigateFallback) {
+export function useGoBack(fallback: Fallback) {
   const router = useRouter()
   const navigate = useNavigate()
 
   return useCallback(() => {
     if (router.history.canGoBack()) {
       router.history.back()
+    } else if (typeof fallback === "function") {
+      fallback()
     } else {
-      navigate(fallback)
+      navigate({ to: fallback.to })
     }
   }, [router, navigate, fallback])
 }

--- a/backoffice/src/hooks/useTableSearchParams.ts
+++ b/backoffice/src/hooks/useTableSearchParams.ts
@@ -12,7 +12,7 @@ export interface TableSearchParams {
 
 export const defaultTableSearch: Required<TableSearchParams> = {
   page: 0,
-  pageSize: 25,
+  pageSize: 50,
   search: "",
   sortBy: "",
   sortOrder: "desc",
@@ -27,7 +27,7 @@ export function validateTableSearch(
       typeof raw.pageSize === "number" &&
       [10, 25, 50, 100].includes(raw.pageSize)
         ? raw.pageSize
-        : 25,
+        : 50,
     search: typeof raw.search === "string" ? raw.search : "",
     sortBy: typeof raw.sortBy === "string" ? raw.sortBy : "",
     sortOrder:
@@ -41,7 +41,7 @@ export function useTableSearchParams(params: TableSearchParams, from: string) {
   const navigate = useNavigate()
 
   const page = params.page ?? 0
-  const pageSize = params.pageSize ?? 25
+  const pageSize = params.pageSize ?? 50
   const search = params.search ?? ""
   const sortBy = params.sortBy ?? ""
   const sortOrder = params.sortOrder ?? "desc"
@@ -75,7 +75,7 @@ export function useTableSearchParams(params: TableSearchParams, from: string) {
         search: (prev: TableSearchParams) => ({
           ...prev,
           page: pag.pageIndex || undefined,
-          pageSize: pag.pageSize === 25 ? undefined : pag.pageSize,
+          pageSize: pag.pageSize === 50 ? undefined : pag.pageSize,
         }),
         replace: true,
       })

--- a/backoffice/src/routes/_layout/admin/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/admin/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { UsersService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { UserForm } from "@/components/forms/UserForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/admin/$id/edit")({
   component: EditUserPage,
@@ -23,15 +24,10 @@ function getUserQueryOptions(userId: string) {
 }
 
 function EditUserContent({ userId }: { userId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/admin" })
   const { data: user } = useSuspenseQuery(getUserQueryOptions(userId))
 
-  return (
-    <UserForm
-      defaultValues={user}
-      onSuccess={() => navigate({ to: "/admin" })}
-    />
-  )
+  return <UserForm defaultValues={user} onSuccess={goBack} />
 }
 
 function EditUserPage() {

--- a/backoffice/src/routes/_layout/admin/index.tsx
+++ b/backoffice/src/routes/_layout/admin/index.tsx
@@ -20,7 +20,7 @@ import {
   validateTableSearch,
 } from "@/hooks/useTableSearchParams"
 
-const PAGE_SIZE = 25
+const PAGE_SIZE = 50
 
 function getTenantUsersQueryOptions(
   tenantId: string | null,

--- a/backoffice/src/routes/_layout/admin/new.tsx
+++ b/backoffice/src/routes/_layout/admin/new.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { UserForm } from "@/components/forms/UserForm"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/admin/new")({
   component: NewUser,
@@ -11,7 +12,7 @@ export const Route = createFileRoute("/_layout/admin/new")({
 })
 
 function NewUser() {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/admin" })
 
   return (
     <FormPageLayout
@@ -19,7 +20,7 @@ function NewUser() {
       description="Create a new user account"
       backTo="/admin"
     >
-      <UserForm onSuccess={() => navigate({ to: "/admin" })} />
+      <UserForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/applications/new.tsx
+++ b/backoffice/src/routes/_layout/applications/new.tsx
@@ -15,9 +15,7 @@ export const Route = createFileRoute("/_layout/applications/new")({
 
 function NewApplication() {
   const navigate = useNavigate()
-  const goBack = useGoBack(() =>
-    navigate({ to: "/applications", search: {} }),
-  )
+  const goBack = useGoBack(() => navigate({ to: "/applications", search: {} }))
   const { isSuperadmin, isUserLoading } = useAuth()
 
   // Only superadmins can create applications via backoffice (for testing)

--- a/backoffice/src/routes/_layout/applications/new.tsx
+++ b/backoffice/src/routes/_layout/applications/new.tsx
@@ -15,7 +15,9 @@ export const Route = createFileRoute("/_layout/applications/new")({
 
 function NewApplication() {
   const navigate = useNavigate()
-  const goBack = useGoBack({ to: "/applications", search: {} })
+  const goBack = useGoBack(() =>
+    navigate({ to: "/applications", search: {} }),
+  )
   const { isSuperadmin, isUserLoading } = useAuth()
 
   // Only superadmins can create applications via backoffice (for testing)

--- a/backoffice/src/routes/_layout/applications/new.tsx
+++ b/backoffice/src/routes/_layout/applications/new.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { ApplicationForm } from "@/components/forms/ApplicationForm"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/applications/new")({
   component: NewApplication,
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_layout/applications/new")({
 
 function NewApplication() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/applications", search: {} })
   const { isSuperadmin, isUserLoading } = useAuth()
 
   // Only superadmins can create applications via backoffice (for testing)
@@ -33,9 +35,7 @@ function NewApplication() {
       description="Create a test application with custom fields (Superadmin only)"
       backTo="/applications"
     >
-      <ApplicationForm
-        onSuccess={() => navigate({ to: "/applications", search: {} })}
-      />
+      <ApplicationForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/coupons/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/coupons/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { CouponsService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { CouponForm } from "@/components/forms/CouponForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/coupons/$id/edit")({
   component: EditCouponPage,
@@ -23,15 +24,10 @@ function getCouponQueryOptions(couponId: string) {
 }
 
 function EditCouponContent({ couponId }: { couponId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/coupons" })
   const { data: coupon } = useSuspenseQuery(getCouponQueryOptions(couponId))
 
-  return (
-    <CouponForm
-      defaultValues={coupon}
-      onSuccess={() => navigate({ to: "/coupons" })}
-    />
-  )
+  return <CouponForm defaultValues={coupon} onSuccess={goBack} />
 }
 
 function EditCouponPage() {

--- a/backoffice/src/routes/_layout/coupons/new.tsx
+++ b/backoffice/src/routes/_layout/coupons/new.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { CouponForm } from "@/components/forms/CouponForm"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/coupons/new")({
   component: NewCoupon,
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_layout/coupons/new")({
 
 function NewCoupon() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/coupons" })
   const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to coupons list - they cannot create new coupons
@@ -33,7 +35,7 @@ function NewCoupon() {
       description="Add a new discount coupon for the event"
       backTo="/coupons"
     >
-      <CouponForm onSuccess={() => navigate({ to: "/coupons" })} />
+      <CouponForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/events/$eventId.edit.tsx
+++ b/backoffice/src/routes/_layout/events/$eventId.edit.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { CalendarClock } from "lucide-react"
 import { Suspense } from "react"
 
@@ -10,6 +10,7 @@ import { EventForm } from "@/components/forms/EventForm"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Skeleton } from "@/components/ui/skeleton"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 function getInitials(
   firstName: string | null | undefined,
@@ -98,7 +99,7 @@ export const Route = createFileRoute("/_layout/events/$eventId/edit")({
 })
 
 function EditEventContent({ eventId }: { eventId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/events" })
   const { data: event } = useSuspenseQuery({
     queryKey: ["events", eventId],
     queryFn: () => EventsService.getEvent({ eventId }),
@@ -107,10 +108,7 @@ function EditEventContent({ eventId }: { eventId: string }) {
   return (
     <div className="space-y-4">
       <CreatedByCard event={event} />
-      <EventForm
-        defaultValues={event}
-        onSuccess={() => navigate({ to: "/events" })}
-      />
+      <EventForm defaultValues={event} onSuccess={goBack} />
     </div>
   )
 }

--- a/backoffice/src/routes/_layout/events/new.tsx
+++ b/backoffice/src/routes/_layout/events/new.tsx
@@ -1,9 +1,10 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { EventForm } from "@/components/forms/EventForm"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
+import { useGoBack } from "@/hooks/useGoBack"
 
 interface NewEventSearch {
   venueId?: string
@@ -23,7 +24,7 @@ export const Route = createFileRoute("/_layout/events/new")({
 })
 
 function NewEventPage() {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/events" })
   const { selectedPopupId } = useWorkspace()
   const { venueId, startTime } = Route.useSearch()
 
@@ -37,7 +38,7 @@ function NewEventPage() {
         <EventForm
           initialVenueId={venueId}
           initialStartIso={startTime}
-          onSuccess={() => navigate({ to: "/events" })}
+          onSuccess={goBack}
         />
       ) : (
         <WorkspaceAlert resource="event" action="create" />

--- a/backoffice/src/routes/_layout/events/tracks/$trackId.edit.tsx
+++ b/backoffice/src/routes/_layout/events/tracks/$trackId.edit.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { CalendarDays } from "lucide-react"
 import { Suspense } from "react"
 
@@ -11,6 +11,7 @@ import { TrackForm } from "@/components/forms/TrackForm"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/events/tracks/$trackId/edit")({
   component: EditTrackPage,
@@ -158,7 +159,7 @@ function TrackEventsList({ trackId }: { trackId: string }) {
 }
 
 function EditTrackContent({ trackId }: { trackId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/events/tracks" })
   const { data: track } = useSuspenseQuery({
     queryKey: ["tracks", trackId],
     queryFn: () => TracksService.getTrack({ trackId }),
@@ -166,10 +167,7 @@ function EditTrackContent({ trackId }: { trackId: string }) {
 
   return (
     <div className="space-y-10">
-      <TrackForm
-        defaultValues={track}
-        onSuccess={() => navigate({ to: "/events/tracks" })}
-      />
+      <TrackForm defaultValues={track} onSuccess={goBack} />
       <section className="space-y-3">
         <div>
           <h2 className="text-lg font-semibold tracking-tight">

--- a/backoffice/src/routes/_layout/events/venues/$venueId.edit.tsx
+++ b/backoffice/src/routes/_layout/events/venues/$venueId.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { EventVenuesService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { VenueForm } from "@/components/forms/VenueForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/events/venues/$venueId/edit")({
   component: EditVenuePage,
@@ -16,18 +17,13 @@ export const Route = createFileRoute("/_layout/events/venues/$venueId/edit")({
 })
 
 function EditVenueContent({ venueId }: { venueId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/events/venues" })
   const { data: venue } = useSuspenseQuery({
     queryKey: ["event-venues", venueId],
     queryFn: () => EventVenuesService.getVenue({ venueId }),
   })
 
-  return (
-    <VenueForm
-      defaultValues={venue}
-      onSuccess={() => navigate({ to: "/events/venues" })}
-    />
-  )
+  return <VenueForm defaultValues={venue} onSuccess={goBack} />
 }
 
 function EditVenuePage() {

--- a/backoffice/src/routes/_layout/events/venues/new.tsx
+++ b/backoffice/src/routes/_layout/events/venues/new.tsx
@@ -1,9 +1,10 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { VenueForm } from "@/components/forms/VenueForm"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/events/venues/new")({
   component: NewVenuePage,
@@ -13,7 +14,7 @@ export const Route = createFileRoute("/_layout/events/venues/new")({
 })
 
 function NewVenuePage() {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/events/venues" })
   const { selectedPopupId } = useWorkspace()
 
   return (
@@ -23,7 +24,7 @@ function NewVenuePage() {
       backTo="/events/venues"
     >
       {selectedPopupId ? (
-        <VenueForm onSuccess={() => navigate({ to: "/events/venues" })} />
+        <VenueForm onSuccess={goBack} />
       ) : (
         <WorkspaceAlert resource="venue" action="create" />
       )}

--- a/backoffice/src/routes/_layout/form-builder/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/form-builder/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { FormFieldsService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { FormFieldForm } from "@/components/forms/FormFieldForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/form-builder/$id/edit")({
   component: EditFormFieldPage,
@@ -23,15 +24,10 @@ function getFormFieldQueryOptions(fieldId: string) {
 }
 
 function EditFormFieldContent({ fieldId }: { fieldId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/form-builder" })
   const { data: field } = useSuspenseQuery(getFormFieldQueryOptions(fieldId))
 
-  return (
-    <FormFieldForm
-      defaultValues={field}
-      onSuccess={() => navigate({ to: "/form-builder" })}
-    />
-  )
+  return <FormFieldForm defaultValues={field} onSuccess={goBack} />
 }
 
 function EditFormFieldPage() {

--- a/backoffice/src/routes/_layout/form-builder/new.tsx
+++ b/backoffice/src/routes/_layout/form-builder/new.tsx
@@ -6,6 +6,7 @@ import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { FormFieldForm } from "@/components/forms/FormFieldForm"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/form-builder/new")({
   component: NewFormField,
@@ -16,6 +17,7 @@ export const Route = createFileRoute("/_layout/form-builder/new")({
 
 function NewFormField() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/form-builder" })
   const { isOperatorOrAbove, isUserLoading } = useAuth()
   const { isContextReady } = useWorkspace()
 
@@ -49,7 +51,7 @@ function NewFormField() {
       description="Add a custom field to application forms"
       backTo="/form-builder"
     >
-      <FormFieldForm onSuccess={() => navigate({ to: "/form-builder" })} />
+      <FormFieldForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/form-builder/sections/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/form-builder/sections/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { FormSectionsService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { FormSectionForm } from "@/components/forms/FormSectionForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/form-builder/sections/$id/edit")(
   {
@@ -25,17 +26,12 @@ function getFormSectionQueryOptions(sectionId: string) {
 }
 
 function EditFormSectionContent({ sectionId }: { sectionId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/form-builder" })
   const { data: section } = useSuspenseQuery(
     getFormSectionQueryOptions(sectionId),
   )
 
-  return (
-    <FormSectionForm
-      defaultValues={section}
-      onSuccess={() => navigate({ to: "/form-builder" })}
-    />
-  )
+  return <FormSectionForm defaultValues={section} onSuccess={goBack} />
 }
 
 function EditFormSectionPage() {

--- a/backoffice/src/routes/_layout/form-builder/sections/new.tsx
+++ b/backoffice/src/routes/_layout/form-builder/sections/new.tsx
@@ -6,6 +6,7 @@ import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { FormSectionForm } from "@/components/forms/FormSectionForm"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/form-builder/sections/new")({
   component: NewFormSection,
@@ -16,6 +17,7 @@ export const Route = createFileRoute("/_layout/form-builder/sections/new")({
 
 function NewFormSection() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/form-builder" })
   const { isOperatorOrAbove, isUserLoading } = useAuth()
   const { isContextReady } = useWorkspace()
 
@@ -47,7 +49,7 @@ function NewFormSection() {
       description="Add a section to group form fields"
       backTo="/form-builder"
     >
-      <FormSectionForm onSuccess={() => navigate({ to: "/form-builder" })} />
+      <FormSectionForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/groups/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/groups/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { GroupsService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { GroupForm } from "@/components/forms/GroupForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/groups/$id/edit")({
   component: EditGroupPage,
@@ -23,15 +24,10 @@ function getGroupQueryOptions(groupId: string) {
 }
 
 function EditGroupContent({ groupId }: { groupId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/groups" })
   const { data: group } = useSuspenseQuery(getGroupQueryOptions(groupId))
 
-  return (
-    <GroupForm
-      defaultValues={group}
-      onSuccess={() => navigate({ to: "/groups" })}
-    />
-  )
+  return <GroupForm defaultValues={group} onSuccess={goBack} />
 }
 
 function EditGroupPage() {

--- a/backoffice/src/routes/_layout/groups/new.tsx
+++ b/backoffice/src/routes/_layout/groups/new.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { GroupForm } from "@/components/forms/GroupForm"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/groups/new")({
   component: NewGroup,
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_layout/groups/new")({
 
 function NewGroup() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/groups" })
   const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to groups list - they cannot create new groups
@@ -33,7 +35,7 @@ function NewGroup() {
       description="Add a new registration group with optional discounts"
       backTo="/groups"
     >
-      <GroupForm onSuccess={() => navigate({ to: "/groups" })} />
+      <GroupForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/humans/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/humans/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { HumansService } from "@/client"
@@ -25,14 +25,16 @@ function getHumanQueryOptions(humanId: string) {
 }
 
 function EditHumanContent({ humanId }: { humanId: string }) {
-  const goBack = useGoBack(getHumansNavigationTarget())
+  const navigate = useNavigate()
+  const goBack = useGoBack(() => navigate(getHumansNavigationTarget()))
   const { data: human } = useSuspenseQuery(getHumanQueryOptions(humanId))
 
   return <HumanForm defaultValues={human} onSuccess={goBack} />
 }
 
 function EditHumanPage() {
-  const goBack = useGoBack(getHumansNavigationTarget())
+  const navigate = useNavigate()
+  const goBack = useGoBack(() => navigate(getHumansNavigationTarget()))
   const { id } = Route.useParams()
 
   return (

--- a/backoffice/src/routes/_layout/humans/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/humans/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { HumansService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { HumanForm } from "@/components/forms/HumanForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 import { getHumansNavigationTarget } from "@/routes/_layout/humans/navigation"
 
 export const Route = createFileRoute("/_layout/humans/$id/edit")({
@@ -24,19 +25,14 @@ function getHumanQueryOptions(humanId: string) {
 }
 
 function EditHumanContent({ humanId }: { humanId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack(getHumansNavigationTarget())
   const { data: human } = useSuspenseQuery(getHumanQueryOptions(humanId))
 
-  return (
-    <HumanForm
-      defaultValues={human}
-      onSuccess={() => navigate(getHumansNavigationTarget())}
-    />
-  )
+  return <HumanForm defaultValues={human} onSuccess={goBack} />
 }
 
 function EditHumanPage() {
-  const navigate = useNavigate()
+  const goBack = useGoBack(getHumansNavigationTarget())
   const { id } = Route.useParams()
 
   return (
@@ -44,7 +40,7 @@ function EditHumanPage() {
       title="Edit Human"
       description="Update human profile information"
       backTo="/humans"
-      onBack={() => navigate(getHumansNavigationTarget())}
+      onBack={goBack}
     >
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>

--- a/backoffice/src/routes/_layout/humans/new.tsx
+++ b/backoffice/src/routes/_layout/humans/new.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { HumanForm } from "@/components/forms/HumanForm"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 import { getHumansNavigationTarget } from "@/routes/_layout/humans/navigation"
 
 export const Route = createFileRoute("/_layout/humans/new")({
@@ -15,6 +16,7 @@ export const Route = createFileRoute("/_layout/humans/new")({
 
 function NewHuman() {
   const navigate = useNavigate()
+  const goBack = useGoBack(getHumansNavigationTarget())
   const { isSuperadmin, isUserLoading } = useAuth()
 
   // Only superadmins can create humans via backoffice (for testing)
@@ -33,9 +35,9 @@ function NewHuman() {
       title="Create Human"
       description="Create a test human (Superadmin only)"
       backTo="/humans"
-      onBack={() => navigate(getHumansNavigationTarget())}
+      onBack={goBack}
     >
-      <HumanForm onSuccess={() => navigate(getHumansNavigationTarget())} />
+      <HumanForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/humans/new.tsx
+++ b/backoffice/src/routes/_layout/humans/new.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/_layout/humans/new")({
 
 function NewHuman() {
   const navigate = useNavigate()
-  const goBack = useGoBack(getHumansNavigationTarget())
+  const goBack = useGoBack(() => navigate(getHumansNavigationTarget()))
   const { isSuperadmin, isUserLoading } = useAuth()
 
   // Only superadmins can create humans via backoffice (for testing)

--- a/backoffice/src/routes/_layout/organizations/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/organizations/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { TenantsService } from "@/client"
@@ -8,6 +8,7 @@ import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { TenantForm } from "@/components/forms/TenantForm"
 import { Skeleton } from "@/components/ui/skeleton"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/organizations/$id/edit")({
   component: EditTenantPage,
@@ -24,19 +25,11 @@ function getTenantQueryOptions(tenantId: string) {
 }
 
 function EditTenantContent({ tenantId }: { tenantId: string }) {
-  const navigate = useNavigate()
   const { isSuperadmin } = useAuth()
+  const goBack = useGoBack({ to: isSuperadmin ? "/organizations" : "/" })
   const { data: tenant } = useSuspenseQuery(getTenantQueryOptions(tenantId))
 
-  const handleSuccess = () => {
-    if (isSuperadmin) {
-      navigate({ to: "/organizations" })
-    } else {
-      navigate({ to: "/" })
-    }
-  }
-
-  return <TenantForm defaultValues={tenant} onSuccess={handleSuccess} />
+  return <TenantForm defaultValues={tenant} onSuccess={goBack} />
 }
 
 function EditTenantPage() {

--- a/backoffice/src/routes/_layout/organizations/new.tsx
+++ b/backoffice/src/routes/_layout/organizations/new.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { TenantForm } from "@/components/forms/TenantForm"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/organizations/new")({
   component: NewTenant,
@@ -11,7 +12,7 @@ export const Route = createFileRoute("/_layout/organizations/new")({
 })
 
 function NewTenant() {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/organizations" })
 
   return (
     <FormPageLayout
@@ -19,7 +20,7 @@ function NewTenant() {
       description="Add a new organization to the platform"
       backTo="/organizations"
     >
-      <TenantForm onSuccess={() => navigate({ to: "/organizations" })} />
+      <TenantForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/popups/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/popups/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { PopupsService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { PopupForm } from "@/components/forms/PopupForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/popups/$id/edit")({
   component: EditPopupPage,
@@ -23,15 +24,10 @@ function getPopupQueryOptions(popupId: string) {
 }
 
 function EditPopupContent({ popupId }: { popupId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/popups" })
   const { data: popup } = useSuspenseQuery(getPopupQueryOptions(popupId))
 
-  return (
-    <PopupForm
-      defaultValues={popup}
-      onSuccess={() => navigate({ to: "/popups" })}
-    />
-  )
+  return <PopupForm defaultValues={popup} onSuccess={goBack} />
 }
 
 function EditPopupPage() {

--- a/backoffice/src/routes/_layout/popups/new.tsx
+++ b/backoffice/src/routes/_layout/popups/new.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { PopupForm } from "@/components/forms/PopupForm"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/popups/new")({
   component: NewPopup,
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_layout/popups/new")({
 
 function NewPopup() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/popups" })
   const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to popups list - they cannot create new popups
@@ -33,7 +35,7 @@ function NewPopup() {
       description="Add a new pop-up to manage"
       backTo="/popups"
     >
-      <PopupForm onSuccess={() => navigate({ to: "/popups" })} />
+      <PopupForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/products/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/products/$id.edit.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 
 import { ProductsService } from "@/client"
@@ -7,6 +7,7 @@ import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { ProductForm } from "@/components/forms/ProductForm"
 import { Skeleton } from "@/components/ui/skeleton"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/products/$id/edit")({
   component: EditProductPage,
@@ -23,15 +24,10 @@ function getProductQueryOptions(productId: string) {
 }
 
 function EditProductContent({ productId }: { productId: string }) {
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/products" })
   const { data: product } = useSuspenseQuery(getProductQueryOptions(productId))
 
-  return (
-    <ProductForm
-      defaultValues={product}
-      onSuccess={() => navigate({ to: "/products" })}
-    />
-  )
+  return <ProductForm defaultValues={product} onSuccess={goBack} />
 }
 
 function EditProductPage() {

--- a/backoffice/src/routes/_layout/products/new.tsx
+++ b/backoffice/src/routes/_layout/products/new.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { ProductForm } from "@/components/forms/ProductForm"
 import useAuth from "@/hooks/useAuth"
+import { useGoBack } from "@/hooks/useGoBack"
 
 export const Route = createFileRoute("/_layout/products/new")({
   component: NewProduct,
@@ -14,6 +15,7 @@ export const Route = createFileRoute("/_layout/products/new")({
 
 function NewProduct() {
   const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/products" })
   const { isOperatorOrAbove, isUserLoading } = useAuth()
 
   // Redirect viewers to products list - they cannot create new products
@@ -33,7 +35,7 @@ function NewProduct() {
       description="Add a new product or ticket type"
       backTo="/products"
     >
-      <ProductForm onSuccess={() => navigate({ to: "/products" })} />
+      <ProductForm onSuccess={goBack} />
     </FormPageLayout>
   )
 }

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -4,7 +4,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query"
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { Check, Info, Trash2 } from "lucide-react"
 import { Suspense, useEffect, useRef, useState } from "react"
 
@@ -45,6 +45,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
 import useCustomToast from "@/hooks/useCustomToast"
+import { useGoBack } from "@/hooks/useGoBack"
 import {
   UnsavedChangesDialog,
   useDirtyBlocker,
@@ -86,7 +87,7 @@ function StepConfigPage() {
 
 function StepConfigContent({ stepId }: { stepId: string }) {
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
+  const goBack = useGoBack({ to: "/ticketing-steps" })
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const { data: step } = useSuspenseQuery(getStepQueryOptions(stepId))
   const isSubmittingRef = useRef(false)
@@ -203,7 +204,7 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     onSuccess: () => {
       showSuccessToast("Step updated")
       queryClient.invalidateQueries({ queryKey: ["ticketing-steps"] })
-      navigate({ to: "/ticketing-steps" })
+      goBack()
     },
     onError: (error: Error) => {
       isSubmittingRef.current = false
@@ -221,7 +222,7 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     onSuccess: () => {
       showSuccessToast("Step deleted")
       queryClient.invalidateQueries({ queryKey: ["ticketing-steps"] })
-      navigate({ to: "/ticketing-steps" })
+      goBack()
     },
     onError: (error: Error) => {
       isSubmittingRef.current = false
@@ -623,10 +624,7 @@ function StepConfigContent({ stepId }: { stepId: string }) {
           </LoadingButton>
         )}
         <div className="flex-1" />
-        <Button
-          variant="outline"
-          onClick={() => navigate({ to: "/ticketing-steps" })}
-        >
+        <Button variant="outline" onClick={goBack}>
           Cancel
         </Button>
         <LoadingButton


### PR DESCRIPTION
## Summary
- Default DataTable pagination is now **50** items (was 25). The selector `[10, 25, 50, 100]` is unchanged so users can still pick another size.
- Form back navigation (FormPageLayout back button + every \`onSuccess\` after create/edit) now prefers \`router.history.back()\`. This preserves the originating list URL — including \`search\`, \`sort\`, \`page\`, and \`pageSize\` — when returning from a detail page. Falls back to a target path when there is no history (deep link / fresh tab).

## Implementation notes
- New hook \`backoffice/src/hooks/useGoBack.ts\` centralizes the canGoBack→back vs. fallback logic.
- \`FormPageLayout\` uses \`useGoBack({ to: backTo })\` internally; \`backTo\` is still the API.
- Every create/edit form (\`products\`, \`popups\`, \`coupons\`, \`groups\`, \`admin\`, \`applications\`, \`events\`, \`events/venues\`, \`events/tracks\`, \`form-builder\` + sections, \`organizations\`, \`humans\`, \`ticketing-steps\`) was migrated to use \`useGoBack\` instead of a fresh \`navigate({ to: \"/list\" })\` on success.
- \`events/tracks/new\` is intentionally NOT migrated — its \`onSuccess\` navigates to the new track's edit page, not back to the list.
- Admin \"Superadmins\" tab keeps \`useState\` (raramente usado, no warrants URL state). \"Users\" tab already used \`useTableSearchParams\` and benefits automatically.

## Test plan
- [ ] Open \`/products\`, set a search/sort/pageSize, click a row → edit → back. Filters restored.
- [ ] Same as above on \`popups\`, \`coupons\`, \`groups\`, \`applications\`, \`events\`, \`events/venues\`, \`humans\`, \`organizations\`.
- [ ] Open \`/products/<id>/edit\` directly (deep link) → back falls through to \`/products\` cleanly.
- [ ] Create new entity in any of the above → \`onSuccess\` returns to filtered list.
- [ ] Pagination selector defaults to 50; switching to 25/100 persists and survives detail round-trips.