### PR TITLE
fix(checkout): include product.images in /checkout/{slug}/runtime response

### DIFF
--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -59,6 +59,7 @@ class CheckoutRuntimeProduct(BaseModel):
     price: Decimal
     compare_price: Decimal | None = None
     image_url: str | None = None
+    images: list[str] = []
     category: str = "ticket"
     currency: str = "USD"
     attendee_category: str | None = None

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -3791,6 +3791,14 @@ export const CheckoutRuntimeProductSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images',
+            default: []
+        },
         category: {
             type: 'string',
             title: 'Category',
@@ -12338,6 +12346,13 @@ export const ProductBatchItemSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
+        },
         category: {
             type: 'string',
             title: 'Category',
@@ -12498,6 +12513,13 @@ export const ProductBatchResultSchema = {
                 }
             ],
             title: 'Image Url'
+        },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
         },
         category: {
             type: 'string',
@@ -12739,6 +12761,13 @@ export const ProductCreateSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
+        },
         category: {
             type: 'string',
             title: 'Category',
@@ -12919,6 +12948,13 @@ export const ProductPublicSchema = {
                 }
             ],
             title: 'Image Url'
+        },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
         },
         category: {
             type: 'string',
@@ -13119,6 +13155,20 @@ export const ProductUpdateSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Images'
+        },
         category: {
             anyOf: [
                 {
@@ -13308,6 +13358,13 @@ export const ProductWithQuantitySchema = {
                 }
             ],
             title: 'Image Url'
+        },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
         },
         category: {
             type: 'string',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -835,6 +835,7 @@ export type CheckoutRuntimeProduct = {
     price: string;
     compare_price?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     currency?: string;
     attendee_category?: (string | null);
@@ -2457,7 +2458,7 @@ export type ProductBatchItem = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
-    images?: Array<string>;
+    images?: Array<(string)>;
     category?: string;
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2483,7 +2484,7 @@ export type ProductBatchResult = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
-    images?: Array<string>;
+    images?: Array<(string)>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);
@@ -2524,7 +2525,7 @@ export type ProductCreate = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
-    images?: Array<string>;
+    images?: Array<(string)>;
     category?: string;
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2563,7 +2564,7 @@ export type ProductPublic = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
-    images?: Array<string>;
+    images?: Array<(string)>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);
@@ -2589,7 +2590,7 @@ export type ProductUpdate = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
-    images?: (Array<string> | null);
+    images?: (Array<(string)> | null);
     category?: (string | null);
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2615,6 +2616,7 @@ export type ProductWithQuantity = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -3791,6 +3791,14 @@ export const CheckoutRuntimeProductSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images',
+            default: []
+        },
         category: {
             type: 'string',
             title: 'Category',
@@ -12338,6 +12346,13 @@ export const ProductBatchItemSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
+        },
         category: {
             type: 'string',
             title: 'Category',
@@ -12498,6 +12513,13 @@ export const ProductBatchResultSchema = {
                 }
             ],
             title: 'Image Url'
+        },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
         },
         category: {
             type: 'string',
@@ -12739,6 +12761,13 @@ export const ProductCreateSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
+        },
         category: {
             type: 'string',
             title: 'Category',
@@ -12919,6 +12948,13 @@ export const ProductPublicSchema = {
                 }
             ],
             title: 'Image Url'
+        },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
         },
         category: {
             type: 'string',
@@ -13119,6 +13155,20 @@ export const ProductUpdateSchema = {
             ],
             title: 'Image Url'
         },
+        images: {
+            anyOf: [
+                {
+                    items: {
+                        type: 'string'
+                    },
+                    type: 'array'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Images'
+        },
         category: {
             anyOf: [
                 {
@@ -13308,6 +13358,13 @@ export const ProductWithQuantitySchema = {
                 }
             ],
             title: 'Image Url'
+        },
+        images: {
+            items: {
+                type: 'string'
+            },
+            type: 'array',
+            title: 'Images'
         },
         category: {
             type: 'string',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -835,6 +835,7 @@ export type CheckoutRuntimeProduct = {
     price: string;
     compare_price?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     currency?: string;
     attendee_category?: (string | null);
@@ -2457,6 +2458,7 @@ export type ProductBatchItem = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2482,6 +2484,7 @@ export type ProductBatchResult = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);
@@ -2522,6 +2525,7 @@ export type ProductCreate = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2560,7 +2564,7 @@ export type ProductPublic = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
-    images?: Array<string>;
+    images?: Array<(string)>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);
@@ -2586,6 +2590,7 @@ export type ProductUpdate = {
     compare_price?: (number | string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: (Array<(string)> | null);
     category?: (string | null);
     duration_type?: (TicketDuration | null);
     sale_starts_at?: (string | null);
@@ -2611,6 +2616,7 @@ export type ProductWithQuantity = {
     compare_price?: (string | null);
     description?: (string | null);
     image_url?: (string | null);
+    images?: Array<(string)>;
     category?: string;
     attendee_category_id?: (string | null);
     duration_type?: (TicketDuration | null);


### PR DESCRIPTION
## Summary
The open-checkout runtime endpoint serialises products through its own \`CheckoutRuntimeProduct\` schema (separate from \`ProductPublic\`). #157 added \`images: list[str]\` to \`ProductBase\` but missed this sibling schema, so the field was silently dropped on the path from DB → portal.

Net effect: the multi-image carousel + lightbox added in #157 worked when the authenticated portal endpoint was hit, but never fired in the **direct-sale open-checkout flow** — which is the actual surface the feature targets.

Adds \`images: list[str] = []\` to \`CheckoutRuntimeProduct\` and the field is now populated correctly.

## Dependency
Requires #157's migration \`0051_product_images\` because the schema references \`product.images\`. Ship together (or after #157 has merged + migrated).

## Test plan
- [x] Hit \`GET /api/v1/checkout/community-meetup/runtime\` locally — \`images\` array present on products that have one configured.
- [x] Local portal: Glamping showcase thumb now shows the \`4\` badge + \`Enlarge\` aria-label + opens \`LightboxOverlay\` with Previous/Next nav.
- [ ] Reviewer: confirm no regression for products with no \`images\` configured (response should serialise \`[]\`, frontend's \`Array.isArray\` check produces \`hasMany === false\` → single-image render unchanged).