### PR TITLE
feat(housing): multi-image carousel + lightbox in grid/showcase

### DIFF
--- a/backend/app/alembic/versions/0051_product_images.py
+++ b/backend/app/alembic/versions/0051_product_images.py
@@ -1,0 +1,39 @@
+"""Add `images` JSONB column to products for multi-image carousel support.
+
+Housing products in the grid/showcase variants now support a gallery of
+images. `image_url` remains the cover (rendered first); `images` holds
+any additional photos rendered in the swipe carousel + lightbox.
+
+Default is `[]` so existing single-image products keep their current
+look (the cover-only render path doesn't read `images`).
+
+Revision ID: 0051_product_images
+Revises: 0050_venue_display_order
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0051_product_images"
+down_revision: str | Sequence[str] | None = "0050_venue_display_order"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "products",
+        sa.Column(
+            "images",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("products", "images")

--- a/backend/app/alembic/versions/370ff7f4e042_product_images.py
+++ b/backend/app/alembic/versions/370ff7f4e042_product_images.py
@@ -8,7 +8,7 @@ Default is `[]` so existing single-image products keep their current
 look (the cover-only render path doesn't read `images`).
 
 Revision ID: 370ff7f4e042
-Revises: 0050_venue_display_order
+Revises: a5601e8133cb
 """
 
 from collections.abc import Sequence
@@ -18,7 +18,7 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 revision: str = "370ff7f4e042"
-down_revision: str | Sequence[str] | None = "0050_venue_display_order"
+down_revision: str | Sequence[str] | None = "a5601e8133cb"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/alembic/versions/370ff7f4e042_product_images.py
+++ b/backend/app/alembic/versions/370ff7f4e042_product_images.py
@@ -7,7 +7,7 @@ any additional photos rendered in the swipe carousel + lightbox.
 Default is `[]` so existing single-image products keep their current
 look (the cover-only render path doesn't read `images`).
 
-Revision ID: 0051_product_images
+Revision ID: 370ff7f4e042
 Revises: 0050_venue_display_order
 """
 
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "0051_product_images"
+revision: str = "370ff7f4e042"
 down_revision: str | Sequence[str] | None = "0050_venue_display_order"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/backend/app/api/product/schemas.py
+++ b/backend/app/api/product/schemas.py
@@ -5,6 +5,7 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from sqlalchemy import Boolean, Numeric, Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Column, DateTime, Field, SQLModel
 
 from app.api.product.sale_window import datetime_to_inclusive_date
@@ -48,6 +49,12 @@ class ProductBase(SQLModel):
     )
     description: str | None = Field(default=None, nullable=True, sa_type=Text())
     image_url: str | None = Field(default=None, nullable=True)
+    # Additional images shown after `image_url` (the cover) in the housing
+    # grid/showcase carousel. Empty for single-image products.
+    images: list[str] = Field(
+        default_factory=list,
+        sa_column=Column(JSONB, nullable=False, server_default="'[]'::jsonb"),
+    )
     category: str = Field(default="ticket", index=True)
     # FK to attendee_categories (authoritative post-migration)
     attendee_category_id: uuid.UUID | None = Field(
@@ -117,6 +124,7 @@ class ProductCreate(BaseModel):
     compare_price: Decimal | None = Field(default=None, ge=0)
     description: str | None = None
     image_url: str | None = None
+    images: list[str] = Field(default_factory=list)
     category: str = "ticket"
     duration_type: TicketDuration | None = None
     sale_starts_at: date | None = None
@@ -189,6 +197,7 @@ class ProductUpdate(BaseModel):
     compare_price: Decimal | None = Field(default=None, ge=0)
     description: str | None = None
     image_url: str | None = None
+    images: list[str] | None = None
     category: str | None = None
     duration_type: TicketDuration | None = None
     sale_starts_at: date | None = None
@@ -240,6 +249,7 @@ class ProductBatchItem(BaseModel):
     compare_price: Decimal | None = Field(default=None, ge=0)
     description: str | None = None
     image_url: str | None = None
+    images: list[str] = Field(default_factory=list)
     category: str = "ticket"
     duration_type: TicketDuration | None = None
     sale_starts_at: date | None = None

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2457,6 +2457,7 @@ export type ProductBatchItem = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<string>;
     category?: string;
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2482,6 +2483,7 @@ export type ProductBatchResult = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<string>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);
@@ -2522,6 +2524,7 @@ export type ProductCreate = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<string>;
     category?: string;
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2560,6 +2563,7 @@ export type ProductPublic = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<string>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);
@@ -2585,6 +2589,7 @@ export type ProductUpdate = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: (Array<string> | null);
     category?: (string | null);
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);

--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -48,6 +48,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { LoadingButton } from "@/components/ui/loading-button"
+import { MultiImageUpload } from "@/components/ui/multi-image-upload"
 import {
   Select,
   SelectContent,
@@ -191,6 +192,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
       compare_price: defaultValues?.compare_price?.toString() ?? "",
       description: defaultValues?.description ?? "",
       image_url: defaultValues?.image_url ?? "",
+      images: defaultValues?.images ?? [],
       category: (defaultValues?.category ?? "ticket") as ProductCategory,
       duration_type: (defaultValues?.duration_type ?? "full") as TicketDuration,
       requires_check_in:
@@ -221,6 +223,9 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
         ? Number.parseInt(value.max_per_order, 10)
         : null
 
+      const isHousing = value.category === "housing"
+      const housingImages = isHousing ? value.images : []
+
       if (isEdit) {
         updateMutation.mutate({
           name: value.name,
@@ -228,6 +233,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
           compare_price: effectiveComparePrice,
           description: value.description || null,
           image_url: value.image_url || null,
+          images: housingImages,
           category: value.category,
           duration_type: isTicket ? value.duration_type : null,
           sale_starts_at:
@@ -253,6 +259,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
           compare_price: effectiveComparePrice ?? undefined,
           description: value.description || undefined,
           image_url: value.image_url || undefined,
+          images: housingImages,
           category: value.category,
           duration_type: isTicket ? value.duration_type : undefined,
           sale_starts_at:
@@ -414,6 +421,33 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
             </div>
           )}
         </form.Field>
+
+        {/* Additional images — housing-only, rendered as a carousel in the
+            grid/showcase checkout variants. The cover above is image #1. */}
+        <form.Subscribe selector={(state) => state.values.category}>
+          {(category) =>
+            category === "housing" ? (
+              <form.Field name="images">
+                {(field) => (
+                  <div className="space-y-2">
+                    <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Additional images
+                    </p>
+                    <p className="px-1 text-xs text-muted-foreground">
+                      Shown after the cover in the grid/showcase carousel. Tap
+                      enlarges to a lightbox.
+                    </p>
+                    <MultiImageUpload
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      disabled={readOnly}
+                    />
+                  </div>
+                )}
+              </form.Field>
+            ) : null
+          }
+        </form.Subscribe>
 
         <Separator />
 

--- a/backoffice/src/components/ui/multi-image-upload.tsx
+++ b/backoffice/src/components/ui/multi-image-upload.tsx
@@ -1,0 +1,71 @@
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "./button"
+import { ImageUpload } from "./image-upload"
+
+interface MultiImageUploadProps {
+  value: string[]
+  onChange: (urls: string[]) => void
+  className?: string
+  disabled?: boolean
+  /** Max number of images (inclusive). Defaults to no limit. */
+  max?: number
+}
+
+export function MultiImageUpload({
+  value,
+  onChange,
+  className,
+  disabled,
+  max,
+}: MultiImageUploadProps) {
+  const atCapacity = max !== undefined && value.length >= max
+
+  const append = (url: string | null) => {
+    if (!url) return
+    if (atCapacity) return
+    onChange([...value, url])
+  }
+
+  const removeAt = (idx: number) => {
+    const next = value.slice()
+    next.splice(idx, 1)
+    onChange(next)
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {value.map((url, idx) => (
+            <div
+              key={`${url}-${idx}`}
+              className="relative h-24 w-24 overflow-hidden rounded-lg border"
+            >
+              <img
+                src={url}
+                alt={`Image ${idx + 1}`}
+                className="h-full w-full object-cover"
+              />
+              {!disabled && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="icon"
+                  aria-label={`Remove image ${idx + 1}`}
+                  className="absolute -top-1.5 -right-1.5 h-5 w-5"
+                  onClick={() => removeAt(idx)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+      {!atCapacity && (
+        <ImageUpload value={null} onChange={append} disabled={disabled} />
+      )}
+    </div>
+  )
+}

--- a/backoffice/src/components/ui/multi-image-upload.tsx
+++ b/backoffice/src/components/ui/multi-image-upload.tsx
@@ -38,22 +38,21 @@ export function MultiImageUpload({
       {value.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {value.map((url, idx) => (
-            <div
-              key={`${url}-${idx}`}
-              className="relative h-24 w-24 overflow-hidden rounded-lg border"
-            >
-              <img
-                src={url}
-                alt={`Image ${idx + 1}`}
-                className="h-full w-full object-cover"
-              />
+            <div key={`${url}-${idx}`} className="relative h-24 w-24">
+              <div className="h-full w-full overflow-hidden rounded-lg border">
+                <img
+                  src={url}
+                  alt={`Image ${idx + 1}`}
+                  className="h-full w-full object-cover"
+                />
+              </div>
               {!disabled && (
                 <Button
                   type="button"
                   variant="destructive"
                   size="icon"
                   aria-label={`Remove image ${idx + 1}`}
-                  className="absolute -top-1.5 -right-1.5 h-5 w-5"
+                  className="absolute -top-2 -right-2 h-6 w-6"
                   onClick={() => removeAt(idx)}
                 >
                   <X className="h-3 w-3" />

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2560,6 +2560,7 @@ export type ProductPublic = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<string>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -386,6 +386,12 @@ function ProductImageCarousel({
   const imageClickProps = hasMany
     ? {
         onClick: openLightbox,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === "Enter" || e.key === " ") {
+            if (e.key === " ") e.preventDefault()
+            openLightbox(e)
+          }
+        },
         role: "button" as const,
         tabIndex: 0,
         "aria-label": t("checkout.housing.carousel.enlarge_aria", {

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import Image from "next/image"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
@@ -346,6 +347,7 @@ function ProductImageCarousel({
   showChevrons?: boolean
   className?: string
 }) {
+  const { t } = useTranslation()
   const [idx, setIdx] = useState(0)
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const hasMany = images.length > 1
@@ -386,7 +388,9 @@ function ProductImageCarousel({
         onClick: openLightbox,
         role: "button" as const,
         tabIndex: 0,
-        "aria-label": `Enlarge ${alt}`,
+        "aria-label": t("checkout.housing.carousel.enlarge_aria", {
+          name: alt,
+        }),
         className: cn(
           "relative w-full bg-muted overflow-hidden cursor-zoom-in",
           aspectClass,
@@ -411,7 +415,7 @@ function ProductImageCarousel({
               type="button"
               onClick={prev}
               className="absolute left-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-black/40 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/60 transition"
-              aria-label="Previous image"
+              aria-label={t("checkout.housing.carousel.previous_image_aria")}
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
@@ -419,7 +423,7 @@ function ProductImageCarousel({
               type="button"
               onClick={next}
               className="absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-black/40 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/60 transition"
-              aria-label="Next image"
+              aria-label={t("checkout.housing.carousel.next_image_aria")}
             >
               <ChevronRight className="w-4 h-4" />
             </button>

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { Building2, Calendar, Check, Home } from "lucide-react"
+import {
+  Building2,
+  Calendar,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Home,
+} from "lucide-react"
 import Image from "next/image"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
@@ -19,6 +26,7 @@ import {
 } from "@/types/checkout"
 import type { ProductsPass } from "@/types/Products"
 import type { VariantProps } from "../registries/variantRegistry"
+import { LightboxOverlay } from "./VariantImageGallery"
 
 /* ── Section types & helpers ─────────────────────────────── */
 
@@ -318,6 +326,133 @@ function CompactCard({
   )
 }
 
+/* ── Product image carousel (grid + showcase only) ───────── */
+
+// Cover + additional images for a housing product. Single-image products
+// render unchanged (no chevrons, no overlay click). Multi-image products
+// get in-place chevrons and tap-to-lightbox using the gallery step's
+// LightboxOverlay. Tap, prev, next stop propagation so the parent card's
+// select-on-tap stays scoped to the non-image regions.
+function ProductImageCarousel({
+  images,
+  alt,
+  aspectClass = "aspect-[4/3]",
+  showChevrons = true,
+  className,
+}: {
+  images: string[]
+  alt: string
+  aspectClass?: string
+  showChevrons?: boolean
+  className?: string
+}) {
+  const [idx, setIdx] = useState(0)
+  const [lightboxOpen, setLightboxOpen] = useState(false)
+  const hasMany = images.length > 1
+
+  const safeIdx = idx < images.length ? idx : 0
+
+  const next = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation()
+    setIdx((i) => (i + 1) % images.length)
+  }
+  const prev = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation()
+    setIdx((i) => (i - 1 + images.length) % images.length)
+  }
+  const openLightbox = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation()
+    setLightboxOpen(true)
+  }
+
+  if (images.length === 0) {
+    return (
+      <div
+        className={cn(
+          "w-full bg-gradient-to-br from-muted to-muted/60 flex items-center justify-center",
+          aspectClass,
+          className,
+        )}
+      >
+        <Home className="w-8 h-8 text-muted-foreground/50" />
+      </div>
+    )
+  }
+
+  // Single-image products keep the parent's tap-to-select UX — bubble all
+  // clicks. Multi-image products take over the image tap to open lightbox.
+  const imageClickProps = hasMany
+    ? {
+        onClick: openLightbox,
+        role: "button" as const,
+        tabIndex: 0,
+        "aria-label": `Enlarge ${alt}`,
+        className: cn(
+          "relative w-full bg-muted overflow-hidden cursor-zoom-in",
+          aspectClass,
+          className,
+        ),
+      }
+    : {
+        className: cn(
+          "relative w-full bg-muted overflow-hidden",
+          aspectClass,
+          className,
+        ),
+      }
+
+  return (
+    <>
+      <div {...imageClickProps}>
+        <Image src={images[safeIdx]} alt={alt} fill className="object-cover" />
+        {hasMany && showChevrons && (
+          <>
+            <button
+              type="button"
+              onClick={prev}
+              className="absolute left-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-black/40 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/60 transition"
+              aria-label="Previous image"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={next}
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 rounded-full bg-black/40 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/60 transition"
+              aria-label="Next image"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-black/40 backdrop-blur-sm text-white text-[10px] font-medium px-2 py-0.5 leading-none">
+              {safeIdx + 1}/{images.length}
+            </div>
+          </>
+        )}
+        {hasMany && !showChevrons && (
+          <div className="absolute bottom-1 right-1 rounded bg-black/50 backdrop-blur-sm text-white text-[10px] font-medium px-1.5 py-0.5 leading-none">
+            {images.length}
+          </div>
+        )}
+      </div>
+      {lightboxOpen && (
+        <LightboxOverlay
+          images={images.map((url, i) => ({ id: `${url}-${i}`, url }))}
+          initialIndex={safeIdx}
+          onClose={() => setLightboxOpen(false)}
+        />
+      )}
+    </>
+  )
+}
+
+// Build the carousel list for a product: cover first, then additional images.
+function productImages(product: ProductsPass): string[] {
+  const extra = Array.isArray(product.images) ? product.images : []
+  return [product.image_url, ...extra].filter(
+    (u): u is string => typeof u === "string" && u.length > 0,
+  )
+}
+
 /* ── Grid card (single product) ──────────────────────────── */
 
 function GridCard({
@@ -365,20 +500,11 @@ function GridCard({
           : "border-border hover:border-muted-foreground/30",
       )}
     >
-      {product.image_url ? (
-        <div className="relative w-full aspect-[4/3] bg-muted">
-          <Image
-            src={product.image_url}
-            alt={product.name}
-            fill
-            className="object-cover"
-          />
-        </div>
-      ) : (
-        <div className="w-full aspect-[4/3] bg-gradient-to-br from-muted to-muted/60 flex items-center justify-center">
-          <Home className="w-8 h-8 text-muted-foreground/50" />
-        </div>
-      )}
+      <ProductImageCarousel
+        images={productImages(product)}
+        alt={product.name}
+        aspectClass="aspect-[4/3]"
+      />
 
       {supportsQty ? (
         <div className="absolute top-2 right-2 rounded-full bg-background/90 backdrop-blur-sm shadow-sm px-1.5 py-0.5">
@@ -739,13 +865,13 @@ function ShowcaseSectionCard({
                     : "bg-muted hover:bg-muted/80 ring-1 ring-border",
                 )}
               >
-                {product.image_url && (
+                {productImages(product).length > 0 && (
                   <div className="w-16 h-16 rounded-lg overflow-hidden bg-muted shrink-0 relative">
-                    <Image
-                      src={product.image_url}
+                    <ProductImageCarousel
+                      images={productImages(product)}
                       alt={product.name}
-                      fill
-                      className="object-cover"
+                      aspectClass="aspect-square"
+                      showChevrons={false}
                     />
                   </div>
                 )}

--- a/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
@@ -18,7 +18,7 @@ import type { VariantProps } from "../registries/variantRegistry"
 // Types & helpers
 // ---------------------------------------------------------------------------
 
-interface GalleryImage {
+export interface GalleryImage {
   id: string
   url: string
   caption?: string
@@ -47,7 +47,7 @@ function Caption({ text }: { text?: string }) {
 // the parent jump to a different image without going through close first.
 // ---------------------------------------------------------------------------
 
-function LightboxOverlay({
+export function LightboxOverlay({
   images,
   initialIndex,
   onClose,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -239,6 +239,13 @@
       "pause_aria": "Pause background video",
       "mute_aria": "Mute background video",
       "unmute_aria": "Unmute background video"
+    },
+    "housing": {
+      "carousel": {
+        "enlarge_aria": "Enlarge {{name}}",
+        "previous_image_aria": "Previous image",
+        "next_image_aria": "Next image"
+      }
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -239,6 +239,13 @@
       "pause_aria": "Pausar video de fondo",
       "mute_aria": "Silenciar video de fondo",
       "unmute_aria": "Activar sonido del video de fondo"
+    },
+    "housing": {
+      "carousel": {
+        "enlarge_aria": "Ampliar {{name}}",
+        "previous_image_aria": "Imagen anterior",
+        "next_image_aria": "Siguiente imagen"
+      }
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -229,6 +229,13 @@
       "pause_aria": "Stöðva bakgrunnsmyndband",
       "mute_aria": "Slökkva á hljóði bakgrunnsmyndbands",
       "unmute_aria": "Kveikja á hljóði bakgrunnsmyndbands"
+    },
+    "housing": {
+      "carousel": {
+        "enlarge_aria": "Stækka {{name}}",
+        "previous_image_aria": "Fyrri mynd",
+        "next_image_aria": "Næsta mynd"
+      }
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -239,6 +239,13 @@
       "pause_aria": "暂停背景视频",
       "mute_aria": "静音背景视频",
       "unmute_aria": "取消静音背景视频"
+    },
+    "housing": {
+      "carousel": {
+        "enlarge_aria": "放大 {{name}}",
+        "previous_image_aria": "上一张图片",
+        "next_image_aria": "下一张图片"
+      }
     }
   },
   "openCheckout": {


### PR DESCRIPTION
## Summary
Housing products can now have multiple photos. In the **grid** and **showcase** checkout variants the extra images surface as a swipeable/chevron carousel and tap-to-lightbox using the gallery step's existing `LightboxOverlay`. The cover (`image_url`) stays as image #1; `images` carries the rest. Other variants and non-housing products are untouched.

## Stack
- **Backend** — alembic migration `0051_product_images` adds `images` JSONB (NOT NULL, default `[]`) to `products`. `ProductBase` / `ProductCreate` / `ProductUpdate` / `ProductBatchItem` schemas gain the field.
- **Backoffice** — new `MultiImageUpload` (a thumbnail list + an "add another" `ImageUpload` tile). `ProductForm` shows "Additional images" only when `category === 'housing'`; for other categories `images` is never sent.
- **Portal** — new `ProductImageCarousel` in `VariantHousingDate`. Single-image products keep their existing tap-to-select UX. Multi-image products: chevron prev/next + "1/N" indicator + tap opens lightbox. `GridCard` routes through it (4:3 aspect). `ShowcaseSectionCard`'s 64×64 thumb uses the same carousel with chevrons hidden — small badge + tap-to-lightbox.
- `LightboxOverlay` and `GalleryImage` are now exported from `VariantImageGallery` for reuse.

## Validation plan
- [ ] Run migrations: `alembic upgrade heads` (the project has multi-head migrations, see memory note).
- [ ] In the backoffice, open a housing product and add 2–3 additional images.
- [ ] Open a checkout with that housing product in a **grid** variant step → carousel chevrons + indicator visible, tap opens lightbox.
- [ ] Repeat in a **showcase** variant step → small "N" badge on the 64×64 thumb, tap opens lightbox.
- [ ] In a **default** or **compact** housing variant → only the cover renders, no chevrons, tap-to-select preserved.

## Out of scope (follow-ups)
- Drag-to-reorder of additional images in the backoffice. Admins currently delete + re-upload to reorder.
- Mobile swipe gesture inside the carousel (chevron + lightbox swipe still works).