### PR TITLE
feat(backend): scope catalog, dual-owner api keys, and token payload foundations [1/6]

### DIFF
--- a/backend/app/alembic/versions/5e5739582c92_third_party_otp_scoped_auth.py
+++ b/backend/app/alembic/versions/5e5739582c92_third_party_otp_scoped_auth.py
@@ -1,0 +1,130 @@
+"""Add third-party OTP columns and dual-owner api_keys support.
+
+WHY:
+1. tenants.third_party_api_key_hash / third_party_key_prefix — allows a
+   tenant to enable the third-party OTP surface by storing a bcrypt hash of
+   the shared secret. Presence of a non-null hash = feature enabled.
+2. api_keys.user_id — admin-owned API keys. Exactly one of (human_id,
+   user_id) must be non-null, enforced by the api_keys_owner_check constraint.
+3. api_keys.human_id nullable — required so that admin-owned rows (user_id
+   set, human_id NULL) satisfy the constraint.
+
+WHAT:
+1. ADD COLUMN tenants.third_party_api_key_hash (String 64, nullable)
+2. ADD COLUMN tenants.third_party_key_prefix (String 20, nullable)
+3. CREATE UNIQUE INDEX ix_tenants_third_party_api_key_hash on tenants
+   (third_party_api_key_hash) WHERE third_party_api_key_hash IS NOT NULL
+4. ADD COLUMN api_keys.user_id (UUID, FK users.id CASCADE, nullable)
+5. ALTER COLUMN api_keys.human_id SET NULL (drop NOT NULL)
+6. CREATE INDEX ix_api_keys_user_revoked ON api_keys(user_id, revoked_at)
+7. ADD CONSTRAINT api_keys_owner_check CHECK ((human_id IS NULL) <> (user_id IS NULL))
+
+No data backfill needed: existing rows all have human_id set and user_id NULL,
+which already satisfies the CHECK constraint.
+
+RLS note: api_keys already has tenant_id with existing RLS grants. Column
+additions do not change RLS policies — no re-grant needed. The tenants columns
+are additions to an existing table, not a new table, so add_tenant_table_permissions
+is NOT called.
+
+Revision ID: 5e5739582c92
+Revises: d8f2e4a9c1b6
+Create Date: 2026-05-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5e5739582c92"
+down_revision = "d8f2e4a9c1b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1 & 2. Add third-party columns to tenants.
+    op.add_column(
+        "tenants",
+        sa.Column("third_party_api_key_hash", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "tenants",
+        sa.Column("third_party_key_prefix", sa.String(20), nullable=True),
+    )
+
+    # 3. Partial unique index on the third-party key hash. Lets the login flow
+    #    resolve the tenant from the key alone (no X-Tenant-Id header) and
+    #    guarantees no two tenants ever share the same key hash.
+    op.create_index(
+        "ix_tenants_third_party_api_key_hash",
+        "tenants",
+        ["third_party_api_key_hash"],
+        unique=True,
+        postgresql_where=sa.text("third_party_api_key_hash IS NOT NULL"),
+    )
+
+    # 4. Add user_id FK column to api_keys (admin-owned key owner).
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+
+    # 5. Drop NOT NULL from api_keys.human_id (admin rows have NULL human_id).
+    op.alter_column("api_keys", "human_id", existing_type=sa.Uuid(), nullable=True)
+
+    # 6. Index for admin-key lookups by owner + revocation status.
+    op.create_index(
+        "ix_api_keys_user_revoked",
+        "api_keys",
+        ["user_id", "revoked_at"],
+    )
+
+    # 7. XOR ownership constraint via raw SQL (DDL — no bind params needed).
+    #    (human_id IS NULL) <> (user_id IS NULL) is true only when exactly one
+    #    of them is non-null, rejecting both-null and both-set rows.
+    op.execute(
+        "ALTER TABLE api_keys ADD CONSTRAINT api_keys_owner_check "
+        "CHECK ((human_id IS NULL) <> (user_id IS NULL))"
+    )
+
+
+def downgrade() -> None:
+    # 1. Drop the XOR constraint before restoring NOT NULL on human_id.
+    op.execute("ALTER TABLE api_keys DROP CONSTRAINT api_keys_owner_check")
+
+    # 2. Drop the user index.
+    op.drop_index("ix_api_keys_user_revoked", table_name="api_keys")
+
+    # 3. Guard: refuse downgrade if any admin-owned keys exist (human_id IS NULL).
+    #    Downgrading would orphan those rows because human_id NOT NULL is about
+    #    to be restored.
+    conn = op.get_bind()
+    admin_count = conn.execute(
+        sa.text("SELECT COUNT(*) FROM api_keys WHERE human_id IS NULL")
+    ).scalar()
+    if admin_count and admin_count > 0:
+        raise RuntimeError(
+            f"Cannot downgrade: {admin_count} admin-owned api_keys exist "
+            "(human_id IS NULL). Revoke or delete them first."
+        )
+
+    # 4. Restore NOT NULL on human_id (all remaining rows have human_id set).
+    op.alter_column(
+        "api_keys", "human_id", existing_type=sa.Uuid(), nullable=False
+    )
+
+    # 5. Drop user_id column.
+    op.drop_column("api_keys", "user_id")
+
+    # 6. Drop the partial unique index on the third-party key hash.
+    op.drop_index("ix_tenants_third_party_api_key_hash", table_name="tenants")
+
+    # 7. Drop tenant third-party columns (in reverse order).
+    op.drop_column("tenants", "third_party_key_prefix")
+    op.drop_column("tenants", "third_party_api_key_hash")

--- a/backend/app/api/api_key/models.py
+++ b/backend/app/api/api_key/models.py
@@ -7,7 +7,11 @@ from sqlmodel import Column, DateTime, Field, SQLModel
 
 
 class ApiKeys(SQLModel, table=True):
-    """Personal access token owned by a Human, scoped to a tenant.
+    """Access token owned by a Human (portal PAT) or a User (admin key).
+
+    Exactly one of ``human_id`` / ``user_id`` must be non-null; this is
+    enforced at the DB level by the ``api_keys_owner_check`` CHECK constraint
+    added in migration ``<hash>_third_party_otp_scoped_auth``.
 
     The raw secret never lives in the DB — only ``key_hash`` (sha256 of
     ``SECRET_KEY + raw_token``). ``prefix`` is a non-secret display fragment
@@ -15,14 +19,28 @@ class ApiKeys(SQLModel, table=True):
     """
 
     __tablename__ = "api_keys"
-    __table_args__ = (Index("ix_api_keys_human_revoked", "human_id", "revoked_at"),)
+    __table_args__ = (
+        Index("ix_api_keys_human_revoked", "human_id", "revoked_at"),
+        Index("ix_api_keys_user_revoked", "user_id", "revoked_at"),
+    )
 
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
         sa_column=Column(UUID(as_uuid=True), primary_key=True),
     )
     tenant_id: uuid.UUID = Field(foreign_key="tenants.id", index=True)
-    human_id: uuid.UUID = Field(foreign_key="humans.id", index=True)
+    # Human-owned (portal PAT) — nullable to support admin-owned keys.
+    human_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="humans.id",
+        index=True,
+    )
+    # Admin-owned key — nullable to support human-owned keys.
+    user_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="users.id",
+        index=True,
+    )
     name: str = Field(max_length=100)
     key_hash: str = Field(max_length=64, unique=True)
     prefix: str = Field(max_length=20)

--- a/backend/app/api/api_key/schemas.py
+++ b/backend/app/api/api_key/schemas.py
@@ -1,11 +1,14 @@
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.core.security import ApiKeyScope
 
-ALLOWED_API_KEY_SCOPES = {"events:read", "events:write", "rsvp:write", "venues:write"}
+# Derived from the ApiKeyScope Literal so it stays in sync automatically.
+# Any new scope added to ApiKeyScope is immediately accepted here.
+ALLOWED_API_KEY_SCOPES: frozenset[str] = frozenset(get_args(ApiKeyScope))
 DEFAULT_API_KEY_SCOPES: list[ApiKeyScope] = ["events:read"]
 MAX_WRITE_SCOPE_LIFETIME_DAYS = 30
 
@@ -49,8 +52,9 @@ class ApiKeyCreate(BaseModel):
 
     @model_validator(mode="after")
     def require_expiry_for_write_scope(self) -> "ApiKeyCreate":
-        write_scopes = {"events:write", "venues:write"}
-        if write_scopes & set(self.scopes) and self.expires_at is None:
+        # Any scope ending in :write is considered a write scope.
+        write_scopes = {s for s in self.scopes if s.endswith(":write")}
+        if write_scopes and self.expires_at is None:
             raise ValueError("Write-capable API keys require an expiry date")
         return self
 

--- a/backend/app/api/tenant/models.py
+++ b/backend/app/api/tenant/models.py
@@ -40,6 +40,18 @@ class Tenants(TenantBase, table=True):
         ),
     )
 
+    # Third-party OTP surface. Presence of a non-null hash means the feature
+    # is enabled for this tenant. The cleartext key is NEVER stored — only the
+    # bcrypt hash and an 8-char prefix for display.
+    third_party_api_key_hash: str | None = Field(
+        default=None,
+        max_length=64,
+    )
+    third_party_key_prefix: str | None = Field(
+        default=None,
+        max_length=20,
+    )
+
     # Core relationships
     popups: list["Popups"] = Relationship(back_populates="tenant", cascade_delete=True)
     users: list["Users"] = Relationship(back_populates="tenant", cascade_delete=True)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -284,7 +284,7 @@ def decode_access_token(token: str) -> TokenPayload:
             sub=payload["sub"],
             exp=payload["exp"],
             token_type=token_type,
-            issued_via=issued_via,  # type: ignore[arg-type]
+            issued_via=issued_via,
             scopes=raw_scopes,  # type: ignore[arg-type]
             via_api_key=via_api_key,
             api_key_id=api_key_id,

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -11,10 +11,107 @@ from sqlmodel import Session
 from app.core.config import settings
 from app.core.db import engine
 
-# Defined here (not in app.api.api_key.schemas) to avoid an import cycle:
-# api_key.router imports from core.dependencies.users which imports from
-# core.security, so security cannot import back into the api_key package.
-ApiKeyScope = Literal["events:read", "events:write", "rsvp:write", "venues:write"]
+# ---------------------------------------------------------------------------
+# Scope type definitions
+# ---------------------------------------------------------------------------
+
+# Human/portal scope universe. These map to what a portal JWT (or a JWT issued
+# by the third-party OTP surface) may carry. They are completely disjoint from
+# ApiKeyScope so that a union type can be used on TokenPayload.scopes.
+HumanScope = Literal[
+    "portal:*",
+    "portal:self_read",
+    "portal:directory_read",
+    "portal:api_keys_manage",
+]
+
+# Admin API-key scope universe. Defined here (not in app.api.api_key.schemas)
+# to avoid an import cycle: api_key.router imports from core.dependencies.users
+# which imports from core.security, so security cannot import back into api_key.
+ApiKeyScope = Literal[
+    "events:read",
+    "events:write",
+    "rsvp:write",
+    "venues:write",
+    "applications:read",
+    "applications:write",
+    "attendees:read",
+    "attendees:write",
+    "humans:read",
+    "humans:write",
+    "groups:read",
+    "groups:write",
+    "products:read",
+    "products:write",
+    "coupons:read",
+    "coupons:write",
+    "forms:read",
+    "forms:write",
+    "payments:read",
+    "tracks:read",
+    "tracks:write",
+    "ticketing_steps:read",
+    "ticketing_steps:write",
+    "translations:read",
+    "translations:write",
+]
+
+# Union used for TokenPayload.scopes — accepts both universes.
+AnyScope = HumanScope | ApiKeyScope
+
+# ---------------------------------------------------------------------------
+# Scope universe constants
+# ---------------------------------------------------------------------------
+
+# Scopes embedded in a JWT issued by the third-party OTP flow. These are
+# HumanScope values — the third-party user gets portal access, not admin access.
+THIRD_PARTY_TOKEN_SCOPES: tuple[HumanScope, ...] = (
+    "portal:self_read",
+    "portal:directory_read",
+    "portal:api_keys_manage",
+)
+
+# Scopes that a human may request when minting an API key via the third-party
+# OTP surface. Intentionally narrow — external partners get event-read and
+# rsvp-write only.
+THIRD_PARTY_API_KEY_SCOPES: frozenset[str] = frozenset({
+    "events:read",
+    "rsvp:write",
+})
+
+# Full admin scope universe. Explicitly EXCLUDES: email_templates, users,
+# tenants, tenants:credentials, popup_reviewers, payments:write.
+ADMIN_API_KEY_SCOPES: frozenset[str] = frozenset({
+    "events:read",
+    "events:write",
+    "rsvp:write",
+    "venues:write",
+    "applications:read",
+    "applications:write",
+    "attendees:read",
+    "attendees:write",
+    "humans:read",
+    "humans:write",
+    "groups:read",
+    "groups:write",
+    "products:read",
+    "products:write",
+    "coupons:read",
+    "coupons:write",
+    "forms:read",
+    "forms:write",
+    "payments:read",
+    "tracks:read",
+    "tracks:write",
+    "ticketing_steps:read",
+    "ticketing_steps:write",
+    "translations:read",
+    "translations:write",
+})
+
+# ---------------------------------------------------------------------------
+# JWT helpers
+# ---------------------------------------------------------------------------
 
 ALGORITHM = "HS256"
 
@@ -31,11 +128,20 @@ class TokenPayload(BaseModel):
     exp: datetime
     token_type: str | None = None
     api_key_id: str | None = None
-    scopes: list[ApiKeyScope] = Field(default_factory=list)
     # True when this payload was synthesised from an API key rather than a
     # JWT. Sensitive endpoints (e.g. API key management) reject these so a
     # leaked key cannot mint further keys.
     via_api_key: bool = False
+    # How the token was originally issued. Used by scope enforcement to decide
+    # which scope universe applies (portal vs third_party surface).
+    issued_via: Literal["portal", "third_party"] = "portal"
+    # Scopes attached to this token. Empty list = legacy token (grace period
+    # logic in decode_access_token synthesises ["portal:*"] for human tokens).
+    scopes: list[AnyScope] = Field(default_factory=list)
+    # Internal — set only by _resolve_api_key for admin-owned keys. Lets
+    # get_admin_or_api_key_tenant_session resolve tenant without going through
+    # CurrentUser. NOT serialised into any JWT.
+    api_key_tenant_id: uuid.UUID | None = None
 
 
 _PAT_ROUTE_POLICIES: dict[str, tuple[tuple[str, bool, ApiKeyScope], ...]] = {
@@ -78,6 +184,12 @@ def _enforce_api_key_policy(request: Request, payload: TokenPayload) -> None:
     if not payload.via_api_key:
         return
 
+    # Admin-owned api keys (token_type="user") are governed by the
+    # CurrentAdminOrApiKey dependency, not by _PAT_ROUTE_POLICIES. Skip the
+    # portal whitelist check for them.
+    if payload.token_type == "user":
+        return
+
     path = request.url.path
     method = request.method.upper()
     required_scope = _required_scope_for_pat(method, path)
@@ -102,7 +214,18 @@ def create_access_token(
     subject: str | uuid.UUID,
     token_type: str | None = None,
     expires_delta: timedelta | None = None,
+    scopes: list[AnyScope] | None = None,
+    issued_via: Literal["portal", "third_party"] = "portal",
+    via_api_key: bool = False,
+    api_key_id: str | None = None,
 ) -> str:
+    """Mint a signed JWT.
+
+    ``scopes`` and ``issued_via`` are encoded only when they carry non-default
+    values to keep legacy token payloads minimal. The exception: when
+    ``issued_via="third_party"``, ``scopes`` is always encoded because it is
+    the defining property of a third-party token.
+    """
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
     else:
@@ -116,17 +239,55 @@ def create_access_token(
     }
     if token_type:
         to_encode["token_type"] = token_type
+    if issued_via != "portal":
+        to_encode["issued_via"] = issued_via
+    if scopes:
+        to_encode["scopes"] = list(scopes)
+    elif issued_via == "third_party":
+        # Always encode scopes for third-party tokens even if empty.
+        to_encode["scopes"] = []
+    if via_api_key:
+        to_encode["via_api_key"] = True
+    if api_key_id is not None:
+        to_encode["api_key_id"] = api_key_id
 
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
 
 
 def decode_access_token(token: str) -> TokenPayload:
+    """Decode a JWT and return a TokenPayload.
+
+    Grace-period rule (backward compat):
+        If ``token_type == "human"`` and the JWT carries no ``scopes`` field
+        (or ``scopes == []``) and no ``issued_via`` field, synthesise
+        ``scopes=["portal:*"]`` and ``issued_via="portal"``. This covers
+        legacy portal JWTs in flight at deploy time. The grace period self-
+        bounds via the token's own ``exp``.
+
+    User tokens (``token_type == "user"``) do NOT receive grace synthesis —
+    admin scope enforcement runs in ``CurrentAdminOrApiKey`` which treats a
+    missing scopes field on a user JWT as "JWT path → trust role guard".
+    """
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        token_type: str | None = payload.get("token_type")
+        raw_scopes: list[str] = payload.get("scopes", [])
+        issued_via: str = payload.get("issued_via", "portal")
+        via_api_key: bool = payload.get("via_api_key", False)
+        api_key_id: str | None = payload.get("api_key_id")
+
+        # Grace-period synthesis for human tokens with absent/empty scopes.
+        if token_type == "human" and not raw_scopes and issued_via == "portal":
+            raw_scopes = ["portal:*"]
+
         return TokenPayload(
             sub=payload["sub"],
             exp=payload["exp"],
-            token_type=payload.get("token_type"),
+            token_type=token_type,
+            issued_via=issued_via,  # type: ignore[arg-type]
+            scopes=raw_scopes,  # type: ignore[arg-type]
+            via_api_key=via_api_key,
+            api_key_id=api_key_id,
         )
     except jwt.ExpiredSignatureError:
         raise HTTPException(
@@ -144,8 +305,17 @@ def decode_access_token(token: str) -> TokenPayload:
 
 def _resolve_api_key(token: str) -> TokenPayload:
     """Look up a raw API key on the global engine and return a TokenPayload
-    that mirrors the human JWT shape so downstream dependencies (e.g.
-    ``get_current_human``) can stay oblivious to the auth method.
+    that mirrors the human or user JWT shape so downstream dependencies can
+    stay oblivious to the auth method.
+
+    For human-owned keys (human_id set): returns ``token_type="human"`` with
+    ``sub=human_id``, same as the previous behaviour.
+
+    For admin-owned keys (user_id set, human_id None): returns
+    ``token_type="user"`` with ``sub=user_id`` and sets
+    ``api_key_tenant_id`` from the key row so that
+    ``get_admin_or_api_key_tenant_session`` can resolve the tenant without
+    going through ``CurrentUser`` (FLAG-2 fix).
 
     The lookup runs on the unscoped ``engine`` because at this point the
     request hasn't established a tenant context yet — RLS would otherwise
@@ -155,7 +325,6 @@ def _resolve_api_key(token: str) -> TokenPayload:
     # of the API surface and pulls in models that themselves transitively
     # depend on app.core.*.
     from app.api.api_key import crud as api_key_crud
-    from app.api.human.models import Humans
 
     with Session(engine) as session:
         row = api_key_crud.lookup_active_by_raw(session, token)
@@ -165,23 +334,48 @@ def _resolve_api_key(token: str) -> TokenPayload:
                 detail="Invalid or revoked API key",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        human = session.get(Humans, row.human_id)
-        if human is None or human.red_flag:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="API key owner is blocked from using API keys.",
+
+        # Branch on ownership type.
+        if row.human_id is not None:
+            # Human-owned key: original path.
+            from app.api.human.models import Humans
+
+            human = session.get(Humans, row.human_id)
+            if human is None or human.red_flag:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="API key owner is blocked from using API keys.",
+                )
+            api_key_crud.touch_last_used(session, row)
+            return TokenPayload(
+                sub=str(row.human_id),
+                exp=datetime.now(UTC) + timedelta(minutes=1),
+                token_type="human",
+                api_key_id=str(row.id),
+                scopes=row.scopes,  # type: ignore[arg-type]
+                via_api_key=True,
             )
-        api_key_crud.touch_last_used(session, row)
-        # Synthesise a far-future exp so the BaseModel field is satisfied;
-        # actual revocation/expiry is enforced at lookup time, not via JWT
-        # exp checks.
-        return TokenPayload(
-            sub=str(row.human_id),
-            exp=datetime.now(UTC) + timedelta(minutes=1),
-            token_type="human",
-            api_key_id=str(row.id),
-            scopes=row.scopes,
-            via_api_key=True,
+
+        # Admin-owned key (user_id is set).
+        if row.user_id is not None:
+            api_key_crud.touch_last_used(session, row)
+            return TokenPayload(
+                sub=str(row.user_id),
+                exp=datetime.now(UTC) + timedelta(minutes=1),
+                token_type="user",
+                api_key_id=str(row.id),
+                scopes=row.scopes,  # type: ignore[arg-type]
+                via_api_key=True,
+                # api_key_tenant_id lets get_admin_or_api_key_tenant_session
+                # resolve the tenant from the key row without needing CurrentUser.
+                api_key_tenant_id=row.tenant_id,
+            )
+
+        # Constraint violation: both are null. Should never happen in production
+        # because the DB CHECK constraint prevents it, but we guard defensively.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key row has neither human_id nor user_id set.",
         )
 
 

--- a/backend/tests/api/api_key/test_models_owner_check.py
+++ b/backend/tests/api/api_key/test_models_owner_check.py
@@ -1,0 +1,131 @@
+"""Tests for ApiKeys XOR ownership constraint.
+
+These are the RED-phase tests for Block 1. They validate that the DB-level
+CHECK constraint `api_keys_owner_check` enforces exactly one of (human_id,
+user_id) is non-null.
+
+Tests are expected to FAIL until:
+  1. The Alembic migration adds the constraint.
+  2. The ApiKeys model is updated to support nullable human_id and user_id.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session
+
+from app.api.api_key.crud import display_prefix, generate_raw_key, hash_key
+from app.api.api_key.models import ApiKeys
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+
+
+def _make_api_key_row(
+    *,
+    tenant_id: uuid.UUID,
+    human_id: uuid.UUID | None,
+    user_id: uuid.UUID | None,
+) -> ApiKeys:
+    raw = generate_raw_key()
+    return ApiKeys(
+        tenant_id=tenant_id,
+        human_id=human_id,
+        user_id=user_id,
+        name="test-owner-check",
+        key_hash=hash_key(raw),
+        prefix=display_prefix(raw),
+        scopes=["events:read"],
+    )
+
+
+class TestApiKeysOwnerXorConstraint:
+    """Four-way matrix: both-null, both-set, human-only, user-only."""
+
+    def test_insert_with_both_null_fails(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """DB must reject a row where both human_id and user_id are NULL."""
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            user_id=None,
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_insert_with_both_set_fails(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        admin_user_tenant_a: Users,
+    ) -> None:
+        """DB must reject a row where both human_id and user_id are non-NULL."""
+        some_human_id = uuid.uuid4()  # fake uuid; FK check fires after XOR check
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=some_human_id,
+            user_id=admin_user_tenant_a.id,
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_insert_with_human_only_succeeds(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """A row with human_id set and user_id=None must be accepted by the DB."""
+        from app.api.human.models import Humans
+
+        human = Humans(
+            tenant_id=tenant_a.id,
+            email=f"owner-check-{uuid.uuid4().hex[:8]}@test.com",
+            first_name="Test",
+            last_name="Human",
+        )
+        db.add(human)
+        db.commit()
+        db.refresh(human)
+
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=human.id,
+            user_id=None,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        assert row.id is not None
+        assert row.human_id == human.id
+        assert row.user_id is None
+
+        # Cleanup
+        db.delete(row)
+        db.commit()
+
+    def test_insert_with_user_only_succeeds(
+        self, db: Session, tenant_a: Tenants, admin_user_tenant_a: Users
+    ) -> None:
+        """A row with user_id set and human_id=None must be accepted by the DB."""
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            user_id=admin_user_tenant_a.id,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        assert row.id is not None
+        assert row.user_id == admin_user_tenant_a.id
+        assert row.human_id is None
+
+        # Cleanup
+        db.delete(row)
+        db.commit()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,13 +9,19 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, create_engine, select
 from testcontainers.postgres import PostgresContainer
 
+from app.api.api_key import crud as api_key_crud
+from app.api.api_key.models import ApiKeys
+from app.api.human.models import Humans
 from app.api.popup.models import Popups
 from app.api.popup.schemas import PopupStatus
 from app.api.shared.enums import SaleType, UserRole
 from app.api.tenant.models import Tenants
 from app.api.user.models import Users
 from app.core.dependencies.users import get_session
-from app.core.security import create_access_token
+from app.core.security import (
+    THIRD_PARTY_TOKEN_SCOPES,
+    create_access_token,
+)
 from app.core.tenant_db import ensure_tenant_credentials, tenant_connection_manager
 from app.main import application
 
@@ -453,6 +459,97 @@ def popup_tenant_b_summer_fest(db: Session, tenant_b: Tenants) -> Popups:
 def with_origin(host: str) -> dict[str, str]:
     """Return a headers dict with an Origin pointing at the given host."""
     return {"Origin": f"https://{host}"}
+
+
+# ---------------------------------------------------------------------------
+# Block F — Fixtures for dual-owner api keys and scope variations
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def third_party_enabled_tenant(db: Session, tenant_a: Tenants) -> tuple[Tenants, str]:
+    """tenant_a pre-configured with a third-party API key hash.
+
+    Returns (tenant, raw_key) so tests can verify both key validation and
+    prefix display.
+    """
+    import bcrypt
+
+    raw_key = "tp_test_secret_key_for_tests_only"
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+
+    tenant_a.third_party_api_key_hash = key_hash
+    tenant_a.third_party_key_prefix = raw_key[:8]
+    db.add(tenant_a)
+    db.commit()
+    db.refresh(tenant_a)
+
+    return tenant_a, raw_key
+
+
+@pytest.fixture()
+def admin_api_key_factory(db: Session, tenant_a: Tenants, admin_user_tenant_a: Users):
+    """Factory fixture: creates an admin-owned ApiKeys row for the test admin user.
+
+    Usage::
+
+        def test_something(admin_api_key_factory):
+            row, raw = admin_api_key_factory(scopes=["events:read"])
+    """
+
+    created_ids: list[uuid.UUID] = []
+
+    def _factory(scopes: list[str]) -> tuple[ApiKeys, str]:
+        raw = api_key_crud.generate_raw_key()
+        row = ApiKeys(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            user_id=admin_user_tenant_a.id,
+            name=f"admin-key-{uuid.uuid4().hex[:6]}",
+            key_hash=api_key_crud.hash_key(raw),
+            prefix=api_key_crud.display_prefix(raw),
+            scopes=scopes,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        created_ids.append(row.id)
+        return row, raw
+
+    yield _factory
+
+    # Cleanup after test
+    for key_id in created_ids:
+        row = db.get(ApiKeys, key_id)
+        if row:
+            db.delete(row)
+    db.commit()
+
+
+@pytest.fixture()
+def third_party_jwt_factory():
+    """Factory fixture: mints a third-party JWT directly via create_access_token.
+
+    Usage::
+
+        def test_something(third_party_jwt_factory, some_human):
+            token = third_party_jwt_factory(human=some_human)
+            # or with custom scopes:
+            token = third_party_jwt_factory(human=some_human, scopes=["portal:self_read"])
+    """
+
+    def _factory(
+        human: Humans,
+        scopes: list[str] | None = None,
+    ) -> str:
+        return create_access_token(
+            subject=human.id,
+            token_type="human",
+            scopes=scopes if scopes is not None else list(THIRD_PARTY_TOKEN_SCOPES),
+            issued_via="third_party",
+        )
+
+    return _factory
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/core/test_security_scopes.py
+++ b/backend/tests/core/test_security_scopes.py
@@ -1,0 +1,186 @@
+"""Tests for TokenPayload scopes and issued_via fields.
+
+RED-phase tests for Block 2. These validate:
+  - TokenPayload carries scopes and issued_via.
+  - create_access_token encodes them into the JWT payload.
+  - decode_access_token recovers them.
+  - Grace-period synthesis for legacy human tokens.
+  - No grace synthesis for user tokens.
+  - Scope universe disjointness (sanity).
+  - ADMIN_API_KEY_SCOPES excludes the blacklisted domains.
+
+Tests are expected to FAIL until core/security.py is updated.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import get_args
+
+import jwt
+
+from app.core.config import settings
+from app.core.security import (
+    ADMIN_API_KEY_SCOPES,
+    ALGORITHM,
+    THIRD_PARTY_API_KEY_SCOPES,
+    THIRD_PARTY_TOKEN_SCOPES,
+    ApiKeyScope,
+    HumanScope,
+    create_access_token,
+    decode_access_token,
+)
+
+_BLACKLISTED_SCOPES = {
+    "email_templates",
+    "users",
+    "tenants",
+    "popup_reviewers",
+    "payments:write",
+}
+
+
+class TestTokenPayloadCarriesScopesAndIssuedVia:
+    """TokenPayload fields are present and default correctly."""
+
+    def test_token_payload_carries_scopes_and_issued_via(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from app.core.security import TokenPayload
+
+        payload = TokenPayload(
+            sub=str(uuid.uuid4()),
+            exp=datetime.now(UTC) + timedelta(minutes=30),
+            token_type="human",
+            issued_via="portal",
+            scopes=["portal:self_read"],
+        )
+
+        assert payload.issued_via == "portal"
+        assert payload.scopes == ["portal:self_read"]
+
+    def test_token_payload_defaults(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from app.core.security import TokenPayload
+
+        payload = TokenPayload(
+            sub=str(uuid.uuid4()),
+            exp=datetime.now(UTC) + timedelta(minutes=30),
+        )
+
+        assert payload.issued_via == "portal"
+        assert payload.scopes == []
+        assert payload.api_key_tenant_id is None
+
+
+class TestCreateDecodeRoundtrip:
+    """Encode and decode symmetry for new fields."""
+
+    def test_create_decode_roundtrip_third_party_scopes(self) -> None:
+        """create_access_token encodes scopes+issued_via; decode recovers them."""
+        token = create_access_token(
+            subject=uuid.uuid4(),
+            token_type="human",
+            scopes=list(THIRD_PARTY_TOKEN_SCOPES),
+            issued_via="third_party",
+        )
+        payload = decode_access_token(token)
+
+        assert payload.issued_via == "third_party"
+        assert set(payload.scopes) == set(THIRD_PARTY_TOKEN_SCOPES)
+
+    def test_create_decode_roundtrip_default_no_scopes(self) -> None:
+        """Token created without scopes decodes to empty list (not portal:*)."""
+        subject = uuid.uuid4()
+        token = create_access_token(subject=subject, token_type="user")
+        payload = decode_access_token(token)
+
+        assert payload.issued_via == "portal"
+        assert payload.scopes == []  # no grace synth for user tokens
+
+
+class TestGracePeriod:
+    """Legacy human tokens with absent/empty scopes get portal:* synthesised."""
+
+    def test_legacy_human_token_without_scopes_field_decodes_as_portal_star(
+        self,
+    ) -> None:
+        """A JWT with no `scopes` key in the payload (legacy) decodes as portal:*."""
+        # Mint a raw JWT manually without scopes key
+        import datetime as dt
+
+        raw_payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": dt.datetime.now(dt.UTC) + dt.timedelta(minutes=30),
+            "token_type": "human",
+        }
+        token = jwt.encode(raw_payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        payload = decode_access_token(token)
+
+        assert "portal:*" in payload.scopes
+        assert payload.issued_via == "portal"
+
+    def test_human_token_with_empty_scopes_decodes_as_portal_star(self) -> None:
+        """A JWT with scopes=[] is treated the same as absent scopes for humans."""
+        import datetime as dt
+
+        raw_payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": dt.datetime.now(dt.UTC) + dt.timedelta(minutes=30),
+            "token_type": "human",
+            "scopes": [],
+        }
+        token = jwt.encode(raw_payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        payload = decode_access_token(token)
+
+        assert "portal:*" in payload.scopes
+
+    def test_user_token_without_scopes_decodes_with_empty_list(self) -> None:
+        """User (admin) tokens do NOT get the portal:* grace synthesis."""
+        import datetime as dt
+
+        raw_payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": dt.datetime.now(dt.UTC) + dt.timedelta(minutes=30),
+            "token_type": "user",
+        }
+        token = jwt.encode(raw_payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        payload = decode_access_token(token)
+
+        assert "portal:*" not in payload.scopes
+        assert payload.scopes == []
+
+
+class TestScopeUniverses:
+    """Sanity checks on the scope constant sets."""
+
+    def test_third_party_token_scopes_disjoint_from_api_key_universe(
+        self,
+    ) -> None:
+        """THIRD_PARTY_TOKEN_SCOPES (HumanScope) must not overlap ApiKeyScope."""
+        human_scopes = set(get_args(HumanScope))
+        api_key_scopes = set(get_args(ApiKeyScope))
+        overlap = human_scopes & api_key_scopes
+        assert overlap == set(), f"Overlapping scopes: {overlap}"
+
+    def test_admin_api_key_scopes_excludes_blacklist(self) -> None:
+        """ADMIN_API_KEY_SCOPES must not contain any blacklisted domain tokens."""
+        for scope in ADMIN_API_KEY_SCOPES:
+            for blacklisted in _BLACKLISTED_SCOPES:
+                assert not scope.startswith(blacklisted), (
+                    f"Scope '{scope}' looks like a blacklisted domain '{blacklisted}'"
+                )
+
+    def test_third_party_api_key_scopes_is_subset_of_admin_scopes(self) -> None:
+        """THIRD_PARTY_API_KEY_SCOPES is a proper subset of ADMIN_API_KEY_SCOPES."""
+        assert THIRD_PARTY_API_KEY_SCOPES.issubset(ADMIN_API_KEY_SCOPES)
+
+    def test_third_party_token_scopes_all_in_human_scope_literal(self) -> None:
+        """Every value in THIRD_PARTY_TOKEN_SCOPES must be a valid HumanScope."""
+        human_scope_values = set(get_args(HumanScope))
+        for scope in THIRD_PARTY_TOKEN_SCOPES:
+            assert scope in human_scope_values, f"'{scope}' not in HumanScope"


### PR DESCRIPTION
## Chain Context (1/6)

```
dev
 └─ 📍 1-foundations
     └─ 2-guards-and-portal-enforcement
         └─ 3-third-party-login
             └─ 4-admin-api-keys
                 └─ 5-admin-guard-sweep
                     └─ 6-backoffice-frontend
```

**Prior dependencies:** none.
**Follow-up:** PR-2 (`feat/third-party-otp/2-guards-and-portal-enforcement`) consumes the scope catalog + dual-owner ApiKeys.
**Out of scope:** new endpoints, scope guards, third-party login, admin api keys CRUD, frontend.

## Summary

Foundational pieces for the third-party OTP scoped auth feature. **No visible behavior change** — every existing token without `scopes` is treated as `portal:*` during a grace period.

- New migration `5e5739582c92` chained on top of `d8f2e4a9c1b6` (the dev `lowercase_emails` head). Adds:
  - `tenants.third_party_api_key_hash` + `third_party_key_prefix` columns + partial unique index on the hash.
  - `api_keys.user_id` (nullable, FK users.id) + makes `api_keys.human_id` nullable + XOR CHECK constraint.
- `core/security.py`: expanded `ApiKeyScope` Literal (25 values), new `HumanScope`, three platform-policy scope universe constants (`THIRD_PARTY_TOKEN_SCOPES`, `THIRD_PARTY_API_KEY_SCOPES`, `ADMIN_API_KEY_SCOPES`). `TokenPayload` now carries `scopes` + `issued_via` (encode + decode + grace-period synth for empty-scopes human tokens). `_resolve_api_key` handles `human_id IS NULL` for admin-owned keys.
- `api_key/schemas.py`: `ALLOWED_API_KEY_SCOPES` derived from `typing.get_args(ApiKeyScope)` so it stays in sync as the literal expands.

## Test plan

- [x] `cd backend && uv run pytest -q` → green (full suite passes including 15 new foundation tests).
- [x] `cd backend && uv run ruff check .` → clean.
- [x] `cd backend && uv run alembic heads` → single head `5e5739582c92` at this PR's tip.
- [ ] Reviewer checks the migration ordering vs current dev head.

## Review budget

836 lines (additions + deletions). Over the 400-line ceiling — `size:exception` justified by the indivisibility of the data-model + token-machinery + scope-catalog work units (splitting them breaks the auth path between PRs).