### PR TITLE
fix(checkout): cart-empty bounce skips content-only steps

### DIFF
--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/checkout/popupCheckoutPolicy"
 import type { TicketingStepPublic } from "@/client"
 import { TicketingStepsService } from "@/client"
+import { CONTENT_ONLY_TEMPLATES } from "@/components/checkout-flow/registries/variantRegistry"
 import { supportsQuantitySelector } from "@/components/ui/QuantitySelector"
 import type { StepProductResolution } from "@/hooks/checkout"
 import {
@@ -723,13 +724,31 @@ export function CheckoutProvider({
   }, [availableSteps, isBuyerInfoComplete])
 
   // findFirstProductStep: pick a step to bounce the user back to when
-  // the cart is empty at confirm time. Visited steps win (the buyer was
-  // actually there), else the first product-bearing step in funnel order.
+  // the cart is empty at confirm time. Skips structural steps (buyer,
+  // confirm, success) AND content-only steps (rich-text hero, FAQs,
+  // gallery, youtube) — none of those let a user add items, so bouncing
+  // there from "cart is empty" is a dead end. Visited steps win.
   const findFirstProductStep = useCallback(
     (visited?: Set<string>): string | null => {
-      const productSteps = (availableSteps as string[]).filter(
-        (s) => s !== "buyer" && s !== "confirm" && s !== "success",
-      )
+      const isProductStep = (stepName: string) => {
+        if (
+          stepName === "buyer" ||
+          stepName === "confirm" ||
+          stepName === "success"
+        ) {
+          return false
+        }
+        const config = effectiveConfiguredSteps.find(
+          (c) =>
+            c.step_type === stepName ||
+            (c.step_type === "tickets" && stepName === "passes"),
+        )
+        if (config?.template && CONTENT_ONLY_TEMPLATES.has(config.template)) {
+          return false
+        }
+        return true
+      }
+      const productSteps = (availableSteps as string[]).filter(isProductStep)
       if (productSteps.length === 0) return null
       if (visited && visited.size > 0) {
         const visitedProduct = productSteps.find((s) => visited.has(s))
@@ -737,7 +756,7 @@ export function CheckoutProvider({
       }
       return productSteps[0]
     },
-    [availableSteps],
+    [availableSteps, effectiveConfiguredSteps],
   )
 
   // hasAnyCartItems: mirrors CartFooter's old `canContinue` cart check,


### PR DESCRIPTION
## Summary
`findFirstProductStep` in `checkoutProvider.tsx` filtered only `buyer`/`confirm`/`success` when picking where to bounce a user with an empty cart from the confirm step. On Amanita-style funnels that have a content-only step at order 0 (`hero` rich-text, `faqs`, `image-gallery`, `youtube-video`), it returned that step — a dead end because none of those let the user actually add items.

Now also filters out steps whose template is in `CONTENT_ONLY_TEMPLATES`, so the bounce lands on the first real product step (`tickets` / `housing` / `merch` / …) in funnel order.

## Why this matters
Reproducible on the Amanita clone: buyer empty + cart empty → click Pay → before this fix lands on the Hero (rich-text content step, no items to add). After: lands on Tu información with the existing "completá los campos" toast.

## Test plan
- [x] Local: confirmed bounce now lands on buyer (or, when buyer is complete, on the first product step) via `agent-browser` on `http://demo.localhost:3000/checkout/community-meetup#confirm`.
- [ ] Reviewer: regression-check on funnels WITHOUT content-only steps — they should hit identical code paths (the new filter is a no-op when no template is in `CONTENT_ONLY_TEMPLATES`).