### PR TITLE
feat(cart): per-step grouped drawer + restored expandable

### DIFF
--- a/portal/src/components/checkout-flow/CartItemList.tsx
+++ b/portal/src/components/checkout-flow/CartItemList.tsx
@@ -83,17 +83,17 @@ export default function CartItemList() {
                 <div className="flex items-center gap-3 flex-1 min-w-0">
                   <Ticket className="w-4 h-4 text-muted-foreground shrink-0" />
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-checkout-title truncate">
+                    <p className="text-sm font-medium text-foreground truncate">
                       {getAttendeeName(pass.attendeeId)}
                     </p>
-                    <p className="text-xs text-checkout-subtitle">
+                    <p className="text-xs text-muted-foreground">
                       {pass.quantity > 1 && <span>{pass.quantity} × </span>}
                       {pass.product.name}
                     </p>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-checkout-title">
+                  <span className="text-sm font-medium text-foreground">
                     {formatCurrency(pass.originalPrice ?? pass.price)}
                   </span>
                   <button
@@ -122,7 +122,7 @@ export default function CartItemList() {
             <div className="flex items-center gap-3 flex-1 min-w-0">
               <Home className="w-4 h-4 text-muted-foreground shrink-0" />
               <div className="min-w-0">
-                <p className="text-sm font-medium text-checkout-title truncate">
+                <p className="text-sm font-medium text-foreground truncate">
                   {cart.housing.quantity > 1 && (
                     <span className="text-muted-foreground">
                       {cart.housing.quantity} ×{" "}
@@ -130,7 +130,7 @@ export default function CartItemList() {
                   )}
                   {cart.housing.product.name}
                 </p>
-                <p className="text-xs text-checkout-subtitle">
+                <p className="text-xs text-muted-foreground">
                   {cart.housing.pricePerDay !== false
                     ? `${cart.housing.nights} night${cart.housing.nights !== 1 ? "s" : ""}`
                     : "Full stay"}
@@ -138,7 +138,7 @@ export default function CartItemList() {
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-checkout-title">
+              <span className="text-sm font-medium text-foreground">
                 {formatCurrency(cart.housing.totalPrice)}
               </span>
               <button
@@ -168,7 +168,7 @@ export default function CartItemList() {
                 <div className="flex items-center gap-3 flex-1 min-w-0">
                   <ShoppingBag className="w-4 h-4 text-muted-foreground shrink-0" />
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-checkout-title truncate">
+                    <p className="text-sm font-medium text-foreground truncate">
                       {item.quantity > 1 && (
                         <span className="text-muted-foreground">
                           {item.quantity} ×{" "}
@@ -179,7 +179,7 @@ export default function CartItemList() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-checkout-title">
+                  <span className="text-sm font-medium text-foreground">
                     {formatCurrency(item.totalPrice)}
                   </span>
                   <button
@@ -205,12 +205,12 @@ export default function CartItemList() {
           <div className="flex items-center justify-between py-2">
             <div className="flex items-center gap-3">
               <Heart className="w-4 h-4 text-muted-foreground shrink-0" />
-              <span className="text-sm font-medium text-checkout-title">
+              <span className="text-sm font-medium text-foreground">
                 Community Support
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-checkout-title">
+              <span className="text-sm font-medium text-foreground">
                 {formatCurrency(cart.patron.amount)}
               </span>
               <button
@@ -241,7 +241,7 @@ export default function CartItemList() {
                 <div className="flex items-center gap-3 flex-1 min-w-0">
                   <Icon className="w-4 h-4 text-muted-foreground shrink-0" />
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-checkout-title truncate">
+                    <p className="text-sm font-medium text-foreground truncate">
                       {item.quantity > 1 && (
                         <span className="text-muted-foreground">
                           {item.quantity} ×{" "}
@@ -252,8 +252,8 @@ export default function CartItemList() {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-checkout-title">
-                    {formatCurrency(item.price)}
+                  <span className="text-sm font-medium text-foreground">
+                    {formatCurrency(item.price * item.quantity)}
                   </span>
                   <button
                     type="button"
@@ -280,11 +280,11 @@ export default function CartItemList() {
           <div className="flex items-center justify-between py-2">
             <div className="flex items-center gap-3">
               <Shield className="w-4 h-4 text-muted-foreground shrink-0" />
-              <span className="text-sm font-medium text-checkout-title">
+              <span className="text-sm font-medium text-foreground">
                 Coverage for all passes
               </span>
             </div>
-            <span className="text-sm font-medium text-checkout-title">
+            <span className="text-sm font-medium text-foreground">
               {formatCurrency(summary.insuranceSubtotal)}
             </span>
           </div>

--- a/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
+++ b/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
@@ -208,7 +208,7 @@ export function OpenCheckoutRuntime({
                       : {}
                   }
                   cartPersistenceEnabled={false}
-                  cartUiEnabled={false}
+                  cartUiEnabled={true}
                   validatePromoCodeOverride={async (code) => {
                     const result = await CouponsService.validateCouponPublic({
                       requestBody: {


### PR DESCRIPTION
## Summary
Revives commit `8b56428` from the unmerged `feat+amanita-checkout-overhaul` branch. The dynamic cart drawer in the open-checkout flow was hidden (`cartUiEnabled={false}`) and, even when surfaced, dumped every dynamic item under a single "Tickets" heading. This PR:

- Groups dynamic items by their originating step (Housing, Parking, …) with the matching step icon + the admin-configured step title.
- Switches drawer copy to theme tokens (`text-foreground` / `text-muted-foreground`) so it follows the step-card surface rebind on themed popups (cream, dark, etc.).
- Subtotal per row now shows `price × quantity` instead of the unit price.
- Flips `cartUiEnabled` to `true` on the open-checkout flow so the expandable drawer is actually reachable.

## Cherry-pick notes
- `CartItemList.tsx` conflict: dev had introduced its own per-step grouping logic in parallel. Resolved by keeping the dev grouping block (it's functionally identical), dropping the amanita duplicate, and taking the amanita surface tokens + `price × quantity` subtotal.
- `OpenCheckoutRuntime.tsx` applied cleanly: single-line flip of `cartUiEnabled`.

## Validation plan
- [ ] Open the open-checkout flow → expandable cart drawer is visible/reachable.
- [ ] Add a housing + a parking item → drawer shows two groups, each with its step title and icon.
- [ ] Bump a row's quantity → subtotal updates to `unit × qty`, not unit-only.
- [ ] Switch the popup theme to a custom card background (cream/dark) → drawer text stays readable.