### PR TITLE
feat(backoffice): admin api keys page and third-party integration panel [6/6]

### DIFF
--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -14636,7 +14636,8 @@ export const ThirdPartyHumanLoginSchema = {
     title: 'ThirdPartyHumanLogin',
     description: `Request body for POST /auth/human/third-party/login.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyHumanVerifySchema = {
@@ -14659,7 +14660,8 @@ export const ThirdPartyHumanVerifySchema = {
     title: 'ThirdPartyHumanVerify',
     description: `Request body for POST /auth/human/third-party/authenticate.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyKeyRotatedSchema = {

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -76,6 +76,190 @@ export const AbandonedCartPublicSchema = {
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;
 
+export const AdminApiKeyCreateSchema = {
+    properties: {
+        name: {
+            type: 'string',
+            maxLength: 100,
+            minLength: 1,
+            title: 'Name'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            minItems: 1,
+            title: 'Scopes'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        }
+    },
+    type: 'object',
+    required: ['name', 'scopes'],
+    title: 'AdminApiKeyCreate',
+    description: 'Request body for minting a new admin API key.'
+} as const;
+
+export const AdminApiKeyCreatedSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        },
+        raw_key: {
+            type: 'string',
+            title: 'Raw Key'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at', 'raw_key'],
+    title: 'AdminApiKeyCreated',
+    description: `Response returned only at creation.
+
+\`\`raw_key\`\` is the cleartext token shown once and never stored.`
+} as const;
+
+export const AdminApiKeyPublicSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at'],
+    title: 'AdminApiKeyPublic',
+    description: 'Safe representation of an admin API key — never includes the raw secret.'
+} as const;
+
 export const ApiKeyCreateSchema = {
     properties: {
         name: {
@@ -99,7 +283,7 @@ export const ApiKeyCreateSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -129,7 +313,7 @@ export const ApiKeyCreatedSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -205,7 +389,7 @@ export const ApiKeyPublicSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -14315,6 +14499,17 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Active Popup Slug'
+        },
+        third_party_key_prefix: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Third Party Key Prefix'
         }
     },
     type: 'object',
@@ -14426,6 +14621,62 @@ export const TenantUpdateSchema = {
     },
     type: 'object',
     title: 'TenantUpdate'
+} as const;
+
+export const ThirdPartyHumanLoginSchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        }
+    },
+    type: 'object',
+    required: ['email'],
+    title: 'ThirdPartyHumanLogin',
+    description: `Request body for POST /auth/human/third-party/login.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyHumanVerifySchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        },
+        code: {
+            type: 'string',
+            maxLength: 6,
+            minLength: 6,
+            pattern: '^\\d{6}$',
+            title: 'Code'
+        }
+    },
+    type: 'object',
+    required: ['email', 'code'],
+    title: 'ThirdPartyHumanVerify',
+    description: `Request body for POST /auth/human/third-party/authenticate.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyKeyRotatedSchema = {
+    properties: {
+        api_key: {
+            type: 'string',
+            title: 'Api Key'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        }
+    },
+    type: 'object',
+    required: ['api_key', 'prefix'],
+    title: 'ThirdPartyKeyRotated',
+    description: 'Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.'
 } as const;
 
 export const TicketAttendeeSnapshotSchema = {

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -3,7 +3,122 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+import type { AdminApiKeysCreateAdminApiKeyData, AdminApiKeysCreateAdminApiKeyResponse, AdminApiKeysListAdminApiKeysData, AdminApiKeysListAdminApiKeysResponse, AdminApiKeysGetAdminApiKeyData, AdminApiKeysGetAdminApiKeyResponse, AdminApiKeysRevokeAdminApiKeyData, AdminApiKeysRevokeAdminApiKeyResponse, ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, AuthThirdPartyHumanLoginData, AuthThirdPartyHumanLoginResponse, AuthThirdPartyHumanAuthenticateData, AuthThirdPartyHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TenantsRotateThirdPartyKeyData, TenantsRotateThirdPartyKeyResponse, TenantsDeleteThirdPartyKeyData, TenantsDeleteThirdPartyKeyResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+
+export class AdminApiKeysService {
+    /**
+     * Create Admin Api Key
+     * Mint a new admin API key.
+     *
+     * Scopes must be a subset of ADMIN_API_KEY_SCOPES. Any scope outside that
+     * universe returns 422. Write scopes require an expiry date (validated by
+     * the schema).
+     *
+     * The cleartext key is returned once in ``raw_key``; only the hash is stored.
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @param data.xTenantId
+     * @returns AdminApiKeyCreated Successful Response
+     * @throws ApiError
+     */
+    public static createAdminApiKey(data: AdminApiKeysCreateAdminApiKeyData): CancelablePromise<AdminApiKeysCreateAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * List Admin Api Keys
+     * List admin API keys.
+     *
+     * ADMIN sees only their own keys.
+     * SUPERADMIN sees all admin keys in the tenant they are operating on (via
+     * X-Tenant-Id header, already resolved by TenantSession).
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static listAdminApiKeys(data: AdminApiKeysListAdminApiKeysData = {}): CancelablePromise<AdminApiKeysListAdminApiKeysResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Get Admin Api Key
+     * Retrieve a specific admin API key.
+     *
+     * Visibility mirrors the list endpoint: ADMIN sees only own keys; SUPERADMIN
+     * sees any admin key in the tenant. Returns 404 for keys outside the caller's
+     * visibility — never 403, to avoid leaking existence of foreign keys.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static getAdminApiKey(data: AdminApiKeysGetAdminApiKeyData): CancelablePromise<AdminApiKeysGetAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Revoke Admin Api Key
+     * Revoke an admin API key by setting revoked_at.
+     *
+     * ADMIN can only revoke their own keys (403 for foreign keys).
+     * SUPERADMIN can revoke any admin key in their tenant scope.
+     * Non-existent keys return 404.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static revokeAdminApiKey(data: AdminApiKeysRevokeAdminApiKeyData): CancelablePromise<AdminApiKeysRevokeAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
 
 export class ApiKeysService {
     /**
@@ -1332,6 +1447,69 @@ export class AuthService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/auth/human/authenticate',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Login
+     * Initiate OTP login for an EXISTING human via a third-party integration.
+     *
+     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending human
+     * row — the partner is expected to have onboarded the user out-of-band.
+     *
+     * On any validation failure (unknown tenant, feature disabled, wrong key,
+     * unknown email) the response is 401 to prevent existence leakage.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns AuthCodeSentResponse Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanLogin(data: AuthThirdPartyHumanLoginData): CancelablePromise<AuthThirdPartyHumanLoginResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/login',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Authenticate
+     * Verify OTP and mint a third-party JWT for an existing human.
+     *
+     * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
+     * The JWT grants portal:self_read, portal:directory_read, and
+     * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns Token Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanAuthenticate(data: AuthThirdPartyHumanAuthenticateData): CancelablePromise<AuthThirdPartyHumanAuthenticateResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/authenticate',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
@@ -5998,6 +6176,59 @@ export class TenantsService {
             }
         });
     }
+    
+    /**
+     * Rotate Third Party Key
+     * Generate and store a new third-party API key for this tenant.
+     *
+     * The raw key is returned ONCE and never stored; only its peppered SHA-256
+     * hash is persisted. Rotation takes effect on the NEXT login attempt;
+     * in-flight JWTs already issued remain valid until their own expiry.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns ThirdPartyKeyRotated Successful Response
+     * @throws ApiError
+     */
+    public static rotateThirdPartyKey(data: TenantsRotateThirdPartyKeyData): CancelablePromise<TenantsRotateThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key/rotate',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Third Party Key
+     * Disable third-party login for this tenant by clearing the key hash.
+     *
+     * After this call, POST /auth/human/third-party/login returns 401 for this
+     * tenant until a new key is rotated in.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteThirdPartyKey(data: TenantsDeleteThirdPartyKeyData): CancelablePromise<TenantsDeleteThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
 }
 
 export class TicketingStepsService {
@@ -6696,8 +6927,8 @@ export class VenuePropertyTypesService {
     /**
      * Create Property Type
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns VenuePropertyTypePublic Successful Response
      * @throws ApiError
      */

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -1459,14 +1459,15 @@ export class AuthService {
      * Third Party Human Login
      * Initiate OTP login for an EXISTING human via a third-party integration.
      *
-     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
-     * Unlike the portal login endpoint, this surface NEVER creates a pending human
-     * row — the partner is expected to have onboarded the user out-of-band.
+     * The caller supplies only a valid third-party API key in
+     * X-Third-Party-Api-Key; the tenant is resolved server-side from the key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending
+     * human row — the partner is expected to have onboarded the user
+     * out-of-band.
      *
-     * On any validation failure (unknown tenant, feature disabled, wrong key,
-     * unknown email) the response is 401 to prevent existence leakage.
+     * On any validation failure (wrong key, unknown email) the response is 401
+     * to prevent existence leakage.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns AuthCodeSentResponse Successful Response
@@ -1477,7 +1478,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/login',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,
@@ -1492,11 +1492,11 @@ export class AuthService {
      * Third Party Human Authenticate
      * Verify OTP and mint a third-party JWT for an existing human.
      *
+     * The tenant is resolved server-side from the third-party API key alone.
      * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
      * The JWT grants portal:self_read, portal:directory_read, and
      * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns Token Successful Response
@@ -1507,7 +1507,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/authenticate',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2886,7 +2886,8 @@ export type TenantUpdate = {
 /**
  * Request body for POST /auth/human/third-party/login.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanLogin = {
     email: string;
@@ -2895,7 +2896,8 @@ export type ThirdPartyHumanLogin = {
 /**
  * Request body for POST /auth/human/third-party/authenticate.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanVerify = {
     email: string;
@@ -3718,7 +3720,6 @@ export type AuthHumanAuthenticateResponse = (Token);
 
 export type AuthThirdPartyHumanLoginData = {
     requestBody: ThirdPartyHumanLogin;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 
@@ -3726,7 +3727,6 @@ export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
 
 export type AuthThirdPartyHumanAuthenticateData = {
     requestBody: ThirdPartyHumanVerify;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -13,6 +13,46 @@ export type AbandonedCartPublic = {
     payments?: Array<CartPaymentInfo>;
 };
 
+/**
+ * Request body for minting a new admin API key.
+ */
+export type AdminApiKeyCreate = {
+    name: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    expires_at?: (string | null);
+};
+
+/**
+ * Response returned only at creation.
+ *
+ * ``raw_key`` is the cleartext token shown once and never stored.
+ */
+export type AdminApiKeyCreated = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+    raw_key: string;
+};
+
+/**
+ * Safe representation of an admin API key — never includes the raw secret.
+ */
+export type AdminApiKeyPublic = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+};
+
 export type AITranslateRequest = {
     entity_type: string;
     entity_id: string;
@@ -25,7 +65,7 @@ export type AITranslateRequest = {
 export type ApiKeyCreate = {
     name: string;
     expires_at?: (string | null);
-    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
 };
 
 /**
@@ -36,7 +76,7 @@ export type ApiKeyCreated = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -51,7 +91,7 @@ export type ApiKeyPublic = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -2828,6 +2868,7 @@ export type TenantPublic = {
     landing_mode?: LandingMode;
     id: string;
     active_popup_slug?: (string | null);
+    third_party_key_prefix?: (string | null);
 };
 
 export type TenantUpdate = {
@@ -2840,6 +2881,33 @@ export type TenantUpdate = {
     custom_domain?: (string | null);
     custom_domain_active?: (boolean | null);
     landing_mode?: (LandingMode | null);
+};
+
+/**
+ * Request body for POST /auth/human/third-party/login.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanLogin = {
+    email: string;
+};
+
+/**
+ * Request body for POST /auth/human/third-party/authenticate.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanVerify = {
+    email: string;
+    code: string;
+};
+
+/**
+ * Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.
+ */
+export type ThirdPartyKeyRotated = {
+    api_key: string;
+    prefix: string;
 };
 
 /**
@@ -3212,6 +3280,33 @@ export type VenueWeeklyHourRef = {
 export type VenueWeeklyHoursUpdate = {
     hours: Array<VenueWeeklyHourInput>;
 };
+
+export type AdminApiKeysCreateAdminApiKeyData = {
+    requestBody: AdminApiKeyCreate;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysCreateAdminApiKeyResponse = (AdminApiKeyCreated);
+
+export type AdminApiKeysListAdminApiKeysData = {
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysListAdminApiKeysResponse = (Array<AdminApiKeyPublic>);
+
+export type AdminApiKeysGetAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysGetAdminApiKeyResponse = (AdminApiKeyPublic);
+
+export type AdminApiKeysRevokeAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysRevokeAdminApiKeyResponse = (void);
 
 export type ApiKeysListApiKeysResponse = (Array<ApiKeyPublic>);
 
@@ -3620,6 +3715,22 @@ export type AuthHumanAuthenticateData = {
 };
 
 export type AuthHumanAuthenticateResponse = (Token);
+
+export type AuthThirdPartyHumanLoginData = {
+    requestBody: ThirdPartyHumanLogin;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
+
+export type AuthThirdPartyHumanAuthenticateData = {
+    requestBody: ThirdPartyHumanVerify;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanAuthenticateResponse = (Token);
 
 export type BaseFieldConfigsListBaseFieldConfigsData = {
     /**
@@ -5082,6 +5193,18 @@ export type TenantsDeleteCredentialsData = {
 
 export type TenantsDeleteCredentialsResponse = (void);
 
+export type TenantsRotateThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsRotateThirdPartyKeyResponse = (ThirdPartyKeyRotated);
+
+export type TenantsDeleteThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsDeleteThirdPartyKeyResponse = (void);
+
 export type TicketingStepsListPortalTicketingStepsData = {
     popupId: string;
 };
@@ -5332,7 +5455,7 @@ export type VenuePropertyTypesListPropertyTypesResponse = (Array<VenuePropertyTy
 
 export type VenuePropertyTypesCreatePropertyTypeData = {
     requestBody: VenuePropertyTypeCreate;
-    xTenantId: string;
+    xTenantId?: (string | null);
 };
 
 export type VenuePropertyTypesCreatePropertyTypeResponse = (VenuePropertyTypePublic);

--- a/backoffice/src/components/Sidebar/AppSidebar.tsx
+++ b/backoffice/src/components/Sidebar/AppSidebar.tsx
@@ -86,6 +86,12 @@ const agenticItems: Item[] = [
   { icon: KeyRound, title: "API Keys", path: "/api-keys" },
 ]
 
+// Feature flag: surface the Agentic access section in the sidebar.
+// The /api-keys route and CRUD endpoints stay live (admins can still create
+// keys via the API), but the UI entry is hidden until we are ready to expose
+// it to users.
+const SHOW_AGENTIC_ACCESS = false
+
 // Superadmin only items - organizations list view
 const superadminItems: Item[] = [
   { icon: Building2, title: "Organizations", path: "/organizations" },
@@ -195,14 +201,16 @@ export function AppSidebar() {
           </SidebarGroup>
         )}
 
-        {/* Agentic access (API Keys + Docs) — admins and superadmins only */}
-        {(currentUser?.role === "admin" ||
-          currentUser?.role === "superadmin") && (
-          <SidebarGroup>
-            <SidebarGroupLabel>Agentic access</SidebarGroupLabel>
-            <Main items={agenticItems} />
-          </SidebarGroup>
-        )}
+        {/* Agentic access (API Keys + Docs) — admins and superadmins only.
+            Gated behind SHOW_AGENTIC_ACCESS while the feature is hidden. */}
+        {SHOW_AGENTIC_ACCESS &&
+          (currentUser?.role === "admin" ||
+            currentUser?.role === "superadmin") && (
+            <SidebarGroup>
+              <SidebarGroupLabel>Agentic access</SidebarGroupLabel>
+              <Main items={agenticItems} />
+            </SidebarGroup>
+          )}
       </SidebarContent>
       <SidebarFooter>
         <SidebarAppearance />

--- a/backoffice/src/components/Sidebar/AppSidebar.tsx
+++ b/backoffice/src/components/Sidebar/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   FormInput,
   Home,
+  KeyRound,
   LayoutList,
   ListTree,
   Mail,
@@ -79,6 +80,11 @@ const eventItems: Item[] = [
 
 // Admin items (admins and superadmins)
 const adminItems: Item[] = [{ icon: Users, title: "Users", path: "/admin" }]
+
+// Agentic access items (admins and superadmins only)
+const agenticItems: Item[] = [
+  { icon: KeyRound, title: "API Keys", path: "/api-keys" },
+]
 
 // Superadmin only items - organizations list view
 const superadminItems: Item[] = [
@@ -186,6 +192,15 @@ export function AppSidebar() {
             <SidebarGroupLabel>Administration</SidebarGroupLabel>
             <Main items={adminNavigationItems} />
             {isSuperadmin && <Main items={superadminItems} />}
+          </SidebarGroup>
+        )}
+
+        {/* Agentic access (API Keys + Docs) — admins and superadmins only */}
+        {(currentUser?.role === "admin" ||
+          currentUser?.role === "superadmin") && (
+          <SidebarGroup>
+            <SidebarGroupLabel>Agentic access</SidebarGroupLabel>
+            <Main items={agenticItems} />
           </SidebarGroup>
         )}
       </SidebarContent>

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -64,7 +64,7 @@ const PORTAL_DOMAIN = import.meta.env.VITE_PORTAL_DOMAIN ?? ""
 export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { isSuperadmin } = useAuth()
+  const { isAdmin, isSuperadmin } = useAuth()
   const [copied, setCopied] = useState(false)
 
   const cnameTarget =
@@ -530,7 +530,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
         </div>
       )}
 
-      {isEdit && (
+      {isEdit && isAdmin && (
         <div className="mx-auto max-w-2xl">
           <ThirdPartyIntegrationSection
             tenantId={defaultValues.id}

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -23,6 +23,7 @@ import {
 import { DangerZone } from "@/components/Common/DangerZone"
 import { FieldError } from "@/components/Common/FieldError"
 import { TenantCredentialsSection } from "@/components/forms/TenantCredentialsSection"
+import { ThirdPartyIntegrationSection } from "@/components/forms/ThirdPartyIntegrationSection"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -526,6 +527,15 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
       {isEdit && isSuperadmin && (
         <div className="mx-auto max-w-2xl">
           <TenantCredentialsSection tenantId={defaultValues.id} />
+        </div>
+      )}
+
+      {isEdit && (
+        <div className="mx-auto max-w-2xl">
+          <ThirdPartyIntegrationSection
+            tenantId={defaultValues.id}
+            prefix={defaultValues.third_party_key_prefix}
+          />
         </div>
       )}
 

--- a/backoffice/src/components/forms/ThirdPartyIntegrationSection.tsx
+++ b/backoffice/src/components/forms/ThirdPartyIntegrationSection.tsx
@@ -1,0 +1,282 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import {
+  AlertTriangle,
+  Check,
+  Copy,
+  Link2,
+  RefreshCw,
+  Unlink,
+} from "lucide-react"
+import { useState } from "react"
+
+import { TenantsService, type ThirdPartyKeyRotated } from "@/client"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { InlineRow, InlineSection } from "@/components/ui/inline-form"
+import { LoadingButton } from "@/components/ui/loading-button"
+import useCustomToast from "@/hooks/useCustomToast"
+import { createErrorHandler } from "@/utils"
+
+interface ThirdPartyIntegrationSectionProps {
+  tenantId: string
+  /** Prefix is null when third-party integration is not yet configured */
+  prefix: string | null | undefined
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        navigator.clipboard.writeText(value)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
+    >
+      {copied ? (
+        <>
+          <Check className="mr-2 h-4 w-4" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="mr-2 h-4 w-4" />
+          Copy key
+        </>
+      )}
+    </Button>
+  )
+}
+
+function RevealKeyDialog({
+  result,
+  onClose,
+}: {
+  result: ThirdPartyKeyRotated
+  onClose: () => void
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Third-party API key generated</DialogTitle>
+          <DialogDescription>
+            Save this key now. You will not be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-md border bg-muted p-3">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+            <p className="text-xs text-muted-foreground">
+              Distribute this key to your third-party integration partner.
+              Anyone with this key can initiate OTP logins for your portal
+              users. Store it securely and rotate it if it is ever compromised.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-3 font-mono text-sm break-all select-all">
+            {result.api_key}
+          </div>
+          <CopyButton value={result.api_key} />
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>I have saved it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RotateConfirmDialog({
+  onConfirm,
+  onClose,
+  isPending,
+}: {
+  onConfirm: () => void
+  onClose: () => void
+  isPending: boolean
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rotate third-party API key</DialogTitle>
+          <DialogDescription>
+            A new key will be generated and the current key will stop working
+            immediately. All third-party clients must be updated to use the new
+            key.
+          </DialogDescription>
+        </DialogHeader>
+        <Alert>
+          <AlertDescription>
+            In-flight portal sessions that were authenticated before rotation
+            will remain valid until their tokens expire naturally.
+          </AlertDescription>
+        </Alert>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton loading={isPending} onClick={onConfirm}>
+            Rotate key
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DisableConfirmDialog({
+  onConfirm,
+  onClose,
+  isPending,
+}: {
+  onConfirm: () => void
+  onClose: () => void
+  isPending: boolean
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disable third-party login</DialogTitle>
+          <DialogDescription>
+            Third-party OTP login will be disabled for all users in this tenant.
+            Existing portal sessions remain valid until they expire.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            variant="destructive"
+            loading={isPending}
+            onClick={onConfirm}
+          >
+            Disable
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function ThirdPartyIntegrationSection({
+  tenantId,
+  prefix,
+}: ThirdPartyIntegrationSectionProps) {
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const queryClient = useQueryClient()
+
+  const [rotateDialogOpen, setRotateDialogOpen] = useState(false)
+  const [disableDialogOpen, setDisableDialogOpen] = useState(false)
+  const [revealResult, setRevealResult] = useState<ThirdPartyKeyRotated | null>(
+    null,
+  )
+
+  const rotateMutation = useMutation({
+    mutationFn: () => TenantsService.rotateThirdPartyKey({ tenantId }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["tenants", tenantId] })
+      setRotateDialogOpen(false)
+      setRevealResult(result)
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => TenantsService.deleteThirdPartyKey({ tenantId }),
+    onSuccess: () => {
+      showSuccessToast("Third-party login disabled")
+      queryClient.invalidateQueries({ queryKey: ["tenants", tenantId] })
+      setDisableDialogOpen(false)
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  const isEnabled = !!prefix
+
+  return (
+    <>
+      <InlineSection title="Third-party integration">
+        <InlineRow
+          icon={<Link2 className="h-4 w-4 text-muted-foreground" />}
+          label="Third-party OTP login"
+          description={
+            isEnabled
+              ? `Enabled - prefix: ${prefix}`
+              : "Disabled - generate a key to enable"
+          }
+        >
+          {isEnabled ? (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setRotateDialogOpen(true)}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Rotate key
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => setDisableDialogOpen(true)}
+              >
+                <Unlink className="mr-2 h-4 w-4" />
+                Disable
+              </Button>
+            </div>
+          ) : (
+            <LoadingButton
+              type="button"
+              variant="outline"
+              size="sm"
+              loading={rotateMutation.isPending}
+              onClick={() => rotateMutation.mutate()}
+            >
+              Generate API key
+            </LoadingButton>
+          )}
+        </InlineRow>
+      </InlineSection>
+
+      {rotateDialogOpen && (
+        <RotateConfirmDialog
+          onConfirm={() => rotateMutation.mutate()}
+          onClose={() => setRotateDialogOpen(false)}
+          isPending={rotateMutation.isPending}
+        />
+      )}
+
+      {disableDialogOpen && (
+        <DisableConfirmDialog
+          onConfirm={() => deleteMutation.mutate()}
+          onClose={() => setDisableDialogOpen(false)}
+          isPending={deleteMutation.isPending}
+        />
+      )}
+
+      {revealResult && (
+        <RevealKeyDialog
+          result={revealResult}
+          onClose={() => setRevealResult(null)}
+        />
+      )}
+    </>
+  )
+}

--- a/backoffice/src/routeTree.gen.ts
+++ b/backoffice/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutPaymentsRouteImport } from './routes/_layout/payments'
 import { Route as LayoutCheckInRouteImport } from './routes/_layout/check-in'
 import { Route as LayoutAttendeesRouteImport } from './routes/_layout/attendees'
+import { Route as LayoutApiKeysRouteImport } from './routes/_layout/api-keys'
 import { Route as LayoutAbandonedCartsRouteImport } from './routes/_layout/abandoned-carts'
 import { Route as LayoutTicketingStepsIndexRouteImport } from './routes/_layout/ticketing-steps/index'
 import { Route as LayoutThemeIndexRouteImport } from './routes/_layout/theme/index'
@@ -98,6 +99,11 @@ const LayoutCheckInRoute = LayoutCheckInRouteImport.update({
 const LayoutAttendeesRoute = LayoutAttendeesRouteImport.update({
   id: '/attendees',
   path: '/attendees',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutApiKeysRoute = LayoutApiKeysRouteImport.update({
+  id: '/api-keys',
+  path: '/api-keys',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutAbandonedCartsRoute = LayoutAbandonedCartsRouteImport.update({
@@ -362,6 +368,7 @@ export interface FileRoutesByFullPath {
   '/': typeof LayoutIndexRoute
   '/login': typeof LoginRoute
   '/abandoned-carts': typeof LayoutAbandonedCartsRoute
+  '/api-keys': typeof LayoutApiKeysRoute
   '/attendees': typeof LayoutAttendeesRoute
   '/check-in': typeof LayoutCheckInRoute
   '/payments': typeof LayoutPaymentsRoute
@@ -418,6 +425,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/abandoned-carts': typeof LayoutAbandonedCartsRoute
+  '/api-keys': typeof LayoutApiKeysRoute
   '/attendees': typeof LayoutAttendeesRoute
   '/check-in': typeof LayoutCheckInRoute
   '/payments': typeof LayoutPaymentsRoute
@@ -477,6 +485,7 @@ export interface FileRoutesById {
   '/_layout': typeof LayoutRouteWithChildren
   '/login': typeof LoginRoute
   '/_layout/abandoned-carts': typeof LayoutAbandonedCartsRoute
+  '/_layout/api-keys': typeof LayoutApiKeysRoute
   '/_layout/attendees': typeof LayoutAttendeesRoute
   '/_layout/check-in': typeof LayoutCheckInRoute
   '/_layout/payments': typeof LayoutPaymentsRoute
@@ -537,6 +546,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/abandoned-carts'
+    | '/api-keys'
     | '/attendees'
     | '/check-in'
     | '/payments'
@@ -593,6 +603,7 @@ export interface FileRouteTypes {
   to:
     | '/login'
     | '/abandoned-carts'
+    | '/api-keys'
     | '/attendees'
     | '/check-in'
     | '/payments'
@@ -651,6 +662,7 @@ export interface FileRouteTypes {
     | '/_layout'
     | '/login'
     | '/_layout/abandoned-carts'
+    | '/_layout/api-keys'
     | '/_layout/attendees'
     | '/_layout/check-in'
     | '/_layout/payments'
@@ -760,6 +772,13 @@ declare module '@tanstack/react-router' {
       path: '/attendees'
       fullPath: '/attendees'
       preLoaderRoute: typeof LayoutAttendeesRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/api-keys': {
+      id: '/_layout/api-keys'
+      path: '/api-keys'
+      fullPath: '/api-keys'
+      preLoaderRoute: typeof LayoutApiKeysRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/abandoned-carts': {
@@ -1110,6 +1129,7 @@ declare module '@tanstack/react-router' {
 
 interface LayoutRouteChildren {
   LayoutAbandonedCartsRoute: typeof LayoutAbandonedCartsRoute
+  LayoutApiKeysRoute: typeof LayoutApiKeysRoute
   LayoutAttendeesRoute: typeof LayoutAttendeesRoute
   LayoutCheckInRoute: typeof LayoutCheckInRoute
   LayoutPaymentsRoute: typeof LayoutPaymentsRoute
@@ -1167,6 +1187,7 @@ interface LayoutRouteChildren {
 
 const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAbandonedCartsRoute: LayoutAbandonedCartsRoute,
+  LayoutApiKeysRoute: LayoutApiKeysRoute,
   LayoutAttendeesRoute: LayoutAttendeesRoute,
   LayoutCheckInRoute: LayoutCheckInRoute,
   LayoutPaymentsRoute: LayoutPaymentsRoute,

--- a/backoffice/src/routes/_layout/api-keys.tsx
+++ b/backoffice/src/routes/_layout/api-keys.tsx
@@ -1,0 +1,588 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import type { ColumnDef } from "@tanstack/react-table"
+import { AlertTriangle, Check, Copy, KeyRound, Plus } from "lucide-react"
+import { useState } from "react"
+
+import {
+  type AdminApiKeyCreate,
+  type AdminApiKeyPublic,
+  AdminApiKeysService,
+} from "@/client"
+import { DataTable } from "@/components/Common/DataTable"
+import { EmptyState } from "@/components/Common/EmptyState"
+import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { Skeleton } from "@/components/ui/skeleton"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import { createErrorHandler } from "@/utils"
+
+// Kept in sync with ADMIN_API_KEY_SCOPES in backend core/security.py
+const ADMIN_API_KEY_SCOPES = [
+  "events:read",
+  "events:write",
+  "rsvp:write",
+  "venues:write",
+  "applications:read",
+  "applications:write",
+  "attendees:read",
+  "attendees:write",
+  "humans:read",
+  "humans:write",
+  "groups:read",
+  "groups:write",
+  "products:read",
+  "products:write",
+  "coupons:read",
+  "coupons:write",
+  "forms:read",
+  "forms:write",
+  "payments:read",
+  "tracks:read",
+  "tracks:write",
+  "ticketing_steps:read",
+  "ticketing_steps:write",
+  "translations:read",
+  "translations:write",
+] as const
+
+type AdminApiKeyScope = (typeof ADMIN_API_KEY_SCOPES)[number]
+
+const SCOPE_GROUPS: { label: string; scopes: AdminApiKeyScope[] }[] = [
+  {
+    label: "Events",
+    scopes: ["events:read", "events:write", "rsvp:write", "venues:write"],
+  },
+  {
+    label: "Applications",
+    scopes: ["applications:read", "applications:write"],
+  },
+  {
+    label: "People",
+    scopes: [
+      "attendees:read",
+      "attendees:write",
+      "humans:read",
+      "humans:write",
+      "groups:read",
+      "groups:write",
+    ],
+  },
+  {
+    label: "Catalog",
+    scopes: [
+      "products:read",
+      "products:write",
+      "coupons:read",
+      "coupons:write",
+      "forms:read",
+      "forms:write",
+    ],
+  },
+  { label: "Financial", scopes: ["payments:read"] },
+  {
+    label: "Structure",
+    scopes: [
+      "tracks:read",
+      "tracks:write",
+      "ticketing_steps:read",
+      "ticketing_steps:write",
+      "translations:read",
+      "translations:write",
+    ],
+  },
+]
+
+export const Route = createFileRoute("/_layout/api-keys")({
+  component: ApiKeysPage,
+  head: () => ({
+    meta: [{ title: "API Keys - EdgeOS" }],
+  }),
+})
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "Never"
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        navigator.clipboard.writeText(value)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
+    >
+      {copied ? (
+        <>
+          <Check className="mr-2 h-4 w-4" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="mr-2 h-4 w-4" />
+          Copy key
+        </>
+      )}
+    </Button>
+  )
+}
+
+function RevealKeyDialog({
+  rawKey,
+  onClose,
+}: {
+  rawKey: string
+  onClose: () => void
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>API key created</DialogTitle>
+          <DialogDescription>
+            Save this key now. You will not be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-md border bg-muted p-3">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+            <p className="text-xs text-muted-foreground">
+              Copy the key below and store it securely. Once you close this
+              dialog, the key is gone from this interface.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-3 font-mono text-sm break-all select-all">
+            {rawKey}
+          </div>
+          <CopyButton value={rawKey} />
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>I have saved it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CreateKeyDialog({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: (rawKey: string) => void
+}) {
+  const { showErrorToast } = useCustomToast()
+  const queryClient = useQueryClient()
+
+  const [name, setName] = useState("")
+  const [selectedScopes, setSelectedScopes] = useState<AdminApiKeyScope[]>([])
+  const [expiresAt, setExpiresAt] = useState("")
+  const [nameError, setNameError] = useState("")
+  const [scopeError, setScopeError] = useState("")
+  const [expiresError, setExpiresError] = useState("")
+
+  const hasWriteScope = selectedScopes.some((s) => s.endsWith(":write"))
+
+  const createMutation = useMutation({
+    mutationFn: (data: AdminApiKeyCreate) =>
+      AdminApiKeysService.createAdminApiKey({ requestBody: data }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] })
+      onCreated(result.raw_key)
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  function toggleScope(scope: AdminApiKeyScope) {
+    setSelectedScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+    )
+    setScopeError("")
+    setExpiresError("")
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    let valid = true
+    if (!name.trim()) {
+      setNameError("Name is required")
+      valid = false
+    }
+    if (selectedScopes.length === 0) {
+      setScopeError("Select at least one scope")
+      valid = false
+    }
+    if (hasWriteScope && !expiresAt) {
+      setExpiresError(
+        "Expiry date is required when any write scope is selected",
+      )
+      valid = false
+    }
+    if (!valid) return
+
+    createMutation.mutate({
+      name: name.trim(),
+      scopes: selectedScopes,
+      expires_at: expiresAt || null,
+    })
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create API key</DialogTitle>
+            <DialogDescription>
+              Admin API keys let external services call the backoffice API on
+              behalf of this admin account.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-5 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="api-key-name">Name</Label>
+              <Input
+                id="api-key-name"
+                placeholder="e.g. CI pipeline"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  setNameError("")
+                }}
+              />
+              {nameError && (
+                <p className="text-sm text-destructive">{nameError}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label>Scopes</Label>
+              <p className="text-xs text-muted-foreground">
+                Select the permissions this key should have.
+              </p>
+              {scopeError && (
+                <p className="text-sm text-destructive">{scopeError}</p>
+              )}
+              <div className="space-y-4">
+                {SCOPE_GROUPS.map((group) => (
+                  <div key={group.label} className="space-y-2">
+                    <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      {group.label}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {group.scopes.map((scope) => {
+                        const isSelected = selectedScopes.includes(scope)
+                        return (
+                          <button
+                            key={scope}
+                            type="button"
+                            onClick={() => toggleScope(scope)}
+                            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                              isSelected
+                                ? "border-primary bg-primary text-primary-foreground"
+                                : "border-muted-foreground/30 bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                            }`}
+                          >
+                            {scope}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="api-key-expires">
+                Expires at
+                {hasWriteScope && (
+                  <span className="ml-1 text-destructive">*</span>
+                )}
+              </Label>
+              {hasWriteScope && (
+                <p className="text-xs text-muted-foreground">
+                  Required when any write scope is selected.
+                </p>
+              )}
+              <Input
+                id="api-key-expires"
+                type="date"
+                value={expiresAt}
+                min={new Date().toISOString().split("T")[0]}
+                onChange={(e) => {
+                  setExpiresAt(e.target.value)
+                  setExpiresError("")
+                }}
+              />
+              {expiresError && (
+                <p className="text-sm text-destructive">{expiresError}</p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <LoadingButton type="submit" loading={createMutation.isPending}>
+              Create key
+            </LoadingButton>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RevokeKeyDialog({
+  keyId,
+  keyName,
+  onClose,
+}: {
+  keyId: string
+  keyName: string
+  onClose: () => void
+}) {
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const queryClient = useQueryClient()
+
+  const revokeMutation = useMutation({
+    mutationFn: () => AdminApiKeysService.revokeAdminApiKey({ keyId }),
+    onSuccess: () => {
+      showSuccessToast("API key revoked")
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] })
+      onClose()
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Revoke API key</DialogTitle>
+          <DialogDescription>
+            Revoke &ldquo;{keyName}&rdquo;? Any service using this key will stop
+            working immediately. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            variant="destructive"
+            loading={revokeMutation.isPending}
+            onClick={() => revokeMutation.mutate()}
+          >
+            Revoke key
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ApiKeysTable() {
+  const [createOpen, setCreateOpen] = useState(false)
+  const [rawKey, setRawKey] = useState<string | null>(null)
+  const [revokeTarget, setRevokeTarget] = useState<AdminApiKeyPublic | null>(
+    null,
+  )
+
+  const { data: keys, isLoading } = useQuery({
+    queryKey: ["admin-api-keys"],
+    queryFn: () => AdminApiKeysService.listAdminApiKeys(),
+  })
+
+  const columns: ColumnDef<AdminApiKeyPublic>[] = [
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: ({ row }) => (
+        <div>
+          <p className="font-medium">{row.original.name}</p>
+          <p className="text-xs text-muted-foreground font-mono">
+            {row.original.prefix}...
+          </p>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "scopes",
+      header: "Scopes",
+      cell: ({ row }) => (
+        <div className="flex flex-wrap gap-1">
+          {row.original.scopes.slice(0, 3).map((scope) => (
+            <Badge key={scope} variant="secondary" className="text-xs">
+              {scope}
+            </Badge>
+          ))}
+          {row.original.scopes.length > 3 && (
+            <Badge variant="outline" className="text-xs">
+              +{row.original.scopes.length - 3} more
+            </Badge>
+          )}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "expires_at",
+      header: "Expires",
+      cell: ({ row }) => (
+        <span className="text-sm">{formatDate(row.original.expires_at)}</span>
+      ),
+    },
+    {
+      accessorKey: "last_used_at",
+      header: "Last used",
+      cell: ({ row }) => (
+        <span className="text-sm">{formatDate(row.original.last_used_at)}</span>
+      ),
+    },
+    {
+      accessorKey: "revoked_at",
+      header: "Status",
+      cell: ({ row }) =>
+        row.original.revoked_at ? (
+          <Badge variant="destructive">Revoked</Badge>
+        ) : (
+          <Badge variant="secondary">Active</Badge>
+        ),
+    },
+    {
+      id: "actions",
+      cell: ({ row }) =>
+        !row.original.revoked_at ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={(e) => {
+              e.stopPropagation()
+              setRevokeTarget(row.original)
+            }}
+          >
+            Revoke
+          </Button>
+        ) : null,
+    },
+  ]
+
+  if (isLoading) return <Skeleton className="h-64 w-full" />
+  if (!keys) return null
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        data={keys}
+        emptyState={
+          <EmptyState
+            icon={KeyRound}
+            title="No API keys yet"
+            description="Create an API key to get started."
+            action={
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Create new key
+              </Button>
+            }
+          />
+        }
+      />
+
+      {createOpen && (
+        <CreateKeyDialog
+          onClose={() => setCreateOpen(false)}
+          onCreated={(key) => {
+            setCreateOpen(false)
+            setRawKey(key)
+          }}
+        />
+      )}
+
+      {rawKey && (
+        <RevealKeyDialog rawKey={rawKey} onClose={() => setRawKey(null)} />
+      )}
+
+      {revokeTarget && (
+        <RevokeKeyDialog
+          keyId={revokeTarget.id}
+          keyName={revokeTarget.name}
+          onClose={() => setRevokeTarget(null)}
+        />
+      )}
+    </>
+  )
+}
+
+function ApiKeysPage() {
+  const { isAdmin } = useAuth()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [rawKey, setRawKey] = useState<string | null>(null)
+
+  if (!isAdmin) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">API Keys</h1>
+          <p className="text-muted-foreground">
+            Manage admin API keys for programmatic backoffice access
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create new key
+        </Button>
+      </div>
+
+      <QueryErrorBoundary>
+        <ApiKeysTable />
+      </QueryErrorBoundary>
+
+      {createOpen && (
+        <CreateKeyDialog
+          onClose={() => setCreateOpen(false)}
+          onCreated={(key) => {
+            setCreateOpen(false)
+            setRawKey(key)
+          }}
+        />
+      )}
+
+      {rawKey && (
+        <RevealKeyDialog rawKey={rawKey} onClose={() => setRawKey(null)} />
+      )}
+    </div>
+  )
+}

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -14636,7 +14636,8 @@ export const ThirdPartyHumanLoginSchema = {
     title: 'ThirdPartyHumanLogin',
     description: `Request body for POST /auth/human/third-party/login.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyHumanVerifySchema = {
@@ -14659,7 +14660,8 @@ export const ThirdPartyHumanVerifySchema = {
     title: 'ThirdPartyHumanVerify',
     description: `Request body for POST /auth/human/third-party/authenticate.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyKeyRotatedSchema = {

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -76,6 +76,190 @@ export const AbandonedCartPublicSchema = {
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;
 
+export const AdminApiKeyCreateSchema = {
+    properties: {
+        name: {
+            type: 'string',
+            maxLength: 100,
+            minLength: 1,
+            title: 'Name'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            minItems: 1,
+            title: 'Scopes'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        }
+    },
+    type: 'object',
+    required: ['name', 'scopes'],
+    title: 'AdminApiKeyCreate',
+    description: 'Request body for minting a new admin API key.'
+} as const;
+
+export const AdminApiKeyCreatedSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        },
+        raw_key: {
+            type: 'string',
+            title: 'Raw Key'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at', 'raw_key'],
+    title: 'AdminApiKeyCreated',
+    description: `Response returned only at creation.
+
+\`\`raw_key\`\` is the cleartext token shown once and never stored.`
+} as const;
+
+export const AdminApiKeyPublicSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at'],
+    title: 'AdminApiKeyPublic',
+    description: 'Safe representation of an admin API key — never includes the raw secret.'
+} as const;
+
 export const ApiKeyCreateSchema = {
     properties: {
         name: {
@@ -99,7 +283,7 @@ export const ApiKeyCreateSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -129,7 +313,7 @@ export const ApiKeyCreatedSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -205,7 +389,7 @@ export const ApiKeyPublicSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -14315,6 +14499,17 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Active Popup Slug'
+        },
+        third_party_key_prefix: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Third Party Key Prefix'
         }
     },
     type: 'object',
@@ -14426,6 +14621,62 @@ export const TenantUpdateSchema = {
     },
     type: 'object',
     title: 'TenantUpdate'
+} as const;
+
+export const ThirdPartyHumanLoginSchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        }
+    },
+    type: 'object',
+    required: ['email'],
+    title: 'ThirdPartyHumanLogin',
+    description: `Request body for POST /auth/human/third-party/login.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyHumanVerifySchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        },
+        code: {
+            type: 'string',
+            maxLength: 6,
+            minLength: 6,
+            pattern: '^\\d{6}$',
+            title: 'Code'
+        }
+    },
+    type: 'object',
+    required: ['email', 'code'],
+    title: 'ThirdPartyHumanVerify',
+    description: `Request body for POST /auth/human/third-party/authenticate.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyKeyRotatedSchema = {
+    properties: {
+        api_key: {
+            type: 'string',
+            title: 'Api Key'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        }
+    },
+    type: 'object',
+    required: ['api_key', 'prefix'],
+    title: 'ThirdPartyKeyRotated',
+    description: 'Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.'
 } as const;
 
 export const TicketAttendeeSnapshotSchema = {

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -3,7 +3,122 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+import type { AdminApiKeysCreateAdminApiKeyData, AdminApiKeysCreateAdminApiKeyResponse, AdminApiKeysListAdminApiKeysData, AdminApiKeysListAdminApiKeysResponse, AdminApiKeysGetAdminApiKeyData, AdminApiKeysGetAdminApiKeyResponse, AdminApiKeysRevokeAdminApiKeyData, AdminApiKeysRevokeAdminApiKeyResponse, ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, AuthThirdPartyHumanLoginData, AuthThirdPartyHumanLoginResponse, AuthThirdPartyHumanAuthenticateData, AuthThirdPartyHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TenantsRotateThirdPartyKeyData, TenantsRotateThirdPartyKeyResponse, TenantsDeleteThirdPartyKeyData, TenantsDeleteThirdPartyKeyResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+
+export class AdminApiKeysService {
+    /**
+     * Create Admin Api Key
+     * Mint a new admin API key.
+     *
+     * Scopes must be a subset of ADMIN_API_KEY_SCOPES. Any scope outside that
+     * universe returns 422. Write scopes require an expiry date (validated by
+     * the schema).
+     *
+     * The cleartext key is returned once in ``raw_key``; only the hash is stored.
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @param data.xTenantId
+     * @returns AdminApiKeyCreated Successful Response
+     * @throws ApiError
+     */
+    public static createAdminApiKey(data: AdminApiKeysCreateAdminApiKeyData): CancelablePromise<AdminApiKeysCreateAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * List Admin Api Keys
+     * List admin API keys.
+     *
+     * ADMIN sees only their own keys.
+     * SUPERADMIN sees all admin keys in the tenant they are operating on (via
+     * X-Tenant-Id header, already resolved by TenantSession).
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static listAdminApiKeys(data: AdminApiKeysListAdminApiKeysData = {}): CancelablePromise<AdminApiKeysListAdminApiKeysResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Get Admin Api Key
+     * Retrieve a specific admin API key.
+     *
+     * Visibility mirrors the list endpoint: ADMIN sees only own keys; SUPERADMIN
+     * sees any admin key in the tenant. Returns 404 for keys outside the caller's
+     * visibility — never 403, to avoid leaking existence of foreign keys.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static getAdminApiKey(data: AdminApiKeysGetAdminApiKeyData): CancelablePromise<AdminApiKeysGetAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Revoke Admin Api Key
+     * Revoke an admin API key by setting revoked_at.
+     *
+     * ADMIN can only revoke their own keys (403 for foreign keys).
+     * SUPERADMIN can revoke any admin key in their tenant scope.
+     * Non-existent keys return 404.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static revokeAdminApiKey(data: AdminApiKeysRevokeAdminApiKeyData): CancelablePromise<AdminApiKeysRevokeAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
 
 export class ApiKeysService {
     /**
@@ -1332,6 +1447,69 @@ export class AuthService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/auth/human/authenticate',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Login
+     * Initiate OTP login for an EXISTING human via a third-party integration.
+     *
+     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending human
+     * row — the partner is expected to have onboarded the user out-of-band.
+     *
+     * On any validation failure (unknown tenant, feature disabled, wrong key,
+     * unknown email) the response is 401 to prevent existence leakage.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns AuthCodeSentResponse Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanLogin(data: AuthThirdPartyHumanLoginData): CancelablePromise<AuthThirdPartyHumanLoginResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/login',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Authenticate
+     * Verify OTP and mint a third-party JWT for an existing human.
+     *
+     * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
+     * The JWT grants portal:self_read, portal:directory_read, and
+     * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns Token Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanAuthenticate(data: AuthThirdPartyHumanAuthenticateData): CancelablePromise<AuthThirdPartyHumanAuthenticateResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/authenticate',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
@@ -5998,6 +6176,59 @@ export class TenantsService {
             }
         });
     }
+    
+    /**
+     * Rotate Third Party Key
+     * Generate and store a new third-party API key for this tenant.
+     *
+     * The raw key is returned ONCE and never stored; only its peppered SHA-256
+     * hash is persisted. Rotation takes effect on the NEXT login attempt;
+     * in-flight JWTs already issued remain valid until their own expiry.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns ThirdPartyKeyRotated Successful Response
+     * @throws ApiError
+     */
+    public static rotateThirdPartyKey(data: TenantsRotateThirdPartyKeyData): CancelablePromise<TenantsRotateThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key/rotate',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Third Party Key
+     * Disable third-party login for this tenant by clearing the key hash.
+     *
+     * After this call, POST /auth/human/third-party/login returns 401 for this
+     * tenant until a new key is rotated in.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteThirdPartyKey(data: TenantsDeleteThirdPartyKeyData): CancelablePromise<TenantsDeleteThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
 }
 
 export class TicketingStepsService {
@@ -6696,8 +6927,8 @@ export class VenuePropertyTypesService {
     /**
      * Create Property Type
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns VenuePropertyTypePublic Successful Response
      * @throws ApiError
      */

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -1459,14 +1459,15 @@ export class AuthService {
      * Third Party Human Login
      * Initiate OTP login for an EXISTING human via a third-party integration.
      *
-     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
-     * Unlike the portal login endpoint, this surface NEVER creates a pending human
-     * row — the partner is expected to have onboarded the user out-of-band.
+     * The caller supplies only a valid third-party API key in
+     * X-Third-Party-Api-Key; the tenant is resolved server-side from the key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending
+     * human row — the partner is expected to have onboarded the user
+     * out-of-band.
      *
-     * On any validation failure (unknown tenant, feature disabled, wrong key,
-     * unknown email) the response is 401 to prevent existence leakage.
+     * On any validation failure (wrong key, unknown email) the response is 401
+     * to prevent existence leakage.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns AuthCodeSentResponse Successful Response
@@ -1477,7 +1478,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/login',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,
@@ -1492,11 +1492,11 @@ export class AuthService {
      * Third Party Human Authenticate
      * Verify OTP and mint a third-party JWT for an existing human.
      *
+     * The tenant is resolved server-side from the third-party API key alone.
      * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
      * The JWT grants portal:self_read, portal:directory_read, and
      * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns Token Successful Response
@@ -1507,7 +1507,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/authenticate',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2886,7 +2886,8 @@ export type TenantUpdate = {
 /**
  * Request body for POST /auth/human/third-party/login.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanLogin = {
     email: string;
@@ -2895,7 +2896,8 @@ export type ThirdPartyHumanLogin = {
 /**
  * Request body for POST /auth/human/third-party/authenticate.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanVerify = {
     email: string;
@@ -3718,7 +3720,6 @@ export type AuthHumanAuthenticateResponse = (Token);
 
 export type AuthThirdPartyHumanLoginData = {
     requestBody: ThirdPartyHumanLogin;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 
@@ -3726,7 +3727,6 @@ export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
 
 export type AuthThirdPartyHumanAuthenticateData = {
     requestBody: ThirdPartyHumanVerify;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -13,6 +13,46 @@ export type AbandonedCartPublic = {
     payments?: Array<CartPaymentInfo>;
 };
 
+/**
+ * Request body for minting a new admin API key.
+ */
+export type AdminApiKeyCreate = {
+    name: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    expires_at?: (string | null);
+};
+
+/**
+ * Response returned only at creation.
+ *
+ * ``raw_key`` is the cleartext token shown once and never stored.
+ */
+export type AdminApiKeyCreated = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+    raw_key: string;
+};
+
+/**
+ * Safe representation of an admin API key — never includes the raw secret.
+ */
+export type AdminApiKeyPublic = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+};
+
 export type AITranslateRequest = {
     entity_type: string;
     entity_id: string;
@@ -25,7 +65,7 @@ export type AITranslateRequest = {
 export type ApiKeyCreate = {
     name: string;
     expires_at?: (string | null);
-    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
 };
 
 /**
@@ -36,7 +76,7 @@ export type ApiKeyCreated = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -51,7 +91,7 @@ export type ApiKeyPublic = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -2828,6 +2868,7 @@ export type TenantPublic = {
     landing_mode?: LandingMode;
     id: string;
     active_popup_slug?: (string | null);
+    third_party_key_prefix?: (string | null);
 };
 
 export type TenantUpdate = {
@@ -2840,6 +2881,33 @@ export type TenantUpdate = {
     custom_domain?: (string | null);
     custom_domain_active?: (boolean | null);
     landing_mode?: (LandingMode | null);
+};
+
+/**
+ * Request body for POST /auth/human/third-party/login.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanLogin = {
+    email: string;
+};
+
+/**
+ * Request body for POST /auth/human/third-party/authenticate.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanVerify = {
+    email: string;
+    code: string;
+};
+
+/**
+ * Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.
+ */
+export type ThirdPartyKeyRotated = {
+    api_key: string;
+    prefix: string;
 };
 
 /**
@@ -3212,6 +3280,33 @@ export type VenueWeeklyHourRef = {
 export type VenueWeeklyHoursUpdate = {
     hours: Array<VenueWeeklyHourInput>;
 };
+
+export type AdminApiKeysCreateAdminApiKeyData = {
+    requestBody: AdminApiKeyCreate;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysCreateAdminApiKeyResponse = (AdminApiKeyCreated);
+
+export type AdminApiKeysListAdminApiKeysData = {
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysListAdminApiKeysResponse = (Array<AdminApiKeyPublic>);
+
+export type AdminApiKeysGetAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysGetAdminApiKeyResponse = (AdminApiKeyPublic);
+
+export type AdminApiKeysRevokeAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysRevokeAdminApiKeyResponse = (void);
 
 export type ApiKeysListApiKeysResponse = (Array<ApiKeyPublic>);
 
@@ -3620,6 +3715,22 @@ export type AuthHumanAuthenticateData = {
 };
 
 export type AuthHumanAuthenticateResponse = (Token);
+
+export type AuthThirdPartyHumanLoginData = {
+    requestBody: ThirdPartyHumanLogin;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
+
+export type AuthThirdPartyHumanAuthenticateData = {
+    requestBody: ThirdPartyHumanVerify;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanAuthenticateResponse = (Token);
 
 export type BaseFieldConfigsListBaseFieldConfigsData = {
     /**
@@ -5082,6 +5193,18 @@ export type TenantsDeleteCredentialsData = {
 
 export type TenantsDeleteCredentialsResponse = (void);
 
+export type TenantsRotateThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsRotateThirdPartyKeyResponse = (ThirdPartyKeyRotated);
+
+export type TenantsDeleteThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsDeleteThirdPartyKeyResponse = (void);
+
 export type TicketingStepsListPortalTicketingStepsData = {
     popupId: string;
 };
@@ -5332,7 +5455,7 @@ export type VenuePropertyTypesListPropertyTypesResponse = (Array<VenuePropertyTy
 
 export type VenuePropertyTypesCreatePropertyTypeData = {
     requestBody: VenuePropertyTypeCreate;
-    xTenantId: string;
+    xTenantId?: (string | null);
 };
 
 export type VenuePropertyTypesCreatePropertyTypeResponse = (VenuePropertyTypePublic);


### PR DESCRIPTION
## Chain Context (6/6)

```
dev
 └─ 1-foundations (#164)
     └─ 2-guards-and-portal-enforcement (#165)
         └─ 3-third-party-login (#166)
             └─ 4-admin-api-keys (#167)
                 └─ 5-admin-guard-sweep (#168)
                     └─ 📍 6-backoffice-frontend
```

**Prior dependencies:** PR-1/2/3/4/5.
**Follow-up:** none. Closes the chain.
**Out of scope:** portal frontend changes — none needed (third-party login is consumed by external partners, not by the portal SPA).

## Summary

- **OpenAPI client regen** for both backoffice and portal (`bash scripts/generate-client.sh`). Reflects the final auth surface: admin api keys CRUD, third-party login without `X-Tenant-Id`, tenant key rotation/delete, third-party `prefix` on `TenantPublic`.
- **Admin API Keys page** at `backoffice/src/routes/_layout/api-keys.tsx`. List + create (multi-select scopes from `ADMIN_API_KEY_SCOPES`, optional expiry, write-scopes require expiry) + revoke. Raw key shown ONCE in a reveal modal with copy + acknowledgement step.
- **Third-party integration panel** in `backoffice/src/components/forms/ThirdPartyIntegrationSection.tsx`, injected into `TenantForm`. Status (enabled with prefix / disabled), generate / rotate / disable actions. Gated by `isAdmin` so OPERATOR/VIEWER/CHECK_IN_CONTROLLER don't see it; ADMIN can only manage their own tenant (enforced server-side too).
- **Feature flag**: \`SHOW_AGENTIC_ACCESS = false\` in `AppSidebar.tsx` hides the "Agentic access" sidebar group containing the API Keys link. The route, components, and tests stay live so admins can still hit `/api-keys` directly when needed; flip the flag when ready to expose.

## Test plan

- [x] `pnpm --filter backoffice run build` → clean (TypeScript compile + bundle).
- [x] `pnpm --filter portal run build` → clean.
- [x] `pnpm --filter backoffice run lint` → clean.
- [ ] **Reviewer smoke test in browser**:
  - Backoffice → org settings → third-party integration panel visible for ADMIN/SUPERADMIN, hidden for OPERATOR.
  - Flip `SHOW_AGENTIC_ACCESS` to `true` locally → "Agentic access → API Keys" sidebar entry appears.
  - `/api-keys` route renders (list + create flow with reveal modal + revoke confirmation).

## Review budget

2174 lines, but **~1500 lines are auto-generated SDK** (`src/client/*.gen.ts` in both backoffice and portal). Human-reviewable diff is roughly 600 lines (one route file + one form component + sidebar gate + TenantForm injection). `size:exception` driven by generated-code volume.

## Notes

- Pre-existing flaky tests in `backend/tests/api/product/test_enforcement_wiring.py` may surface on full-suite runs (fixture session-scope contamination); they pass when run in isolation. Not introduced by this chain.
- 166 \`ty\` diagnostics across the backend — pre-existing project-wide; not blocking but worth tracking separately.