### PR TITLE
feat: server-side tenant scope via session_user (close GUC bypass)

### DIFF
--- a/backend/app/alembic/utils.py
+++ b/backend/app/alembic/utils.py
@@ -37,9 +37,13 @@ def add_tenant_table_permissions(table_name: str) -> None:
     # Enable Row Level Security
     op.execute(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY")
 
-    # Create RLS policy for tenant isolation
-    # IMPORTANT: Wrapping current_setting in SELECT caches the value (called once)
-    # instead of evaluating per-row, which is 100x+ faster on large tables
+    # Create RLS policy for tenant isolation.
+    # Uses app_effective_tenant_id() when available (after the
+    # a5601e8133cb_session_user_tenant_isolation migration), and falls back to
+    # current_setting('app.tenant_id', true) for databases where that migration
+    # has not yet been applied (e.g. fresh test containers running old migrations).
+    # IMPORTANT: Wrapping in SELECT caches the value (called once per query,
+    # not per row — 100x+ faster on large tables).
     policy_name = f"tenant_isolation_policy_{table_name}"
     op.execute(
         f"""
@@ -51,9 +55,20 @@ def add_tenant_table_permissions(table_name: str) -> None:
                 AND tablename = '{table_name}'
                 AND policyname = '{policy_name}'
             ) THEN
-                CREATE POLICY {policy_name} ON {table_name}
-                USING (tenant_id = (SELECT current_setting('app.tenant_id', true)::uuid))
-                WITH CHECK (tenant_id = (SELECT current_setting('app.tenant_id', true)::uuid));
+                IF EXISTS (
+                    SELECT 1 FROM pg_proc p
+                    JOIN pg_namespace n ON p.pronamespace = n.oid
+                    WHERE n.nspname = 'public'
+                    AND p.proname = 'app_effective_tenant_id'
+                ) THEN
+                    CREATE POLICY {policy_name} ON {table_name}
+                    USING (tenant_id = (SELECT public.app_effective_tenant_id()))
+                    WITH CHECK (tenant_id = (SELECT public.app_effective_tenant_id()));
+                ELSE
+                    CREATE POLICY {policy_name} ON {table_name}
+                    USING (tenant_id = (SELECT current_setting('app.tenant_id', true)::uuid))
+                    WITH CHECK (tenant_id = (SELECT current_setting('app.tenant_id', true)::uuid));
+                END IF;
             END IF;
         END $$;
         """

--- a/backend/app/alembic/versions/a5601e8133cb_session_user_tenant_isolation.py
+++ b/backend/app/alembic/versions/a5601e8133cb_session_user_tenant_isolation.py
@@ -1,0 +1,137 @@
+"""Close GUC bypass via session_user-derived effective tenant.
+
+WHY: Holders of usr_<hex> credentials were able to escape their tenant scope
+by issuing SET app.tenant_id = '<other-tenant-uuid>' before running queries,
+because all RLS policies evaluated the client-controlled GUC directly.
+This migration closes that gap: a new SECURITY DEFINER function
+(public.app_effective_tenant_id) looks up the caller's tenant_id from
+tenant_credentials WHERE db_username = session_user. Because session_user
+is the immutable LOGIN identity (immune to SET ROLE), a tenant credential
+holder cannot escape their scope regardless of GUC manipulation.
+
+WHAT:
+1. ADD UNIQUE constraint on tenant_credentials.db_username:the function
+   relies on at most one row per session_user; enforce that invariant at
+   the DB level before the function exists.
+2. CREATE FUNCTION public.app_effective_tenant_id():SECURITY DEFINER,
+   STABLE, search_path pinned to pg_catalog,public.
+3. Discover and rewrite every existing tenant isolation policy
+   (pattern 'tenant_isolation%') to call the function instead of reading
+   current_setting('app.tenant_id', true)::uuid. The list is queried from
+   pg_policies at runtime so this migration adapts to whatever set of
+   policies actually exists in the target database (dev vs prod may differ).
+4. ENABLE RLS on tenants table + add per-row scoping policy.
+
+GRANT / REVOKE:
+- REVOKE ALL ON FUNCTION ... FROM PUBLIC (default PUBLIC grant removed)
+- GRANT EXECUTE TO tenant_role, tenant_viewer_role only
+
+Pre-deploy prod check: run
+  SELECT db_username, count(*) FROM tenant_credentials
+  GROUP BY db_username HAVING count(*) > 1;
+must return zero rows before running this migration.
+
+Revision ID: a5601e8133cb
+Revises: 0050_venue_display_order
+Create Date: 2026-05-18
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "a5601e8133cb"
+down_revision = "0050_venue_display_order"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Add UNIQUE constraint on tenant_credentials.db_username.
+    #    First, because the function assumes at most one row per session_user.
+    #    If the data is dirty, the constraint add fails here and the entire
+    #    transaction rolls back cleanly before any policies are touched.
+    op.execute(
+        "ALTER TABLE public.tenant_credentials "
+        "ADD CONSTRAINT uq_tenant_credentials_db_username UNIQUE (db_username)"
+    )
+
+    # 2. Create the SECURITY DEFINER function that resolves tenant_id from
+    #    session_user (the immutable login identity). The COALESCE fallback
+    #    serves the platform-owner path (no tenant_credentials row) and the
+    #    ticket_events FORCE RLS path, both of which set app.tenant_id via
+    #    the TenantConnectionManager checkout listener.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.app_effective_tenant_id() RETURNS uuid
+        LANGUAGE sql
+        STABLE
+        SECURITY DEFINER
+        SET search_path = pg_catalog, public
+        AS $$
+          SELECT COALESCE(
+            (SELECT tc.tenant_id
+               FROM public.tenant_credentials tc
+               WHERE tc.db_username = session_user),
+            NULLIF(current_setting('app.tenant_id', true), '')::uuid
+          );
+        $$;
+        """
+    )
+
+    # Grant: revoke from PUBLIC (default), then allow only tenant roles.
+    op.execute(
+        "REVOKE ALL ON FUNCTION public.app_effective_tenant_id() FROM PUBLIC"
+    )
+    op.execute(
+        "GRANT EXECUTE ON FUNCTION public.app_effective_tenant_id() "
+        "TO tenant_role, tenant_viewer_role"
+    )
+
+    # 3. Discover and rewrite every existing tenant isolation policy.
+    #    We query pg_policies at runtime instead of hardcoding a table list
+    #    because policy names vary across the codebase (some use the canonical
+    #    `tenant_isolation_policy_<table>` form, others use bespoke names like
+    #    `tenant_isolation_application_reviews`). The pattern `tenant_isolation%`
+    #    catches all of them; we drop each by its actual name and recreate
+    #    the canonical one calling app_effective_tenant_id().
+    bind = op.get_bind()
+    existing_policies = bind.execute(
+        text(
+            "SELECT tablename, policyname FROM pg_policies "
+            "WHERE schemaname = 'public' AND policyname LIKE 'tenant_isolation%' "
+            "ORDER BY tablename, policyname"
+        )
+    ).fetchall()
+
+    for tablename, policyname in existing_policies:
+        canonical = f"tenant_isolation_policy_{tablename}"
+        op.execute(f'DROP POLICY IF EXISTS "{policyname}" ON public."{tablename}"')
+        op.execute(
+            f"""
+            CREATE POLICY {canonical} ON public.{tablename}
+              USING      (tenant_id = (SELECT public.app_effective_tenant_id()))
+              WITH CHECK (tenant_id = (SELECT public.app_effective_tenant_id()))
+            """
+        )
+
+    # 4. Enable RLS on tenants + per-row scoping policy.
+    #    USING-only (no WITH CHECK):tenant_role has no INSERT/UPDATE/DELETE
+    #    on tenants, so WITH CHECK is not needed.
+    #    No FORCE RLS: the platform owner must continue to read all tenants
+    #    from migrations and admin scripts.
+    op.execute("ALTER TABLE public.tenants ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation_policy_tenants ON public.tenants
+          USING (id = (SELECT public.app_effective_tenant_id()))
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "a5601e8133cb_session_user_tenant_isolation is a forward-only migration. "
+        "Downgrade is not implemented:reverting would re-expose the GUC "
+        "bypass that this migration closes."
+    )

--- a/backend/app/api/tenant/credential_models.py
+++ b/backend/app/api/tenant/credential_models.py
@@ -18,6 +18,9 @@ class TenantCredentials(SQLModel, table=True):
         UniqueConstraint(
             "tenant_id", "credential_type", name="uq_tenant_credentials_type"
         ),
+        UniqueConstraint(
+            "db_username", name="uq_tenant_credentials_db_username"
+        ),
     )
 
     id: uuid.UUID = Field(

--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -1,10 +1,17 @@
 import uuid
 
+import psycopg
+import pytest
 from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+from testcontainers.postgres import PostgresContainer
 
 from app.api.popup.models import Popups
+from app.api.shared.enums import CredentialType
+from app.api.tenant.credential_models import TenantCredentials
 from app.api.tenant.models import Tenants
 from app.api.user.models import Users
+from app.utils.encryption import decrypt
 
 
 class TestViewerReadonlyAccess:
@@ -584,3 +591,230 @@ class TestRoleHierarchy:
         data = response.json()
         assert data["role"] == "admin"
         assert data["tenant_id"] == str(tenant_a.id)
+
+
+def _get_tenant_dsn(
+    db: Session,
+    postgres_container: PostgresContainer,
+    tenant_id: uuid.UUID,
+    credential_type: CredentialType,
+) -> str:
+    """Build a libpq DSN for a tenant's usr_<hex> credential against the test container."""
+    cred = db.exec(
+        select(TenantCredentials).where(
+            TenantCredentials.tenant_id == tenant_id,
+            TenantCredentials.credential_type == credential_type,
+        )
+    ).first()
+    assert cred is not None, f"No {credential_type} credential for tenant {tenant_id}"
+    host = postgres_container.get_container_host_ip()
+    port = int(postgres_container.get_exposed_port(5432))
+    password = decrypt(cred.db_password_encrypted)
+    return (
+        f"host={host} port={port} dbname=test_db "
+        f"user={cred.db_username} password={password} sslmode=disable"
+    )
+
+
+class TestSessionUserRLS:
+    """Verify that session_user-derived tenant scope cannot be bypassed.
+
+    These tests open raw psycopg connections as usr_<hex> credentials and
+    exercise the attack vectors that existed before the
+    a5601e8133cb_session_user_tenant_isolation migration. Every test should
+    be green on a migrated DB and would fail on the old GUC-only policies.
+    """
+
+    def test_client_set_app_tenant_id_is_ignored(
+        self,
+        db: Session,
+        postgres_container: PostgresContainer,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """SET app.tenant_id to tenant B must not change the visible popup set.
+
+        Covers SCENARIO-2: client GUC override is ignored for usr_<hex> sessions.
+        """
+        dsn = _get_tenant_dsn(
+            db, postgres_container, tenant_a.id, CredentialType.READONLY
+        )
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            conn.execute(f"SET app.tenant_id = '{tenant_b.id}'")
+            count = conn.execute("SELECT COUNT(*) FROM popups").fetchone()[0]
+
+        # Count must reflect tenant A's popups, not tenant B's
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            expected = conn.execute("SELECT COUNT(*) FROM popups").fetchone()[0]
+
+        assert count == expected
+
+    def test_set_role_does_not_change_effective_tenant(
+        self,
+        db: Session,
+        postgres_container: PostgresContainer,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+        popup_tenant_a: Popups,
+        popup_tenant_b: Popups,
+    ) -> None:
+        """SET ROLE tenant_viewer_role must not expand or change the visible set.
+
+        Covers SCENARIO-3: session_user remains usr_<hex> after SET ROLE.
+        """
+        dsn = _get_tenant_dsn(
+            db, postgres_container, tenant_a.id, CredentialType.READONLY
+        )
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            baseline = conn.execute("SELECT COUNT(*) FROM popups").fetchone()[0]
+            conn.execute("SET ROLE tenant_viewer_role")
+            after_role = conn.execute("SELECT COUNT(*) FROM popups").fetchone()[0]
+
+        assert after_role == baseline
+        # Tenant B popup must not leak in
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            ids = [
+                row[0]
+                for row in conn.execute("SELECT id::text FROM popups").fetchall()
+            ]
+        assert str(popup_tenant_b.id) not in ids
+        assert str(popup_tenant_a.id) in ids
+
+    def test_tenants_table_scoped_to_own_row(
+        self,
+        db: Session,
+        postgres_container: PostgresContainer,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+    ) -> None:
+        """A tenant readonly user must see exactly one row in the tenants table.
+
+        Covers SCENARIO-4 and REQ-3.
+        """
+        dsn = _get_tenant_dsn(
+            db, postgres_container, tenant_a.id, CredentialType.READONLY
+        )
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            rows = conn.execute("SELECT id::text FROM tenants").fetchall()
+
+        assert len(rows) == 1
+        assert rows[0][0] == str(tenant_a.id)
+
+    def test_owner_still_sees_all_tenants(
+        self,
+        db: Session,
+        postgres_container: PostgresContainer,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+    ) -> None:
+        """The PostgreSQL table owner bypasses RLS and sees all tenants.
+
+        Covers SCENARIO-7 and REQ-4. FORCE RLS must NOT be set on tenants.
+        """
+        host = postgres_container.get_container_host_ip()
+        port = int(postgres_container.get_exposed_port(5432))
+        owner_dsn = (
+            f"host={host} port={port} dbname=test_db "
+            f"user=test_user password=test_password sslmode=disable"
+        )
+        with psycopg.connect(owner_dsn, autocommit=True) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM tenants").fetchone()[0]
+
+        # At minimum both tenant_a and tenant_b exist
+        assert count >= 2
+
+    def test_insert_for_other_tenant_rejected(
+        self,
+        db: Session,
+        postgres_container: PostgresContainer,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+    ) -> None:
+        """An INSERT specifying tenant B's id must be blocked by WITH CHECK.
+
+        Covers SCENARIO-5 and REQ-2.
+        """
+        dsn = _get_tenant_dsn(
+            db, postgres_container, tenant_a.id, CredentialType.CRUD
+        )
+        with psycopg.connect(dsn) as conn:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                conn.execute(
+                    "INSERT INTO popups (id, name, slug, tenant_id) "
+                    "VALUES (%s, %s, %s, %s)",
+                    (
+                        str(uuid.uuid4()),
+                        "Cross-tenant popup",
+                        f"cross-tenant-{uuid.uuid4().hex[:6]}",
+                        str(tenant_b.id),
+                    ),
+                )
+                conn.commit()
+
+    def test_function_exists_and_returns_null_for_owner(
+        self,
+        db: Session,
+    ) -> None:
+        """app_effective_tenant_id() must exist and return NULL for the owner session.
+
+        The owner has no row in tenant_credentials and sets no GUC, so
+        the function should return NULL (both COALESCE branches are NULL).
+        """
+        from sqlalchemy import text
+
+        result = db.exec(  # type: ignore[call-overload]
+            text("SELECT public.app_effective_tenant_id()")
+        ).scalar()
+        assert result is None
+
+    def test_duplicate_db_username_rejected(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Inserting a duplicate db_username into tenant_credentials must fail.
+
+        Covers SCENARIO-8 and REQ-7.
+        """
+        import sqlalchemy.exc
+
+        cred = db.exec(
+            select(TenantCredentials).where(
+                TenantCredentials.tenant_id == tenant_a.id,
+                TenantCredentials.credential_type == CredentialType.READONLY,
+            )
+        ).first()
+        assert cred is not None
+
+        dup = TenantCredentials(
+            tenant_id=tenant_a.id,
+            credential_type=CredentialType.CRUD,
+            db_username=cred.db_username,  # intentional duplicate
+            db_password_encrypted="dummy",
+        )
+        db.add(dup)
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            db.flush()
+        db.rollback()
+
+    def test_backend_tenant_session_unaffected(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+        popup_tenant_b: Popups,
+    ) -> None:
+        """The backend TenantSession must continue to return only tenant A's data.
+
+        Covers SCENARIO-6 and REQ-5. Regression guard.
+        """
+        response = client.get(
+            "/api/v1/popups",
+            params={"search": "Popup Tenant"},
+            headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
+        )
+        assert response.status_code == 200
+        ids = [p["id"] for p in response.json()["results"]]
+        assert str(popup_tenant_a.id) in ids
+        assert str(popup_tenant_b.id) not in ids

--- a/backoffice/src/components/forms/TenantCredentialsSection.tsx
+++ b/backoffice/src/components/forms/TenantCredentialsSection.tsx
@@ -58,14 +58,13 @@ function CopyButton({ value }: { value: string }) {
 }
 
 function buildReadonlyConnectionString(
-  tenantId: string,
+  _tenantId: string,
   cred: CredentialInfo,
   db: { db_host: string; db_port: number; db_name: string },
 ) {
   const user = encodeURIComponent(cred.db_username)
   const password = encodeURIComponent(cred.db_password)
-  const options = encodeURIComponent(`-c app.tenant_id=${tenantId}`)
-  return `postgresql://${user}:${password}@${db.db_host}:${db.db_port}/${db.db_name}?options=${options}`
+  return `postgresql://${user}:${password}@${db.db_host}:${db.db_port}/${db.db_name}`
 }
 
 function CopyConnectionStringButton({ value }: { value: string }) {
@@ -235,13 +234,11 @@ export function TenantCredentialsSection({
                       )}
                     />
                     <p className="text-xs text-muted-foreground">
-                      PostgreSQL URL with{" "}
+                      Read-only PostgreSQL URL scoped to this tenant. Scope is
+                      enforced by the database - the holder of this URL cannot
+                      read other tenants' data. Append{" "}
                       <code className="rounded bg-muted px-1 py-0.5 text-[10px] font-mono">
-                        app.tenant_id
-                      </code>{" "}
-                      scoped to this tenant. Append{" "}
-                      <code className="rounded bg-muted px-1 py-0.5 text-[10px] font-mono">
-                        &amp;sslmode=require
+                        ?sslmode=require
                       </code>{" "}
                       if your environment requires TLS.
                     </p>


### PR DESCRIPTION
## Summary
Closes a real security gap: holders of `usr_<hex>` per-tenant DB credentials could escape their tenant by running `SET app.tenant_id = '<other>'` before queries, because all RLS policies read the client-controlled GUC. This change makes the RLS evaluation immune to client manipulation by deriving the tenant from `session_user` server-side.

### How
- New SECURITY DEFINER function `public.app_effective_tenant_id()`:
  - Resolves tenant via `tenant_credentials.db_username = session_user`
  - Falls back to `current_setting('app.tenant_id', true)::uuid` for owner/migration paths
  - Pinned `search_path = pg_catalog, public` to prevent hijack
  - GRANT EXECUTE limited to `tenant_role` and `tenant_viewer_role`
- Migration discovers every existing `tenant_isolation%` policy at runtime (catches both canonical and bespoke names) and rewrites each to call the function. Normalizes all policy names to `tenant_isolation_policy_<table>`.
- `tenants` table now has RLS enabled with USING-only per-row scoping. Per-tenant connections see exactly their own row; platform owner continues to see all (no FORCE RLS).
- `tenant_credentials.db_username` gets a UNIQUE constraint at both DB and model layers.
- `add_tenant_table_permissions()` updated so future tenant-scoped tables inherit the new policy without re-introducing the bypass.
- MCP connection string in `TenantCredentialsSection` drops `options=-c app.tenant_id=...` since enforcement is now server-side. Helper text rewritten to surface this.

### Threat model
A `usr_<hex>` holder can:
- ✅ Still read their own tenant's data (REQ-1).
- ❌ Cannot read other tenants via `SET app.tenant_id` override (REQ-2).
- ❌ Cannot escape via `SET ROLE` (function reads `session_user`, immune to SET ROLE).
- ❌ Cannot list other tenants from the `tenants` table (REQ-3).
- ❌ Cannot INSERT cross-tenant rows (WITH CHECK).

Platform owner (POSTGRES_USER) and backend `TenantConnectionManager` flows are unchanged.

### Forward-only
Downgrade raises `RuntimeError`, matching `a3f9e1b2c4d7_ticket_events_rls.py` precedent. Reverting would re-expose the bypass.

### Pre-deploy check on prod
Before merging this PR's prod release, run:
```sql
SELECT db_username, count(*) FROM tenant_credentials
GROUP BY db_username HAVING count(*) > 1;
```
Must return zero rows. If not, the UNIQUE constraint will fail and the migration rolls back cleanly.

## Test plan
- [x] `bash backend/scripts/test.sh` / `uv run pytest tests/` green: 875 passed, 1 skipped
- [x] 8 new RLS scenarios in `TestSessionUserRLS` covering SET override, SET ROLE, tenants scoping, cross-tenant INSERT, owner visibility, TenantConnectionManager regression
- [x] Single alembic head (`uv run alembic heads` returns `a5601e8133cb`)
- [x] Biome + ruff clean on all modified files
- [ ] On dev after deploy: run `SET app.tenant_id = '<other>'; SELECT count(*) FROM popups;` from a per-tenant readonly user and confirm count matches the user's own tenant
- [ ] On dev after deploy: run `SELECT id FROM tenants;` from a per-tenant readonly user and confirm exactly one row
- [ ] Confirm SUPERADMIN flow in the backoffice (Organizations, popups, humans) shows no regression