### PR TITLE
fix(checkout): stable per-item ids in FAQs accordion

### DIFF
--- a/portal/src/components/checkout-flow/variants/VariantFaqs.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantFaqs.tsx
@@ -24,7 +24,12 @@ interface FaqItem {
 function parseFaqs(templateConfig: VariantProps["templateConfig"]): FaqItem[] {
   const raw = templateConfig?.items
   if (!Array.isArray(raw) || raw.length === 0) return []
-  return raw as FaqItem[]
+  // Without a stable id, opening one row makes `openId === item.id` match every undefined item.
+  return (raw as Partial<FaqItem>[]).map((item, idx) => ({
+    id: item.id ?? `faq-${idx}`,
+    question: item.question ?? "",
+    answer: item.answer ?? "",
+  }))
 }
 
 function SectionTitle({ title }: { title?: string }) {


### PR DESCRIPTION
## Summary
- `parseFaqs` cast raw template-config items as `FaqItem[]` without ensuring each item had an `id`.
- When the admin payload omitted `id`, every item's `openId === item.id` check collapsed to `undefined === undefined`, so opening any FAQ row opened them all.
- Falls back to `faq-${idx}` when no id is present, preserving any explicit id the admin set.

## Test plan
- [ ] Manual: configure a FAQs step with seed items lacking `id` and verify tap-to-toggle behaves as single-open accordion.
- [ ] Manual: configure with explicit `id` per item and confirm those ids are still respected.