### PR TITLE
feat(checkout): respect real buyer-step row when present

### DIFF
--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -240,8 +240,14 @@ export function CheckoutProvider({
       return configuredSteps
     }
 
-    // Inherit show_title/show_watermark from confirm: buyer sits adjacent to it
-    // and admins typically want consistent display between the two.
+    // Post-migration, every direct-sale popup carries a real `buyer` row whose
+    // position the admin controls from the backoffice — use it as-is.
+    if (configuredSteps.some((step) => step.step_type === "buyer")) {
+      return configuredSteps
+    }
+
+    // Legacy fallback: popup hasn't been migrated yet. Synthesize a buyer
+    // step and slot it just before confirm so checkout still works.
     const confirmStep = configuredSteps.find(
       (step) => step.step_type === "confirm",
     )
@@ -264,21 +270,18 @@ export function CheckoutProvider({
       show_watermark: confirmStep?.show_watermark ?? true,
     }
 
-    const withoutBuyer = configuredSteps.filter(
-      (step) => step.step_type !== "buyer",
-    )
-    const confirmIndex = withoutBuyer.findIndex(
+    const confirmIndex = configuredSteps.findIndex(
       (step) => step.step_type === "confirm",
     )
 
     if (confirmIndex === -1) {
-      return [...withoutBuyer, buyerStep]
+      return [...configuredSteps, buyerStep]
     }
 
     return [
-      ...withoutBuyer.slice(0, confirmIndex),
+      ...configuredSteps.slice(0, confirmIndex),
       buyerStep,
-      ...withoutBuyer.slice(confirmIndex),
+      ...configuredSteps.slice(confirmIndex),
     ]
   }, [buyerFormSchema, cityId, configuredSteps, submitMode, t])
 


### PR DESCRIPTION
## Summary
- After alembic migration `c8d3a5e1f29b` backfills a real `ticketing_steps` row (step_type=`buyer`, template=`buyer-form`) for every direct-sale popup, the portal was still synthesizing its own buyer step with `order: 9998` and slice-splicing it just before confirm — silently ignoring the admin-controlled position on the real row.
- `effectiveConfiguredSteps` now early-returns `configuredSteps` when it already contains a `buyer` row, so the admin's order (and title, emoji, etc.) wins.
- The synthetic-injection fallback remains for legacy popups that haven't been backfilled yet — safe to delete once we're confident every direct-sale popup has a row.

## What changes for tenants
- Admins can now reorder, rename, and re-emoji the "Tu información" step from the backoffice ticketing-steps editor.
- Tenants whose buyer row title is still the default `"Your information"` (set by the migration) will see that string in every locale instead of the previous i18n key `checkout.buyer_step_title`. If that's undesirable, they update the title on the row itself.

## Test plan
- [ ] Manual: in a popup post-migration, drag the buyer step to position 0 in the backoffice → confirm the portal renders it first.
- [ ] Manual: confirm a popup pre-migration (no buyer row, if any still exist) still renders the synthetic step before confirm.
- [ ] Manual: confirm `CartFooter`'s "Continuar from buyer" pre-gate still fires regardless of buyer's position in the funnel.
- [ ] Manual: confirm the `findFirstIncompleteStep` bounce from the confirm step still lands on the buyer step.

## Out of scope
The amanita branch's commit 7e25872 bundled this with i18n cleanup (errors.payment_failed etc.), an email-validation rule, and ConfirmStep polish. Those land separately if needed — this PR is just the buyer-row plumbing.