### PR TITLE
feat(checkout): mp4 video background with audio toggle

### DIFF
--- a/backend/app/api/upload/router.py
+++ b/backend/app/api/upload/router.py
@@ -13,7 +13,10 @@ from app.services.storage import storage_service
 router = APIRouter(prefix="/uploads", tags=["uploads"])
 
 ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp"}
-ALLOWED_BACKOFFICE_TYPES = ALLOWED_IMAGE_TYPES | {"application/pdf"}
+ALLOWED_VIDEO_TYPES = {"video/mp4"}
+ALLOWED_BACKOFFICE_TYPES = ALLOWED_IMAGE_TYPES | ALLOWED_VIDEO_TYPES | {
+    "application/pdf"
+}
 ALLOWED_PORTAL_TYPES = ALLOWED_IMAGE_TYPES
 
 
@@ -39,7 +42,12 @@ def _build_presigned_url(
         extension = "bin"
 
     key_tenant = str(tenant_id) if tenant_id else "superadmin"
-    folder = "documents" if content_type == "application/pdf" else "images"
+    if content_type == "application/pdf":
+        folder = "documents"
+    elif content_type.startswith("video/"):
+        folder = "videos"
+    else:
+        folder = "images"
     key = f"{key_tenant}/{folder}/{uuid4()}.{extension}"
 
     storage = storage_service()

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -832,7 +832,8 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                     <p className="text-sm font-medium">Checkout Background</p>
                     <p className="text-xs text-muted-foreground">
                       Full-screen background for checkout, invite, and success
-                      pages. Falls back to Cover Image, then tenant background.
+                      pages. Image or MP4 video (autoplay + audio toggle). Falls
+                      back to Cover Image, then tenant background.
                     </p>
                   </div>
                 </div>
@@ -840,6 +841,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                   value={field.state.value || null}
                   onChange={(url) => field.handleChange(url ?? "")}
                   disabled={readOnly}
+                  accept="image+video"
                 />
               </div>
             )}

--- a/backoffice/src/components/ui/image-upload.tsx
+++ b/backoffice/src/components/ui/image-upload.tsx
@@ -17,6 +17,16 @@ interface ImageUploadProps {
    * pre-cropped to the display aspect instead of being cropped by CSS.
    */
   cropAspect?: number
+  /** When "image+video", also accepts .mp4. Preview switches to <video>. */
+  accept?: "image" | "image+video"
+}
+
+const IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"]
+const VIDEO_TYPES = ["video/mp4"]
+const VIDEO_MAX_BYTES = 30 * 1024 * 1024 // 30 MB — short background loops only.
+
+function isVideoUrl(url: string): boolean {
+  return url.split("?")[0].split("#")[0].toLowerCase().endsWith(".mp4")
 }
 
 export function ImageUpload({
@@ -25,8 +35,17 @@ export function ImageUpload({
   className,
   disabled,
   cropAspect,
+  accept = "image",
 }: ImageUploadProps) {
-  const { uploadFile, uploadProgress, reset, isUploading } = useFileUpload()
+  const allowVideo = accept === "image+video"
+  const acceptedTypes = allowVideo
+    ? [...IMAGE_TYPES, ...VIDEO_TYPES]
+    : IMAGE_TYPES
+  const inputAccept = acceptedTypes.join(",")
+  const { uploadFile, uploadProgress, reset, isUploading } = useFileUpload({
+    acceptedTypes,
+    maxSize: allowVideo ? VIDEO_MAX_BYTES : undefined,
+  })
   const [dragActive, setDragActive] = useState(false)
   const [pendingCrop, setPendingCrop] = useState<{
     url: string
@@ -47,7 +66,10 @@ export function ImageUpload({
 
   const handleFile = useCallback(
     async (file: File) => {
-      if (cropAspect) {
+      // Videos bypass the cropper — the cropper only knows how to crop a
+      // still image.
+      const isVideo = file.type.startsWith("video/")
+      if (cropAspect && !isVideo) {
         const url = URL.createObjectURL(file)
         setPendingCrop({ url, name: file.name })
         return
@@ -120,11 +142,22 @@ export function ImageUpload({
     return (
       <>
         <div className={cn("relative inline-block min-h-[80px] min-w-[80px]", className)}>
-          <img
-            src={value}
-            alt="Uploaded"
-            className="max-w-full h-auto rounded-lg border max-h-48 object-contain"
-          />
+          {isVideoUrl(value) ? (
+            <video
+              src={value}
+              className="max-w-full h-auto rounded-lg border max-h-48 object-contain"
+              muted
+              autoPlay
+              loop
+              playsInline
+            />
+          ) : (
+            <img
+              src={value}
+              alt="Uploaded"
+              className="max-w-full h-auto rounded-lg border max-h-48 object-contain"
+            />
+          )}
           {!disabled && (
             <Button
               type="button"
@@ -193,12 +226,14 @@ export function ImageUpload({
               Drag & drop or click to upload
             </p>
             <p className="text-xs text-muted-foreground">
-              PNG, JPG, GIF, WebP up to 10MB
+              {allowVideo
+                ? "PNG, JPG, GIF, WebP up to 10MB · MP4 up to 30MB"
+                : "PNG, JPG, GIF, WebP up to 10MB"}
             </p>
             <input
               type="file"
               className="hidden"
-              accept="image/jpeg,image/png,image/gif,image/webp"
+              accept={inputAccept}
               onChange={handleChange}
               disabled={disabled}
             />

--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -2,10 +2,11 @@
 
 import { useParams } from "next/navigation"
 import { useTranslation } from "react-i18next"
+import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import { OpenCheckoutRuntime } from "@/components/checkout-flow/OpenCheckoutRuntime"
 import { SidebarProvider } from "@/components/Sidebar/SidebarComponents"
 import useAuth from "@/hooks/useAuth"
-import { getBackgroundProps } from "@/lib/background-image"
+import { getCheckoutBackground } from "@/lib/background-image"
 import { useCheckoutRuntime } from "./hooks/useCheckoutRuntime"
 
 export default function OpenTicketingCheckoutPage() {
@@ -48,7 +49,7 @@ export default function OpenTicketingCheckoutPage() {
     )
   }
 
-  const background = getBackgroundProps(runtime.popup, "checkout")
+  const background = getCheckoutBackground(runtime.popup, "checkout")
 
   return (
     <SidebarProvider
@@ -62,9 +63,12 @@ export default function OpenTicketingCheckoutPage() {
       }
     >
       <main
-        className={`h-svh overflow-y-auto no-scrollbar ${background.className}`.trim()}
-        style={background.style}
+        className={`h-svh overflow-y-auto no-scrollbar ${background.type === "none" ? "bg-background" : ""}`.trim()}
+        style={background.type === "image" ? background.style : undefined}
       >
+        {background.type === "video" && (
+          <CheckoutBackgroundVideo url={background.url} />
+        )}
         <OpenCheckoutRuntime
           runtime={runtime}
           popupSlug={popupSlug}

--- a/portal/src/app/groups/[groupSlug]/page.tsx
+++ b/portal/src/app/groups/[groupSlug]/page.tsx
@@ -2,8 +2,9 @@
 
 import { useParams } from "next/navigation"
 import { PopupCheckoutContent } from "@/app/checkout/components/PopupCheckoutContent"
+import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import useGetPublicGroup from "@/hooks/useGetPublicGroup"
-import { getBackgroundProps } from "@/lib/background-image"
+import { getCheckoutBackground } from "@/lib/background-image"
 import { useCityProvider } from "@/providers/cityProvider"
 
 const LoadingFallback = () => (
@@ -38,14 +39,23 @@ const GroupCheckoutPage = () => {
     )
   }
 
-  const background = getBackgroundProps(popup, "groups")
+  const background = getCheckoutBackground(popup, "groups")
+  const contentBackground =
+    background.type === "image"
+      ? { className: "", style: background.style }
+      : { className: background.type === "none" ? "bg-background" : "" }
 
   return (
-    <PopupCheckoutContent
-      popup={popup}
-      background={background}
-      groupId={group.id}
-    />
+    <>
+      {background.type === "video" && (
+        <CheckoutBackgroundVideo url={background.url} />
+      )}
+      <PopupCheckoutContent
+        popup={popup}
+        background={contentBackground}
+        groupId={group.id}
+      />
+    </>
   )
 }
 

--- a/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
@@ -2,9 +2,10 @@
 
 import { useParams, useRouter } from "next/navigation"
 import { useEffect } from "react"
+import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
 import { Loader } from "@/components/ui/Loader"
-import { getBackgroundProps } from "@/lib/background-image"
+import { getCheckoutBackground } from "@/lib/background-image"
 import { CheckoutProvider } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 import PassesProvider, { usePassesProvider } from "@/providers/passesProvider"
@@ -14,7 +15,7 @@ export default function BuyPassesContent() {
   const router = useRouter()
   const { attendeePasses: attendees, products } = usePassesProvider()
   const { getCity } = useCityProvider()
-  const background = getBackgroundProps(getCity(), "passes")
+  const background = getCheckoutBackground(getCity(), "passes")
 
   // The portal layout owns the scroll container (<main id="portal-scroll">),
   // and the SnapDotNav indicator sits on the right edge of the viewport. The
@@ -37,9 +38,12 @@ export default function BuyPassesContent() {
   return (
     <PassesProvider attendees={attendees} restoreFromCart>
       <CheckoutProvider initialStep="passes">
+        {background.type === "video" && (
+          <CheckoutBackgroundVideo url={background.url} />
+        )}
         <div
-          className={`min-h-full w-full ${background.className}`}
-          style={background.style}
+          className={`min-h-full w-full ${background.type === "none" ? "bg-background" : ""}`.trim()}
+          style={background.type === "image" ? background.style : undefined}
         >
           <ScrollyCheckoutFlow
             onBack={handleBack}

--- a/portal/src/components/CheckoutBackgroundVideo.tsx
+++ b/portal/src/components/CheckoutBackgroundVideo.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { Pause, Play, Volume2, VolumeX } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { cn } from "@/lib/utils"
+
+interface CheckoutBackgroundVideoProps {
+  url: string
+  className?: string
+}
+
+// Full-bleed `<video>` rendered behind the checkout. Tries autoplay with
+// sound; browsers block that without a prior user gesture, so on
+// NotAllowedError we restart muted and surface a "Tap for sound" overlay
+// the user can click to satisfy the gesture requirement.
+export function CheckoutBackgroundVideo({
+  url,
+  className,
+}: CheckoutBackgroundVideoProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [muted, setMuted] = useState(false)
+  const [paused, setPaused] = useState(false)
+  const [autoplayBlocked, setAutoplayBlocked] = useState(false)
+
+  useEffect(() => {
+    const el = videoRef.current
+    if (!el) return
+    el.muted = false
+    el.play().catch(() => {
+      el.muted = true
+      setMuted(true)
+      setAutoplayBlocked(true)
+      el.play().catch(() => {
+        // Even muted autoplay can fail in obscure setups — give up; the user
+        // can press play.
+        setPaused(true)
+      })
+    })
+  }, [])
+
+  const enableSound = () => {
+    const el = videoRef.current
+    if (!el) return
+    el.muted = false
+    setMuted(false)
+    setAutoplayBlocked(false)
+    if (el.paused) el.play().catch(() => setPaused(true))
+  }
+
+  const toggleMute = () => {
+    const el = videoRef.current
+    if (!el) return
+    el.muted = !el.muted
+    setMuted(el.muted)
+    if (!el.muted) setAutoplayBlocked(false)
+  }
+
+  const togglePlay = () => {
+    const el = videoRef.current
+    if (!el) return
+    if (el.paused) {
+      el.play().catch(() => setPaused(true))
+      setPaused(false)
+    } else {
+      el.pause()
+      setPaused(true)
+    }
+  }
+
+  return (
+    <>
+      {/* biome-ignore lint/a11y/useMediaCaption: decorative background video, not communicative content */}
+      <video
+        ref={videoRef}
+        src={url}
+        className={cn(
+          "fixed inset-0 w-full h-full object-cover -z-10",
+          className,
+        )}
+        autoPlay
+        loop
+        playsInline
+        preload="auto"
+      />
+      <div className="fixed bottom-4 right-4 z-40 flex items-center gap-2 pointer-events-none">
+        {autoplayBlocked && (
+          <button
+            type="button"
+            onClick={enableSound}
+            className="pointer-events-auto rounded-full bg-black/70 backdrop-blur-sm text-white text-xs font-medium px-3 py-1.5 flex items-center gap-1.5 shadow-md hover:bg-black/80 transition"
+          >
+            <Volume2 className="w-3.5 h-3.5" />
+            Tap for sound
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={togglePlay}
+          aria-label={
+            paused ? "Play background video" : "Pause background video"
+          }
+          className="pointer-events-auto w-8 h-8 rounded-full bg-black/50 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/70 transition"
+        >
+          {paused ? (
+            <Play className="w-3.5 h-3.5" />
+          ) : (
+            <Pause className="w-3.5 h-3.5" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={toggleMute}
+          aria-label={
+            muted ? "Unmute background video" : "Mute background video"
+          }
+          className="pointer-events-auto w-8 h-8 rounded-full bg-black/50 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/70 transition"
+        >
+          {muted ? (
+            <VolumeX className="w-3.5 h-3.5" />
+          ) : (
+            <Volume2 className="w-3.5 h-3.5" />
+          )}
+        </button>
+      </div>
+    </>
+  )
+}

--- a/portal/src/components/CheckoutBackgroundVideo.tsx
+++ b/portal/src/components/CheckoutBackgroundVideo.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useReducedMotion } from "framer-motion"
 import { Pause, Play, Volume2, VolumeX } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -8,25 +9,42 @@ import { cn } from "@/lib/utils"
 interface CheckoutBackgroundVideoProps {
   url: string
   className?: string
+  // TODO: thread a popup-level poster field through when one exists on the
+  // popup schema. For now callers can pass a static frame URL explicitly.
+  poster?: string
+  preload?: "none" | "metadata" | "auto"
 }
 
 // Full-bleed `<video>` rendered behind the checkout. Tries autoplay with
 // sound; browsers block that without a prior user gesture, so on
 // NotAllowedError we restart muted and surface a "Tap for sound" overlay
 // the user can click to satisfy the gesture requirement.
+//
+// Honors `prefers-reduced-motion`: when set, the video does NOT autoplay —
+// we render the poster (or first frame) and let the user opt in via the
+// play button. This avoids motion-triggered discomfort on entry.
 export function CheckoutBackgroundVideo({
   url,
   className,
+  poster,
+  preload = "metadata",
 }: CheckoutBackgroundVideoProps) {
   const { t } = useTranslation()
+  const prefersReducedMotion = useReducedMotion()
   const videoRef = useRef<HTMLVideoElement>(null)
   const [muted, setMuted] = useState(false)
-  const [paused, setPaused] = useState(false)
+  const [paused, setPaused] = useState(prefersReducedMotion ?? false)
   const [autoplayBlocked, setAutoplayBlocked] = useState(false)
 
   useEffect(() => {
     const el = videoRef.current
     if (!el) return
+    if (prefersReducedMotion) {
+      // Reduced motion: do not autoplay; user can press play.
+      el.pause()
+      setPaused(true)
+      return
+    }
     el.muted = false
     el.play().catch(() => {
       el.muted = true
@@ -38,7 +56,7 @@ export function CheckoutBackgroundVideo({
         setPaused(true)
       })
     })
-  }, [])
+  }, [prefersReducedMotion])
 
   const enableSound = () => {
     const el = videoRef.current
@@ -75,14 +93,15 @@ export function CheckoutBackgroundVideo({
       <video
         ref={videoRef}
         src={url}
+        poster={poster}
         className={cn(
           "fixed inset-0 w-full h-full object-cover -z-10",
           className,
         )}
-        autoPlay
+        autoPlay={!prefersReducedMotion}
         loop
         playsInline
-        preload="auto"
+        preload={preload}
       />
       <div className="fixed bottom-4 right-4 z-40 flex items-center gap-2 pointer-events-none">
         {autoplayBlocked && (

--- a/portal/src/components/CheckoutBackgroundVideo.tsx
+++ b/portal/src/components/CheckoutBackgroundVideo.tsx
@@ -2,6 +2,7 @@
 
 import { Pause, Play, Volume2, VolumeX } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 
 interface CheckoutBackgroundVideoProps {
@@ -17,6 +18,7 @@ export function CheckoutBackgroundVideo({
   url,
   className,
 }: CheckoutBackgroundVideoProps) {
+  const { t } = useTranslation()
   const videoRef = useRef<HTMLVideoElement>(null)
   const [muted, setMuted] = useState(false)
   const [paused, setPaused] = useState(false)
@@ -90,14 +92,16 @@ export function CheckoutBackgroundVideo({
             className="pointer-events-auto rounded-full bg-black/70 backdrop-blur-sm text-white text-xs font-medium px-3 py-1.5 flex items-center gap-1.5 shadow-md hover:bg-black/80 transition"
           >
             <Volume2 className="w-3.5 h-3.5" />
-            Tap for sound
+            {t("checkout.video.tap_for_sound")}
           </button>
         )}
         <button
           type="button"
           onClick={togglePlay}
           aria-label={
-            paused ? "Play background video" : "Pause background video"
+            paused
+              ? t("checkout.video.play_aria")
+              : t("checkout.video.pause_aria")
           }
           className="pointer-events-auto w-8 h-8 rounded-full bg-black/50 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/70 transition"
         >
@@ -111,7 +115,9 @@ export function CheckoutBackgroundVideo({
           type="button"
           onClick={toggleMute}
           aria-label={
-            muted ? "Unmute background video" : "Mute background video"
+            muted
+              ? t("checkout.video.unmute_aria")
+              : t("checkout.video.mute_aria")
           }
           className="pointer-events-auto w-8 h-8 rounded-full bg-black/50 backdrop-blur-sm text-white flex items-center justify-center hover:bg-black/70 transition"
         >

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -232,6 +232,13 @@
       "patron": "Patron",
       "buyer": "Your information",
       "confirm": "Review & Confirm"
+    },
+    "video": {
+      "tap_for_sound": "Tap for sound",
+      "play_aria": "Play background video",
+      "pause_aria": "Pause background video",
+      "mute_aria": "Mute background video",
+      "unmute_aria": "Unmute background video"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -232,6 +232,13 @@
       "patron": "Patrono",
       "buyer": "Tu información",
       "confirm": "Revisar y Confirmar"
+    },
+    "video": {
+      "tap_for_sound": "Tocá para activar el sonido",
+      "play_aria": "Reproducir video de fondo",
+      "pause_aria": "Pausar video de fondo",
+      "mute_aria": "Silenciar video de fondo",
+      "unmute_aria": "Activar sonido del video de fondo"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -222,6 +222,13 @@
       "merch": "Vörur",
       "patron": "Styrktaraðili",
       "confirm": "Yfirfara og staðfesta"
+    },
+    "video": {
+      "tap_for_sound": "Smelltu fyrir hljóð",
+      "play_aria": "Spila bakgrunnsmyndband",
+      "pause_aria": "Stöðva bakgrunnsmyndband",
+      "mute_aria": "Slökkva á hljóði bakgrunnsmyndbands",
+      "unmute_aria": "Kveikja á hljóði bakgrunnsmyndbands"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -232,6 +232,13 @@
       "patron": "赞助人",
       "buyer": "您的信息",
       "confirm": "审核并确认"
+    },
+    "video": {
+      "tap_for_sound": "点击开启声音",
+      "play_aria": "播放背景视频",
+      "pause_aria": "暂停背景视频",
+      "mute_aria": "静音背景视频",
+      "unmute_aria": "取消静音背景视频"
     }
   },
   "openCheckout": {

--- a/portal/src/lib/background-image.ts
+++ b/portal/src/lib/background-image.ts
@@ -21,6 +21,49 @@ export function resolveCheckoutBackgroundUrl(
   return popup?.express_checkout_background || null
 }
 
+// Treat any .mp4 (case-insensitive, query-strings ignored) as a video.
+// Other extensions are assumed to be images — same as before this field
+// accepted video.
+function isVideoUrl(url: string): boolean {
+  const pathname = url.split("?")[0].split("#")[0].toLowerCase()
+  return pathname.endsWith(".mp4")
+}
+
+export type CheckoutBackground =
+  | { type: "none"; className: string }
+  | { type: "image"; className: string; style: React.CSSProperties }
+  | { type: "video"; className: string; url: string }
+
+export function getCheckoutBackground(
+  popup: PopupPublic | null | undefined,
+  context: CheckoutBackgroundContext,
+): CheckoutBackground {
+  const url = resolveCheckoutBackgroundUrl(popup, context)
+
+  if (!url) {
+    return { type: "none", className: "bg-background" }
+  }
+
+  if (isVideoUrl(url)) {
+    return { type: "video", className: "", url }
+  }
+
+  return {
+    type: "image",
+    className: "",
+    style: {
+      backgroundImage: `url(${url})`,
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+      backgroundRepeat: "no-repeat",
+      backgroundAttachment: "fixed",
+    },
+  }
+}
+
+// Back-compat wrapper. Returns the spread-onto-main shape image consumers
+// have always used. Video URLs now collapse to the empty/no-bg case so
+// callers that haven't migrated to <CheckoutBackgroundLayer> don't break.
 export function getBackgroundProps(
   popup: PopupPublic | null | undefined,
   context: CheckoutBackgroundContext,
@@ -28,23 +71,7 @@ export function getBackgroundProps(
   className: string
   style: React.CSSProperties | undefined
 } {
-  const imageUrl = resolveCheckoutBackgroundUrl(popup, context)
-
-  if (imageUrl) {
-    return {
-      className: "",
-      style: {
-        backgroundImage: `url(${imageUrl})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundRepeat: "no-repeat",
-        backgroundAttachment: "fixed",
-      },
-    }
-  }
-
-  return {
-    className: "bg-background",
-    style: undefined,
-  }
+  const bg = getCheckoutBackground(popup, context)
+  if (bg.type === "image") return { className: bg.className, style: bg.style }
+  return { className: bg.className || "bg-background", style: undefined }
 }


### PR DESCRIPTION
## Summary
The popup-level `express_checkout_background` field can now point at an `.mp4` and the portal will render it as a full-bleed background video on the checkout, groups, and passes pages. Browsers block autoplay-with-sound without a prior user gesture, so the player tries autoplay-with-sound first and falls back to muted with a **"Tap for sound"** affordance that satisfies the gesture requirement when clicked. Always-visible play/pause and mute/unmute toggles sit in the bottom-right corner.

## Stack
- **Backend** — `video/mp4` added to the backoffice upload allowlist (`ALLOWED_VIDEO_TYPES`). Videos route to a separate `videos/` folder in object storage to keep image/video URLs separable.
- **Backoffice** — `ImageUpload` gains an `accept="image+video"` mode (file picker accepts mp4, max-size bumped to 30 MB, preview renders `<video muted autoPlay loop>` for `.mp4`, cropper skipped for videos). `PopupForm`'s checkout-background field passes `accept="image+video"` and the copy mentions MP4.
- **Portal** — `lib/background-image.ts` now exposes `getCheckoutBackground()` returning a discriminated `{type: "none" | "image" | "video"}` payload. The old `getBackgroundProps` stays as a back-compat wrapper. New `<CheckoutBackgroundVideo>` component renders the player + controls. Three consumer pages branch on the discriminated background.

## Validation plan
- [ ] Upload an .mp4 to a popup's "Checkout Background" field. Open the checkout — video autoplays full-bleed, controls visible bottom-right.
- [ ] First-load behaviour: browser blocks sound, "Tap for sound" appears, click → audio enables.
- [ ] Mute/unmute and play/pause toggles work.
- [ ] Refresh: subsequent loads on the same origin may keep sound on (browsers remember the user-engagement signal).
- [ ] Set the field back to an image — checkout returns to static background, no controls.
- [ ] Confirm `groups` and `passes` checkout-background contexts also render video when enabled in `theme_config.checkout_background_contexts`.

## Notes for reviewers
- Tenants who already use `theme_config.checkout_background_contexts` to fan the background across `checkout` / `groups` / `passes` get the video on all three the moment they upload one; no per-context opt-in is added.
- 30 MB is a conservative ceiling for an autoplaying background loop. We can raise it later if real assets push past that.