### PR TITLE
Release: third-party OTP scoped auth + admin api keys

### DIFF
--- a/backend/app/alembic/versions/3e8f4a2b1c5d_humans_auth_code_origin.py
+++ b/backend/app/alembic/versions/3e8f4a2b1c5d_humans_auth_code_origin.py
@@ -1,0 +1,38 @@
+"""Add auth_code_origin to humans for OTP origin tagging.
+
+WHY:
+The OTP code stored on Humans is shared across login flows (portal regular,
+third-party). Without an origin tag, a code emitted by the third-party flow
+can be redeemed via the portal flow, escalating from a scoped JWT to a full
+portal:* JWT. Tagging each emitted code with its origin lets the verify path
+enforce strict isolation per flow.
+
+WHAT:
+1. ADD COLUMN humans.auth_code_origin (String 20, nullable)
+
+NULL means legacy / portal-origin (treated as portal during the grace
+period to avoid breaking in-flight codes at deploy time).
+
+Revision ID: 3e8f4a2b1c5d
+Revises: 5e5739582c92
+Create Date: 2026-05-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "3e8f4a2b1c5d"
+down_revision = "5e5739582c92"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "humans",
+        sa.Column("auth_code_origin", sa.String(20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("humans", "auth_code_origin")

--- a/backend/app/alembic/versions/5e5739582c92_third_party_otp_scoped_auth.py
+++ b/backend/app/alembic/versions/5e5739582c92_third_party_otp_scoped_auth.py
@@ -1,0 +1,130 @@
+"""Add third-party OTP columns and dual-owner api_keys support.
+
+WHY:
+1. tenants.third_party_api_key_hash / third_party_key_prefix — allows a
+   tenant to enable the third-party OTP surface by storing a bcrypt hash of
+   the shared secret. Presence of a non-null hash = feature enabled.
+2. api_keys.user_id — admin-owned API keys. Exactly one of (human_id,
+   user_id) must be non-null, enforced by the api_keys_owner_check constraint.
+3. api_keys.human_id nullable — required so that admin-owned rows (user_id
+   set, human_id NULL) satisfy the constraint.
+
+WHAT:
+1. ADD COLUMN tenants.third_party_api_key_hash (String 64, nullable)
+2. ADD COLUMN tenants.third_party_key_prefix (String 20, nullable)
+3. CREATE UNIQUE INDEX ix_tenants_third_party_api_key_hash on tenants
+   (third_party_api_key_hash) WHERE third_party_api_key_hash IS NOT NULL
+4. ADD COLUMN api_keys.user_id (UUID, FK users.id CASCADE, nullable)
+5. ALTER COLUMN api_keys.human_id SET NULL (drop NOT NULL)
+6. CREATE INDEX ix_api_keys_user_revoked ON api_keys(user_id, revoked_at)
+7. ADD CONSTRAINT api_keys_owner_check CHECK ((human_id IS NULL) <> (user_id IS NULL))
+
+No data backfill needed: existing rows all have human_id set and user_id NULL,
+which already satisfies the CHECK constraint.
+
+RLS note: api_keys already has tenant_id with existing RLS grants. Column
+additions do not change RLS policies — no re-grant needed. The tenants columns
+are additions to an existing table, not a new table, so add_tenant_table_permissions
+is NOT called.
+
+Revision ID: 5e5739582c92
+Revises: d8f2e4a9c1b6
+Create Date: 2026-05-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5e5739582c92"
+down_revision = "d8f2e4a9c1b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1 & 2. Add third-party columns to tenants.
+    op.add_column(
+        "tenants",
+        sa.Column("third_party_api_key_hash", sa.String(64), nullable=True),
+    )
+    op.add_column(
+        "tenants",
+        sa.Column("third_party_key_prefix", sa.String(20), nullable=True),
+    )
+
+    # 3. Partial unique index on the third-party key hash. Lets the login flow
+    #    resolve the tenant from the key alone (no X-Tenant-Id header) and
+    #    guarantees no two tenants ever share the same key hash.
+    op.create_index(
+        "ix_tenants_third_party_api_key_hash",
+        "tenants",
+        ["third_party_api_key_hash"],
+        unique=True,
+        postgresql_where=sa.text("third_party_api_key_hash IS NOT NULL"),
+    )
+
+    # 4. Add user_id FK column to api_keys (admin-owned key owner).
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "user_id",
+            sa.Uuid(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+
+    # 5. Drop NOT NULL from api_keys.human_id (admin rows have NULL human_id).
+    op.alter_column("api_keys", "human_id", existing_type=sa.Uuid(), nullable=True)
+
+    # 6. Index for admin-key lookups by owner + revocation status.
+    op.create_index(
+        "ix_api_keys_user_revoked",
+        "api_keys",
+        ["user_id", "revoked_at"],
+    )
+
+    # 7. XOR ownership constraint via raw SQL (DDL — no bind params needed).
+    #    (human_id IS NULL) <> (user_id IS NULL) is true only when exactly one
+    #    of them is non-null, rejecting both-null and both-set rows.
+    op.execute(
+        "ALTER TABLE api_keys ADD CONSTRAINT api_keys_owner_check "
+        "CHECK ((human_id IS NULL) <> (user_id IS NULL))"
+    )
+
+
+def downgrade() -> None:
+    # 1. Drop the XOR constraint before restoring NOT NULL on human_id.
+    op.execute("ALTER TABLE api_keys DROP CONSTRAINT api_keys_owner_check")
+
+    # 2. Drop the user index.
+    op.drop_index("ix_api_keys_user_revoked", table_name="api_keys")
+
+    # 3. Guard: refuse downgrade if any admin-owned keys exist (human_id IS NULL).
+    #    Downgrading would orphan those rows because human_id NOT NULL is about
+    #    to be restored.
+    conn = op.get_bind()
+    admin_count = conn.execute(
+        sa.text("SELECT COUNT(*) FROM api_keys WHERE human_id IS NULL")
+    ).scalar()
+    if admin_count and admin_count > 0:
+        raise RuntimeError(
+            f"Cannot downgrade: {admin_count} admin-owned api_keys exist "
+            "(human_id IS NULL). Revoke or delete them first."
+        )
+
+    # 4. Restore NOT NULL on human_id (all remaining rows have human_id set).
+    op.alter_column(
+        "api_keys", "human_id", existing_type=sa.Uuid(), nullable=False
+    )
+
+    # 5. Drop user_id column.
+    op.drop_column("api_keys", "user_id")
+
+    # 6. Drop the partial unique index on the third-party key hash.
+    op.drop_index("ix_tenants_third_party_api_key_hash", table_name="tenants")
+
+    # 7. Drop tenant third-party columns (in reverse order).
+    op.drop_column("tenants", "third_party_key_prefix")
+    op.drop_column("tenants", "third_party_api_key_hash")

--- a/backend/app/alembic/versions/5e5739582c92_third_party_otp_scoped_auth.py
+++ b/backend/app/alembic/versions/5e5739582c92_third_party_otp_scoped_auth.py
@@ -2,8 +2,8 @@
 
 WHY:
 1. tenants.third_party_api_key_hash / third_party_key_prefix — allows a
-   tenant to enable the third-party OTP surface by storing a bcrypt hash of
-   the shared secret. Presence of a non-null hash = feature enabled.
+   tenant to enable the third-party OTP surface by storing a peppered SHA-256
+   hash of the shared secret. Presence of a non-null hash = feature enabled.
 2. api_keys.user_id — admin-owned API keys. Exactly one of (human_id,
    user_id) must be non-null, enforced by the api_keys_owner_check constraint.
 3. api_keys.human_id nullable — required so that admin-owned rows (user_id

--- a/backend/app/api/admin_api_key/__init__.py
+++ b/backend/app/api/admin_api_key/__init__.py
@@ -1,0 +1,3 @@
+from app.api.admin_api_key.router import router
+
+__all__ = ["router"]

--- a/backend/app/api/admin_api_key/crud.py
+++ b/backend/app/api/admin_api_key/crud.py
@@ -1,0 +1,62 @@
+"""Admin API key CRUD — thin wrappers around app.api.api_key.crud.
+
+Both modules share the underlying ApiKeys table and the primitives
+(hash_key, generate_raw_key, display_prefix). This module keeps the
+admin-specific DB operations local to the admin_api_key package so
+each router's policy stays self-contained.
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlmodel import Session
+
+from app.api.api_key import crud as _base
+from app.api.api_key.models import ApiKeys
+
+
+def create(
+    session: Session,
+    *,
+    tenant_id: uuid.UUID,
+    user_id: uuid.UUID,
+    name: str,
+    expires_at: datetime | None,
+    scopes: list[str],
+) -> tuple[ApiKeys, str]:
+    """Mint and persist an admin-owned key. Returns (row, raw_token)."""
+    return _base.create_for_user(
+        session,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        name=name,
+        expires_at=expires_at,
+        scopes=scopes,
+    )
+
+
+def list_own(session: Session, user_id: uuid.UUID) -> list[ApiKeys]:
+    """All keys for the given admin user (own keys only)."""
+    return _base.list_for_user(session, user_id)
+
+
+def list_all(session: Session) -> list[ApiKeys]:
+    """All admin keys visible on the session (SUPERADMIN path, relies on RLS)."""
+    return _base.list_all_admin_keys(session)
+
+
+def get_own(
+    session: Session, key_id: uuid.UUID, user_id: uuid.UUID
+) -> ApiKeys | None:
+    """Fetch a key by id, scoped to the given user. None if not found/not owned."""
+    return _base.get_for_user(session, key_id, user_id)
+
+
+def get_any(session: Session, key_id: uuid.UUID) -> ApiKeys | None:
+    """Fetch any admin key by id on the session (SUPERADMIN path, relies on RLS)."""
+    return _base.get_any_admin_key(session, key_id)
+
+
+def revoke(session: Session, row: ApiKeys) -> ApiKeys:
+    """Soft-revoke: set revoked_at. Idempotent if already revoked."""
+    return _base.revoke(session, row)

--- a/backend/app/api/admin_api_key/router.py
+++ b/backend/app/api/admin_api_key/router.py
@@ -1,0 +1,206 @@
+"""Admin API keys router — /backoffice/api-keys.
+
+Guards:
+  - All endpoints require CurrentAdmin (role >= ADMIN; VIEWER → 403).
+  - API-key authenticated callers are rejected (_require_jwt): an admin key
+    cannot mint or manage other admin keys (same argument as portal api_key/).
+
+Visibility (REQ-BA-03):
+  - ADMIN sees only their own keys (user_id == caller.id).
+  - SUPERADMIN sees all admin keys in the tenant they target via X-Tenant-Id.
+
+Revocation (REQ-OW-05, REQ-BA-05):
+  - ADMIN may only revoke their own keys (403 otherwise).
+  - SUPERADMIN may revoke any admin key in their tenant scope.
+
+Scope validation (REQ-AK-06):
+  - Requested scopes must be a subset of ADMIN_API_KEY_SCOPES → 422 if not.
+"""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+
+from app.api.admin_api_key import crud
+from app.api.admin_api_key.schemas import (
+    AdminApiKeyCreate,
+    AdminApiKeyCreated,
+    AdminApiKeyPublic,
+)
+from app.api.shared.enums import UserRole
+from app.core.dependencies.users import (
+    CurrentAdmin,
+    TenantSession,
+)
+from app.core.security import ADMIN_API_KEY_SCOPES, TokenPayload, get_token_payload
+
+router = APIRouter(prefix="/backoffice/api-keys", tags=["admin-api-keys"])
+
+
+def _require_jwt(
+    token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
+) -> None:
+    """Reject callers authenticated via API key.
+
+    Admin API keys cannot mint or manage other admin API keys — an attacker
+    with a leaked key must not be able to bootstrap permanent access.
+    Administrators must use their JWT session for key lifecycle operations.
+    """
+    if getattr(token_payload, "via_api_key", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="API keys cannot manage other API keys; sign in to the backoffice.",
+        )
+
+
+JwtOnly = Annotated[None, Depends(_require_jwt)]
+
+
+@router.post("", response_model=AdminApiKeyCreated, status_code=status.HTTP_201_CREATED)
+async def create_admin_api_key(
+    payload: AdminApiKeyCreate,
+    db: TenantSession,
+    current_user: CurrentAdmin,
+    _: JwtOnly,
+    x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+) -> AdminApiKeyCreated:
+    """Mint a new admin API key.
+
+    Scopes must be a subset of ADMIN_API_KEY_SCOPES. Any scope outside that
+    universe returns 422. Write scopes require an expiry date (validated by
+    the schema).
+
+    The cleartext key is returned once in ``raw_key``; only the hash is stored.
+    """
+    # Resolve tenant_id: ADMIN uses their own; SUPERADMIN must supply X-Tenant-Id.
+    if current_user.role == UserRole.SUPERADMIN:
+        if not x_tenant_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="X-Tenant-Id header required for superadmin access",
+            )
+        try:
+            tenant_id = uuid.UUID(x_tenant_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid tenant ID format",
+            )
+    else:
+        if not current_user.tenant_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User has no tenant assigned",
+            )
+        tenant_id = current_user.tenant_id
+
+    # Second wall: scope universe check (REQ-AK-06).
+    invalid = set(payload.scopes) - ADMIN_API_KEY_SCOPES
+    if invalid:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Scopes not permitted for admin API keys: {sorted(invalid)}",
+        )
+
+    row, raw = crud.create(
+        db,
+        tenant_id=tenant_id,
+        user_id=current_user.id,
+        name=payload.name.strip(),
+        expires_at=payload.expires_at,
+        scopes=payload.scopes,
+    )
+    return AdminApiKeyCreated.model_validate({**row.model_dump(), "raw_key": raw})
+
+
+@router.get("", response_model=list[AdminApiKeyPublic])
+async def list_admin_api_keys(
+    db: TenantSession,
+    current_user: CurrentAdmin,
+    _: JwtOnly,
+) -> list[AdminApiKeyPublic]:
+    """List admin API keys.
+
+    ADMIN sees only their own keys.
+    SUPERADMIN sees all admin keys in the tenant they are operating on (via
+    X-Tenant-Id header, already resolved by TenantSession).
+    """
+    if current_user.role == UserRole.SUPERADMIN:
+        rows = crud.list_all(db)
+    else:
+        rows = crud.list_own(db, current_user.id)
+    return [AdminApiKeyPublic.model_validate(r) for r in rows]
+
+
+@router.get("/{key_id}", response_model=AdminApiKeyPublic)
+async def get_admin_api_key(
+    key_id: uuid.UUID,
+    db: TenantSession,
+    current_user: CurrentAdmin,
+    _: JwtOnly,
+) -> AdminApiKeyPublic:
+    """Retrieve a specific admin API key.
+
+    Visibility mirrors the list endpoint: ADMIN sees only own keys; SUPERADMIN
+    sees any admin key in the tenant. Returns 404 for keys outside the caller's
+    visibility — never 403, to avoid leaking existence of foreign keys.
+    """
+    if current_user.role == UserRole.SUPERADMIN:
+        row = crud.get_any(db, key_id)
+    else:
+        row = crud.get_own(db, key_id, current_user.id)
+
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="API key not found",
+        )
+    return AdminApiKeyPublic.model_validate(row)
+
+
+@router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_admin_api_key(
+    key_id: uuid.UUID,
+    db: TenantSession,
+    current_user: CurrentAdmin,
+    _: JwtOnly,
+) -> None:
+    """Revoke an admin API key by setting revoked_at.
+
+    ADMIN can only revoke their own keys (403 for foreign keys).
+    SUPERADMIN can revoke any admin key in their tenant scope.
+    Non-existent keys return 404.
+    """
+    if current_user.role == UserRole.SUPERADMIN:
+        row = crud.get_any(db, key_id)
+        if not row:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="API key not found",
+            )
+    else:
+        # Look up any admin key with this id to distinguish 404 vs 403.
+        from sqlmodel import select
+
+        from app.api.api_key.models import ApiKeys
+
+        any_row = db.exec(
+            select(ApiKeys)
+            .where(ApiKeys.id == key_id)
+            .where(ApiKeys.user_id.is_not(None))
+        ).first()
+
+        if not any_row:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="API key not found",
+            )
+        if any_row.user_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You can only revoke your own API keys",
+            )
+        row = any_row
+
+    crud.revoke(db, row)

--- a/backend/app/api/admin_api_key/schemas.py
+++ b/backend/app/api/admin_api_key/schemas.py
@@ -1,0 +1,81 @@
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import get_args
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.core.security import ApiKeyScope
+
+# All scope values valid in the ApiKeyScope Literal — used for schema-level
+# validation (unknown scope string → 422 before router-level universe check).
+_ALL_API_KEY_SCOPES: frozenset[str] = frozenset(get_args(ApiKeyScope))
+
+MAX_WRITE_SCOPE_LIFETIME_DAYS = 30
+
+
+class AdminApiKeyCreate(BaseModel):
+    """Request body for minting a new admin API key."""
+
+    name: str = Field(min_length=1, max_length=100)
+    scopes: list[ApiKeyScope] = Field(min_length=1)
+    expires_at: datetime | None = None
+
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes_universe(cls, scopes: list[str]) -> list[str]:
+        if not scopes:
+            raise ValueError("At least one scope is required")
+        normalized = list(dict.fromkeys(scopes))
+        # First wall: reject anything not in the global ApiKeyScope Literal.
+        invalid = [s for s in normalized if s not in _ALL_API_KEY_SCOPES]
+        if invalid:
+            raise ValueError(f"Unknown scopes: {', '.join(sorted(invalid))}")
+        return normalized
+
+    @field_validator("expires_at")
+    @classmethod
+    def validate_expiry(cls, expires_at: datetime | None) -> datetime | None:
+        if expires_at is None:
+            return None
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        now = datetime.now(UTC)
+        if expires_at <= now:
+            raise ValueError("API key expiry must be in the future")
+        max_expiry = now + timedelta(days=MAX_WRITE_SCOPE_LIFETIME_DAYS)
+        if expires_at > max_expiry:
+            raise ValueError(
+                f"API key expiry cannot be more than {MAX_WRITE_SCOPE_LIFETIME_DAYS} days ahead"
+            )
+        return expires_at
+
+    @model_validator(mode="after")
+    def require_expiry_for_write_scope(self) -> "AdminApiKeyCreate":
+        write_scopes = {s for s in self.scopes if s.endswith(":write")}
+        if write_scopes and self.expires_at is None:
+            raise ValueError("Write-capable API keys require an expiry date")
+        return self
+
+
+class AdminApiKeyPublic(BaseModel):
+    """Safe representation of an admin API key — never includes the raw secret."""
+
+    id: uuid.UUID
+    name: str
+    prefix: str
+    scopes: list[ApiKeyScope]
+    created_at: datetime
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None
+    revoked_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminApiKeyCreated(AdminApiKeyPublic):
+    """Response returned only at creation.
+
+    ``raw_key`` is the cleartext token shown once and never stored.
+    """
+
+    raw_key: str

--- a/backend/app/api/api_key/crud.py
+++ b/backend/app/api/api_key/crud.py
@@ -113,6 +113,95 @@ def revoke(session: Session, row: ApiKeys) -> ApiKeys:
     return row
 
 
+def create_for_user(
+    session: Session,
+    *,
+    tenant_id: uuid.UUID,
+    user_id: uuid.UUID,
+    name: str,
+    expires_at: datetime | None,
+    scopes: list[str],
+) -> tuple[ApiKeys, str]:
+    """Mint and persist an admin-owned key. Returns (row, raw_token).
+
+    Mirrors ``create_for_human`` but persists ``user_id`` and leaves
+    ``human_id=None``, satisfying the XOR CHECK constraint.
+    """
+    raw = generate_raw_key()
+    row = ApiKeys(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        human_id=None,
+        name=name,
+        key_hash=hash_key(raw),
+        prefix=display_prefix(raw),
+        scopes=scopes,
+        expires_at=expires_at,
+    )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row, raw
+
+
+def list_for_user(session: Session, user_id: uuid.UUID) -> list[ApiKeys]:
+    """All keys (active + revoked) for the given user, newest first.
+
+    Includes revoked entries so the caller can display an audit trail.
+    """
+    return list(
+        session.exec(
+            select(ApiKeys)
+            .where(ApiKeys.user_id == user_id)
+            .order_by(ApiKeys.created_at.desc())
+        ).all()
+    )
+
+
+def list_all_admin_keys(session: Session) -> list[ApiKeys]:
+    """All admin keys visible on the given session, newest first.
+
+    Relies on RLS to scope the result to the correct tenant when the session
+    is a tenant-scoped engine (SUPERADMIN path). Returns only rows where
+    ``user_id`` is set (admin-owned); never returns human-owned keys.
+    """
+    return list(
+        session.exec(
+            select(ApiKeys)
+            .where(ApiKeys.user_id.is_not(None))
+            .order_by(ApiKeys.created_at.desc())
+        ).all()
+    )
+
+
+def get_for_user(
+    session: Session, key_id: uuid.UUID, user_id: uuid.UUID
+) -> ApiKeys | None:
+    """Fetch a specific key visible to the given user.
+
+    Returns None if the key doesn't exist or belongs to a different user.
+    """
+    return session.exec(
+        select(ApiKeys).where(ApiKeys.id == key_id).where(ApiKeys.user_id == user_id)
+    ).first()
+
+
+def get_any_admin_key(
+    session: Session, key_id: uuid.UUID
+) -> ApiKeys | None:
+    """Fetch an admin key by id on the current session (SUPERADMIN path).
+
+    Relies on RLS to scope to the correct tenant. Returns None if the key
+    does not exist, belongs to a different tenant (RLS hides it), or is
+    a human-owned key (user_id is None).
+    """
+    return session.exec(
+        select(ApiKeys)
+        .where(ApiKeys.id == key_id)
+        .where(ApiKeys.user_id.is_not(None))
+    ).first()
+
+
 def revoke_all_for_human(session: Session, human_id: uuid.UUID) -> int:
     rows = list(
         session.exec(

--- a/backend/app/api/api_key/models.py
+++ b/backend/app/api/api_key/models.py
@@ -7,7 +7,11 @@ from sqlmodel import Column, DateTime, Field, SQLModel
 
 
 class ApiKeys(SQLModel, table=True):
-    """Personal access token owned by a Human, scoped to a tenant.
+    """Access token owned by a Human (portal PAT) or a User (admin key).
+
+    Exactly one of ``human_id`` / ``user_id`` must be non-null; this is
+    enforced at the DB level by the ``api_keys_owner_check`` CHECK constraint
+    added in migration ``<hash>_third_party_otp_scoped_auth``.
 
     The raw secret never lives in the DB — only ``key_hash`` (sha256 of
     ``SECRET_KEY + raw_token``). ``prefix`` is a non-secret display fragment
@@ -15,14 +19,28 @@ class ApiKeys(SQLModel, table=True):
     """
 
     __tablename__ = "api_keys"
-    __table_args__ = (Index("ix_api_keys_human_revoked", "human_id", "revoked_at"),)
+    __table_args__ = (
+        Index("ix_api_keys_human_revoked", "human_id", "revoked_at"),
+        Index("ix_api_keys_user_revoked", "user_id", "revoked_at"),
+    )
 
     id: uuid.UUID = Field(
         default_factory=uuid.uuid4,
         sa_column=Column(UUID(as_uuid=True), primary_key=True),
     )
     tenant_id: uuid.UUID = Field(foreign_key="tenants.id", index=True)
-    human_id: uuid.UUID = Field(foreign_key="humans.id", index=True)
+    # Human-owned (portal PAT) — nullable to support admin-owned keys.
+    human_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="humans.id",
+        index=True,
+    )
+    # Admin-owned key — nullable to support human-owned keys.
+    user_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="users.id",
+        index=True,
+    )
     name: str = Field(max_length=100)
     key_hash: str = Field(max_length=64, unique=True)
     prefix: str = Field(max_length=20)

--- a/backend/app/api/api_key/router.py
+++ b/backend/app/api/api_key/router.py
@@ -10,7 +10,11 @@ from app.core.dependencies.users import (
     HumanTenantSession,
     RequireHumanScopeApiKeysManage,
 )
-from app.core.security import TokenPayload, get_token_payload
+from app.core.security import (
+    THIRD_PARTY_API_KEY_SCOPES,
+    TokenPayload,
+    get_token_payload,
+)
 
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
 
@@ -63,10 +67,20 @@ async def create_api_key(
     payload: ApiKeyCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
     _: JwtOnly,
     __: HumanCanManageApiKeys,
     ___: RequireHumanScopeApiKeysManage,
 ) -> ApiKeyCreated:
+    # REQ-AK-04: third-party JWTs may only mint keys within THIRD_PARTY_API_KEY_SCOPES.
+    if getattr(token_payload, "issued_via", "portal") == "third_party":
+        invalid = set(payload.scopes) - THIRD_PARTY_API_KEY_SCOPES
+        if invalid:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"These scopes are not permitted for third-party sessions: {sorted(invalid)}",
+            )
+
     row, raw = crud.create_for_human(
         db,
         tenant_id=current_human.tenant_id,

--- a/backend/app/api/api_key/router.py
+++ b/backend/app/api/api_key/router.py
@@ -5,7 +5,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.api_key import crud
 from app.api.api_key.schemas import ApiKeyCreate, ApiKeyCreated, ApiKeyPublic
-from app.core.dependencies.users import CurrentHuman, HumanTenantSession
+from app.core.dependencies.users import (
+    CurrentHuman,
+    HumanTenantSession,
+    RequireHumanScopeApiKeysManage,
+)
 from app.core.security import TokenPayload, get_token_payload
 
 router = APIRouter(prefix="/api-keys", tags=["api-keys"])
@@ -48,6 +52,7 @@ async def list_api_keys(
     current_human: CurrentHuman,
     _: JwtOnly,
     __: HumanCanManageApiKeys,
+    ___: RequireHumanScopeApiKeysManage,
 ) -> list[ApiKeyPublic]:
     rows = crud.list_for_human(db, current_human.id)
     return [ApiKeyPublic.model_validate(r) for r in rows]
@@ -60,6 +65,7 @@ async def create_api_key(
     current_human: CurrentHuman,
     _: JwtOnly,
     __: HumanCanManageApiKeys,
+    ___: RequireHumanScopeApiKeysManage,
 ) -> ApiKeyCreated:
     row, raw = crud.create_for_human(
         db,
@@ -79,6 +85,7 @@ async def revoke_api_key(
     current_human: CurrentHuman,
     _: JwtOnly,
     __: HumanCanManageApiKeys,
+    ___: RequireHumanScopeApiKeysManage,
 ) -> None:
     row = crud.get_for_human(db, key_id, current_human.id)
     if not row:

--- a/backend/app/api/api_key/schemas.py
+++ b/backend/app/api/api_key/schemas.py
@@ -1,11 +1,14 @@
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.core.security import ApiKeyScope
 
-ALLOWED_API_KEY_SCOPES = {"events:read", "events:write", "rsvp:write", "venues:write"}
+# Derived from the ApiKeyScope Literal so it stays in sync automatically.
+# Any new scope added to ApiKeyScope is immediately accepted here.
+ALLOWED_API_KEY_SCOPES: frozenset[str] = frozenset(get_args(ApiKeyScope))
 DEFAULT_API_KEY_SCOPES: list[ApiKeyScope] = ["events:read"]
 MAX_WRITE_SCOPE_LIFETIME_DAYS = 30
 
@@ -49,8 +52,9 @@ class ApiKeyCreate(BaseModel):
 
     @model_validator(mode="after")
     def require_expiry_for_write_scope(self) -> "ApiKeyCreate":
-        write_scopes = {"events:write", "venues:write"}
-        if write_scopes & set(self.scopes) and self.expires_at is None:
+        # Any scope ending in :write is considered a write scope.
+        write_scopes = {s for s in self.scopes if s.endswith(":write")}
+        if write_scopes and self.expires_at is None:
             raise ValueError("Write-capable API keys require an expiry date")
         return self
 

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -37,13 +37,14 @@ from app.api.attendee.schemas import (
 from app.api.shared.enums import SaleType, UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
-    CurrentAdmin,
+    AdminOrApiKey_ApplicationsRead,
+    AdminOrApiKey_ApplicationsWrite,
+    AdminOrApiKeySession_ApplicationsRead,
+    AdminOrApiKeySession_ApplicationsWrite,
     CurrentHuman,
-    CurrentOperator,
     HumanTenantSession,
     RequireHumanScopeDirectoryRead,
     RequireHumanScopeSelfRead,
-    TenantSession,
 )
 from app.services.email_helpers import send_application_status_email
 
@@ -139,8 +140,8 @@ def _build_application_public(
 
 @router.get("", response_model=ListModel[ApplicationPublic])
 async def list_applications(
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_ApplicationsRead,
+    _: AdminOrApiKey_ApplicationsRead,
     popup_id: uuid.UUID | None = None,
     human_id: uuid.UUID | None = None,
     reviewed_by: uuid.UUID | None = None,
@@ -194,8 +195,8 @@ async def list_applications(
 @router.post("", response_model=ApplicationPublic, status_code=status.HTTP_201_CREATED)
 async def create_application_admin(
     app_in: ApplicationAdminCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_ApplicationsWrite,
+    current_user: AdminOrApiKey_ApplicationsWrite,
 ) -> ApplicationPublic:
     """Create an application as admin (BO only - superadmin for testing).
 
@@ -240,8 +241,8 @@ async def create_application_admin(
 @router.get("/{application_id}", response_model=ApplicationPublic)
 async def get_application(
     application_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_ApplicationsRead,
+    _: AdminOrApiKey_ApplicationsRead,
 ) -> ApplicationPublic:
     """Get a single application (BO only)."""
     application = crud.applications_crud.get(db, application_id)
@@ -1041,8 +1042,8 @@ async def delete_my_attendee(
 async def review_scholarship(
     application_id: uuid.UUID,
     decision: ScholarshipDecisionRequest,
-    db: TenantSession,
-    _: CurrentAdmin,
+    db: AdminOrApiKeySession_ApplicationsWrite,
+    _: AdminOrApiKey_ApplicationsWrite,
 ) -> ApplicationPublic:
     """Approve or reject a scholarship request on an application (BO admin only).
 

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -41,6 +41,8 @@ from app.core.dependencies.users import (
     CurrentHuman,
     CurrentOperator,
     HumanTenantSession,
+    RequireHumanScopeDirectoryRead,
+    RequireHumanScopeSelfRead,
     TenantSession,
 )
 from app.services.email_helpers import send_application_status_email
@@ -257,6 +259,7 @@ async def get_application(
 async def list_my_applications(
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[ApplicationPublic]:
@@ -277,6 +280,7 @@ async def list_my_applications(
 async def list_my_tickets(
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> list[AttendeeWithTickets]:
     """List all tickets for the current human (Portal).
 
@@ -335,6 +339,7 @@ async def get_my_participation(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ParticipationResponse:
     """Get participation status for the current human in a popup (Portal).
 
@@ -387,6 +392,7 @@ async def get_my_purchases(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> list[AttendeePurchases]:
     """Get purchased products grouped by attendee for a popup (Portal)."""
     from app.api.attendee.crud import attendees_crud
@@ -424,6 +430,7 @@ async def get_my_application(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ApplicationPublic:
     """Get current human's application for a popup (Portal)."""
     application = crud.applications_crud.get_by_human_popup(
@@ -455,6 +462,7 @@ async def detach_companion(
     body: DetachCompanionRequest,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> None:
     """Remove the current human from being a companion on another applicant's
     application for the given popup.
@@ -507,6 +515,7 @@ async def create_my_application(
     app_in: ApplicationCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ApplicationPublic:
     """Create an application for the current human (Portal)."""
     # Check for existing application
@@ -562,6 +571,7 @@ async def update_my_application(
     app_in: ApplicationUpdate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ApplicationPublic:
     """Update current human's application (Portal)."""
     application = crud.applications_crud.get_by_human_popup(
@@ -823,6 +833,7 @@ async def list_attendees_directory(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     _: CurrentHuman,
+    _scope: RequireHumanScopeDirectoryRead,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
     q: str | None = None,
@@ -855,6 +866,7 @@ async def export_attendees_directory_csv(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     _: CurrentHuman,
+    _scope: RequireHumanScopeDirectoryRead,
     q: str | None = None,
 ) -> Response:
     """Export attendees directory as CSV (Portal).
@@ -920,6 +932,7 @@ async def add_my_attendee(
     attendee_in: AttendeeCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ApplicationPublic:
     """Add an attendee to current human's application (Portal)."""
     application = crud.applications_crud.get_by_human_popup(
@@ -954,6 +967,7 @@ async def update_my_attendee(
     attendee_in: AttendeeUpdate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ApplicationPublic:
     """Update an attendee in current human's application (Portal)."""
     from app.api.attendee.crud import attendees_crud
@@ -1002,6 +1016,7 @@ async def delete_my_attendee(
     attendee_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> ApplicationPublic:
     """Delete an attendee from current human's application (Portal)."""
     application = crud.applications_crud.get_by_human_popup(
@@ -1076,6 +1091,7 @@ async def get_popup_access(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> PopupAccessResponse:
     """Resolve access for the authenticated Human to a specific popup.
 

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -24,9 +24,12 @@ from app.api.check_in.crud import (
 from app.api.check_in.schemas import CheckInPayload
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
+    AdminOrApiKey_AttendeesWrite,
+    AdminOrApiKeySession_AttendeesWrite,
+    CheckInOrApiKey_AttendeesRead,
+    CheckInOrApiKeySession_AttendeesRead,
     CurrentCheckInOperator,
     CurrentHuman,
-    CurrentOperator,
     HumanTenantSession,
     RequireHumanScopeDirectoryRead,
     RequireHumanScopeSelfRead,
@@ -391,8 +394,8 @@ async def delete_my_attendee_for_popup(
 
 @router.get("", response_model=ListModel[AttendeeListItem])
 async def list_attendees(
-    db: TenantSession,
-    _: CurrentCheckInOperator,
+    db: CheckInOrApiKeySession_AttendeesRead,
+    _: CheckInOrApiKey_AttendeesRead,
     application_id: uuid.UUID | None = None,
     popup_id: uuid.UUID | None = None,
     email: str | None = None,
@@ -451,8 +454,8 @@ async def list_attendees(
 @router.get("/{attendee_id}", response_model=AttendeeWithOriginPublic)
 async def get_attendee(
     attendee_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentCheckInOperator,
+    db: CheckInOrApiKeySession_AttendeesRead,
+    _: CheckInOrApiKey_AttendeesRead,
 ) -> AttendeeWithOriginPublic:
     """Get a single attendee with full ticket details (BO only).
 
@@ -479,8 +482,8 @@ async def get_attendee(
 async def update_attendee(
     attendee_id: uuid.UUID,
     attendee_in: AttendeeUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_AttendeesWrite,
+    _current_user: AdminOrApiKey_AttendeesWrite,
 ) -> AttendeeWithOriginPublic:
     """Update an attendee (BO only)."""
 
@@ -501,8 +504,8 @@ async def update_attendee(
 @router.delete("/{attendee_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_attendee(
     attendee_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_AttendeesWrite,
+    _current_user: AdminOrApiKey_AttendeesWrite,
 ) -> None:
     """Delete an attendee (BO only)."""
 

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -28,6 +28,8 @@ from app.core.dependencies.users import (
     CurrentHuman,
     CurrentOperator,
     HumanTenantSession,
+    RequireHumanScopeDirectoryRead,
+    RequireHumanScopeSelfRead,
     TenantSession,
 )
 
@@ -138,6 +140,7 @@ async def list_my_attendees_by_popup(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeDirectoryRead,
     skip: PaginationSkip = 0,
     limit: _AttendeeLimit = 50,
 ) -> ListModel[AttendeeWithOriginPublic]:
@@ -171,6 +174,7 @@ async def create_my_attendee_for_popup(
     attendee_in: AttendeeCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> AttendeeWithOriginPublic:
     """Create a companion attendee (spouse/child) for the current Human's application.
 
@@ -294,6 +298,7 @@ async def update_my_attendee_for_popup(
     attendee_in: AttendeeUpdate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> AttendeeWithOriginPublic:
     """Update a companion attendee using the dual-path auth predicate.
 
@@ -348,6 +353,7 @@ async def delete_my_attendee_for_popup(
     attendee_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> dict:
     """Delete a companion attendee using the dual-path auth predicate.
 

--- a/backend/app/api/auth/crud.py
+++ b/backend/app/api/auth/crud.py
@@ -220,6 +220,7 @@ async def _send_human_code(
     *,
     tenant_id: uuid.UUID,
     human: "Humans",
+    origin: str = "portal",
 ) -> tuple[str, int]:
     """Generate and send an OTP for an already-resolved human record.
 
@@ -227,19 +228,26 @@ async def _send_human_code(
     (third-party surface). Never creates a pending row — callers are
     responsible for ensuring the human record already exists.
 
+    `origin` tags the code so the verify path can enforce flow isolation
+    (a third-party code cannot be redeemed via the portal flow). Defaults
+    to "portal" to keep the regular human login backwards-compatible.
+
     Returns (email, CODE_EXPIRATION_MINUTES).
     """
     auth_code = generate_auth_code()
     tenant = session.get(Tenants, tenant_id)
 
     if is_redis_available():
-        auth_code_store.store_human_code(tenant_id, human.email, auth_code, is_pending=False)
+        auth_code_store.store_human_code(
+            tenant_id, human.email, auth_code, is_pending=False, origin=origin
+        )
         logger.debug(f"Auth code stored in Redis for existing human: {human.email}")
     else:
         code_expiration = create_code_expiration(CODE_EXPIRATION_MINUTES)
         human.auth_code = auth_code
         human.code_expiration = code_expiration
         human.auth_attempts = 0
+        human.auth_code_origin = origin
         session.add(human)
         session.commit()
 
@@ -299,7 +307,9 @@ async def login_existing_human(
             detail="Authentication failed",
         )
 
-    return await _send_human_code(session, tenant_id=tenant_id, human=existing)
+    return await _send_human_code(
+        session, tenant_id=tenant_id, human=existing, origin="third_party"
+    )
 
 
 async def login_human(
@@ -405,6 +415,7 @@ async def authenticate_human(
     email: str,
     tenant_id: uuid.UUID,
     code: str,
+    expected_origin: str = "portal",
 ) -> Humans:
     """
     Verify authentication code for a human.
@@ -412,17 +423,13 @@ async def authenticate_human(
     If human exists: authenticate using human record (like user authentication).
     If human doesn't exist: create human from pending record after validation.
 
-    Args:
-        session: Database session
-        email: Human's email address
-        tenant_id: Tenant ID
-        code: 6-digit authentication code
+    `expected_origin` scopes verification to codes that were emitted by the
+    matching flow (portal vs third_party). Codes stored with a different
+    origin will not be found in Redis (different key prefix) and will fail
+    the DB-fallback origin check. The pending-human branch is portal-only.
 
-    Returns:
-        Authenticated human
-
-    Raises:
-        HTTPException: If verification fails
+    Legacy compat: a row whose `auth_code_origin` is NULL is treated as
+    portal-origin so in-flight codes from before the upgrade still work.
     """
     # First check if human already exists
     human_statement = select(Humans).where(
@@ -435,7 +442,7 @@ async def authenticate_human(
         # Human exists: authenticate
         if is_redis_available():
             is_valid, error_message = auth_code_store.verify_human_code(
-                tenant_id, email, code, is_pending=False
+                tenant_id, email, code, is_pending=False, origin=expected_origin
             )
             if not is_valid:
                 if "Maximum" in error_message:
@@ -461,6 +468,15 @@ async def authenticate_human(
                     detail="Maximum authentication attempts exceeded. Please request a new code.",
                 )
 
+            stored_origin = existing_human.auth_code_origin or "portal"
+            if stored_origin != expected_origin:
+                # Same human, valid code in storage, but emitted by a
+                # different flow. Reject without leaking which flow.
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid authentication code",
+                )
+
             is_valid, error_message = is_code_valid(
                 stored_code=existing_human.auth_code,
                 provided_code=code,
@@ -481,6 +497,7 @@ async def authenticate_human(
             existing_human.auth_code = None
             existing_human.code_expiration = None
             existing_human.auth_attempts = 0
+            existing_human.auth_code_origin = None
             session.add(existing_human)
             session.commit()
 

--- a/backend/app/api/auth/crud.py
+++ b/backend/app/api/auth/crud.py
@@ -215,6 +215,93 @@ async def authenticate_user(
     return user
 
 
+async def _send_human_code(
+    session: Session,
+    *,
+    tenant_id: uuid.UUID,
+    human: "Humans",
+) -> tuple[str, int]:
+    """Generate and send an OTP for an already-resolved human record.
+
+    Shared by login_human (existing-human branch) and login_existing_human
+    (third-party surface). Never creates a pending row — callers are
+    responsible for ensuring the human record already exists.
+
+    Returns (email, CODE_EXPIRATION_MINUTES).
+    """
+    auth_code = generate_auth_code()
+    tenant = session.get(Tenants, tenant_id)
+
+    if is_redis_available():
+        auth_code_store.store_human_code(tenant_id, human.email, auth_code, is_pending=False)
+        logger.debug(f"Auth code stored in Redis for existing human: {human.email}")
+    else:
+        code_expiration = create_code_expiration(CODE_EXPIRATION_MINUTES)
+        human.auth_code = auth_code
+        human.code_expiration = code_expiration
+        human.auth_attempts = 0
+        session.add(human)
+        session.commit()
+
+    email_service = get_email_service()
+    success = await email_service.send_login_code_human(
+        to=human.email,
+        subject=f"Your Login Code - {tenant.name if tenant else settings.PROJECT_NAME}",
+        context=LoginCodeHumanContext(
+            first_name=human.display_name,
+            tenant_name=tenant.name if tenant else settings.PROJECT_NAME,
+            auth_code=auth_code,
+            expiration_minutes=CODE_EXPIRATION_MINUTES,
+        ),
+        tenant_id=tenant_id,
+        from_address=tenant.sender_email if tenant else settings.SENDER_EMAIL,
+        from_name=tenant.sender_name if tenant else settings.SENDER_NAME,
+        db_session=session,
+    )
+
+    if not success:
+        logger.error(f"Failed to send auth code email to {human.email}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send authentication code",
+        )
+
+    logger.info(f"Auth code sent to human: {human.email}")
+    return human.email, CODE_EXPIRATION_MINUTES
+
+
+async def login_existing_human(
+    session: Session,
+    *,
+    tenant_id: uuid.UUID,
+    email: str,
+) -> tuple[str, int]:
+    """Send OTP for an EXISTING human. Never creates a pending row.
+
+    Used by the third-party login surface where the partner has already
+    onboarded the user out-of-band and only needs portal access.
+
+    On unknown email raises 401 to keep the response indistinguishable
+    from the invalid-api-key case (non-disclosing per REQ-TP-03).
+    """
+    check_rate_limit(f"third_party_human:{tenant_id}:{email.lower()}")
+
+    existing = session.exec(
+        select(Humans).where(
+            Humans.email == email,
+            Humans.tenant_id == tenant_id,
+        )
+    ).first()
+
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication failed",
+        )
+
+    return await _send_human_code(session, tenant_id=tenant_id, human=existing)
+
+
 async def login_human(
     session: Session,
     data: HumanAuth,
@@ -229,58 +316,18 @@ async def login_human(
     )
     existing_human = session.exec(statement).first()
 
-    # Generate code
-    auth_code = generate_auth_code()
-
     tenant = session.get(Tenants, data.tenant_id)
 
     if existing_human:
-        # Human exists: store auth code
-        if is_redis_available():
-            auth_code_store.store_human_code(
-                data.tenant_id, data.email, auth_code, is_pending=False
-            )
-            logger.debug(f"Auth code stored in Redis for existing human: {data.email}")
-        else:
-            # Fall back to database storage
-            code_expiration = create_code_expiration(CODE_EXPIRATION_MINUTES)
-            existing_human.auth_code = auth_code
-            existing_human.code_expiration = code_expiration
-            existing_human.auth_attempts = 0
-            session.add(existing_human)
-            session.commit()
-
-        # Get display name from latest application for email personalization
-        display_name = existing_human.display_name
-
-        # Send email with code
-        email_service = get_email_service()
-        success = await email_service.send_login_code_human(
-            to=data.email,
-            subject=f"Your Login Code - {tenant.name if tenant else settings.PROJECT_NAME}",
-            context=LoginCodeHumanContext(
-                first_name=display_name,
-                tenant_name=tenant.name if tenant else settings.PROJECT_NAME,
-                auth_code=auth_code,
-                expiration_minutes=CODE_EXPIRATION_MINUTES,
-            ),
+        # Delegate to shared helper — sends code for the resolved human record
+        return await _send_human_code(
+            session,
             tenant_id=data.tenant_id,
-            from_address=tenant.sender_email if tenant else settings.SENDER_EMAIL,
-            from_name=tenant.sender_name if tenant else settings.SENDER_NAME,
-            db_session=session,
+            human=existing_human,
         )
 
-        if not success:
-            logger.error(f"Failed to send auth code email to {data.email}")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to send authentication code",
-            )
-
-        logger.info(f"Auth code sent to existing human: {data.email}")
-        return data.email, CODE_EXPIRATION_MINUTES
-
     # Human doesn't exist: create pending record
+    auth_code = generate_auth_code()
     if is_redis_available():
         # Store pending human data and auth code in Redis
         pending_human_store.store(

--- a/backend/app/api/auth/router.py
+++ b/backend/app/api/auth/router.py
@@ -1,9 +1,10 @@
+import secrets
 import uuid
 
-import bcrypt
 from fastapi import APIRouter, Header, HTTPException, status
 from loguru import logger
 
+from app.api.api_key.crud import hash_key as hash_api_key
 from app.api.auth.crud import (
     authenticate_human,
     authenticate_user,
@@ -45,13 +46,10 @@ def _validate_third_party_key(
             detail="Third-party login not enabled for this tenant",
         )
 
-    try:
-        key_matches = bcrypt.checkpw(
-            raw_key.encode(),
-            tenant.third_party_api_key_hash.encode(),
-        )
-    except Exception:
-        key_matches = False
+    key_matches = secrets.compare_digest(
+        hash_api_key(raw_key),
+        tenant.third_party_api_key_hash,
+    )
 
     if not key_matches:
         raise HTTPException(

--- a/backend/app/api/auth/router.py
+++ b/backend/app/api/auth/router.py
@@ -265,6 +265,7 @@ async def third_party_human_authenticate(
         email=request.email,
         tenant_id=tenant.id,
         code=request.code,
+        expected_origin="third_party",
     )
 
     access_token = create_access_token(

--- a/backend/app/api/auth/router.py
+++ b/backend/app/api/auth/router.py
@@ -1,9 +1,13 @@
-from fastapi import APIRouter
+import uuid
+
+import bcrypt
+from fastapi import APIRouter, Header, HTTPException, status
 from loguru import logger
 
 from app.api.auth.crud import (
     authenticate_human,
     authenticate_user,
+    login_existing_human,
     login_human,
     login_user,
 )
@@ -11,14 +15,51 @@ from app.api.auth.schemas import (
     AuthCodeSentResponse,
     HumanAuth,
     HumanVerify,
+    ThirdPartyHumanLogin,
+    ThirdPartyHumanVerify,
     UserAuth,
     UserVerify,
 )
 from app.api.shared.enums import UserRole
+from app.api.tenant.models import Tenants
 from app.core.dependencies.users import SessionDep
-from app.core.security import Token, create_access_token
+from app.core.security import THIRD_PARTY_TOKEN_SCOPES, Token, create_access_token
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _validate_third_party_key(
+    session,
+    tenant_id: uuid.UUID,
+    raw_key: str,
+) -> Tenants:
+    """Resolve tenant and validate the third-party API key.
+
+    Raises HTTP 401 for any failure (disabled feature, wrong key, unknown
+    tenant) — keeps all failure branches indistinguishable to callers.
+    """
+    tenant = session.get(Tenants, tenant_id)
+    if tenant is None or tenant.third_party_api_key_hash is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Third-party login not enabled for this tenant",
+        )
+
+    try:
+        key_matches = bcrypt.checkpw(
+            raw_key.encode(),
+            tenant.third_party_api_key_hash.encode(),
+        )
+    except Exception:
+        key_matches = False
+
+    if not key_matches:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid third-party API key",
+        )
+
+    return tenant
 
 
 @router.post("/user/login", response_model=AuthCodeSentResponse)
@@ -168,5 +209,70 @@ async def human_authenticate(
 
     access_token = create_access_token(subject=human.id, token_type="human")
     logger.info(f"Human authenticated: {human.email}")
+
+    return Token(access_token=access_token)
+
+
+@router.post("/human/third-party/login", response_model=AuthCodeSentResponse)
+async def third_party_human_login(
+    request: ThirdPartyHumanLogin,
+    session: SessionDep,
+    x_tenant_id: uuid.UUID = Header(..., alias="X-Tenant-Id"),
+    x_third_party_api_key: str = Header(..., alias="X-Third-Party-Api-Key"),
+) -> AuthCodeSentResponse:
+    """Initiate OTP login for an EXISTING human via a third-party integration.
+
+    The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
+    Unlike the portal login endpoint, this surface NEVER creates a pending human
+    row — the partner is expected to have onboarded the user out-of-band.
+
+    On any validation failure (unknown tenant, feature disabled, wrong key,
+    unknown email) the response is 401 to prevent existence leakage.
+    """
+    _validate_third_party_key(session, x_tenant_id, x_third_party_api_key)
+
+    email, expiration_minutes = await login_existing_human(
+        session=session,
+        tenant_id=x_tenant_id,
+        email=request.email,
+    )
+
+    logger.info(f"Third-party OTP sent to human: {email}")
+    return AuthCodeSentResponse(
+        message="Mail sent successfully",
+        email=email,
+        expires_in_minutes=expiration_minutes,
+    )
+
+
+@router.post("/human/third-party/authenticate", response_model=Token)
+async def third_party_human_authenticate(
+    request: ThirdPartyHumanVerify,
+    session: SessionDep,
+    x_tenant_id: uuid.UUID = Header(..., alias="X-Tenant-Id"),
+    x_third_party_api_key: str = Header(..., alias="X-Third-Party-Api-Key"),
+) -> Token:
+    """Verify OTP and mint a third-party JWT for an existing human.
+
+    Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
+    The JWT grants portal:self_read, portal:directory_read, and
+    portal:api_keys_manage on the portal surface; it does NOT grant admin access.
+    """
+    _validate_third_party_key(session, x_tenant_id, x_third_party_api_key)
+
+    human = await authenticate_human(
+        session=session,
+        email=request.email,
+        tenant_id=x_tenant_id,
+        code=request.code,
+    )
+
+    access_token = create_access_token(
+        subject=human.id,
+        token_type="human",
+        scopes=list(THIRD_PARTY_TOKEN_SCOPES),
+        issued_via="third_party",
+    )
+    logger.info(f"Third-party human authenticated: {human.email}")
 
     return Token(access_token=access_token)

--- a/backend/app/api/auth/router.py
+++ b/backend/app/api/auth/router.py
@@ -1,8 +1,8 @@
 import secrets
-import uuid
 
 from fastapi import APIRouter, Header, HTTPException, status
 from loguru import logger
+from sqlmodel import select
 
 from app.api.api_key.crud import hash_key as hash_api_key
 from app.api.auth.crud import (
@@ -31,30 +31,31 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 def _validate_third_party_key(
     session,
-    tenant_id: uuid.UUID,
     raw_key: str,
 ) -> Tenants:
-    """Resolve tenant and validate the third-party API key.
+    """Resolve the tenant from the third-party API key alone.
 
-    Raises HTTP 401 for any failure (disabled feature, wrong key, unknown
-    tenant) — keeps all failure branches indistinguishable to callers.
+    Hashes the raw key, looks up the tenant by the (partially unique) hash
+    column. All failure branches collapse to a single 401 — callers cannot
+    distinguish unknown key, wrong key, or disabled tenant from each other.
     """
-    tenant = session.get(Tenants, tenant_id)
-    if tenant is None or tenant.third_party_api_key_hash is None:
+    key_hash = hash_api_key(raw_key)
+    tenant = session.exec(
+        select(Tenants).where(Tenants.third_party_api_key_hash == key_hash)
+    ).first()
+
+    if tenant is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Third-party login not enabled for this tenant",
+            detail="Invalid third-party credentials",
         )
 
-    key_matches = secrets.compare_digest(
-        hash_api_key(raw_key),
-        tenant.third_party_api_key_hash,
-    )
-
-    if not key_matches:
+    # Defensive constant-time compare — the index lookup is already a strict
+    # equality match, but the explicit check makes the timing path uniform.
+    if not secrets.compare_digest(key_hash, tenant.third_party_api_key_hash or ""):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid third-party API key",
+            detail="Invalid third-party credentials",
         )
 
     return tenant
@@ -215,23 +216,24 @@ async def human_authenticate(
 async def third_party_human_login(
     request: ThirdPartyHumanLogin,
     session: SessionDep,
-    x_tenant_id: uuid.UUID = Header(..., alias="X-Tenant-Id"),
     x_third_party_api_key: str = Header(..., alias="X-Third-Party-Api-Key"),
 ) -> AuthCodeSentResponse:
     """Initiate OTP login for an EXISTING human via a third-party integration.
 
-    The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
-    Unlike the portal login endpoint, this surface NEVER creates a pending human
-    row — the partner is expected to have onboarded the user out-of-band.
+    The caller supplies only a valid third-party API key in
+    X-Third-Party-Api-Key; the tenant is resolved server-side from the key.
+    Unlike the portal login endpoint, this surface NEVER creates a pending
+    human row — the partner is expected to have onboarded the user
+    out-of-band.
 
-    On any validation failure (unknown tenant, feature disabled, wrong key,
-    unknown email) the response is 401 to prevent existence leakage.
+    On any validation failure (wrong key, unknown email) the response is 401
+    to prevent existence leakage.
     """
-    _validate_third_party_key(session, x_tenant_id, x_third_party_api_key)
+    tenant = _validate_third_party_key(session, x_third_party_api_key)
 
     email, expiration_minutes = await login_existing_human(
         session=session,
-        tenant_id=x_tenant_id,
+        tenant_id=tenant.id,
         email=request.email,
     )
 
@@ -247,21 +249,21 @@ async def third_party_human_login(
 async def third_party_human_authenticate(
     request: ThirdPartyHumanVerify,
     session: SessionDep,
-    x_tenant_id: uuid.UUID = Header(..., alias="X-Tenant-Id"),
     x_third_party_api_key: str = Header(..., alias="X-Third-Party-Api-Key"),
 ) -> Token:
     """Verify OTP and mint a third-party JWT for an existing human.
 
+    The tenant is resolved server-side from the third-party API key alone.
     Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
     The JWT grants portal:self_read, portal:directory_read, and
     portal:api_keys_manage on the portal surface; it does NOT grant admin access.
     """
-    _validate_third_party_key(session, x_tenant_id, x_third_party_api_key)
+    tenant = _validate_third_party_key(session, x_third_party_api_key)
 
     human = await authenticate_human(
         session=session,
         email=request.email,
-        tenant_id=x_tenant_id,
+        tenant_id=tenant.id,
         code=request.code,
     )
 

--- a/backend/app/api/auth/schemas.py
+++ b/backend/app/api/auth/schemas.py
@@ -47,6 +47,26 @@ class HumanVerify(BaseModel):
     _normalize_email = field_validator("email", mode="after")(_normalize_email)
 
 
+# Third-party OTP authentication schemas
+class ThirdPartyHumanLogin(BaseModel):
+    """Request body for POST /auth/human/third-party/login.
+
+    Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+    """
+
+    email: EmailStr
+
+
+class ThirdPartyHumanVerify(BaseModel):
+    """Request body for POST /auth/human/third-party/authenticate.
+
+    Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+    """
+
+    email: EmailStr
+    code: str = Field(min_length=6, max_length=6, pattern=r"^\d{6}$")
+
+
 # Response schemas
 class AuthTokenResponse(BaseModel):
     """Response containing JWT access token."""

--- a/backend/app/api/auth/schemas.py
+++ b/backend/app/api/auth/schemas.py
@@ -51,7 +51,8 @@ class HumanVerify(BaseModel):
 class ThirdPartyHumanLogin(BaseModel):
     """Request body for POST /auth/human/third-party/login.
 
-    Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+    The API key comes from the X-Third-Party-Api-Key header; the tenant is
+    resolved server-side from the key.
     """
 
     email: EmailStr
@@ -60,7 +61,8 @@ class ThirdPartyHumanLogin(BaseModel):
 class ThirdPartyHumanVerify(BaseModel):
     """Request body for POST /auth/human/third-party/authenticate.
 
-    Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+    The API key comes from the X-Third-Party-Api-Key header; the tenant is
+    resolved server-side from the key.
     """
 
     email: EmailStr

--- a/backend/app/api/coupon/router.py
+++ b/backend/app/api/coupon/router.py
@@ -15,11 +15,12 @@ from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
+    AdminOrApiKey_CouponsRead,
+    AdminOrApiKey_CouponsWrite,
+    AdminOrApiKeySession_CouponsRead,
+    AdminOrApiKeySession_CouponsWrite,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
     SessionDep,
-    TenantSession,
 )
 from app.core.rate_limit import RateLimit
 
@@ -55,8 +56,8 @@ async def validate_coupon_public(
 
 @router.get("", response_model=ListModel[CouponPublic])
 async def list_coupons(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_CouponsRead,
+    _: AdminOrApiKey_CouponsRead,
     popup_id: uuid.UUID | None = None,
     is_active: bool | None = None,
     search: str | None = None,
@@ -87,8 +88,8 @@ async def list_coupons(
 @router.get("/{coupon_id}", response_model=CouponPublic)
 async def get_coupon(
     coupon_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_CouponsRead,
+    _: AdminOrApiKey_CouponsRead,
 ) -> CouponPublic:
     """Get a single coupon by ID (BO only)."""
     coupon = crud.coupons_crud.get(db, coupon_id)
@@ -121,8 +122,8 @@ async def validate_coupon(
 @router.post("", response_model=CouponPublic, status_code=status.HTTP_201_CREATED)
 async def create_coupon(
     coupon_in: CouponCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_CouponsWrite,
+    current_user: AdminOrApiKey_CouponsWrite,
 ) -> CouponPublic:
     """Create a new coupon (BO only)."""
 
@@ -166,8 +167,8 @@ async def create_coupon(
 async def update_coupon(
     coupon_id: uuid.UUID,
     coupon_in: CouponUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_CouponsWrite,
+    _current_user: AdminOrApiKey_CouponsWrite,
 ) -> CouponPublic:
     """Update a coupon (BO only)."""
 
@@ -195,8 +196,8 @@ async def update_coupon(
 @router.delete("/{coupon_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_coupon(
     coupon_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_CouponsWrite,
+    _current_user: AdminOrApiKey_CouponsWrite,
 ) -> None:
     """Delete a coupon (BO only)."""
 

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -38,11 +38,13 @@ from app.api.event.schemas import (
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
+    AdminOrApiKey_EventsRead,
+    AdminOrApiKey_EventsWrite,
+    AdminOrApiKeySession_EventsRead,
+    AdminOrApiKeySession_EventsWrite,
     CurrentHuman,
-    CurrentOperator,
     HumanTenantSession,
     SessionDep,
-    TenantSession,
 )
 from app.core.rate_limit import RateLimit
 from app.services.event_itip import (
@@ -780,8 +782,8 @@ async def list_public_calendar(
 
 @router.get("", response_model=ListModel[EventPublic])
 async def list_events(
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
     popup_id: uuid.UUID | None = None,
     event_status: EventStatus | None = None,
     kind: str | None = None,
@@ -835,8 +837,8 @@ async def list_events(
 @router.get("/{event_id}", response_model=EventPublic)
 async def get_event(
     event_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -849,8 +851,8 @@ async def get_event(
 @router.post("", response_model=EventPublic, status_code=status.HTTP_201_CREATED)
 async def create_event(
     event_in: EventCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     from app.api.event.models import Events
     from app.api.popup.crud import popups_crud
@@ -914,8 +916,8 @@ async def create_event(
 async def update_event(
     event_id: uuid.UUID,
     event_in: EventUpdate,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -977,8 +979,8 @@ async def update_event(
 @router.post("/{event_id}/cancel", response_model=EventPublic)
 async def cancel_event(
     event_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -999,8 +1001,8 @@ async def cancel_event(
 @router.delete("/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_event(
     event_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> None:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1025,8 +1027,8 @@ async def delete_event(
 async def set_recurrence(
     event_id: uuid.UUID,
     payload: RecurrenceUpdate,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     """Set/replace/clear the RRULE on a series master.
 
@@ -1079,8 +1081,8 @@ async def set_recurrence(
 @router.get("/{event_id}/overrides", response_model=list[EventPublic])
 async def list_overrides(
     event_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> list[EventPublic]:
     """Detached override children of a recurring series master.
 
@@ -1108,8 +1110,8 @@ async def list_overrides(
 async def detach_occurrence(
     event_id: uuid.UUID,
     payload: OccurrenceRef,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     """Materialize a single occurrence of a recurring series as its own row.
 
@@ -1205,8 +1207,8 @@ async def detach_occurrence(
 async def delete_occurrence(
     event_id: uuid.UUID,
     payload: OccurrenceRef,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> None:
     """Skip a single occurrence by appending it to the master's EXDATEs.
 
@@ -1295,8 +1297,8 @@ def _run_availability_check(
 @router.post("/check-availability", response_model=EventAvailabilityResult)
 async def check_availability(
     payload: EventAvailabilityCheck,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> EventAvailabilityResult:
     """Check whether a venue is free for a candidate time window."""
     return _run_availability_check(db, payload)
@@ -1359,8 +1361,8 @@ def _conflicting_event_summary(
 )
 async def check_recurring_availability(
     payload: EventRecurringAvailabilityCheck,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> EventRecurringAvailabilityResult:
     """Server-side preflight for a (possibly recurring) event.
 
@@ -1512,8 +1514,8 @@ async def check_recurring_availability(
 @router.get("/{event_id}/invitations", response_model=list[EventInvitationPublic])
 async def list_invitations(
     event_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> list[EventInvitationPublic]:
     from sqlmodel import select
 
@@ -1606,8 +1608,8 @@ def _run_bulk_invite(
 async def bulk_invite(
     event_id: uuid.UUID,
     payload: EventInvitationBulkCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventInvitationBulkResult:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1623,8 +1625,8 @@ async def bulk_invite(
 async def delete_invitation(
     event_id: uuid.UUID,
     invitation_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> None:
     inv = crud.invitations_crud.get(db, invitation_id)
     if not inv or inv.event_id != event_id:
@@ -1772,8 +1774,8 @@ async def _send_event_approval_email(
 async def approve_event(
     event_id: uuid.UUID,
     payload: EventApprovalPayload,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1812,8 +1814,8 @@ async def approve_event(
 async def reject_event(
     event_id: uuid.UUID,
     payload: EventApprovalPayload,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1874,8 +1876,8 @@ async def delete_portal_invitation(
 @router.get("/{event_id}/ics")
 async def export_event_ics(
     event_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> Response:
     event = crud.events_crud.get(db, event_id)
     if not event:

--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -14,11 +14,12 @@ from app.api.event_participant.schemas import (
 )
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
+    AdminOrApiKey_EventsRead,
+    AdminOrApiKey_RsvpWrite,
+    AdminOrApiKeySession_EventsRead,
+    AdminOrApiKeySession_RsvpWrite,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
     HumanTenantSession,
-    TenantSession,
 )
 
 router = APIRouter(prefix="/event-participants", tags=["event-participants"])
@@ -56,8 +57,8 @@ def _participants_with_names(db, participants: list) -> list[EventParticipantPub
 
 @router.get("", response_model=ListModel[EventParticipantPublic])
 async def list_participants(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
     event_id: uuid.UUID | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
@@ -86,8 +87,8 @@ async def list_participants(
 )
 async def admin_add_participant(
     participant_in: EventParticipantCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_RsvpWrite,
+    current_user: AdminOrApiKey_RsvpWrite,
 ) -> EventParticipantPublic:
     """Admin adds a participant to an event (backoffice)."""
     from app.api.event.crud import events_crud
@@ -134,8 +135,8 @@ async def admin_add_participant(
 async def update_participant(
     participant_id: uuid.UUID,
     participant_in: EventParticipantUpdate,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_RsvpWrite,
+    _: AdminOrApiKey_RsvpWrite,
 ) -> EventParticipantPublic:
     """Update a participant (backoffice)."""
 
@@ -153,8 +154,8 @@ async def update_participant(
 @router.delete("/{participant_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_participant(
     participant_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_RsvpWrite,
+    _: AdminOrApiKey_RsvpWrite,
 ) -> None:
     """Delete a participant (backoffice)."""
 

--- a/backend/app/api/event_venue/router.py
+++ b/backend/app/api/event_venue/router.py
@@ -37,12 +37,12 @@ from app.api.event_venue.schemas import (
 )
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
+    AdminOrApiKey_EventsRead,
+    AdminOrApiKey_VenuesWrite,
+    AdminOrApiKeySession_EventsRead,
+    AdminOrApiKeySession_VenuesWrite,
     CurrentHuman,
-    CurrentTenant,
-    CurrentUser,
-    CurrentWriter,
     HumanTenantSession,
-    TenantSession,
 )
 
 GALLERY_MAX_PHOTOS = 10
@@ -144,8 +144,8 @@ def _get_venue_or_404(db, venue_id: uuid.UUID) -> EventVenues:
 
 @router.get("", response_model=ListModel[EventVenuePublic])
 async def list_venues(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
     popup_id: uuid.UUID | None = None,
     search: str | None = None,
     skip: PaginationSkip = 0,
@@ -177,8 +177,8 @@ async def list_venues(
 @router.patch("/reorder", status_code=status.HTTP_204_NO_CONTENT)
 async def reorder_venues(
     payload: VenueReorderPayload,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> None:
     """Persist a manual venue ordering for a popup.
 
@@ -225,8 +225,8 @@ async def reorder_venues(
 @router.get("/{venue_id}", response_model=EventVenuePublic)
 async def get_venue(
     venue_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> EventVenuePublic:
     venue = _get_venue_or_404(db, venue_id)
     return EventVenuePublic.model_validate(venue)
@@ -235,8 +235,8 @@ async def get_venue(
 @router.post("", response_model=EventVenuePublic, status_code=status.HTTP_201_CREATED)
 async def create_venue(
     venue_in: EventVenueCreate,
-    db: TenantSession,
-    current_user: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    current_user: AdminOrApiKey_VenuesWrite,
 ) -> EventVenuePublic:
     from app.api.popup.crud import popups_crud
     from app.api.shared.enums import UserRole
@@ -269,8 +269,8 @@ async def create_venue(
 async def update_venue(
     venue_id: uuid.UUID,
     venue_in: EventVenueUpdate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> EventVenuePublic:
     venue = _get_venue_or_404(db, venue_id)
     update_data = venue_in.model_dump(exclude_unset=True, exclude={"property_type_ids"})
@@ -286,8 +286,8 @@ async def update_venue(
 @router.delete("/{venue_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_venue(
     venue_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> None:
     venue = _get_venue_or_404(db, venue_id)
     crud.event_venues_crud.delete(db, venue)
@@ -302,8 +302,8 @@ async def delete_venue(
 async def set_weekly_hours(
     venue_id: uuid.UUID,
     payload: VenueWeeklyHoursUpdate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> dict:
     venue = _get_venue_or_404(db, venue_id)
     existing = list(
@@ -351,8 +351,8 @@ async def set_weekly_hours(
 @router.get("/{venue_id}/exceptions", response_model=list[VenueExceptionPublic])
 async def list_exceptions(
     venue_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> list[VenueExceptionPublic]:
     rows = list(
         db.exec(
@@ -372,8 +372,8 @@ async def list_exceptions(
 async def create_exception(
     venue_id: uuid.UUID,
     payload: VenueExceptionCreate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> VenueExceptionPublic:
     venue = _get_venue_or_404(db, venue_id)
     if payload.start_datetime >= payload.end_datetime:
@@ -402,8 +402,8 @@ async def update_exception(
     venue_id: uuid.UUID,
     exception_id: uuid.UUID,
     payload: VenueExceptionUpdate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> VenueExceptionPublic:
     exc = db.get(VenueExceptions, exception_id)
     if not exc or exc.venue_id != venue_id:
@@ -423,8 +423,8 @@ async def update_exception(
 async def delete_exception(
     venue_id: uuid.UUID,
     exception_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> None:
     exc = db.get(VenueExceptions, exception_id)
     if not exc or exc.venue_id != venue_id:
@@ -441,8 +441,8 @@ async def delete_exception(
 @router.get("/{venue_id}/photos", response_model=list[VenuePhotoPublic])
 async def list_photos(
     venue_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> list[VenuePhotoPublic]:
     rows = list(
         db.exec(
@@ -462,8 +462,8 @@ async def list_photos(
 async def add_photo(
     venue_id: uuid.UUID,
     payload: VenuePhotoCreate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> VenuePhotoPublic:
     venue = _get_venue_or_404(db, venue_id)
     current_count = len(
@@ -491,8 +491,8 @@ async def update_photo(
     venue_id: uuid.UUID,
     photo_id: uuid.UUID,
     payload: VenuePhotoUpdate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> VenuePhotoPublic:
     photo = db.get(VenuePhotos, photo_id)
     if not photo or photo.venue_id != venue_id:
@@ -509,8 +509,8 @@ async def update_photo(
 async def delete_photo(
     venue_id: uuid.UUID,
     photo_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> None:
     photo = db.get(VenuePhotos, photo_id)
     if not photo or photo.venue_id != venue_id:
@@ -695,8 +695,8 @@ def _compute_availability(
 @router.get("/{venue_id}/availability", response_model=VenueAvailability)
 async def get_availability(
     venue_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
     start: datetime = Query(...),
     end: datetime = Query(...),
     exclude_event_id: uuid.UUID | None = Query(default=None),
@@ -870,8 +870,8 @@ async def create_portal_venue(
 
 @property_types_router.get("", response_model=list[VenuePropertyTypePublic])
 async def list_property_types(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsRead,
+    _: AdminOrApiKey_EventsRead,
 ) -> list[VenuePropertyTypePublic]:
     rows = list(
         db.exec(select(VenuePropertyTypes).order_by(VenuePropertyTypes.name)).all()
@@ -886,14 +886,13 @@ async def list_property_types(
 )
 async def create_property_type(
     payload: VenuePropertyTypeCreate,
-    db: TenantSession,
-    current_tenant: CurrentTenant,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    current_user: AdminOrApiKey_VenuesWrite,
 ) -> VenuePropertyTypePublic:
     # Always write to the tenant in the request's workspace context so
     # superadmins (no user.tenant_id) work too.
     pt = VenuePropertyTypes(
-        tenant_id=current_tenant.id,
+        tenant_id=current_user.tenant_id,
         name=payload.name,
         icon=payload.icon,
     )
@@ -913,8 +912,8 @@ async def create_property_type(
 async def update_property_type(
     property_type_id: uuid.UUID,
     payload: VenuePropertyTypeUpdate,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> VenuePropertyTypePublic:
     pt = db.get(VenuePropertyTypes, property_type_id)
     if not pt:
@@ -933,8 +932,8 @@ async def update_property_type(
 )
 async def delete_property_type(
     property_type_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentWriter,
+    db: AdminOrApiKeySession_VenuesWrite,
+    _: AdminOrApiKey_VenuesWrite,
 ) -> None:
     pt = db.get(VenuePropertyTypes, property_type_id)
     if not pt:

--- a/backend/app/api/form_field/router.py
+++ b/backend/app/api/form_field/router.py
@@ -22,11 +22,12 @@ from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.translation.service import delete_translations_for_entity
 from app.core.dependencies.users import (
+    AdminOrApiKey_FormsRead,
+    AdminOrApiKey_FormsWrite,
+    AdminOrApiKeySession_FormsRead,
+    AdminOrApiKeySession_FormsWrite,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
     HumanTenantSession,
-    TenantSession,
 )
 
 router = APIRouter(prefix="/form-fields", tags=["form-fields"])
@@ -77,8 +78,8 @@ def _get_base_fields_as_public(db: "Session", popup: "Popups") -> list[FormField
 
 @router.get("", response_model=ListModel[FormFieldPublic])
 async def list_form_fields(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_FormsRead,
+    _: AdminOrApiKey_FormsRead,
     popup_id: uuid.UUID | None = None,
     search: str | None = None,
     skip: PaginationSkip = 0,
@@ -132,8 +133,8 @@ async def list_form_fields(
 @router.get("/catalog/{popup_id}", response_model=list[CatalogField])
 async def list_available_base_fields(
     popup_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_FormsRead,
+    _: AdminOrApiKey_FormsRead,
 ) -> list[CatalogField]:
     """List catalog base fields that are not yet configured for this popup.
 
@@ -185,8 +186,8 @@ async def list_available_base_fields(
 async def create_base_field_config(
     popup_id: uuid.UUID,
     field_name: str,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    _current_user: AdminOrApiKey_FormsWrite,
 ) -> FormFieldPublic:
     """Add a catalog base field to a popup by creating its BaseFieldConfig."""
     from app.api.popup.crud import popups_crud
@@ -268,8 +269,8 @@ async def create_base_field_config(
 @router.get("/{field_id}", response_model=FormFieldPublic)
 async def get_form_field(
     field_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_FormsRead,
+    _: AdminOrApiKey_FormsRead,
 ) -> FormFieldPublic:
     field = crud.form_fields_crud.get(db, field_id)
 
@@ -290,8 +291,8 @@ async def get_form_field(
 @router.post("", response_model=FormFieldPublic, status_code=status.HTTP_201_CREATED)
 async def create_form_field(
     field_in: FormFieldCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    current_user: AdminOrApiKey_FormsWrite,
 ) -> FormFieldPublic:
     if current_user.role == UserRole.SUPERADMIN:
         from app.api.popup.crud import popups_crud
@@ -327,8 +328,8 @@ async def create_form_field(
 async def update_form_field(
     field_id: uuid.UUID,
     field_in: FormFieldUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    _current_user: AdminOrApiKey_FormsWrite,
 ) -> FormFieldPublic:
     field = crud.form_fields_crud.get(db, field_id)
 
@@ -402,8 +403,8 @@ async def update_form_field(
 @router.delete("/{field_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_form_field(
     field_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    _current_user: AdminOrApiKey_FormsWrite,
 ) -> None:
     field = crud.form_fields_crud.get(db, field_id)
 
@@ -435,8 +436,8 @@ async def delete_form_field(
 @router.get("/schema/{popup_id}", response_model=dict[str, Any])
 async def get_application_schema(
     popup_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_FormsRead,
+    _: AdminOrApiKey_FormsRead,
 ) -> dict[str, Any]:
     """Get the complete application schema for a popup.
 

--- a/backend/app/api/form_section/router.py
+++ b/backend/app/api/form_section/router.py
@@ -15,15 +15,20 @@ from app.api.form_section.schemas import (
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.translation.service import delete_translations_for_entity
-from app.core.dependencies.users import CurrentOperator, CurrentUser, TenantSession
+from app.core.dependencies.users import (
+    AdminOrApiKey_FormsRead,
+    AdminOrApiKey_FormsWrite,
+    AdminOrApiKeySession_FormsRead,
+    AdminOrApiKeySession_FormsWrite,
+)
 
 router = APIRouter(prefix="/form-sections", tags=["form-sections"])
 
 
 @router.get("", response_model=ListModel[FormSectionPublic])
 async def list_form_sections(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_FormsRead,
+    _: AdminOrApiKey_FormsRead,
     popup_id: uuid.UUID | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
@@ -63,8 +68,8 @@ def _section_allowed_by_flags(section: FormSections, popup: Any) -> bool:
 @router.get("/{section_id}", response_model=FormSectionPublic)
 async def get_form_section(
     section_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_FormsRead,
+    _: AdminOrApiKey_FormsRead,
 ) -> FormSectionPublic:
     section = crud.form_sections_crud.get(db, section_id)
 
@@ -80,8 +85,8 @@ async def get_form_section(
 @router.post("", response_model=FormSectionPublic, status_code=status.HTTP_201_CREATED)
 async def create_form_section(
     section_in: FormSectionCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    current_user: AdminOrApiKey_FormsWrite,
 ) -> FormSectionPublic:
     from app.api.popup.crud import popups_crud
 
@@ -135,8 +140,8 @@ async def create_form_section(
 async def update_form_section(
     section_id: uuid.UUID,
     section_in: FormSectionUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    _current_user: AdminOrApiKey_FormsWrite,
 ) -> FormSectionPublic:
     section = crud.form_sections_crud.get(db, section_id)
 
@@ -153,8 +158,8 @@ async def update_form_section(
 @router.delete("/{section_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_form_section(
     section_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_FormsWrite,
+    _current_user: AdminOrApiKey_FormsWrite,
 ) -> None:
     section = crud.form_sections_crud.get(db, section_id)
 

--- a/backend/app/api/group/router.py
+++ b/backend/app/api/group/router.py
@@ -20,11 +20,12 @@ from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.translation.service import delete_translations_for_entity
 from app.core.dependencies.users import (
+    AdminOrApiKey_GroupsRead,
+    AdminOrApiKey_GroupsWrite,
+    AdminOrApiKeySession_GroupsRead,
+    AdminOrApiKeySession_GroupsWrite,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
     SessionDep,
-    TenantSession,
 )
 from app.utils.utils import slugify
 
@@ -84,8 +85,8 @@ def _build_members(group: Groups) -> list[GroupMemberPublic]:
 
 @router.get("", response_model=ListModel[GroupPublic])
 async def list_groups(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_GroupsRead,
+    _: AdminOrApiKey_GroupsRead,
     popup_id: uuid.UUID | None = None,
     search: str | None = None,
     skip: PaginationSkip = 0,
@@ -110,8 +111,8 @@ async def list_groups(
 @router.get("/{group_id}", response_model=GroupWithMembers)
 async def get_group(
     group_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_GroupsRead,
+    _: AdminOrApiKey_GroupsRead,
 ) -> GroupWithMembers:
     """Get a single group with members (BO only)."""
     group = crud.groups_crud.get_with_members(db, group_id)
@@ -131,8 +132,8 @@ async def get_group(
 @router.post("", response_model=GroupPublic, status_code=status.HTTP_201_CREATED)
 async def create_group(
     group_in: GroupCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_GroupsWrite,
+    current_user: AdminOrApiKey_GroupsWrite,
 ) -> GroupPublic:
     """Create a new group (BO only)."""
 
@@ -173,8 +174,8 @@ async def create_group(
 async def update_group(
     group_id: uuid.UUID,
     group_in: GroupAdminUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_GroupsWrite,
+    _current_user: AdminOrApiKey_GroupsWrite,
 ) -> GroupPublic:
     """Update a group (BO only - full admin access)."""
 
@@ -201,8 +202,8 @@ async def update_group(
 @router.delete("/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_group(
     group_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_GroupsWrite,
+    _current_user: AdminOrApiKey_GroupsWrite,
 ) -> None:
     """Delete a group (BO only)."""
 

--- a/backend/app/api/human/router.py
+++ b/backend/app/api/human/router.py
@@ -16,10 +16,12 @@ from app.api.human.schemas import (
 )
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
-    CurrentAdmin,
+    AdminOrApiKey_HumansRead,
+    AdminOrApiKey_HumansWrite,
+    AdminOrApiKeySession_HumansRead,
+    AdminOrApiKeySession_HumansWrite,
     CurrentHuman,
     CurrentSuperadmin,
-    CurrentWriter,
     HumanTenantSession,
     RequireHumanScopeDirectoryRead,
     RequireHumanScopeSelfRead,
@@ -32,8 +34,8 @@ router = APIRouter(prefix="/humans", tags=["humans"])
 
 @router.get("", response_model=ListModel[HumanPublic])
 async def list_humans(
-    db: TenantSession,
-    _: CurrentAdmin,
+    db: AdminOrApiKeySession_HumansRead,
+    _: AdminOrApiKey_HumansRead,
     search: str | None = None,
     popup_id: uuid.UUID | None = None,
     incomplete_application: bool = False,
@@ -181,8 +183,8 @@ async def search_humans_portal(
 @router.get("/{human_id}", response_model=HumanPublic)
 async def get_human(
     human_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentAdmin,
+    db: AdminOrApiKeySession_HumansRead,
+    _: AdminOrApiKey_HumansRead,
 ) -> HumanPublic:
     human = crud.get(db, human_id)
 
@@ -199,8 +201,8 @@ async def get_human(
 async def update_human(
     human_id: uuid.UUID,
     human_in: HumanUpdate,
-    db: TenantSession,
-    _current_user: CurrentWriter,
+    db: AdminOrApiKeySession_HumansWrite,
+    _current_user: AdminOrApiKey_HumansWrite,
 ) -> HumanPublic:
     human = crud.get(db, human_id)
 
@@ -244,8 +246,8 @@ async def update_human(
 @router.post("/{human_id}/api-keys/revoke", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_human_api_keys(
     human_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentWriter,
+    db: AdminOrApiKeySession_HumansWrite,
+    _current_user: AdminOrApiKey_HumansWrite,
 ) -> None:
     human = crud.get(db, human_id)
     if not human:
@@ -260,8 +262,8 @@ async def revoke_human_api_keys(
 @router.get("/{human_id}/api-keys", response_model=list[ApiKeyPublic])
 async def list_human_api_keys(
     human_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentWriter,
+    db: AdminOrApiKeySession_HumansRead,
+    _current_user: AdminOrApiKey_HumansRead,
 ) -> list[ApiKeyPublic]:
     human = crud.get(db, human_id)
     if not human:

--- a/backend/app/api/human/router.py
+++ b/backend/app/api/human/router.py
@@ -21,6 +21,8 @@ from app.core.dependencies.users import (
     CurrentSuperadmin,
     CurrentWriter,
     HumanTenantSession,
+    RequireHumanScopeDirectoryRead,
+    RequireHumanScopeSelfRead,
     TenantSession,
 )
 from app.services.email_helpers import send_application_status_email
@@ -112,6 +114,7 @@ async def create_human(
 @router.get("/me", response_model=HumanPublic)
 async def get_current_human_info(
     current_user: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> HumanPublic:
     return HumanPublic.model_validate(current_user)
 
@@ -120,6 +123,7 @@ async def get_current_human_info(
 async def get_current_human_profile_stats(
     current_human: CurrentHuman,
     db: HumanTenantSession,
+    _scope: RequireHumanScopeSelfRead,
 ) -> HumanProfileStats:
     """Aggregate popup history and total days attended for the profile page."""
     return crud.get_profile_stats(db, current_human.id)
@@ -130,6 +134,7 @@ async def update_current_human(
     human_in: HumanProfileUpdate,
     current_human: CurrentHuman,
     db: HumanTenantSession,
+    _scope: RequireHumanScopeSelfRead,
 ) -> HumanPublic:
     """Update the current authenticated human's profile."""
     human = crud.get(db, current_human.id)
@@ -148,6 +153,7 @@ async def update_current_human(
 async def search_humans_portal(
     db: HumanTenantSession,
     _: CurrentHuman,
+    _scope: RequireHumanScopeDirectoryRead,
     search: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 20,

--- a/backend/app/api/human/schemas.py
+++ b/backend/app/api/human/schemas.py
@@ -33,6 +33,9 @@ class HumanBase(SQLModel):
         default=None, sa_type=DateTime(timezone=True)
     )
     auth_attempts: int = Field(default=0)
+    # NULL = legacy/portal-origin; otherwise tags the flow that emitted the
+    # current OTP so the verify path can reject cross-flow redemption.
+    auth_code_origin: str | None = Field(default=None, max_length=20)
 
 
 class HumanPublic(BaseModel):

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -22,9 +22,10 @@ from app.api.payment.schemas import (
 )
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
+    AdminOrApiKey_PaymentsRead,
+    AdminOrApiKeySession_PaymentsRead,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
+    CurrentOperatorJwtOnly,
     HumanTenantSession,
     RequireHumanScopeSelfRead,
     SessionDep,
@@ -330,8 +331,8 @@ def _require_external_id(external_id: str | None) -> str:
 
 @router.get("", response_model=ListModel[PaymentPublic])
 async def list_payments(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_PaymentsRead,
+    _: AdminOrApiKey_PaymentsRead,
     popup_id: uuid.UUID | None = None,
     application_id: uuid.UUID | None = None,
     external_id: str | None = None,
@@ -378,8 +379,8 @@ async def list_payments(
 @router.get("/{payment_id}", response_model=PaymentPublic)
 async def get_payment(
     payment_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_PaymentsRead,
+    _: AdminOrApiKey_PaymentsRead,
 ) -> PaymentPublic:
     """Get a single payment (BO only)."""
     payment = payments_crud.get(db, payment_id)
@@ -396,8 +397,8 @@ async def get_payment(
 @router.get("/{payment_id}/invoice")
 async def get_payment_invoice(
     payment_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_PaymentsRead,
+    _: AdminOrApiKey_PaymentsRead,
 ) -> Response:
     """Download invoice PDF for a payment (BO only).
 
@@ -462,7 +463,7 @@ async def update_payment(
     payment_id: uuid.UUID,
     payment_in: PaymentUpdate,
     db: TenantSession,
-    _current_user: CurrentOperator,
+    _current_user: CurrentOperatorJwtOnly,
 ) -> PaymentPublic:
     """Update a payment (BO only)."""
 

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -26,6 +26,7 @@ from app.core.dependencies.users import (
     CurrentOperator,
     CurrentUser,
     HumanTenantSession,
+    RequireHumanScopeSelfRead,
     SessionDep,
     TenantSession,
 )
@@ -498,6 +499,7 @@ async def create_my_application_fee(
     fee_in: ApplicationFeeCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> PaymentPublic:
     """Create an application fee payment for current human's application (Portal).
 
@@ -523,6 +525,7 @@ async def list_my_payments_by_popup(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
     skip: Annotated[int, Query(ge=0, description="Number of payments to skip")] = 0,
     limit: Annotated[
         int, Query(ge=1, le=100, description="Max payments to return (max 100)")
@@ -551,6 +554,7 @@ async def get_my_latest_payment(
     application_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> PaymentStatusCheck:
     """Get the latest payment status for an application owned by current human (Portal)."""
     from app.api.application.crud import applications_crud
@@ -581,6 +585,7 @@ async def get_my_payment_status(
     payment_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> PaymentStatusCheck:
     """Get the current status for an owned payment (Portal)."""
     payment = _get_portal_owned_payment_or_404(db, payment_id, current_human)
@@ -596,6 +601,7 @@ async def list_my_payments(
     application_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[PaymentPublic]:
@@ -625,6 +631,7 @@ async def get_my_invoice(
     payment_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> Response:
     """Download invoice PDF for a payment owned by current human (Portal).
 
@@ -677,6 +684,7 @@ async def preview_my_payment(
     payment_in: PaymentCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> PaymentPreview:
     """
     Preview a payment calculation without creating it (Portal).
@@ -709,6 +717,7 @@ async def create_my_payment(
     payment_in: PaymentCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    _scope: RequireHumanScopeSelfRead,
 ) -> PaymentPublic:
     """
     Create a payment for current human's application (Portal).

--- a/backend/app/api/product/crud.py
+++ b/backend/app/api/product/crud.py
@@ -194,6 +194,27 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
         session.refresh(db_obj)
         return db_obj
 
+    def _count_active_sales(
+        self, session: Session, product_id: uuid.UUID
+    ) -> int:
+        """Sum quantities of units currently holding stock for this product.
+
+        Counts payment_products rows whose payment is in a stock-holding
+        status — mirrors the same set of statuses that gate decrement /
+        restore (pending = reserved, approved = paid). Rejected / expired /
+        cancelled payments are excluded because they release stock.
+        """
+        result = session.execute(
+            text(
+                "SELECT COALESCE(SUM(pp.quantity), 0) "
+                "FROM payment_products pp "
+                "JOIN payments p ON p.id = pp.payment_id "
+                "WHERE pp.product_id = :pid "
+                "AND p.status IN ('pending', 'approved')"
+            ).bindparams(pid=product_id)
+        ).scalar()
+        return int(result or 0)
+
     def update(
         self,
         session: Session,
@@ -203,9 +224,18 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
         """Update product fields.
 
         When `total_stock_cap` changes without an explicit `total_stock_remaining`,
-        recompute remaining to preserve `sold = old_cap - old_remaining`. Otherwise
-        the CHECK constraint `total_stock_remaining <= total_stock_cap` rejects
-        any cap reduction below the stale remaining.
+        recompute remaining so that the existing sold count is preserved. Two
+        cases:
+
+        1. `old_cap` and `old_remaining` are both tracked → derive sold from the
+           counter (`old_cap - old_remaining`).
+        2. Either was NULL (product was unlimited, or never seeded) → count real
+           sales from `payment_products` to avoid losing prior sales when a cap
+           is added after the fact.
+
+        Without this, the CHECK constraint `total_stock_remaining <= total_stock_cap`
+        rejects cap reductions, and (worse) sales made while the product was
+        unlimited get silently dropped when the cap is added later.
         """
         update_data = sale_dates_to_persistence(obj_in.model_dump(exclude_unset=True))
 
@@ -227,7 +257,11 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
             if new_cap is None:
                 update_data["total_stock_remaining"] = None
             elif old_cap is None or old_remaining is None:
-                update_data["total_stock_remaining"] = new_cap
+                # Product was unlimited (or never seeded) — any prior sales
+                # weren't tracked in the counter. Pull sold from payment_products
+                # so we don't silently grant extra inventory.
+                sold = self._count_active_sales(session, db_obj.id)
+                update_data["total_stock_remaining"] = max(0, new_cap - sold)
             else:
                 sold = old_cap - old_remaining
                 update_data["total_stock_remaining"] = max(0, new_cap - sold)

--- a/backend/app/api/product/router.py
+++ b/backend/app/api/product/router.py
@@ -21,10 +21,12 @@ from app.api.translation.service import (
     get_translations_bulk,
 )
 from app.core.dependencies.users import (
+    AdminOrApiKey_ProductsRead,
+    AdminOrApiKey_ProductsWrite,
+    AdminOrApiKeySession_ProductsRead,
+    AdminOrApiKeySession_ProductsWrite,
     CurrentHuman,
-    CurrentOperator,
     CurrentSuperadmin,
-    CurrentUser,
     HumanTenantSession,
     SessionDep,
     TenantSession,
@@ -59,8 +61,8 @@ async def list_product_categories(
 
 @router.get("", response_model=ListModel[ProductPublic])
 async def list_products(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_ProductsRead,
+    _: AdminOrApiKey_ProductsRead,
     popup_id: uuid.UUID | None = None,
     is_active: bool | None = None,
     category: str | None = None,
@@ -178,8 +180,8 @@ async def create_products_batch(
 @router.get("/{product_id}", response_model=ProductPublic)
 async def get_product(
     product_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_ProductsRead,
+    _: AdminOrApiKey_ProductsRead,
 ) -> ProductPublic:
     """Get a single product by ID."""
     product = crud.products_crud.get(db, product_id)
@@ -196,8 +198,8 @@ async def get_product(
 @router.post("", response_model=ProductPublic, status_code=status.HTTP_201_CREATED)
 async def create_product(
     product_in: ProductCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_ProductsWrite,
+    current_user: AdminOrApiKey_ProductsWrite,
 ) -> ProductPublic:
     """Create a new product."""
 
@@ -243,8 +245,8 @@ async def create_product(
 async def update_product(
     product_id: uuid.UUID,
     product_in: ProductUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_ProductsWrite,
+    _current_user: AdminOrApiKey_ProductsWrite,
 ) -> ProductPublic:
     """Update a product."""
 
@@ -274,8 +276,8 @@ async def update_product(
 @router.delete("/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_product(
     product_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_ProductsWrite,
+    _current_user: AdminOrApiKey_ProductsWrite,
 ) -> None:
     """Delete a product.
 

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from app.api import (
+    admin_api_key,
     api_key,
     application,
     application_review,
@@ -44,6 +45,7 @@ api_router.include_router(auth.router)
 api_router.include_router(tenant.router)
 api_router.include_router(human.router)
 api_router.include_router(api_key.router)
+api_router.include_router(admin_api_key.router)
 api_router.include_router(popup.router)
 api_router.include_router(attendee_category.router)
 

--- a/backend/app/api/tenant/models.py
+++ b/backend/app/api/tenant/models.py
@@ -41,8 +41,8 @@ class Tenants(TenantBase, table=True):
     )
 
     # Third-party OTP surface. Presence of a non-null hash means the feature
-    # is enabled for this tenant. The cleartext key is NEVER stored — only the
-    # bcrypt hash and an 8-char prefix for display.
+    # is enabled for this tenant. The cleartext key is NEVER stored; only the
+    # peppered SHA-256 hash and an 8-char prefix for display.
     third_party_api_key_hash: str | None = Field(
         default=None,
         max_length=64,

--- a/backend/app/api/tenant/models.py
+++ b/backend/app/api/tenant/models.py
@@ -40,6 +40,18 @@ class Tenants(TenantBase, table=True):
         ),
     )
 
+    # Third-party OTP surface. Presence of a non-null hash means the feature
+    # is enabled for this tenant. The cleartext key is NEVER stored — only the
+    # bcrypt hash and an 8-char prefix for display.
+    third_party_api_key_hash: str | None = Field(
+        default=None,
+        max_length=64,
+    )
+    third_party_key_prefix: str | None = Field(
+        default=None,
+        max_length=20,
+    )
+
     # Core relationships
     popups: list["Popups"] = Relationship(back_populates="tenant", cascade_delete=True)
     users: list["Users"] = Relationship(back_populates="tenant", cascade_delete=True)

--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -1,10 +1,10 @@
 import secrets
 import uuid
 
-import bcrypt
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 
+from app.api.api_key.crud import hash_key as hash_api_key
 from app.api.shared.enums import CredentialType, LandingMode, UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.tenant import crud
@@ -32,12 +32,12 @@ _THIRD_PARTY_KEY_PREFIX_LEN = 8
 
 
 def _hash_third_party_key(raw_key: str) -> str:
-    """bcrypt hash for tenant third-party API keys.
+    """Peppered SHA-256 hash for tenant third-party API keys.
 
-    bcrypt is used (not SHA-256) because the auth endpoint validates with
-    bcrypt.checkpw — both sides must use the same algorithm.
+    Uses the same `hash_key` primitive as `api_keys.key_hash` so all api-key
+    style secrets share one hashing convention.
     """
-    return bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    return hash_api_key(raw_key)
 
 
 @router.get("/public/by-domain/{domain}", response_model=TenantPublic)
@@ -381,9 +381,9 @@ async def rotate_third_party_key(
 ) -> ThirdPartyKeyRotated:
     """Generate and store a new third-party API key for this tenant.
 
-    The raw key is returned ONCE and never stored — only the bcrypt hash is
-    persisted. Rotation takes effect on the NEXT login attempt; in-flight JWTs
-    already issued remain valid until their own expiry.
+    The raw key is returned ONCE and never stored; only its peppered SHA-256
+    hash is persisted. Rotation takes effect on the NEXT login attempt;
+    in-flight JWTs already issued remain valid until their own expiry.
 
     Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
     """

--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -1,5 +1,7 @@
+import secrets
 import uuid
 
+import bcrypt
 from fastapi import APIRouter, HTTPException, status
 from sqlalchemy.exc import IntegrityError
 
@@ -7,7 +9,12 @@ from app.api.shared.enums import CredentialType, LandingMode, UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.tenant import crud
 from app.api.tenant.credential_schemas import CredentialInfo, TenantCredentialResponse
-from app.api.tenant.schemas import TenantCreate, TenantPublic, TenantUpdate
+from app.api.tenant.schemas import (
+    TenantCreate,
+    TenantPublic,
+    TenantUpdate,
+    ThirdPartyKeyRotated,
+)
 from app.core.config import settings
 from app.core.dependencies.users import (
     CurrentAdmin,
@@ -19,6 +26,18 @@ from app.core.redis import domain_cache
 from app.core.tenant_db import get_tenant_credential, revoke_tenant_credentials
 
 router = APIRouter(prefix="/tenants", tags=["tenants"])
+
+
+_THIRD_PARTY_KEY_PREFIX_LEN = 8
+
+
+def _hash_third_party_key(raw_key: str) -> str:
+    """bcrypt hash for tenant third-party API keys.
+
+    bcrypt is used (not SHA-256) because the auth endpoint validates with
+    bcrypt.checkpw — both sides must use the same algorithm.
+    """
+    return bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
 
 
 @router.get("/public/by-domain/{domain}", response_model=TenantPublic)
@@ -349,3 +368,80 @@ async def delete_credentials(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tenant has no credentials to revoke",
         )
+
+
+@router.post(
+    "/{tenant_id}/third-party-key/rotate",
+    response_model=ThirdPartyKeyRotated,
+)
+async def rotate_third_party_key(
+    tenant_id: uuid.UUID,
+    db: SessionDep,
+    current_user: CurrentAdmin,
+) -> ThirdPartyKeyRotated:
+    """Generate and store a new third-party API key for this tenant.
+
+    The raw key is returned ONCE and never stored — only the bcrypt hash is
+    persisted. Rotation takes effect on the NEXT login attempt; in-flight JWTs
+    already issued remain valid until their own expiry.
+
+    Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+    """
+    if current_user.role == UserRole.ADMIN and current_user.tenant_id != tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin can only manage their own tenant third-party key",
+        )
+
+    tenant = crud.get(db, tenant_id)
+    if tenant is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    raw_key = secrets.token_urlsafe(32)
+    key_hash = _hash_third_party_key(raw_key)
+    prefix = raw_key[:_THIRD_PARTY_KEY_PREFIX_LEN]
+
+    tenant.third_party_api_key_hash = key_hash
+    tenant.third_party_key_prefix = prefix
+    db.add(tenant)
+    db.commit()
+
+    return ThirdPartyKeyRotated(api_key=raw_key, prefix=prefix)
+
+
+@router.delete(
+    "/{tenant_id}/third-party-key",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_third_party_key(
+    tenant_id: uuid.UUID,
+    db: SessionDep,
+    current_user: CurrentAdmin,
+) -> None:
+    """Disable third-party login for this tenant by clearing the key hash.
+
+    After this call, POST /auth/human/third-party/login returns 401 for this
+    tenant until a new key is rotated in.
+
+    Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+    """
+    if current_user.role == UserRole.ADMIN and current_user.tenant_id != tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin can only manage their own tenant third-party key",
+        )
+
+    tenant = crud.get(db, tenant_id)
+    if tenant is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not found",
+        )
+
+    tenant.third_party_api_key_hash = None
+    tenant.third_party_key_prefix = None
+    db.add(tenant)
+    db.commit()

--- a/backend/app/api/tenant/schemas.py
+++ b/backend/app/api/tenant/schemas.py
@@ -114,3 +114,12 @@ class TenantPublic(TenantBase):
     # Computed projection — NOT a DB column. Populated by the router after resolving
     # the active direct-sale popup for tenants in landing_mode=checkout.
     active_popup_slug: str | None = None
+    # Display fragment for the third-party key (prefix only — hash is NEVER exposed).
+    third_party_key_prefix: str | None = None
+
+
+class ThirdPartyKeyRotated(SQLModel):
+    """Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored."""
+
+    api_key: str
+    prefix: str

--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -11,11 +11,12 @@ from app.api.ticketing_step.schemas import (
     TicketingStepUpdate,
 )
 from app.core.dependencies.users import (
+    AdminOrApiKey_TicketingStepsRead,
+    AdminOrApiKey_TicketingStepsWrite,
+    AdminOrApiKeySession_TicketingStepsRead,
+    AdminOrApiKeySession_TicketingStepsWrite,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
     HumanTenantSession,
-    TenantSession,
 )
 
 router = APIRouter(prefix="/ticketing-steps", tags=["ticketing-steps"])
@@ -37,8 +38,8 @@ async def list_portal_ticketing_steps(
 
 @router.get("", response_model=ListModel[TicketingStepPublic])
 async def list_ticketing_steps(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_TicketingStepsRead,
+    _: AdminOrApiKey_TicketingStepsRead,
     popup_id: uuid.UUID | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
@@ -59,8 +60,8 @@ async def list_ticketing_steps(
 @router.get("/{step_id}", response_model=TicketingStepPublic)
 async def get_ticketing_step(
     step_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_TicketingStepsRead,
+    _: AdminOrApiKey_TicketingStepsRead,
 ) -> TicketingStepPublic:
     step = crud.ticketing_steps_crud.get(db, step_id)
 
@@ -124,8 +125,8 @@ def _validate_template_config_fk(
 )
 async def create_ticketing_step(
     step_in: TicketingStepCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TicketingStepsWrite,
+    current_user: AdminOrApiKey_TicketingStepsWrite,
 ) -> TicketingStepPublic:
     if current_user.role == UserRole.SUPERADMIN:
         from app.api.popup.crud import popups_crud
@@ -166,8 +167,8 @@ async def create_ticketing_step(
 async def update_ticketing_step(
     step_id: uuid.UUID,
     step_in: TicketingStepUpdate,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TicketingStepsWrite,
+    _current_user: AdminOrApiKey_TicketingStepsWrite,
 ) -> TicketingStepPublic:
     step = crud.ticketing_steps_crud.get(db, step_id)
 
@@ -201,8 +202,8 @@ async def update_ticketing_step(
 @router.delete("/{step_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_ticketing_step(
     step_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TicketingStepsWrite,
+    _current_user: AdminOrApiKey_TicketingStepsWrite,
 ) -> None:
     step = crud.ticketing_steps_crud.get(db, step_id)
 

--- a/backend/app/api/track/router.py
+++ b/backend/app/api/track/router.py
@@ -7,11 +7,12 @@ from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, 
 from app.api.track import crud
 from app.api.track.schemas import TrackCreate, TrackPublic, TrackUpdate
 from app.core.dependencies.users import (
+    AdminOrApiKey_TracksRead,
+    AdminOrApiKey_TracksWrite,
+    AdminOrApiKeySession_TracksRead,
+    AdminOrApiKeySession_TracksWrite,
     CurrentHuman,
-    CurrentOperator,
-    CurrentUser,
     HumanTenantSession,
-    TenantSession,
 )
 
 router = APIRouter(prefix="/tracks", tags=["tracks"])
@@ -24,8 +25,8 @@ router = APIRouter(prefix="/tracks", tags=["tracks"])
 
 @router.get("", response_model=ListModel[TrackPublic])
 async def list_tracks(
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_TracksRead,
+    _: AdminOrApiKey_TracksRead,
     popup_id: uuid.UUID | None = None,
     search: str | None = None,
     skip: PaginationSkip = 0,
@@ -56,8 +57,8 @@ async def list_tracks(
 @router.get("/{track_id}", response_model=TrackPublic)
 async def get_track(
     track_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_TracksRead,
+    _: AdminOrApiKey_TracksRead,
 ) -> TrackPublic:
     track = crud.tracks_crud.get(db, track_id)
     if not track:
@@ -70,8 +71,8 @@ async def get_track(
 @router.post("", response_model=TrackPublic, status_code=status.HTTP_201_CREATED)
 async def create_track(
     track_in: TrackCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TracksWrite,
+    current_user: AdminOrApiKey_TracksWrite,
 ) -> TrackPublic:
     from app.api.popup.crud import popups_crud
     from app.api.shared.enums import UserRole
@@ -105,8 +106,8 @@ async def create_track(
 async def update_track(
     track_id: uuid.UUID,
     track_in: TrackUpdate,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_TracksWrite,
+    _: AdminOrApiKey_TracksWrite,
 ) -> TrackPublic:
     track = crud.tracks_crud.get(db, track_id)
     if not track:
@@ -120,8 +121,8 @@ async def update_track(
 @router.delete("/{track_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_track(
     track_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentOperator,
+    db: AdminOrApiKeySession_TracksWrite,
+    _: AdminOrApiKey_TracksWrite,
 ) -> None:
     track = crud.tracks_crud.get(db, track_id)
     if not track:
@@ -134,8 +135,8 @@ async def delete_track(
 @router.get("/{track_id}/events", response_model=ListModel[EventPublic])
 async def list_track_events(
     track_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_TracksRead,
+    _: AdminOrApiKey_TracksRead,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[EventPublic]:

--- a/backend/app/api/translation/router.py
+++ b/backend/app/api/translation/router.py
@@ -8,7 +8,12 @@ from app.api.shared.enums import UserRole
 from app.api.translation.crud import translations_crud
 from app.api.translation.schemas import TranslationCreate, TranslationPublic
 from app.api.translation.service import TRANSLATABLE_FIELDS
-from app.core.dependencies.users import CurrentOperator, CurrentUser, TenantSession
+from app.core.dependencies.users import (
+    AdminOrApiKey_TranslationsRead,
+    AdminOrApiKey_TranslationsWrite,
+    AdminOrApiKeySession_TranslationsRead,
+    AdminOrApiKeySession_TranslationsWrite,
+)
 
 router = APIRouter(prefix="/translations", tags=["translations"])
 
@@ -17,8 +22,8 @@ router = APIRouter(prefix="/translations", tags=["translations"])
 async def list_translations(
     entity_type: str,
     entity_id: uuid.UUID,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_TranslationsRead,
+    _: AdminOrApiKey_TranslationsRead,
 ) -> list[TranslationPublic]:
     """List all translations for an entity."""
     translations = translations_crud.find_by_entity(db, entity_type, entity_id)
@@ -28,8 +33,8 @@ async def list_translations(
 @router.post("", response_model=TranslationPublic, status_code=status.HTTP_201_CREATED)
 async def upsert_translation(
     translation_in: TranslationCreate,
-    db: TenantSession,
-    current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TranslationsWrite,
+    current_user: AdminOrApiKey_TranslationsWrite,
     x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> TranslationPublic:
     """Create or update a translation for an entity."""
@@ -62,8 +67,8 @@ class AITranslateRequest(BaseModel):
 @router.post("/ai-translate", response_model=dict[str, str])
 async def ai_translate(
     request: AITranslateRequest,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TranslationsWrite,
+    _current_user: AdminOrApiKey_TranslationsWrite,
 ) -> dict[str, str]:
     """Use AI to generate draft translations for an entity. Returns translated fields (not saved)."""
     if request.entity_type not in TRANSLATABLE_FIELDS:
@@ -114,8 +119,8 @@ async def ai_translate(
 @router.delete("/{translation_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_translation(
     translation_id: uuid.UUID,
-    db: TenantSession,
-    _current_user: CurrentOperator,
+    db: AdminOrApiKeySession_TranslationsWrite,
+    _current_user: AdminOrApiKey_TranslationsWrite,
     _x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> None:
     """Delete a translation."""

--- a/backend/app/api/user/router.py
+++ b/backend/app/api/user/router.py
@@ -7,7 +7,7 @@ from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.user import crud
 from app.api.user.schemas import UserCreate, UserPublic, UserUpdate
-from app.core.dependencies.users import CurrentOperator, CurrentUser, SessionDep
+from app.core.dependencies.users import CurrentOperatorJwtOnly, CurrentUser, SessionDep
 
 router = APIRouter(prefix="/users", tags=["users"])
 
@@ -37,7 +37,7 @@ ROLE_HIERARCHY = {
 @router.get("", response_model=ListModel[UserPublic])
 async def list_users(
     db: SessionDep,
-    current_user: CurrentOperator,
+    current_user: CurrentOperatorJwtOnly,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
     tenant_id: uuid.UUID | None = None,
@@ -89,7 +89,7 @@ async def get_current_user_info(
 async def get_user(
     user_id: uuid.UUID,
     db: SessionDep,
-    current_user: CurrentOperator,
+    current_user: CurrentOperatorJwtOnly,
 ) -> UserPublic:
     user = crud.get(db, user_id)
 
@@ -126,7 +126,7 @@ async def get_user(
 async def create_user(
     user_in: UserCreate,
     db: SessionDep,
-    current_user: CurrentOperator,
+    current_user: CurrentOperatorJwtOnly,
 ) -> UserPublic:
     allowed_roles = ROLE_HIERARCHY.get(current_user.role, [])
     if user_in.role not in allowed_roles:
@@ -167,7 +167,7 @@ async def update_user(
     user_id: uuid.UUID,
     user_in: UserUpdate,
     db: SessionDep,
-    current_user: CurrentOperator,
+    current_user: CurrentOperatorJwtOnly,
 ) -> UserPublic:
     user = crud.get(db, user_id)
 
@@ -224,7 +224,7 @@ async def update_user(
 async def delete_user(
     user_id: uuid.UUID,
     db: SessionDep,
-    current_user: CurrentOperator,
+    current_user: CurrentOperatorJwtOnly,
 ) -> None:
     user = crud.get(db, user_id)
 

--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -8,7 +8,7 @@ from sqlmodel import Session, select
 
 from app.api.shared.enums import UserRole
 from app.core.db import engine
-from app.core.security import TokenPayload, get_token_payload
+from app.core.security import ApiKeyScope, HumanScope, TokenPayload, get_token_payload
 
 if TYPE_CHECKING:
     from app.api.human.schemas import HumanPublic
@@ -354,3 +354,239 @@ def get_human_tenant_session(
 
 
 HumanTenantSession = Annotated[Session, Depends(get_human_tenant_session)]
+
+
+# ---------------------------------------------------------------------------
+# require_human_scope — portal scope guard (Block 4, task 4.2)
+# ---------------------------------------------------------------------------
+
+
+def require_human_scope(scope: HumanScope):
+    """Return a dependency that enforces a specific HumanScope on portal routes.
+
+    Pass conditions (REQ-SE-01 through REQ-SE-05):
+      - ``portal:*`` in payload.scopes (explicit wildcard or grace-synthesised).
+      - The exact requested ``scope`` is in payload.scopes.
+
+    Raises HTTP 403 otherwise. Does NOT re-check JWT authenticity — additive on
+    top of ``get_current_human``.
+    """
+
+    def _guard(
+        token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
+    ) -> None:
+        if "portal:*" in token_payload.scopes:
+            return
+        if scope in token_payload.scopes:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Your session does not have permission to access this resource. "
+                f"Required scope: {scope}."
+            ),
+        )
+
+    return _guard
+
+
+# ---------------------------------------------------------------------------
+# CurrentAdminOrApiKey — dual-auth guard for admin endpoints (Block 4, task 4.3)
+# ---------------------------------------------------------------------------
+
+
+def CurrentAdminOrApiKey(scope: ApiKeyScope):
+    """Return a dependency that accepts admin JWTs or scoped admin api-keys.
+
+    Path A — JWT admin:
+      token_type="user", via_api_key=False, role in (ADMIN, SUPERADMIN).
+      Scope is implicitly granted; role gates the whole catalog.
+
+    Path B — Admin api-key:
+      token_type="user", via_api_key=True, ``scope`` in payload.scopes.
+
+    Anything else (human JWT, human api-key, unauthenticated) raises 403.
+    """
+
+    def _dep(
+        token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
+        db: "SessionDep",
+    ) -> "UserPublic":
+        if token_payload.token_type != "user":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This endpoint requires an admin session or an admin API key.",
+            )
+
+        if not token_payload.via_api_key:
+            # Path A: JWT-authenticated user — enforce role.
+            user = fetch_authenticated_user(token_payload, db, require_token_type="user")
+            if user.role not in (UserRole.SUPERADMIN, UserRole.ADMIN):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Admin access required.",
+                )
+            return user
+
+        # Path B: admin-owned api-key — enforce scope.
+        if scope not in token_payload.scopes:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"API key lacks required scope: {scope}",
+            )
+        return fetch_authenticated_user(token_payload, db, require_token_type="user")
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# get_admin_or_api_key_tenant_session — tenant session for dual-auth (4.4)
+# ---------------------------------------------------------------------------
+
+
+def get_admin_or_api_key_tenant_session(scope: ApiKeyScope):
+    """Return a factory that yields a tenant-scoped Session.
+
+    Resolves tenant_id:
+      - api-key branch: from ``token_payload.api_key_tenant_id`` (set by
+        ``_resolve_api_key`` for admin-owned keys — FLAG-2 fix).
+      - JWT branch: delegates to ``get_tenant_session`` (existing logic —
+        supports SUPERADMIN + X-Tenant-Id and regular admin).
+
+    Design R-A1 note: the JWT branch uses ``yield from`` delegation to
+    ``get_tenant_session``. FastAPI's generator lifecycle handles cleanup
+    correctly because the outer generator itself is a generator (``yield from``
+    propagates both ``send()`` and ``throw()`` so the inner generator's
+    ``finally`` block still runs on request teardown).
+    """
+
+    def _dep(
+        current_user: Annotated["UserPublic", Depends(CurrentAdminOrApiKey(scope))],
+        token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
+        db: "SessionDep",
+        x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    ) -> Generator[Session]:
+        if token_payload.via_api_key:
+            from app.api.shared.enums import CredentialType
+            from app.core.tenant_db import tenant_connection_manager
+
+            tenant_id = token_payload.api_key_tenant_id
+            if tenant_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="API key has no tenant context.",
+                )
+
+            cached_cred = tenant_connection_manager.get_credential(
+                db, tenant_id, CredentialType.CRUD
+            )
+            if not cached_cred:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Tenant credentials not configured",
+                )
+
+            tenant_engine = tenant_connection_manager.get_engine(
+                tenant_id,
+                CredentialType.CRUD,
+                cached_cred.username,
+                cached_cred.password,
+            )
+            with Session(tenant_engine) as tenant_session:
+                yield tenant_session
+        else:
+            # JWT branch — delegate to the existing get_tenant_session logic.
+            yield from get_tenant_session(current_user, db, x_tenant_id)
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
+# Per-scope Annotated aliases (Block 4, task 4.5)
+# Design R-A2: one alias pair per scope in ADMIN_API_KEY_SCOPES (~56 LOC).
+# If this module grows past ~400 LOC, split into admin_scopes.py.
+# ---------------------------------------------------------------------------
+
+# events
+AdminOrApiKey_EventsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("events:read"))]
+AdminOrApiKey_EventsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("events:write"))]
+AdminOrApiKeySession_EventsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("events:read"))]
+AdminOrApiKeySession_EventsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("events:write"))]
+
+# rsvp
+AdminOrApiKey_RsvpWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("rsvp:write"))]
+AdminOrApiKeySession_RsvpWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("rsvp:write"))]
+
+# venues
+AdminOrApiKey_VenuesWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("venues:write"))]
+AdminOrApiKeySession_VenuesWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("venues:write"))]
+
+# applications
+AdminOrApiKey_ApplicationsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("applications:read"))]
+AdminOrApiKey_ApplicationsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("applications:write"))]
+AdminOrApiKeySession_ApplicationsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("applications:read"))]
+AdminOrApiKeySession_ApplicationsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("applications:write"))]
+
+# attendees
+AdminOrApiKey_AttendeesRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("attendees:read"))]
+AdminOrApiKey_AttendeesWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("attendees:write"))]
+AdminOrApiKeySession_AttendeesRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("attendees:read"))]
+AdminOrApiKeySession_AttendeesWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("attendees:write"))]
+
+# humans
+AdminOrApiKey_HumansRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("humans:read"))]
+AdminOrApiKey_HumansWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("humans:write"))]
+AdminOrApiKeySession_HumansRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("humans:read"))]
+AdminOrApiKeySession_HumansWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("humans:write"))]
+
+# groups
+AdminOrApiKey_GroupsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("groups:read"))]
+AdminOrApiKey_GroupsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("groups:write"))]
+AdminOrApiKeySession_GroupsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("groups:read"))]
+AdminOrApiKeySession_GroupsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("groups:write"))]
+
+# products
+AdminOrApiKey_ProductsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("products:read"))]
+AdminOrApiKey_ProductsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("products:write"))]
+AdminOrApiKeySession_ProductsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("products:read"))]
+AdminOrApiKeySession_ProductsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("products:write"))]
+
+# coupons
+AdminOrApiKey_CouponsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("coupons:read"))]
+AdminOrApiKey_CouponsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("coupons:write"))]
+AdminOrApiKeySession_CouponsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("coupons:read"))]
+AdminOrApiKeySession_CouponsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("coupons:write"))]
+
+# forms
+AdminOrApiKey_FormsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("forms:read"))]
+AdminOrApiKey_FormsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("forms:write"))]
+AdminOrApiKeySession_FormsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("forms:read"))]
+AdminOrApiKeySession_FormsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("forms:write"))]
+
+# payments (read-only; payments:write is intentionally excluded from the universe)
+AdminOrApiKey_PaymentsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("payments:read"))]
+AdminOrApiKeySession_PaymentsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("payments:read"))]
+
+# tracks
+AdminOrApiKey_TracksRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("tracks:read"))]
+AdminOrApiKey_TracksWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("tracks:write"))]
+AdminOrApiKeySession_TracksRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("tracks:read"))]
+AdminOrApiKeySession_TracksWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("tracks:write"))]
+
+# ticketing_steps
+AdminOrApiKey_TicketingStepsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("ticketing_steps:read"))]
+AdminOrApiKey_TicketingStepsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("ticketing_steps:write"))]
+AdminOrApiKeySession_TicketingStepsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("ticketing_steps:read"))]
+AdminOrApiKeySession_TicketingStepsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("ticketing_steps:write"))]
+
+# translations
+AdminOrApiKey_TranslationsRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("translations:read"))]
+AdminOrApiKey_TranslationsWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("translations:write"))]
+AdminOrApiKeySession_TranslationsRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("translations:read"))]
+AdminOrApiKeySession_TranslationsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("translations:write"))]
+
+# Portal scope guards (require_human_scope based) — Annotated wrappers
+RequireHumanScopePortalStar = Annotated[None, Depends(require_human_scope("portal:*"))]
+RequireHumanScopeSelfRead = Annotated[None, Depends(require_human_scope("portal:self_read"))]
+RequireHumanScopeDirectoryRead = Annotated[None, Depends(require_human_scope("portal:directory_read"))]
+RequireHumanScopeApiKeysManage = Annotated[None, Depends(require_human_scope("portal:api_keys_manage"))]

--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -199,6 +199,26 @@ CurrentWriter = Annotated["UserPublic", Depends(require_write_permission)]
 CurrentCheckInOperator = Annotated["UserPublic", Depends(get_check_in_operator)]
 
 
+def get_operator_jwt_only(
+    token_payload: Annotated["TokenPayload", Depends(get_token_payload)],
+    current_user: Annotated["UserPublic", Depends(get_operator)],
+) -> "UserPublic":
+    """Like get_operator but explicitly rejects API-key tokens.
+
+    Used for endpoints that are intentionally JWT-only by policy (e.g. PATCH
+    /payments) — api-key callers receive 403 regardless of their scopes.
+    """
+    if token_payload.via_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This endpoint requires a JWT session; API keys are not accepted.",
+        )
+    return current_user
+
+
+CurrentOperatorJwtOnly = Annotated["UserPublic", Depends(get_operator_jwt_only)]
+
+
 def get_current_tenant(
     db: SessionDep,
     x_tenant_id: Annotated[str, Header(alias="X-Tenant-Id")],
@@ -420,8 +440,10 @@ def CurrentAdminOrApiKey(scope: ApiKeyScope):
 
         if not token_payload.via_api_key:
             # Path A: JWT-authenticated user — enforce role.
+            # Matches the former CurrentOperator gate: SUPERADMIN, ADMIN, OPERATOR.
+            # CHECK_IN_CONTROLLER and VIEWER are excluded.
             user = fetch_authenticated_user(token_payload, db, require_token_type="user")
-            if user.role not in (UserRole.SUPERADMIN, UserRole.ADMIN):
+            if user.role not in (UserRole.SUPERADMIN, UserRole.ADMIN, UserRole.OPERATOR):
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Admin access required.",
@@ -502,6 +524,97 @@ def get_admin_or_api_key_tenant_session(scope: ApiKeyScope):
 
 
 # ---------------------------------------------------------------------------
+# CurrentCheckInOrApiKey — wider JWT gate for check-in-accessible routes
+# ---------------------------------------------------------------------------
+
+
+def CurrentCheckInOrApiKey(scope: ApiKeyScope):
+    """Like CurrentAdminOrApiKey but also accepts CHECK_IN_CONTROLLER JWTs.
+
+    Used for routes that scanners (check-in controllers) need read access to
+    (e.g. GET /attendees) but that must still accept admin api-keys with the
+    appropriate scope on the api-key path.
+    """
+
+    def _dep(
+        token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
+        db: "SessionDep",
+    ) -> "UserPublic":
+        if token_payload.token_type != "user":
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="This endpoint requires an admin session or an admin API key.",
+            )
+
+        if not token_payload.via_api_key:
+            user = fetch_authenticated_user(token_payload, db, require_token_type="user")
+            if user.role not in (
+                UserRole.SUPERADMIN,
+                UserRole.ADMIN,
+                UserRole.OPERATOR,
+                UserRole.CHECK_IN_CONTROLLER,
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Admin access required.",
+                )
+            return user
+
+        # Api-key path: enforce scope.
+        if scope not in token_payload.scopes:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"API key lacks required scope: {scope}",
+            )
+        return fetch_authenticated_user(token_payload, db, require_token_type="user")
+
+    return _dep
+
+
+def get_check_in_or_api_key_tenant_session(scope: ApiKeyScope):
+    """Tenant session factory paired with CurrentCheckInOrApiKey."""
+
+    def _dep(
+        current_user: Annotated["UserPublic", Depends(CurrentCheckInOrApiKey(scope))],
+        token_payload: Annotated[TokenPayload, Depends(get_token_payload)],
+        db: "SessionDep",
+        x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
+    ) -> Generator[Session]:
+        if token_payload.via_api_key:
+            from app.api.shared.enums import CredentialType
+            from app.core.tenant_db import tenant_connection_manager
+
+            tenant_id = token_payload.api_key_tenant_id
+            if tenant_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="API key has no tenant context.",
+                )
+
+            cached_cred = tenant_connection_manager.get_credential(
+                db, tenant_id, CredentialType.CRUD
+            )
+            if not cached_cred:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Tenant credentials not configured",
+                )
+
+            tenant_engine = tenant_connection_manager.get_engine(
+                tenant_id,
+                CredentialType.CRUD,
+                cached_cred.username,
+                cached_cred.password,
+            )
+            with Session(tenant_engine) as tenant_session:
+                yield tenant_session
+        else:
+            yield from get_tenant_session(current_user, db, x_tenant_id)
+
+    return _dep
+
+
+# ---------------------------------------------------------------------------
 # Per-scope Annotated aliases (Block 4, task 4.5)
 # Design R-A2: one alias pair per scope in ADMIN_API_KEY_SCOPES (~56 LOC).
 # If this module grows past ~400 LOC, split into admin_scopes.py.
@@ -528,10 +641,14 @@ AdminOrApiKeySession_ApplicationsRead = Annotated[Session, Depends(get_admin_or_
 AdminOrApiKeySession_ApplicationsWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("applications:write"))]
 
 # attendees
+# Write routes: admin JWT or scoped api-key.
 AdminOrApiKey_AttendeesRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("attendees:read"))]
 AdminOrApiKey_AttendeesWrite = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("attendees:write"))]
 AdminOrApiKeySession_AttendeesRead = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("attendees:read"))]
 AdminOrApiKeySession_AttendeesWrite = Annotated[Session, Depends(get_admin_or_api_key_tenant_session("attendees:write"))]
+# Read routes with check-in controller access (scanners can list/get attendees).
+CheckInOrApiKey_AttendeesRead = Annotated["UserPublic", Depends(CurrentCheckInOrApiKey("attendees:read"))]
+CheckInOrApiKeySession_AttendeesRead = Annotated[Session, Depends(get_check_in_or_api_key_tenant_session("attendees:read"))]
 
 # humans
 AdminOrApiKey_HumansRead = Annotated["UserPublic", Depends(CurrentAdminOrApiKey("humans:read"))]

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -146,11 +146,23 @@ class AuthCodeStore:
         return self._store_code(self.PREFIX_USER, str(user_id), code)
 
     def store_human_code(
-        self, tenant_id: uuid.UUID, email: str, code: str, is_pending: bool = False
+        self,
+        tenant_id: uuid.UUID,
+        email: str,
+        code: str,
+        is_pending: bool = False,
+        origin: str = "portal",
     ) -> bool:
-        """Store auth code for a human (existing or pending)."""
+        """Store auth code for a human (existing or pending).
+
+        `origin` segments the key so codes emitted by different flows
+        (portal, third_party) live in separate slots and cannot be
+        redeemed cross-flow. Pending codes always use portal-origin (the
+        third-party flow rejects unknown emails before reaching the
+        pending path).
+        """
         prefix = self.PREFIX_PENDING if is_pending else self.PREFIX_HUMAN
-        identifier = f"{tenant_id}:{email.lower()}"
+        identifier = f"{origin}:{tenant_id}:{email.lower()}"
         return self._store_code(prefix, identifier, code)
 
     def _store_code(self, prefix: str, identifier: str, code: str) -> bool:
@@ -177,11 +189,20 @@ class AuthCodeStore:
         return self._verify_code(self.PREFIX_USER, str(user_id), code)
 
     def verify_human_code(
-        self, tenant_id: uuid.UUID, email: str, code: str, is_pending: bool = False
+        self,
+        tenant_id: uuid.UUID,
+        email: str,
+        code: str,
+        is_pending: bool = False,
+        origin: str = "portal",
     ) -> tuple[bool, str]:
-        """Verify auth code for a human."""
+        """Verify auth code for a human against the given origin slot.
+
+        Codes are stored per-origin (see `store_human_code`); reading the
+        portal slot will not see a code emitted by the third-party flow.
+        """
         prefix = self.PREFIX_PENDING if is_pending else self.PREFIX_HUMAN
-        identifier = f"{tenant_id}:{email.lower()}"
+        identifier = f"{origin}:{tenant_id}:{email.lower()}"
         return self._verify_code(prefix, identifier, code)
 
     def _verify_code(self, prefix: str, identifier: str, code: str) -> tuple[bool, str]:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -11,10 +11,107 @@ from sqlmodel import Session
 from app.core.config import settings
 from app.core.db import engine
 
-# Defined here (not in app.api.api_key.schemas) to avoid an import cycle:
-# api_key.router imports from core.dependencies.users which imports from
-# core.security, so security cannot import back into the api_key package.
-ApiKeyScope = Literal["events:read", "events:write", "rsvp:write", "venues:write"]
+# ---------------------------------------------------------------------------
+# Scope type definitions
+# ---------------------------------------------------------------------------
+
+# Human/portal scope universe. These map to what a portal JWT (or a JWT issued
+# by the third-party OTP surface) may carry. They are completely disjoint from
+# ApiKeyScope so that a union type can be used on TokenPayload.scopes.
+HumanScope = Literal[
+    "portal:*",
+    "portal:self_read",
+    "portal:directory_read",
+    "portal:api_keys_manage",
+]
+
+# Admin API-key scope universe. Defined here (not in app.api.api_key.schemas)
+# to avoid an import cycle: api_key.router imports from core.dependencies.users
+# which imports from core.security, so security cannot import back into api_key.
+ApiKeyScope = Literal[
+    "events:read",
+    "events:write",
+    "rsvp:write",
+    "venues:write",
+    "applications:read",
+    "applications:write",
+    "attendees:read",
+    "attendees:write",
+    "humans:read",
+    "humans:write",
+    "groups:read",
+    "groups:write",
+    "products:read",
+    "products:write",
+    "coupons:read",
+    "coupons:write",
+    "forms:read",
+    "forms:write",
+    "payments:read",
+    "tracks:read",
+    "tracks:write",
+    "ticketing_steps:read",
+    "ticketing_steps:write",
+    "translations:read",
+    "translations:write",
+]
+
+# Union used for TokenPayload.scopes — accepts both universes.
+AnyScope = HumanScope | ApiKeyScope
+
+# ---------------------------------------------------------------------------
+# Scope universe constants
+# ---------------------------------------------------------------------------
+
+# Scopes embedded in a JWT issued by the third-party OTP flow. These are
+# HumanScope values — the third-party user gets portal access, not admin access.
+THIRD_PARTY_TOKEN_SCOPES: tuple[HumanScope, ...] = (
+    "portal:self_read",
+    "portal:directory_read",
+    "portal:api_keys_manage",
+)
+
+# Scopes that a human may request when minting an API key via the third-party
+# OTP surface. Intentionally narrow — external partners get event-read and
+# rsvp-write only.
+THIRD_PARTY_API_KEY_SCOPES: frozenset[str] = frozenset({
+    "events:read",
+    "rsvp:write",
+})
+
+# Full admin scope universe. Explicitly EXCLUDES: email_templates, users,
+# tenants, tenants:credentials, popup_reviewers, payments:write.
+ADMIN_API_KEY_SCOPES: frozenset[str] = frozenset({
+    "events:read",
+    "events:write",
+    "rsvp:write",
+    "venues:write",
+    "applications:read",
+    "applications:write",
+    "attendees:read",
+    "attendees:write",
+    "humans:read",
+    "humans:write",
+    "groups:read",
+    "groups:write",
+    "products:read",
+    "products:write",
+    "coupons:read",
+    "coupons:write",
+    "forms:read",
+    "forms:write",
+    "payments:read",
+    "tracks:read",
+    "tracks:write",
+    "ticketing_steps:read",
+    "ticketing_steps:write",
+    "translations:read",
+    "translations:write",
+})
+
+# ---------------------------------------------------------------------------
+# JWT helpers
+# ---------------------------------------------------------------------------
 
 ALGORITHM = "HS256"
 
@@ -31,11 +128,20 @@ class TokenPayload(BaseModel):
     exp: datetime
     token_type: str | None = None
     api_key_id: str | None = None
-    scopes: list[ApiKeyScope] = Field(default_factory=list)
     # True when this payload was synthesised from an API key rather than a
     # JWT. Sensitive endpoints (e.g. API key management) reject these so a
     # leaked key cannot mint further keys.
     via_api_key: bool = False
+    # How the token was originally issued. Used by scope enforcement to decide
+    # which scope universe applies (portal vs third_party surface).
+    issued_via: Literal["portal", "third_party"] = "portal"
+    # Scopes attached to this token. Empty list = legacy token (grace period
+    # logic in decode_access_token synthesises ["portal:*"] for human tokens).
+    scopes: list[AnyScope] = Field(default_factory=list)
+    # Internal — set only by _resolve_api_key for admin-owned keys. Lets
+    # get_admin_or_api_key_tenant_session resolve tenant without going through
+    # CurrentUser. NOT serialised into any JWT.
+    api_key_tenant_id: uuid.UUID | None = None
 
 
 _PAT_ROUTE_POLICIES: dict[str, tuple[tuple[str, bool, ApiKeyScope], ...]] = {
@@ -78,6 +184,12 @@ def _enforce_api_key_policy(request: Request, payload: TokenPayload) -> None:
     if not payload.via_api_key:
         return
 
+    # Admin-owned api keys (token_type="user") are governed by the
+    # CurrentAdminOrApiKey dependency, not by _PAT_ROUTE_POLICIES. Skip the
+    # portal whitelist check for them.
+    if payload.token_type == "user":
+        return
+
     path = request.url.path
     method = request.method.upper()
     required_scope = _required_scope_for_pat(method, path)
@@ -102,7 +214,18 @@ def create_access_token(
     subject: str | uuid.UUID,
     token_type: str | None = None,
     expires_delta: timedelta | None = None,
+    scopes: list[AnyScope] | None = None,
+    issued_via: Literal["portal", "third_party"] = "portal",
+    via_api_key: bool = False,
+    api_key_id: str | None = None,
 ) -> str:
+    """Mint a signed JWT.
+
+    ``scopes`` and ``issued_via`` are encoded only when they carry non-default
+    values to keep legacy token payloads minimal. The exception: when
+    ``issued_via="third_party"``, ``scopes`` is always encoded because it is
+    the defining property of a third-party token.
+    """
     if expires_delta:
         expire = datetime.now(UTC) + expires_delta
     else:
@@ -116,17 +239,55 @@ def create_access_token(
     }
     if token_type:
         to_encode["token_type"] = token_type
+    if issued_via != "portal":
+        to_encode["issued_via"] = issued_via
+    if scopes:
+        to_encode["scopes"] = list(scopes)
+    elif issued_via == "third_party":
+        # Always encode scopes for third-party tokens even if empty.
+        to_encode["scopes"] = []
+    if via_api_key:
+        to_encode["via_api_key"] = True
+    if api_key_id is not None:
+        to_encode["api_key_id"] = api_key_id
 
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
 
 
 def decode_access_token(token: str) -> TokenPayload:
+    """Decode a JWT and return a TokenPayload.
+
+    Grace-period rule (backward compat):
+        If ``token_type == "human"`` and the JWT carries no ``scopes`` field
+        (or ``scopes == []``) and no ``issued_via`` field, synthesise
+        ``scopes=["portal:*"]`` and ``issued_via="portal"``. This covers
+        legacy portal JWTs in flight at deploy time. The grace period self-
+        bounds via the token's own ``exp``.
+
+    User tokens (``token_type == "user"``) do NOT receive grace synthesis —
+    admin scope enforcement runs in ``CurrentAdminOrApiKey`` which treats a
+    missing scopes field on a user JWT as "JWT path → trust role guard".
+    """
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[ALGORITHM])
+        token_type: str | None = payload.get("token_type")
+        raw_scopes: list[str] = payload.get("scopes", [])
+        issued_via: str = payload.get("issued_via", "portal")
+        via_api_key: bool = payload.get("via_api_key", False)
+        api_key_id: str | None = payload.get("api_key_id")
+
+        # Grace-period synthesis for human tokens with absent/empty scopes.
+        if token_type == "human" and not raw_scopes and issued_via == "portal":
+            raw_scopes = ["portal:*"]
+
         return TokenPayload(
             sub=payload["sub"],
             exp=payload["exp"],
-            token_type=payload.get("token_type"),
+            token_type=token_type,
+            issued_via=issued_via,
+            scopes=raw_scopes,  # type: ignore[arg-type]
+            via_api_key=via_api_key,
+            api_key_id=api_key_id,
         )
     except jwt.ExpiredSignatureError:
         raise HTTPException(
@@ -144,8 +305,17 @@ def decode_access_token(token: str) -> TokenPayload:
 
 def _resolve_api_key(token: str) -> TokenPayload:
     """Look up a raw API key on the global engine and return a TokenPayload
-    that mirrors the human JWT shape so downstream dependencies (e.g.
-    ``get_current_human``) can stay oblivious to the auth method.
+    that mirrors the human or user JWT shape so downstream dependencies can
+    stay oblivious to the auth method.
+
+    For human-owned keys (human_id set): returns ``token_type="human"`` with
+    ``sub=human_id``, same as the previous behaviour.
+
+    For admin-owned keys (user_id set, human_id None): returns
+    ``token_type="user"`` with ``sub=user_id`` and sets
+    ``api_key_tenant_id`` from the key row so that
+    ``get_admin_or_api_key_tenant_session`` can resolve the tenant without
+    going through ``CurrentUser`` (FLAG-2 fix).
 
     The lookup runs on the unscoped ``engine`` because at this point the
     request hasn't established a tenant context yet — RLS would otherwise
@@ -155,7 +325,6 @@ def _resolve_api_key(token: str) -> TokenPayload:
     # of the API surface and pulls in models that themselves transitively
     # depend on app.core.*.
     from app.api.api_key import crud as api_key_crud
-    from app.api.human.models import Humans
 
     with Session(engine) as session:
         row = api_key_crud.lookup_active_by_raw(session, token)
@@ -165,23 +334,48 @@ def _resolve_api_key(token: str) -> TokenPayload:
                 detail="Invalid or revoked API key",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        human = session.get(Humans, row.human_id)
-        if human is None or human.red_flag:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="API key owner is blocked from using API keys.",
+
+        # Branch on ownership type.
+        if row.human_id is not None:
+            # Human-owned key: original path.
+            from app.api.human.models import Humans
+
+            human = session.get(Humans, row.human_id)
+            if human is None or human.red_flag:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="API key owner is blocked from using API keys.",
+                )
+            api_key_crud.touch_last_used(session, row)
+            return TokenPayload(
+                sub=str(row.human_id),
+                exp=datetime.now(UTC) + timedelta(minutes=1),
+                token_type="human",
+                api_key_id=str(row.id),
+                scopes=row.scopes,  # type: ignore[arg-type]
+                via_api_key=True,
             )
-        api_key_crud.touch_last_used(session, row)
-        # Synthesise a far-future exp so the BaseModel field is satisfied;
-        # actual revocation/expiry is enforced at lookup time, not via JWT
-        # exp checks.
-        return TokenPayload(
-            sub=str(row.human_id),
-            exp=datetime.now(UTC) + timedelta(minutes=1),
-            token_type="human",
-            api_key_id=str(row.id),
-            scopes=row.scopes,
-            via_api_key=True,
+
+        # Admin-owned key (user_id is set).
+        if row.user_id is not None:
+            api_key_crud.touch_last_used(session, row)
+            return TokenPayload(
+                sub=str(row.user_id),
+                exp=datetime.now(UTC) + timedelta(minutes=1),
+                token_type="user",
+                api_key_id=str(row.id),
+                scopes=row.scopes,  # type: ignore[arg-type]
+                via_api_key=True,
+                # api_key_tenant_id lets get_admin_or_api_key_tenant_session
+                # resolve the tenant from the key row without needing CurrentUser.
+                api_key_tenant_id=row.tenant_id,
+            )
+
+        # Constraint violation: both are null. Should never happen in production
+        # because the DB CHECK constraint prevents it, but we guard defensively.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key row has neither human_id nor user_id set.",
         )
 
 

--- a/backend/tests/api/admin_api_key/test_crud.py
+++ b/backend/tests/api/admin_api_key/test_crud.py
@@ -1,0 +1,431 @@
+"""Admin API keys CRUD contract tests.
+
+RED-phase for Block 6. All tests should FAIL until:
+  - POST /backoffice/api-keys is implemented.
+  - GET /backoffice/api-keys is implemented.
+  - GET /backoffice/api-keys/{key_id} is implemented.
+  - DELETE /backoffice/api-keys/{key_id} is implemented.
+  - app/api/admin_api_key/ module exists and is wired.
+
+REQ-BA-01 ... REQ-BA-05, REQ-AK-06
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.api_key import crud as api_key_crud
+from app.api.api_key.models import ApiKeys
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+
+BASE_URL = "/api/v1/backoffice/api-keys"
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _tenant_header(tenant_id: uuid.UUID) -> dict[str, str]:
+    return {"X-Tenant-Id": str(tenant_id)}
+
+
+def _auth_tenant(token: str, tenant_id: uuid.UUID) -> dict[str, str]:
+    return {**_bearer(token), **_tenant_header(tenant_id)}
+
+
+def _future_expiry() -> str:
+    return (datetime.now(UTC) + timedelta(days=7)).isoformat()
+
+
+class TestCreateAdminApiKey:
+    """REQ-BA-04, REQ-AK-06."""
+
+    def test_admin_can_create_admin_api_key(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        tenant_a: Tenants,
+    ) -> None:
+        """ADMIN creates a key with an allowed scope. Response contains raw key."""
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(admin_token_tenant_a),
+            json={"name": "my-events-key", "scopes": ["events:read"]},
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert "raw_key" in data
+        assert data["raw_key"].startswith("eos_live_")
+        assert data["scopes"] == ["events:read"]
+        assert "prefix" in data
+        assert "id" in data
+
+    def test_admin_can_create_key_with_write_scope_and_expiry(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        tenant_a: Tenants,
+    ) -> None:
+        """Write scope requires expires_at — key is created when expiry is provided."""
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(admin_token_tenant_a),
+            json={
+                "name": "write-key",
+                "scopes": ["attendees:write"],
+                "expires_at": _future_expiry(),
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    def test_write_scope_without_expiry_returns_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Write scope without expires_at returns 422 (schema validation)."""
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(admin_token_tenant_a),
+            json={"name": "write-no-expiry", "scopes": ["attendees:write"]},
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_viewer_cannot_create_admin_api_key(
+        self,
+        client: TestClient,
+        viewer_token_tenant_a: str,
+    ) -> None:
+        """VIEWER is rejected with 403. REQ-BA-02."""
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(viewer_token_tenant_a),
+            json={"name": "viewer-key", "scopes": ["events:read"]},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_excluded_scope_returns_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Scope outside ADMIN_API_KEY_SCOPES returns 422. REQ-AK-06."""
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(admin_token_tenant_a),
+            json={
+                "name": "excluded-scope",
+                "scopes": ["email_templates:write"],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_payments_write_excluded_scope_returns_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """payments:write is explicitly excluded from ADMIN_API_KEY_SCOPES → 422."""
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(admin_token_tenant_a),
+            json={
+                "name": "payments-write-key",
+                "scopes": ["payments:write"],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+
+    def test_created_key_has_user_id_and_null_human_id(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_user_tenant_a: Users,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """XOR constraint: created admin key has user_id set and human_id=None."""
+        from sqlmodel import select
+
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(admin_token_tenant_a),
+            json={"name": "ownership-check", "scopes": ["events:read"]},
+        )
+        assert resp.status_code == 201, resp.text
+        key_id = uuid.UUID(resp.json()["id"])
+
+        row = db.exec(select(ApiKeys).where(ApiKeys.id == key_id)).first()
+        assert row is not None
+        assert row.user_id == admin_user_tenant_a.id
+        assert row.human_id is None
+
+
+class TestListAdminApiKeys:
+    """REQ-BA-03: visibility rules."""
+
+    def test_admin_sees_only_own_keys(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_user_tenant_a: Users,
+        admin_user_tenant_b: Users,
+        admin_token_tenant_a: str,
+        admin_api_key_factory,
+    ) -> None:
+        """ADMIN list returns only keys belonging to current user."""
+        # Create one key for admin_a, one for admin_b (different user)
+        row_a, _ = admin_api_key_factory(scopes=["events:read"])
+
+        resp = client.get(BASE_URL, headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+        items = resp.json()
+        returned_ids = {item["id"] for item in items}
+
+        assert str(row_a.id) in returned_ids
+        # Verify every returned key belongs to admin_a
+        from sqlmodel import select
+
+        for item in items:
+            row = db.exec(select(ApiKeys).where(ApiKeys.id == uuid.UUID(item["id"]))).first()
+            assert row is not None
+            assert row.user_id == admin_user_tenant_a.id
+
+    def test_viewer_cannot_list_keys(
+        self,
+        client: TestClient,
+        viewer_token_tenant_a: str,
+    ) -> None:
+        """VIEWER receives 403 on GET /backoffice/api-keys."""
+        resp = client.get(BASE_URL, headers=_bearer(viewer_token_tenant_a))
+        assert resp.status_code == 403, resp.text
+
+    def test_list_does_not_include_raw_key(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        admin_api_key_factory,
+    ) -> None:
+        """Listing keys never exposes the raw secret."""
+        admin_api_key_factory(scopes=["events:read"])
+
+        resp = client.get(BASE_URL, headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+        for item in resp.json():
+            assert "raw_key" not in item
+            assert "key_hash" not in item
+
+    def test_superadmin_sees_all_keys_in_tenant(
+        self,
+        client: TestClient,
+        db: Session,
+        superadmin_token: str,
+        admin_user_tenant_a: Users,
+        tenant_a: Tenants,
+        admin_api_key_factory,
+    ) -> None:
+        """SUPERADMIN with X-Tenant-Id header sees all keys for that tenant."""
+        row, _ = admin_api_key_factory(scopes=["events:read"])
+
+        resp = client.get(
+            BASE_URL,
+            headers={**_bearer(superadmin_token), **_tenant_header(tenant_a.id)},
+        )
+        assert resp.status_code == 200, resp.text
+        items = resp.json()
+        returned_ids = {item["id"] for item in items}
+        assert str(row.id) in returned_ids
+
+
+class TestGetAdminApiKey:
+    """GET /backoffice/api-keys/{key_id}."""
+
+    def test_admin_can_get_own_key(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        admin_api_key_factory,
+    ) -> None:
+        """ADMIN can retrieve a specific key they own."""
+        row, _ = admin_api_key_factory(scopes=["events:read"])
+
+        resp = client.get(f"{BASE_URL}/{row.id}", headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["id"] == str(row.id)
+        assert "raw_key" not in data
+
+    def test_admin_cannot_get_another_users_key(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_user_tenant_b: Users,
+        admin_token_tenant_a: str,
+        tenant_b: Tenants,
+    ) -> None:
+        """ADMIN from tenant_a gets 404 for a key owned by admin_b (not 403 — no existence leak)."""
+        raw = api_key_crud.generate_raw_key()
+        row_b = ApiKeys(
+            tenant_id=tenant_b.id,
+            human_id=None,
+            user_id=admin_user_tenant_b.id,
+            name="other-admin-key",
+            key_hash=api_key_crud.hash_key(raw),
+            prefix=api_key_crud.display_prefix(raw),
+            scopes=["events:read"],
+        )
+        db.add(row_b)
+        db.commit()
+        db.refresh(row_b)
+
+        resp = client.get(f"{BASE_URL}/{row_b.id}", headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 404, resp.text
+
+        # Cleanup
+        db.delete(row_b)
+        db.commit()
+
+    def test_get_nonexistent_key_returns_404(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Non-existent key_id returns 404."""
+        resp = client.get(f"{BASE_URL}/{uuid.uuid4()}", headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 404, resp.text
+
+
+class TestRevokeAdminApiKey:
+    """DELETE /backoffice/api-keys/{key_id} — revocation rules (REQ-BA-05, REQ-OW-05)."""
+
+    def test_admin_can_revoke_own_key(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_token_tenant_a: str,
+        admin_api_key_factory,
+    ) -> None:
+        """ADMIN revokes their own key. revoked_at is set; response is 204."""
+        from sqlmodel import select
+
+        row, _ = admin_api_key_factory(scopes=["events:read"])
+
+        resp = client.delete(f"{BASE_URL}/{row.id}", headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 204, resp.text
+
+        db.refresh(row)
+        assert row.revoked_at is not None
+
+    def test_admin_cannot_revoke_another_users_key(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_user_tenant_b: Users,
+        admin_token_tenant_a: str,
+        tenant_b: Tenants,
+    ) -> None:
+        """ADMIN can only revoke their own keys. Foreign key → 403."""
+        raw = api_key_crud.generate_raw_key()
+        row_b = ApiKeys(
+            tenant_id=tenant_b.id,
+            human_id=None,
+            user_id=admin_user_tenant_b.id,
+            name="other-admin-revoke",
+            key_hash=api_key_crud.hash_key(raw),
+            prefix=api_key_crud.display_prefix(raw),
+            scopes=["events:read"],
+        )
+        db.add(row_b)
+        db.commit()
+        db.refresh(row_b)
+
+        resp = client.delete(f"{BASE_URL}/{row_b.id}", headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code in (403, 404), resp.text
+
+        # Cleanup
+        db.delete(row_b)
+        db.commit()
+
+    def test_revoke_nonexistent_key_returns_404(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Non-existent key_id returns 404."""
+        resp = client.delete(f"{BASE_URL}/{uuid.uuid4()}", headers=_bearer(admin_token_tenant_a))
+        assert resp.status_code == 404, resp.text
+
+    def test_viewer_cannot_revoke_key(
+        self,
+        client: TestClient,
+        viewer_token_tenant_a: str,
+        admin_api_key_factory,
+    ) -> None:
+        """VIEWER cannot revoke keys — 403."""
+        row, _ = admin_api_key_factory(scopes=["events:read"])
+        resp = client.delete(f"{BASE_URL}/{row.id}", headers=_bearer(viewer_token_tenant_a))
+        assert resp.status_code == 403, resp.text
+
+    def test_superadmin_can_revoke_any_key_in_tenant(
+        self,
+        client: TestClient,
+        db: Session,
+        superadmin_token: str,
+        tenant_a: Tenants,
+        admin_api_key_factory,
+    ) -> None:
+        """SUPERADMIN can revoke any admin key in their tenant scope."""
+        row, _ = admin_api_key_factory(scopes=["events:read"])
+
+        resp = client.delete(
+            f"{BASE_URL}/{row.id}",
+            headers={**_bearer(superadmin_token), **_tenant_header(tenant_a.id)},
+        )
+        assert resp.status_code == 204, resp.text
+
+        db.refresh(row)
+        assert row.revoked_at is not None
+
+
+class TestAdminApiKeyCannotMintAnotherKey:
+    """Admin api keys cannot mint more admin api keys (same security argument as portal)."""
+
+    def test_admin_api_key_token_cannot_call_create_endpoint(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_user_tenant_a: Users,
+        tenant_a: Tenants,
+        admin_api_key_factory,
+    ) -> None:
+        """A request authenticated via admin api-key cannot mint more admin keys."""
+        from unittest.mock import patch
+
+        from app.core.security import _resolve_api_key
+
+        row, raw = admin_api_key_factory(scopes=["events:read"])
+
+        with patch("app.core.security.engine", db.get_bind()):
+            payload = _resolve_api_key(raw)
+
+        # Build an api-key style token to send as Bearer
+        from app.core.security import create_access_token
+
+        api_key_token = create_access_token(
+            subject=admin_user_tenant_a.id,
+            token_type="user",
+            via_api_key=True,
+            api_key_id=str(row.id),
+            scopes=row.scopes,
+        )
+
+        resp = client.post(
+            BASE_URL,
+            headers=_bearer(api_key_token),
+            json={"name": "recursive-key", "scopes": ["events:read"]},
+        )
+        assert resp.status_code == 403, resp.text

--- a/backend/tests/api/admin_api_key/test_crud.py
+++ b/backend/tests/api/admin_api_key/test_crud.py
@@ -310,7 +310,6 @@ class TestRevokeAdminApiKey:
         admin_api_key_factory,
     ) -> None:
         """ADMIN revokes their own key. revoked_at is set; response is 204."""
-        from sqlmodel import select
 
         row, _ = admin_api_key_factory(scopes=["events:read"])
 
@@ -410,7 +409,7 @@ class TestAdminApiKeyCannotMintAnotherKey:
         row, raw = admin_api_key_factory(scopes=["events:read"])
 
         with patch("app.core.security.engine", db.get_bind()):
-            payload = _resolve_api_key(raw)
+            _resolve_api_key(raw)
 
         # Build an api-key style token to send as Bearer
         from app.core.security import create_access_token

--- a/backend/tests/api/admin_api_key/test_domain_dual_auth.py
+++ b/backend/tests/api/admin_api_key/test_domain_dual_auth.py
@@ -1,0 +1,832 @@
+"""Domain dual-auth contract tests for Block 9 (admin guard sweep).
+
+Per-domain tests verifying that admin api-keys with matching scopes can call
+representative backoffice endpoints, missing scopes return 403, and the JWT
+path continues to work unchanged.
+
+RED-phase for Block 9. Tests fail until routers swap CurrentOperator/CurrentUser/
+CurrentWriter/CurrentAdmin + TenantSession to AdminOrApiKey_* + AdminOrApiKeySession_*
+aliases.
+
+Domains covered: attendees, events, applications, groups, products, coupons,
+form_fields, form_sections, payments, tracks, ticketing_steps, translations,
+event_participants, event_venues.
+
+REQ-AA-01 ... REQ-AA-06
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+
+
+def _api_key_headers(raw_key: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {raw_key}"}
+
+
+def _jwt_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Attendees domain  (attendees:read / attendees:write)
+# ---------------------------------------------------------------------------
+
+
+class TestAttendeesDualAuth:
+    """GET /attendees requires attendees:read. PATCH/DELETE require attendees:write."""
+
+    def test_jwt_admin_list_attendees_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Existing JWT admin path still works after swap."""
+        resp = client.get("/api/v1/attendees", headers=_jwt_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_attendees_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+        tenant_a: Tenants,
+    ) -> None:
+        """Admin api-key with attendees:read can list attendees."""
+        _, raw = admin_api_key_factory(scopes=["attendees:read"])
+        resp = client.get("/api/v1/attendees", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_attendees_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        """Admin api-key without attendees:read is rejected on GET /attendees."""
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/attendees", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_attendees_read_get_attendee_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        """Admin api-key with attendees:read — GET /attendees/{id} returns 404 for nonexistent."""
+        _, raw = admin_api_key_factory(scopes=["attendees:read"])
+        nonexistent = uuid.uuid4()
+        resp = client.get(
+            f"/api/v1/attendees/{nonexistent}", headers=_api_key_headers(raw)
+        )
+        # 404 means it passed auth (got to the handler) — no 403
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Events domain  (events:read / events:write)
+# ---------------------------------------------------------------------------
+
+
+class TestEventsDualAuth:
+    """GET /events requires events:read. POST/PATCH/DELETE require events:write."""
+
+    def test_jwt_admin_list_events_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get("/api/v1/events", headers=_jwt_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_events_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/events", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_events_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["attendees:read"])
+        resp = client.get("/api/v1/events", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_events_write_post_returns_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+        tenant_a: Tenants,
+        popup_tenant_a,
+    ) -> None:
+        """Admin api-key with events:write can reach the create handler (422 for bad body)."""
+        _, raw = admin_api_key_factory(scopes=["events:write"])
+        resp = client.post(
+            "/api/v1/events",
+            headers=_api_key_headers(raw),
+            json={"popup_id": str(popup_tenant_a.id), "title": "Test"},
+        )
+        # 201, 422 = auth passed. 403 = auth rejected.
+        assert resp.status_code != 403, resp.text
+
+    def test_api_key_missing_events_write_post_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+        popup_tenant_a,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.post(
+            "/api/v1/events",
+            headers=_api_key_headers(raw),
+            json={"popup_id": str(popup_tenant_a.id), "title": "Test"},
+        )
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Applications domain  (applications:read / applications:write)
+# ---------------------------------------------------------------------------
+
+
+class TestApplicationsDualAuth:
+    """GET /applications requires applications:read. POST/PATCH require applications:write."""
+
+    def test_jwt_admin_list_applications_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/applications", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_applications_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["applications:read"])
+        resp = client.get("/api/v1/applications", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_applications_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/applications", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_applications_read_get_by_id_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["applications:read"])
+        resp = client.get(
+            f"/api/v1/applications/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        # 404 means auth passed
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Groups domain  (groups:read / groups:write)
+# ---------------------------------------------------------------------------
+
+
+class TestGroupsDualAuth:
+    """GET /groups requires groups:read. POST/PATCH/DELETE require groups:write."""
+
+    def test_jwt_admin_list_groups_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get("/api/v1/groups", headers=_jwt_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_groups_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["groups:read"])
+        resp = client.get("/api/v1/groups", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_groups_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/groups", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_groups_read_get_by_id_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["groups:read"])
+        resp = client.get(
+            f"/api/v1/groups/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Products domain  (products:read / products:write)
+# ---------------------------------------------------------------------------
+
+
+class TestProductsDualAuth:
+    """GET /products requires products:read. PATCH/DELETE require products:write."""
+
+    def test_jwt_admin_list_products_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/products", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_products_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["products:read"])
+        resp = client.get("/api/v1/products", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_products_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/products", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_products_write_patch_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        """products:write key can reach PATCH handler (404 for nonexistent id)."""
+        _, raw = admin_api_key_factory(scopes=["products:write"])
+        resp = client.patch(
+            f"/api/v1/products/{uuid.uuid4()}",
+            headers=_api_key_headers(raw),
+            json={"name": "updated"},
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_api_key_missing_products_write_patch_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["products:read"])
+        resp = client.patch(
+            f"/api/v1/products/{uuid.uuid4()}",
+            headers=_api_key_headers(raw),
+            json={"name": "updated"},
+        )
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Coupons domain  (coupons:read / coupons:write)
+# ---------------------------------------------------------------------------
+
+
+class TestCouponsDualAuth:
+    """GET /coupons requires coupons:read. POST/PATCH/DELETE require coupons:write."""
+
+    def test_jwt_admin_list_coupons_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get("/api/v1/coupons", headers=_jwt_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_coupons_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["coupons:read"])
+        resp = client.get("/api/v1/coupons", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_coupons_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/coupons", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_coupons_read_get_by_id_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["coupons:read"])
+        resp = client.get(
+            f"/api/v1/coupons/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Form fields domain  (forms:read / forms:write)
+# ---------------------------------------------------------------------------
+
+
+class TestFormFieldsDualAuth:
+    """GET /form-fields requires forms:read. POST/PATCH/DELETE require forms:write."""
+
+    def test_jwt_admin_list_form_fields_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/form-fields", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_forms_read_list_form_fields_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["forms:read"])
+        resp = client.get("/api/v1/form-fields", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_forms_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/form-fields", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_forms_read_list_form_sections_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["forms:read"])
+        resp = client.get("/api/v1/form-sections", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_forms_read_form_sections_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/form-sections", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Payments domain  (payments:read only — write is excluded by design)
+# ---------------------------------------------------------------------------
+
+
+class TestPaymentsDualAuth:
+    """GET /payments requires payments:read. PATCH /payments is JWT-only (excluded)."""
+
+    def test_jwt_admin_list_payments_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/payments", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_payments_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["payments:read"])
+        resp = client.get("/api/v1/payments", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_payments_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/payments", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_payments_read_get_by_id_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["payments:read"])
+        resp = client.get(
+            f"/api/v1/payments/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_api_key_with_payments_read_cannot_patch_payment(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        """PATCH /payments is JWT-only — api-key must not be accepted even with payments:read."""
+        _, raw = admin_api_key_factory(scopes=["payments:read"])
+        resp = client.patch(
+            f"/api/v1/payments/{uuid.uuid4()}",
+            headers=_api_key_headers(raw),
+            json={"status": "approved"},
+        )
+        # 403 (api-key path rejected) or 401 is acceptable; 404 would mean auth passed which is wrong
+        assert resp.status_code in (401, 403), resp.text
+
+
+# ---------------------------------------------------------------------------
+# Tracks domain  (tracks:read / tracks:write)
+# ---------------------------------------------------------------------------
+
+
+class TestTracksDualAuth:
+    """GET /tracks requires tracks:read. POST/PATCH/DELETE require tracks:write."""
+
+    def test_jwt_admin_list_tracks_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get("/api/v1/tracks", headers=_jwt_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_tracks_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["tracks:read"])
+        resp = client.get("/api/v1/tracks", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_tracks_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/tracks", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_tracks_write_delete_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["tracks:write"])
+        resp = client.delete(
+            f"/api/v1/tracks/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Ticketing steps domain  (ticketing_steps:read / ticketing_steps:write)
+# ---------------------------------------------------------------------------
+
+
+class TestTicketingStepsDualAuth:
+    """GET /ticketing-steps requires ticketing_steps:read. POST/PATCH/DELETE require write."""
+
+    def test_jwt_admin_list_ticketing_steps_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/ticketing-steps", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_ticketing_steps_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["ticketing_steps:read"])
+        resp = client.get("/api/v1/ticketing-steps", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_ticketing_steps_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/ticketing-steps", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_ticketing_steps_read_get_by_id_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["ticketing_steps:read"])
+        resp = client.get(
+            f"/api/v1/ticketing-steps/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Translations domain  (translations:read / translations:write)
+# ---------------------------------------------------------------------------
+
+
+class TestTranslationsDualAuth:
+    """GET /translations requires translations:read. POST/DELETE require translations:write."""
+
+    def test_jwt_admin_list_translations_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/translations",
+            headers=_jwt_headers(admin_token_tenant_a),
+            params={"entity_type": "product", "entity_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_translations_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["translations:read"])
+        resp = client.get(
+            "/api/v1/translations",
+            headers=_api_key_headers(raw),
+            params={"entity_type": "product", "entity_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_translations_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get(
+            "/api/v1/translations",
+            headers=_api_key_headers(raw),
+            params={"entity_type": "product", "entity_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_translations_write_delete_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["translations:write"])
+        resp = client.delete(
+            f"/api/v1/translations/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Event participants domain  (rsvp:write for admin, events:read for list)
+# ---------------------------------------------------------------------------
+
+
+class TestEventParticipantsDualAuth:
+    """Backoffice GET /event-participants requires events:read.
+    POST/PATCH/DELETE require rsvp:write."""
+
+    def test_jwt_admin_list_participants_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/event-participants", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_events_read_list_participants_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/event-participants", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_events_read_list_participants_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["attendees:read"])
+        resp = client.get("/api/v1/event-participants", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_rsvp_write_patch_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["rsvp:write"])
+        resp = client.patch(
+            f"/api/v1/event-participants/{uuid.uuid4()}",
+            headers=_api_key_headers(raw),
+            json={"role": "speaker"},
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_api_key_missing_rsvp_write_patch_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.patch(
+            f"/api/v1/event-participants/{uuid.uuid4()}",
+            headers=_api_key_headers(raw),
+            json={"role": "speaker"},
+        )
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Event venues domain  (events:read for list, venues:write for mutations)
+# ---------------------------------------------------------------------------
+
+
+class TestEventVenuesDualAuth:
+    """GET /event-venues requires events:read. POST/PATCH/DELETE require venues:write."""
+
+    def test_jwt_admin_list_venues_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get(
+            "/api/v1/event-venues", headers=_jwt_headers(admin_token_tenant_a)
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_events_read_list_venues_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/event-venues", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_events_read_list_venues_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["attendees:read"])
+        resp = client.get("/api/v1/event-venues", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_venues_write_delete_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["venues:write"])
+        resp = client.delete(
+            f"/api/v1/event-venues/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_api_key_missing_venues_write_delete_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.delete(
+            f"/api/v1/event-venues/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Humans domain  (humans:read / humans:write — admin routes only)
+# ---------------------------------------------------------------------------
+
+
+class TestHumansDualAuth:
+    """GET /humans (admin list) requires humans:read. PATCH requires humans:write.
+    POST /humans is superadmin-only and stays JWT-only."""
+
+    def test_jwt_admin_list_humans_succeeds(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        resp = client.get("/api/v1/humans", headers=_jwt_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_humans_read_list_succeeds(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["humans:read"])
+        resp = client.get("/api/v1/humans", headers=_api_key_headers(raw))
+        assert resp.status_code == 200, resp.text
+
+    def test_api_key_missing_humans_read_returns_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/humans", headers=_api_key_headers(raw))
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_humans_read_get_by_id_returns_404_not_403(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        _, raw = admin_api_key_factory(scopes=["humans:read"])
+        resp = client.get(
+            f"/api/v1/humans/{uuid.uuid4()}", headers=_api_key_headers(raw)
+        )
+        assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Excluded domains — verify they are still JWT-only
+# ---------------------------------------------------------------------------
+
+
+class TestExcludedDomains:
+    """email_templates, users, tenants, popup_reviewers are JWT-only."""
+
+    def test_api_key_cannot_call_users_endpoint(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        """Admin api-key must NOT access /users."""
+        _, raw = admin_api_key_factory(scopes=["events:read"])
+        resp = client.get("/api/v1/users", headers=_api_key_headers(raw))
+        # API key path returns 403 (CurrentAdmin/CurrentSuperadmin guard rejects it)
+        assert resp.status_code in (401, 403), resp.text
+
+    def test_api_key_cannot_patch_payment(
+        self,
+        client: TestClient,
+        admin_api_key_factory,
+    ) -> None:
+        """PATCH /payments must never accept an api-key, even with payments:read."""
+        _, raw = admin_api_key_factory(scopes=["payments:read"])
+        resp = client.patch(
+            f"/api/v1/payments/{uuid.uuid4()}",
+            headers=_api_key_headers(raw),
+            json={"status": "approved"},
+        )
+        assert resp.status_code in (401, 403), resp.text

--- a/backend/tests/api/admin_api_key/test_domain_dual_auth.py
+++ b/backend/tests/api/admin_api_key/test_domain_dual_auth.py
@@ -19,11 +19,9 @@ from __future__ import annotations
 
 import uuid
 
-import pytest
 from fastapi.testclient import TestClient
 
 from app.api.tenant.models import Tenants
-from app.api.user.models import Users
 
 
 def _api_key_headers(raw_key: str) -> dict[str, str]:

--- a/backend/tests/api/api_key/test_admin_api_key_resolution.py
+++ b/backend/tests/api/api_key/test_admin_api_key_resolution.py
@@ -1,0 +1,116 @@
+"""Tests for _resolve_api_key with admin-owned api keys.
+
+Validates:
+  - Human-owned key row returns token_type="human".
+  - Admin-owned key row (user_id set) returns token_type="user".
+  - Admin-owned key sets api_key_tenant_id on the TokenPayload (FLAG-2 fix).
+
+These tests use the database (testcontainers) to verify the full resolution path.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlmodel import Session
+
+from app.api.api_key import crud as api_key_crud
+from app.api.api_key.models import ApiKeys
+from app.api.human.models import Humans
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+
+
+class TestResolveApiKeyOwnership:
+    """_resolve_api_key returns the correct token_type and api_key_tenant_id."""
+
+    def test_resolve_api_key_for_human_owned_row_sets_token_type_human(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Human-owned key resolves to token_type='human'."""
+        from unittest.mock import patch
+
+        from app.core.security import _resolve_api_key
+
+        # Create a human for this test
+        human = Humans(
+            email=f"human-apikey-test-{uuid.uuid4().hex[:8]}@test.com",
+            tenant_id=tenant_a.id,
+        )
+        db.add(human)
+        db.commit()
+        db.refresh(human)
+
+        raw = api_key_crud.generate_raw_key()
+        row = ApiKeys(
+            tenant_id=tenant_a.id,
+            human_id=human.id,
+            user_id=None,
+            name="test-human-key",
+            key_hash=api_key_crud.hash_key(raw),
+            prefix=api_key_crud.display_prefix(raw),
+            scopes=["events:read"],
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        # Patch the engine used inside _resolve_api_key to our test engine.
+
+        with patch("app.core.security.engine", db.get_bind()):
+            payload = _resolve_api_key(raw)
+
+        assert payload.token_type == "human"
+        assert payload.sub == str(human.id)
+        assert payload.via_api_key is True
+        assert payload.api_key_tenant_id is None  # human keys don't set this
+
+        # Cleanup
+        db.delete(row)
+        db.delete(human)
+        db.commit()
+
+    def test_resolve_api_key_for_user_owned_row_sets_token_type_user(
+        self,
+        db: Session,
+        admin_user_tenant_a: Users,
+        tenant_a: Tenants,
+        admin_api_key_factory,
+    ) -> None:
+        """Admin-owned key resolves to token_type='user'."""
+        from unittest.mock import patch
+
+        from app.core.security import _resolve_api_key
+
+        row, raw = admin_api_key_factory(scopes=["attendees:read"])
+
+        with patch("app.core.security.engine", db.get_bind()):
+            payload = _resolve_api_key(raw)
+
+        assert payload.token_type == "user"
+        assert payload.sub == str(admin_user_tenant_a.id)
+        assert payload.via_api_key is True
+
+    def test_resolve_api_key_synthesises_api_key_tenant_id(
+        self,
+        db: Session,
+        admin_user_tenant_a: Users,
+        tenant_a: Tenants,
+        admin_api_key_factory,
+    ) -> None:
+        """Admin-owned key sets api_key_tenant_id from the key's tenant_id (FLAG-2 fix)."""
+        from unittest.mock import patch
+
+        from app.core.security import _resolve_api_key
+
+        row, raw = admin_api_key_factory(scopes=["attendees:read"])
+
+        with patch("app.core.security.engine", db.get_bind()):
+            payload = _resolve_api_key(raw)
+
+        # api_key_tenant_id must be set to the key's tenant so that
+        # get_admin_or_api_key_tenant_session can resolve the tenant
+        # without needing to go through CurrentUser.
+        assert payload.api_key_tenant_id == tenant_a.id

--- a/backend/tests/api/api_key/test_models_owner_check.py
+++ b/backend/tests/api/api_key/test_models_owner_check.py
@@ -1,0 +1,131 @@
+"""Tests for ApiKeys XOR ownership constraint.
+
+These are the RED-phase tests for Block 1. They validate that the DB-level
+CHECK constraint `api_keys_owner_check` enforces exactly one of (human_id,
+user_id) is non-null.
+
+Tests are expected to FAIL until:
+  1. The Alembic migration adds the constraint.
+  2. The ApiKeys model is updated to support nullable human_id and user_id.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session
+
+from app.api.api_key.crud import display_prefix, generate_raw_key, hash_key
+from app.api.api_key.models import ApiKeys
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+
+
+def _make_api_key_row(
+    *,
+    tenant_id: uuid.UUID,
+    human_id: uuid.UUID | None,
+    user_id: uuid.UUID | None,
+) -> ApiKeys:
+    raw = generate_raw_key()
+    return ApiKeys(
+        tenant_id=tenant_id,
+        human_id=human_id,
+        user_id=user_id,
+        name="test-owner-check",
+        key_hash=hash_key(raw),
+        prefix=display_prefix(raw),
+        scopes=["events:read"],
+    )
+
+
+class TestApiKeysOwnerXorConstraint:
+    """Four-way matrix: both-null, both-set, human-only, user-only."""
+
+    def test_insert_with_both_null_fails(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """DB must reject a row where both human_id and user_id are NULL."""
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            user_id=None,
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_insert_with_both_set_fails(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        admin_user_tenant_a: Users,
+    ) -> None:
+        """DB must reject a row where both human_id and user_id are non-NULL."""
+        some_human_id = uuid.uuid4()  # fake uuid; FK check fires after XOR check
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=some_human_id,
+            user_id=admin_user_tenant_a.id,
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            db.commit()
+        db.rollback()
+
+    def test_insert_with_human_only_succeeds(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """A row with human_id set and user_id=None must be accepted by the DB."""
+        from app.api.human.models import Humans
+
+        human = Humans(
+            tenant_id=tenant_a.id,
+            email=f"owner-check-{uuid.uuid4().hex[:8]}@test.com",
+            first_name="Test",
+            last_name="Human",
+        )
+        db.add(human)
+        db.commit()
+        db.refresh(human)
+
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=human.id,
+            user_id=None,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        assert row.id is not None
+        assert row.human_id == human.id
+        assert row.user_id is None
+
+        # Cleanup
+        db.delete(row)
+        db.commit()
+
+    def test_insert_with_user_only_succeeds(
+        self, db: Session, tenant_a: Tenants, admin_user_tenant_a: Users
+    ) -> None:
+        """A row with user_id set and human_id=None must be accepted by the DB."""
+        row = _make_api_key_row(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            user_id=admin_user_tenant_a.id,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+
+        assert row.id is not None
+        assert row.user_id == admin_user_tenant_a.id
+        assert row.human_id is None
+
+        # Cleanup
+        db.delete(row)
+        db.commit()

--- a/backend/tests/api/api_key/test_third_party_scope_restriction.py
+++ b/backend/tests/api/api_key/test_third_party_scope_restriction.py
@@ -1,0 +1,122 @@
+"""Portal api-key minting scope restriction for third-party JWT callers.
+
+RED-phase for the Block 4 leftover (verify-S2 finding).
+
+REQ-AK-04: When issued_via=third_party, requested scopes MUST be a
+           subset of THIRD_PARTY_API_KEY_SCOPES. Outside → 403.
+REQ-AK-05: When issued_via=portal, existing validation is unchanged.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.human.models import Humans
+from app.api.tenant.models import Tenants
+
+CREATE_URL = "/api/v1/api-keys"
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_human(db: Session, *, tenant: Tenants, email: str) -> Humans:
+    h = Humans(tenant_id=tenant.id, email=email)
+    db.add(h)
+    db.commit()
+    db.refresh(h)
+    return h
+
+
+class TestThirdPartyJwtApiKeyMintingRestriction:
+    """REQ-AK-04."""
+
+    def test_third_party_jwt_can_mint_events_read_key(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+        third_party_jwt_factory,
+    ) -> None:
+        """events:read is in THIRD_PARTY_API_KEY_SCOPES → key created (201)."""
+        tenant, _raw = third_party_enabled_tenant
+        email = f"tp-mint-ok-{uuid.uuid4().hex[:8]}@example.com"
+        human = _make_human(db, tenant=tenant, email=email)
+        token = third_party_jwt_factory(human=human)
+
+        resp = client.post(
+            CREATE_URL,
+            headers=_bearer(token),
+            json={"name": "tp-events", "scopes": ["events:read"]},
+        )
+        assert resp.status_code == 201, resp.text
+
+    def test_third_party_jwt_cannot_mint_venues_write_key(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+        third_party_jwt_factory,
+    ) -> None:
+        """venues:write is NOT in THIRD_PARTY_API_KEY_SCOPES → 403."""
+        tenant, _raw = third_party_enabled_tenant
+        email = f"tp-mint-block-{uuid.uuid4().hex[:8]}@example.com"
+        human = _make_human(db, tenant=tenant, email=email)
+        token = third_party_jwt_factory(human=human)
+
+        resp = client.post(
+            CREATE_URL,
+            headers=_bearer(token),
+            json={"name": "tp-venues", "scopes": ["venues:write"]},
+        )
+        assert resp.status_code == 403, resp.text
+
+    def test_third_party_jwt_cannot_mint_rsvp_and_venues_mixed(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+        third_party_jwt_factory,
+    ) -> None:
+        """Mixed scopes where venues:write is not in subset → 403."""
+        tenant, _raw = third_party_enabled_tenant
+        email = f"tp-mint-mixed-{uuid.uuid4().hex[:8]}@example.com"
+        human = _make_human(db, tenant=tenant, email=email)
+        token = third_party_jwt_factory(human=human)
+
+        resp = client.post(
+            CREATE_URL,
+            headers=_bearer(token),
+            json={"name": "tp-mixed", "scopes": ["rsvp:write", "venues:write"]},
+        )
+        assert resp.status_code == 403, resp.text
+
+
+class TestPortalJwtApiKeyMintingUnchanged:
+    """REQ-AK-05: portal JWT behavior must not regress."""
+
+    def test_portal_jwt_can_mint_events_read_key(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """Regular portal JWT (no issued_via / scopes=portal:*) can mint events:read."""
+        from app.core.security import create_access_token
+
+        tenant, _raw = third_party_enabled_tenant
+        email = f"portal-mint-ok-{uuid.uuid4().hex[:8]}@example.com"
+        human = _make_human(db, tenant=tenant, email=email)
+        # Mint a legacy-style portal JWT (no scopes, no issued_via)
+        token = create_access_token(subject=human.id, token_type="human")
+
+        resp = client.post(
+            CREATE_URL,
+            headers=_bearer(token),
+            json={"name": "portal-events", "scopes": ["events:read"]},
+        )
+        assert resp.status_code == 201, resp.text

--- a/backend/tests/api/api_key/test_third_party_scope_restriction.py
+++ b/backend/tests/api/api_key/test_third_party_scope_restriction.py
@@ -62,16 +62,23 @@ class TestThirdPartyJwtApiKeyMintingRestriction:
         third_party_enabled_tenant: tuple[Tenants, str],
         third_party_jwt_factory,
     ) -> None:
-        """venues:write is NOT in THIRD_PARTY_API_KEY_SCOPES → 403."""
+        """venues:write is NOT in THIRD_PARTY_API_KEY_SCOPES → 403.
+
+        expires_at is provided so schema-level write-requires-expiry does not
+        fire before our router check reaches the third-party universe guard.
+        """
+        from datetime import UTC, datetime, timedelta
+
         tenant, _raw = third_party_enabled_tenant
         email = f"tp-mint-block-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant, email=email)
         token = third_party_jwt_factory(human=human)
+        expiry = (datetime.now(UTC) + timedelta(days=7)).isoformat()
 
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "tp-venues", "scopes": ["venues:write"]},
+            json={"name": "tp-venues", "scopes": ["venues:write"], "expires_at": expiry},
         )
         assert resp.status_code == 403, resp.text
 
@@ -82,16 +89,23 @@ class TestThirdPartyJwtApiKeyMintingRestriction:
         third_party_enabled_tenant: tuple[Tenants, str],
         third_party_jwt_factory,
     ) -> None:
-        """Mixed scopes where venues:write is not in subset → 403."""
+        """Mixed scopes where venues:write is not in subset → 403.
+
+        expires_at is provided so schema-level write-requires-expiry validator
+        does not reject the request before the third-party universe guard runs.
+        """
+        from datetime import UTC, datetime, timedelta
+
         tenant, _raw = third_party_enabled_tenant
         email = f"tp-mint-mixed-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant, email=email)
         token = third_party_jwt_factory(human=human)
+        expiry = (datetime.now(UTC) + timedelta(days=7)).isoformat()
 
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "tp-mixed", "scopes": ["rsvp:write", "venues:write"]},
+            json={"name": "tp-mixed", "scopes": ["rsvp:write", "venues:write"], "expires_at": expiry},
         )
         assert resp.status_code == 403, resp.text
 

--- a/backend/tests/api/auth/test_third_party_login.py
+++ b/backend/tests/api/auth/test_third_party_login.py
@@ -314,3 +314,55 @@ class TestThirdPartyJwtAccess:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Cross-flow OTP isolation — a code emitted by the third-party flow
+# MUST NOT be redeemable via the portal /authenticate endpoint, and
+# vice-versa.
+# ---------------------------------------------------------------------------
+
+
+class TestCrossFlowOtpIsolation:
+    def test_third_party_code_cannot_authenticate_via_portal(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """An OTP emitted via third-party login must be rejected by the
+        regular portal /auth/human/authenticate endpoint."""
+        from unittest.mock import patch
+
+        from app.services.email import EmailService
+
+        tenant, raw_key = third_party_enabled_tenant
+        email = f"tp-isolate-{uuid.uuid4().hex[:8]}@example.com"
+        _make_human(db, tenant=tenant, email=email)
+
+        captured_code: list[str] = []
+
+        async def _fake_send(_self, **kwargs) -> bool:  # noqa: ANN001
+            captured_code.append(kwargs["context"].auth_code)
+            return True
+
+        with patch.object(EmailService, "send_login_code_human", _fake_send):
+            login_resp = client.post(
+                LOGIN_URL,
+                headers=_login_headers(raw_key),
+                json={"email": email},
+            )
+        assert login_resp.status_code == 200
+        assert captured_code
+
+        portal_resp = client.post(
+            "/api/v1/auth/human/authenticate",
+            json={
+                "email": email,
+                "tenant_id": str(tenant.id),
+                "code": captured_code[0],
+            },
+        )
+        assert portal_resp.status_code == 401, (
+            "Third-party code must not be redeemable via portal authenticate"
+        )

--- a/backend/tests/api/auth/test_third_party_login.py
+++ b/backend/tests/api/auth/test_third_party_login.py
@@ -1,0 +1,333 @@
+"""Third-party OTP login + authenticate endpoint contract tests.
+
+RED-phase for Block 5. All tests should FAIL until:
+  - ThirdPartyHumanLogin / ThirdPartyHumanVerify schemas are added.
+  - login_existing_human / _send_human_code are added to auth/crud.py.
+  - POST /auth/human/third-party/login and /auth/human/third-party/authenticate
+    are wired up in auth/router.py.
+
+REQ-TP-01 ... REQ-TP-07
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.human.models import Humans
+from app.api.tenant.models import Tenants
+from app.core.security import THIRD_PARTY_TOKEN_SCOPES, decode_access_token
+
+LOGIN_URL = "/api/v1/auth/human/third-party/login"
+AUTH_URL = "/api/v1/auth/human/third-party/authenticate"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_human(db: Session, *, tenant: Tenants, email: str) -> Humans:
+    h = Humans(tenant_id=tenant.id, email=email)
+    db.add(h)
+    db.commit()
+    db.refresh(h)
+    return h
+
+
+def _login_headers(tenant_id: uuid.UUID, api_key: str) -> dict[str, str]:
+    return {
+        "X-Tenant-Id": str(tenant_id),
+        "X-Third-Party-Api-Key": api_key,
+    }
+
+
+# ---------------------------------------------------------------------------
+# REQ-TP-01 — missing header returns 422 (FastAPI required-header validation)
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyLoginHeaders:
+    def test_missing_api_key_header_returns_422(
+        self,
+        client: TestClient,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """X-Third-Party-Api-Key is required. Absent header → 422."""
+        tenant, _raw = third_party_enabled_tenant
+        resp = client.post(
+            LOGIN_URL,
+            headers={"X-Tenant-Id": str(tenant.id)},
+            json={"email": "nobody@example.com"},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_tenant_id_header_returns_422(
+        self,
+        client: TestClient,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """X-Tenant-Id is required. Absent header → 422."""
+        _, raw_key = third_party_enabled_tenant
+        resp = client.post(
+            LOGIN_URL,
+            headers={"X-Third-Party-Api-Key": raw_key},
+            json={"email": "nobody@example.com"},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# REQ-TP-02 — invalid / disabled key returns 401
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyLoginKeyValidation:
+    def test_wrong_api_key_returns_401(
+        self,
+        client: TestClient,
+        third_party_enabled_tenant: tuple[Tenants, str],
+        db: Session,
+    ) -> None:
+        """A key that doesn't match the stored hash → 401."""
+        tenant, _raw = third_party_enabled_tenant
+        email = f"key-mismatch-{uuid.uuid4().hex[:6]}@example.com"
+        _make_human(db, tenant=tenant, email=email)
+
+        resp = client.post(
+            LOGIN_URL,
+            headers=_login_headers(tenant.id, "definitely_wrong_key"),
+            json={"email": email},
+        )
+        assert resp.status_code == 401
+
+    def test_disabled_tenant_third_party_returns_401(
+        self,
+        client: TestClient,
+        tenant_b: Tenants,
+    ) -> None:
+        """Tenant with third_party_api_key_hash=NULL → 401 (feature not enabled)."""
+        # tenant_b has no third_party_api_key_hash set in conftest
+        assert tenant_b.third_party_api_key_hash is None
+        resp = client.post(
+            LOGIN_URL,
+            headers=_login_headers(tenant_b.id, "any_key"),
+            json={"email": "nobody@example.com"},
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# REQ-TP-03 / REQ-TP-07 — existing-human-only; no auto-create
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyLoginExistingHumanOnly:
+    def test_unknown_email_returns_generic_error_and_does_not_create_human(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """Unknown email → generic error (401 or 404). No new human row created."""
+        tenant, raw_key = third_party_enabled_tenant
+        email = f"tp-ghost-{uuid.uuid4().hex[:8]}@example.com"
+
+        before_count = len(
+            list(
+                db.exec(
+                    select(Humans).where(
+                        Humans.tenant_id == tenant.id, Humans.email == email
+                    )
+                ).all()
+            )
+        )
+
+        resp = client.post(
+            LOGIN_URL,
+            headers=_login_headers(tenant.id, raw_key),
+            json={"email": email},
+        )
+        assert resp.status_code in {401, 404}
+
+        after_count = len(
+            list(
+                db.exec(
+                    select(Humans).where(
+                        Humans.tenant_id == tenant.id, Humans.email == email
+                    )
+                ).all()
+            )
+        )
+        assert after_count == before_count, "Must not create a new human row"
+
+
+# ---------------------------------------------------------------------------
+# REQ-TP-04 — valid key + existing human → OTP sent, 200
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyLoginHappyPath:
+    def test_existing_human_receives_otp(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """Valid key + existing human → mail sent, 200 response."""
+        tenant, raw_key = third_party_enabled_tenant
+        email = f"tp-login-ok-{uuid.uuid4().hex[:8]}@example.com"
+        _make_human(db, tenant=tenant, email=email)
+
+        with pytest.MonkeyPatch.context() as mp:
+            sent: list[str] = []
+
+            async def _fake_send(*args, **kwargs) -> bool:  # noqa: ANN002
+                sent.append(kwargs.get("to") or (args[0] if args else ""))
+                return True
+
+            mp.setattr(
+                "app.services.email.EmailService.send_login_code_human",
+                _fake_send,
+            )
+
+            resp = client.post(
+                LOGIN_URL,
+                headers=_login_headers(tenant.id, raw_key),
+                json={"email": email},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "message" in data
+
+
+# ---------------------------------------------------------------------------
+# REQ-TP-05 — authenticate happy path → JWT with third_party scopes
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyAuthenticate:
+    def test_authenticate_mints_jwt_with_third_party_issued_via_and_scopes(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """Valid OTP verify → JWT where issued_via=third_party, scopes=THIRD_PARTY_TOKEN_SCOPES."""
+        from unittest.mock import patch
+
+        tenant, raw_key = third_party_enabled_tenant
+        email = f"tp-auth-ok-{uuid.uuid4().hex[:8]}@example.com"
+        _make_human(db, tenant=tenant, email=email)
+
+        captured_code: list[str] = []
+
+        async def _fake_send(self, to, subject, context, **kwargs) -> bool:  # noqa: ANN001
+            captured_code.append(context.auth_code)
+            return True
+
+        from app.services.email import EmailService
+
+        with patch.object(EmailService, "send_login_code_human", _fake_send):
+            login_resp = client.post(
+                LOGIN_URL,
+                headers=_login_headers(tenant.id, raw_key),
+                json={"email": email},
+            )
+        assert login_resp.status_code == 200, login_resp.text
+        assert captured_code, "Expected email to be sent with OTP code"
+
+        code = captured_code[0]
+        auth_resp = client.post(
+            AUTH_URL,
+            headers=_login_headers(tenant.id, raw_key),
+            json={"email": email, "code": code},
+        )
+        assert auth_resp.status_code == 200, auth_resp.text
+        token_data = auth_resp.json()
+        assert "access_token" in token_data
+
+        payload = decode_access_token(token_data["access_token"])
+        assert payload.issued_via == "third_party"
+        assert set(payload.scopes) == set(THIRD_PARTY_TOKEN_SCOPES)
+
+    def test_wrong_code_returns_error(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """Correct key, correct email, wrong OTP → non-200."""
+        from unittest.mock import patch
+
+        from app.services.email import EmailService
+
+        tenant, raw_key = third_party_enabled_tenant
+        email = f"tp-wrong-code-{uuid.uuid4().hex[:8]}@example.com"
+        _make_human(db, tenant=tenant, email=email)
+
+        async def _fake_send(self, *args, **kwargs) -> bool:  # noqa: ANN001 ANN002
+            return True
+
+        with patch.object(EmailService, "send_login_code_human", _fake_send):
+            login_resp = client.post(
+                LOGIN_URL,
+                headers=_login_headers(tenant.id, raw_key),
+                json={"email": email},
+            )
+        assert login_resp.status_code == 200
+
+        auth_resp = client.post(
+            AUTH_URL,
+            headers=_login_headers(tenant.id, raw_key),
+            json={"email": email, "code": "000000"},
+        )
+        assert auth_resp.status_code != 200
+
+    def test_authenticate_wrong_api_key_returns_401(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+    ) -> None:
+        """Authenticate with wrong key → 401 even if code would be valid."""
+        tenant, _raw = third_party_enabled_tenant
+        email = f"tp-auth-badkey-{uuid.uuid4().hex[:8]}@example.com"
+        _make_human(db, tenant=tenant, email=email)
+
+        resp = client.post(
+            AUTH_URL,
+            headers=_login_headers(tenant.id, "wrong_key"),
+            json={"email": email, "code": "123456"},
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# REQ-TP-05 — JWT issued by third-party can call self_read endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestThirdPartyJwtAccess:
+    def test_third_party_jwt_can_call_self_read_endpoint(
+        self,
+        client: TestClient,
+        db: Session,
+        third_party_enabled_tenant: tuple[Tenants, str],
+        third_party_jwt_factory,
+    ) -> None:
+        """A JWT minted via third-party path can call GET /humans/me."""
+        tenant, _raw = third_party_enabled_tenant
+        email = f"tp-me-{uuid.uuid4().hex[:8]}@example.com"
+        human = _make_human(db, tenant=tenant, email=email)
+
+        token = third_party_jwt_factory(human=human)
+        resp = client.get(
+            "/api/v1/humans/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200

--- a/backend/tests/api/auth/test_third_party_login.py
+++ b/backend/tests/api/auth/test_third_party_login.py
@@ -38,11 +38,8 @@ def _make_human(db: Session, *, tenant: Tenants, email: str) -> Humans:
     return h
 
 
-def _login_headers(tenant_id: uuid.UUID, api_key: str) -> dict[str, str]:
-    return {
-        "X-Tenant-Id": str(tenant_id),
-        "X-Third-Party-Api-Key": api_key,
-    }
+def _login_headers(api_key: str) -> dict[str, str]:
+    return {"X-Third-Party-Api-Key": api_key}
 
 
 # ---------------------------------------------------------------------------
@@ -54,27 +51,10 @@ class TestThirdPartyLoginHeaders:
     def test_missing_api_key_header_returns_422(
         self,
         client: TestClient,
-        third_party_enabled_tenant: tuple[Tenants, str],
     ) -> None:
         """X-Third-Party-Api-Key is required. Absent header → 422."""
-        tenant, _raw = third_party_enabled_tenant
         resp = client.post(
             LOGIN_URL,
-            headers={"X-Tenant-Id": str(tenant.id)},
-            json={"email": "nobody@example.com"},
-        )
-        assert resp.status_code == 422
-
-    def test_missing_tenant_id_header_returns_422(
-        self,
-        client: TestClient,
-        third_party_enabled_tenant: tuple[Tenants, str],
-    ) -> None:
-        """X-Tenant-Id is required. Absent header → 422."""
-        _, raw_key = third_party_enabled_tenant
-        resp = client.post(
-            LOGIN_URL,
-            headers={"X-Third-Party-Api-Key": raw_key},
             json={"email": "nobody@example.com"},
         )
         assert resp.status_code == 422
@@ -92,29 +72,32 @@ class TestThirdPartyLoginKeyValidation:
         third_party_enabled_tenant: tuple[Tenants, str],
         db: Session,
     ) -> None:
-        """A key that doesn't match the stored hash → 401."""
+        """A key that doesn't match any tenant's stored hash → 401."""
         tenant, _raw = third_party_enabled_tenant
         email = f"key-mismatch-{uuid.uuid4().hex[:6]}@example.com"
         _make_human(db, tenant=tenant, email=email)
 
         resp = client.post(
             LOGIN_URL,
-            headers=_login_headers(tenant.id, "definitely_wrong_key"),
+            headers=_login_headers("definitely_wrong_key"),
             json={"email": email},
         )
         assert resp.status_code == 401
 
-    def test_disabled_tenant_third_party_returns_401(
+    def test_unknown_key_returns_401(
         self,
         client: TestClient,
         tenant_b: Tenants,
     ) -> None:
-        """Tenant with third_party_api_key_hash=NULL → 401 (feature not enabled)."""
-        # tenant_b has no third_party_api_key_hash set in conftest
+        """An arbitrary key that no tenant has registered → 401 (collapses with the
+        wrong-key branch — callers cannot distinguish disabled vs unknown).
+        """
+        # tenant_b has no third_party_api_key_hash set; the key below doesn't
+        # match any row either way.
         assert tenant_b.third_party_api_key_hash is None
         resp = client.post(
             LOGIN_URL,
-            headers=_login_headers(tenant_b.id, "any_key"),
+            headers=_login_headers("any_key"),
             json={"email": "nobody@example.com"},
         )
         assert resp.status_code == 401
@@ -148,7 +131,7 @@ class TestThirdPartyLoginExistingHumanOnly:
 
         resp = client.post(
             LOGIN_URL,
-            headers=_login_headers(tenant.id, raw_key),
+            headers=_login_headers(raw_key),
             json={"email": email},
         )
         assert resp.status_code in {401, 404}
@@ -196,7 +179,7 @@ class TestThirdPartyLoginHappyPath:
 
             resp = client.post(
                 LOGIN_URL,
-                headers=_login_headers(tenant.id, raw_key),
+                headers=_login_headers(raw_key),
                 json={"email": email},
             )
 
@@ -235,7 +218,7 @@ class TestThirdPartyAuthenticate:
         with patch.object(EmailService, "send_login_code_human", _fake_send):
             login_resp = client.post(
                 LOGIN_URL,
-                headers=_login_headers(tenant.id, raw_key),
+                headers=_login_headers(raw_key),
                 json={"email": email},
             )
         assert login_resp.status_code == 200, login_resp.text
@@ -244,7 +227,7 @@ class TestThirdPartyAuthenticate:
         code = captured_code[0]
         auth_resp = client.post(
             AUTH_URL,
-            headers=_login_headers(tenant.id, raw_key),
+            headers=_login_headers(raw_key),
             json={"email": email, "code": code},
         )
         assert auth_resp.status_code == 200, auth_resp.text
@@ -276,14 +259,14 @@ class TestThirdPartyAuthenticate:
         with patch.object(EmailService, "send_login_code_human", _fake_send):
             login_resp = client.post(
                 LOGIN_URL,
-                headers=_login_headers(tenant.id, raw_key),
+                headers=_login_headers(raw_key),
                 json={"email": email},
             )
         assert login_resp.status_code == 200
 
         auth_resp = client.post(
             AUTH_URL,
-            headers=_login_headers(tenant.id, raw_key),
+            headers=_login_headers(raw_key),
             json={"email": email, "code": "000000"},
         )
         assert auth_resp.status_code != 200
@@ -301,7 +284,7 @@ class TestThirdPartyAuthenticate:
 
         resp = client.post(
             AUTH_URL,
-            headers=_login_headers(tenant.id, "wrong_key"),
+            headers=_login_headers("wrong_key"),
             json={"email": email, "code": "123456"},
         )
         assert resp.status_code == 401

--- a/backend/tests/api/auth/test_third_party_login.py
+++ b/backend/tests/api/auth/test_third_party_login.py
@@ -226,8 +226,8 @@ class TestThirdPartyAuthenticate:
 
         captured_code: list[str] = []
 
-        async def _fake_send(self, to, subject, context, **kwargs) -> bool:  # noqa: ANN001
-            captured_code.append(context.auth_code)
+        async def _fake_send(_self, **kwargs) -> bool:  # noqa: ANN001
+            captured_code.append(kwargs["context"].auth_code)
             return True
 
         from app.services.email import EmailService
@@ -270,7 +270,7 @@ class TestThirdPartyAuthenticate:
         email = f"tp-wrong-code-{uuid.uuid4().hex[:8]}@example.com"
         _make_human(db, tenant=tenant, email=email)
 
-        async def _fake_send(self, *args, **kwargs) -> bool:  # noqa: ANN001 ANN002
+        async def _fake_send(_self, *_args, **_kwargs) -> bool:  # noqa: ANN001
             return True
 
         with patch.object(EmailService, "send_login_code_human", _fake_send):

--- a/backend/tests/api/product/test_cap_seed_from_real_sales.py
+++ b/backend/tests/api/product/test_cap_seed_from_real_sales.py
@@ -1,0 +1,228 @@
+"""Regression: setting a cap on a previously-unlimited product must count real
+sales from payment_products, not silently seed remaining=cap.
+
+Reproduces the bug where a Conference T-Shirt with cap=NULL had 1 unit sold,
+then admin set cap=1, and remaining was seeded to 1 — letting a second buyer
+exceed the cap.
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.payment.models import PaymentProducts, Payments
+from app.api.payment.schemas import PaymentStatus
+from app.api.popup.models import Popups
+from app.api.product.crud import products_crud
+from app.api.product.models import Products
+from app.api.product.schemas import ProductUpdate
+from app.api.tenant.models import Tenants
+
+
+def _make_unlimited_product(
+    db: Session, tenant: Tenants, popup: Popups
+) -> Products:
+    suffix = uuid.uuid4().hex[:8]
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"unlimited-{suffix}",
+        slug=f"unlimited-{suffix}",
+        price=Decimal("35"),
+        category="merch",
+        total_stock_cap=None,
+        total_stock_remaining=None,
+        is_active=True,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _record_sale(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    product: Products,
+    qty: int,
+    status: PaymentStatus = PaymentStatus.APPROVED,
+) -> Payments:
+    """Create a payment + payment_products snapshot mimicking a real sale.
+
+    Mirrors the helpers in tests/api/payment/test_stock_restoration.py — kept
+    self-contained here so this regression test doesn't cross-import.
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+    from app.api.attendee.models import Attendees
+    from app.api.human.models import Humans
+
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"sale-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Sale",
+        last_name="Test",
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.flush()
+
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        name="Sale Attendee",
+        category="main",
+        email=f"att-{uuid.uuid4().hex[:8]}@test.com",
+        check_in_code=f"S{uuid.uuid4().hex[:4].upper()}",
+    )
+    db.add(attendee)
+    db.flush()
+
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        status=status.value,
+        amount=Decimal(str(product.price * qty)),
+        currency="ARS",
+        external_id=f"sf-{uuid.uuid4().hex[:16]}",
+    )
+    db.add(payment)
+    db.flush()
+
+    pp = PaymentProducts(
+        tenant_id=tenant.id,
+        payment_id=payment.id,
+        product_id=product.id,
+        attendee_id=attendee.id,
+        quantity=qty,
+        product_name=product.name,
+        product_description=None,
+        product_price=product.price,
+        product_category=product.category or "merch",
+        product_currency="ARS",
+    )
+    db.add(pp)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def test_setting_cap_on_unlimited_product_counts_real_sales(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """cap=NULL with 1 APPROVED sale → PATCH cap=1 → remaining=0 (sold preserved)."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(db, tenant_a, popup_tenant_a, product, qty=1)
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=1))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_cap == 1
+    assert refreshed.total_stock_remaining == 0, (
+        "Expected remaining=0 because 1 unit was already sold while the "
+        "product was unlimited. Got "
+        f"{refreshed.total_stock_remaining} — sold count was silently dropped."
+    )
+
+
+def test_setting_cap_on_unlimited_product_counts_pending_sales(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """Pending payments hold stock too — they must count toward sold."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=2, status=PaymentStatus.PENDING
+    )
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=5))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_remaining == 3, (
+        "Pending sales hold stock until the payment expires — they must be "
+        "counted when seeding remaining from a fresh cap."
+    )
+
+
+def test_setting_cap_excludes_cancelled_and_expired_sales(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """Cancelled / expired / rejected payments released stock — must NOT count."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=1, status=PaymentStatus.CANCELLED
+    )
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=1, status=PaymentStatus.EXPIRED
+    )
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=1, status=PaymentStatus.REJECTED
+    )
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=5))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_remaining == 5, (
+        "Released payments must not count as sold. Got "
+        f"{refreshed.total_stock_remaining}."
+    )
+
+
+def test_setting_cap_below_real_sold_clamps_to_zero(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """If sold > new_cap (admin underprovisioned), remaining clamps to 0."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(db, tenant_a, popup_tenant_a, product, qty=10)
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=3))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_cap == 3
+    assert refreshed.total_stock_remaining == 0
+
+
+def test_api_patch_cap_on_unlimited_with_sales(
+    client: TestClient,
+    db: Session,
+    admin_token_tenant_a: str,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """End-to-end: PATCH via admin endpoint also counts real sales."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(db, tenant_a, popup_tenant_a, product, qty=1)
+
+    resp = client.patch(
+        f"/api/v1/products/{product.id}",
+        headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
+        json={"total_stock_cap": 1},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total_stock_cap"] == 1
+    assert data["total_stock_remaining"] == 0

--- a/backend/tests/api/tenant/test_third_party_key_rotation.py
+++ b/backend/tests/api/tenant/test_third_party_key_rotation.py
@@ -10,14 +10,10 @@ REQ-TR-01 ... REQ-TR-04
 
 from __future__ import annotations
 
-import uuid
-
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.api.tenant.models import Tenants
-from app.api.user.models import Users
 
 ROTATE_URL = "/api/v1/tenants/{tenant_id}/third-party-key/rotate"
 REVOKE_URL = "/api/v1/tenants/{tenant_id}/third-party-key"

--- a/backend/tests/api/tenant/test_third_party_key_rotation.py
+++ b/backend/tests/api/tenant/test_third_party_key_rotation.py
@@ -1,0 +1,161 @@
+"""Third-party key rotation and revocation endpoint tests.
+
+RED-phase for Block 7. All tests should FAIL until:
+  - POST /tenants/{tenant_id}/third-party-key/rotate is wired up.
+  - DELETE /tenants/{tenant_id}/third-party-key is wired up.
+  - ThirdPartyKeyRotated schema is added to tenant/schemas.py.
+
+REQ-TR-01 ... REQ-TR-04
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+
+ROTATE_URL = "/api/v1/tenants/{tenant_id}/third-party-key/rotate"
+REVOKE_URL = "/api/v1/tenants/{tenant_id}/third-party-key"
+LOGIN_URL = "/api/v1/auth/human/third-party/login"
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _superadmin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestThirdPartyKeyRotate:
+    """REQ-TR-02, REQ-TR-04."""
+
+    def test_admin_rotate_returns_raw_key_once(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """ADMIN can rotate. Response includes raw api_key and prefix."""
+        url = ROTATE_URL.format(tenant_id=tenant_a.id)
+        resp = client.post(url, headers=_admin_headers(admin_token_tenant_a))
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "api_key" in data
+        assert "prefix" in data
+        assert len(data["api_key"]) >= 10
+
+        # Hash must be stored on tenant row
+        db.refresh(tenant_a)
+        assert tenant_a.third_party_api_key_hash is not None
+        assert tenant_a.third_party_key_prefix == data["prefix"]
+
+    def test_rotate_invalidates_old_key_on_next_login(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """After rotation, the old raw key is rejected at login."""
+        # First rotate to get a known key
+        url = ROTATE_URL.format(tenant_id=tenant_a.id)
+        resp1 = client.post(url, headers=_admin_headers(admin_token_tenant_a))
+        assert resp1.status_code == 200, resp1.text
+        old_key = resp1.json()["api_key"]
+
+        # Rotate again — old_key should now be invalid
+        resp2 = client.post(url, headers=_admin_headers(admin_token_tenant_a))
+        assert resp2.status_code == 200, resp2.text
+
+        # Try to login with old key
+        login_resp = client.post(
+            LOGIN_URL,
+            headers={
+                "X-Tenant-Id": str(tenant_a.id),
+                "X-Third-Party-Api-Key": old_key,
+            },
+            json={"email": "anyone@example.com"},
+        )
+        assert login_resp.status_code == 401
+
+    def test_viewer_cannot_rotate(
+        self,
+        client: TestClient,
+        tenant_a: Tenants,
+        viewer_token_tenant_a: str,
+    ) -> None:
+        """REQ-TR-04: VIEWER must receive 403."""
+        url = ROTATE_URL.format(tenant_id=tenant_a.id)
+        resp = client.post(url, headers=_admin_headers(viewer_token_tenant_a))
+        assert resp.status_code == 403
+
+    def test_superadmin_can_rotate_any_tenant(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_b: Tenants,
+        superadmin_token: str,
+    ) -> None:
+        """SUPERADMIN can rotate keys for any tenant."""
+        url = ROTATE_URL.format(tenant_id=tenant_b.id)
+        resp = client.post(url, headers=_superadmin_headers(superadmin_token))
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert "api_key" in data
+
+        db.refresh(tenant_b)
+        assert tenant_b.third_party_api_key_hash is not None
+
+    def test_admin_cannot_rotate_other_tenant(
+        self,
+        client: TestClient,
+        tenant_b: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """ADMIN of tenant A must not rotate tenant B key → 403."""
+        url = ROTATE_URL.format(tenant_id=tenant_b.id)
+        resp = client.post(url, headers=_admin_headers(admin_token_tenant_a))
+        assert resp.status_code == 403
+
+
+class TestThirdPartyKeyRevoke:
+    """DELETE endpoint disables third-party login for the tenant."""
+
+    def test_delete_clears_hash_and_prefix(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """After DELETE the tenant's hash and prefix columns are NULL → 204."""
+        # Ensure key is set first
+        rotate_url = ROTATE_URL.format(tenant_id=tenant_a.id)
+        r = client.post(rotate_url, headers=_admin_headers(admin_token_tenant_a))
+        assert r.status_code == 200
+
+        delete_url = REVOKE_URL.format(tenant_id=tenant_a.id)
+        resp = client.delete(delete_url, headers=_admin_headers(admin_token_tenant_a))
+        assert resp.status_code == 204
+
+        db.refresh(tenant_a)
+        assert tenant_a.third_party_api_key_hash is None
+        assert tenant_a.third_party_key_prefix is None
+
+    def test_viewer_cannot_delete_key(
+        self,
+        client: TestClient,
+        tenant_a: Tenants,
+        viewer_token_tenant_a: str,
+    ) -> None:
+        """VIEWER must receive 403 on DELETE."""
+        url = REVOKE_URL.format(tenant_id=tenant_a.id)
+        resp = client.delete(url, headers=_admin_headers(viewer_token_tenant_a))
+        assert resp.status_code == 403

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,13 +9,19 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, create_engine, select
 from testcontainers.postgres import PostgresContainer
 
+from app.api.api_key import crud as api_key_crud
+from app.api.api_key.models import ApiKeys
+from app.api.human.models import Humans
 from app.api.popup.models import Popups
 from app.api.popup.schemas import PopupStatus
 from app.api.shared.enums import SaleType, UserRole
 from app.api.tenant.models import Tenants
 from app.api.user.models import Users
 from app.core.dependencies.users import get_session
-from app.core.security import create_access_token
+from app.core.security import (
+    THIRD_PARTY_TOKEN_SCOPES,
+    create_access_token,
+)
 from app.core.tenant_db import ensure_tenant_credentials, tenant_connection_manager
 from app.main import application
 
@@ -453,6 +459,97 @@ def popup_tenant_b_summer_fest(db: Session, tenant_b: Tenants) -> Popups:
 def with_origin(host: str) -> dict[str, str]:
     """Return a headers dict with an Origin pointing at the given host."""
     return {"Origin": f"https://{host}"}
+
+
+# ---------------------------------------------------------------------------
+# Block F — Fixtures for dual-owner api keys and scope variations
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def third_party_enabled_tenant(db: Session, tenant_a: Tenants) -> tuple[Tenants, str]:
+    """tenant_a pre-configured with a third-party API key hash.
+
+    Returns (tenant, raw_key) so tests can verify both key validation and
+    prefix display.
+    """
+    import bcrypt
+
+    raw_key = "tp_test_secret_key_for_tests_only"
+    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+
+    tenant_a.third_party_api_key_hash = key_hash
+    tenant_a.third_party_key_prefix = raw_key[:8]
+    db.add(tenant_a)
+    db.commit()
+    db.refresh(tenant_a)
+
+    return tenant_a, raw_key
+
+
+@pytest.fixture()
+def admin_api_key_factory(db: Session, tenant_a: Tenants, admin_user_tenant_a: Users):
+    """Factory fixture: creates an admin-owned ApiKeys row for the test admin user.
+
+    Usage::
+
+        def test_something(admin_api_key_factory):
+            row, raw = admin_api_key_factory(scopes=["events:read"])
+    """
+
+    created_ids: list[uuid.UUID] = []
+
+    def _factory(scopes: list[str]) -> tuple[ApiKeys, str]:
+        raw = api_key_crud.generate_raw_key()
+        row = ApiKeys(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            user_id=admin_user_tenant_a.id,
+            name=f"admin-key-{uuid.uuid4().hex[:6]}",
+            key_hash=api_key_crud.hash_key(raw),
+            prefix=api_key_crud.display_prefix(raw),
+            scopes=scopes,
+        )
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        created_ids.append(row.id)
+        return row, raw
+
+    yield _factory
+
+    # Cleanup after test
+    for key_id in created_ids:
+        row = db.get(ApiKeys, key_id)
+        if row:
+            db.delete(row)
+    db.commit()
+
+
+@pytest.fixture()
+def third_party_jwt_factory():
+    """Factory fixture: mints a third-party JWT directly via create_access_token.
+
+    Usage::
+
+        def test_something(third_party_jwt_factory, some_human):
+            token = third_party_jwt_factory(human=some_human)
+            # or with custom scopes:
+            token = third_party_jwt_factory(human=some_human, scopes=["portal:self_read"])
+    """
+
+    def _factory(
+        human: Humans,
+        scopes: list[str] | None = None,
+    ) -> str:
+        return create_access_token(
+            subject=human.id,
+            token_type="human",
+            scopes=scopes if scopes is not None else list(THIRD_PARTY_TOKEN_SCOPES),
+            issued_via="third_party",
+        )
+
+    return _factory
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -473,10 +473,8 @@ def third_party_enabled_tenant(db: Session, tenant_a: Tenants) -> tuple[Tenants,
     Returns (tenant, raw_key) so tests can verify both key validation and
     prefix display.
     """
-    import bcrypt
-
     raw_key = "tp_test_secret_key_for_tests_only"
-    key_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+    key_hash = api_key_crud.hash_key(raw_key)
 
     tenant_a.third_party_api_key_hash = key_hash
     tenant_a.third_party_key_prefix = raw_key[:8]

--- a/backend/tests/core/dependencies/test_scope_guards.py
+++ b/backend/tests/core/dependencies/test_scope_guards.py
@@ -1,0 +1,299 @@
+"""Tests for require_human_scope and CurrentAdminOrApiKey dependency guards.
+
+RED-phase tests for Block 4. These validate:
+  - require_human_scope passes on portal:* wildcard (explicit or grace-synthesised).
+  - require_human_scope passes on exact matching scope.
+  - require_human_scope raises 403 on missing scope.
+  - CurrentAdminOrApiKey JWT path: ADMIN succeeds, VIEWER is rejected.
+  - CurrentAdminOrApiKey api-key path: matching scope succeeds, missing scope is 403.
+  - CurrentAdminOrApiKey rejects human JWTs outright.
+  - get_admin_or_api_key_tenant_session resolves tenant from api_key row (api-key branch).
+  - get_admin_or_api_key_tenant_session delegates to get_tenant_session (JWT branch).
+
+Tests are expected to FAIL until app/core/dependencies/users.py is updated.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.security import (
+    TokenPayload,
+    create_access_token,
+    decode_access_token,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _human_payload(scopes: list[str]) -> TokenPayload:
+    return TokenPayload(
+        sub=str(uuid.uuid4()),
+        exp=datetime.now(UTC) + timedelta(minutes=30),
+        token_type="human",
+        scopes=scopes,  # type: ignore[arg-type]
+        issued_via="portal",
+    )
+
+
+def _user_payload(
+    user_id: uuid.UUID | None = None,
+    scopes: list[str] | None = None,
+    via_api_key: bool = False,
+    api_key_tenant_id: uuid.UUID | None = None,
+) -> TokenPayload:
+    return TokenPayload(
+        sub=str(user_id or uuid.uuid4()),
+        exp=datetime.now(UTC) + timedelta(minutes=30),
+        token_type="user",
+        scopes=scopes or [],  # type: ignore[arg-type]
+        issued_via="portal",
+        via_api_key=via_api_key,
+        api_key_tenant_id=api_key_tenant_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# require_human_scope
+# ---------------------------------------------------------------------------
+
+
+class TestRequireHumanScope:
+    """Scope guard for portal (human) routes."""
+
+    def test_require_human_scope_accepts_explicit_wildcard(self) -> None:
+        """A token with portal:* passes any HumanScope check."""
+        from app.core.dependencies.users import require_human_scope
+
+        payload = _human_payload(["portal:*"])
+        guard = require_human_scope("portal:self_read")
+        # Should not raise
+        guard(payload)
+
+    def test_require_human_scope_accepts_grace_synthesised_wildcard(self) -> None:
+        """A legacy token whose scopes were synthesised to [portal:*] passes."""
+        from app.core.dependencies.users import require_human_scope
+
+        # decode_access_token synthesises portal:* for empty-scopes human tokens.
+        token = create_access_token(
+            subject=uuid.uuid4(),
+            token_type="human",
+        )
+        payload = decode_access_token(token)
+        assert "portal:*" in payload.scopes  # confirm synthesis happened
+
+        guard = require_human_scope("portal:directory_read")
+        # Should not raise
+        guard(payload)
+
+    def test_require_human_scope_accepts_matching_scope(self) -> None:
+        """A token with the exact requested scope passes."""
+        from app.core.dependencies.users import require_human_scope
+
+        payload = _human_payload(["portal:self_read"])
+        guard = require_human_scope("portal:self_read")
+        guard(payload)  # Should not raise
+
+    def test_require_human_scope_rejects_missing_scope(self) -> None:
+        """A token without the required scope and without portal:* raises 403."""
+        from app.core.dependencies.users import require_human_scope
+
+        payload = _human_payload(["portal:self_read"])
+        guard = require_human_scope("portal:directory_read")
+        with pytest.raises(HTTPException) as exc_info:
+            guard(payload)
+        assert exc_info.value.status_code == 403
+
+    def test_require_human_scope_rejects_empty_explicit_scope_list(self) -> None:
+        """A token with an explicit empty scopes list (no grace synth) raises 403.
+
+        Note: in practice decode_access_token synthesises portal:* for human tokens
+        with empty scopes. This tests the guard itself with a raw payload that has
+        no scopes at all (edge case for direct payload construction).
+        """
+        from app.core.dependencies.users import require_human_scope
+
+        # Build a payload with scopes=[] directly — simulates a future non-human
+        # token or a specially crafted payload bypassing decode.
+        payload = _human_payload([])
+        guard = require_human_scope("portal:self_read")
+        with pytest.raises(HTTPException) as exc_info:
+            guard(payload)
+        assert exc_info.value.status_code == 403
+
+    def test_require_human_scope_wildcard_token_passes_directory_read(self) -> None:
+        """Explicit portal:* token passes portal:directory_read guard (REQ-TV-04)."""
+        from app.core.dependencies.users import require_human_scope
+
+        payload = _human_payload(["portal:*"])
+        guard = require_human_scope("portal:directory_read")
+        guard(payload)  # Should not raise
+
+    def test_require_human_scope_wildcard_token_passes_api_keys_manage(self) -> None:
+        """Explicit portal:* token passes portal:api_keys_manage guard."""
+        from app.core.dependencies.users import require_human_scope
+
+        payload = _human_payload(["portal:*"])
+        guard = require_human_scope("portal:api_keys_manage")
+        guard(payload)  # Should not raise
+
+    def test_require_human_scope_specific_token_fails_other_scope(self) -> None:
+        """Token with only portal:self_read fails portal:api_keys_manage (REQ-SE-03)."""
+        from app.core.dependencies.users import require_human_scope
+
+        payload = _human_payload(["portal:self_read"])
+        guard = require_human_scope("portal:api_keys_manage")
+        with pytest.raises(HTTPException) as exc_info:
+            guard(payload)
+        assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# CurrentAdminOrApiKey
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentAdminOrApiKey:
+    """Dual-auth guard for admin endpoints."""
+
+    def test_jwt_path_admin_role_succeeds(
+        self,
+        db,
+        admin_user_tenant_a,
+    ) -> None:
+        """Admin JWT (role=ADMIN) is accepted; returns UserPublic."""
+        from app.api.shared.enums import UserRole
+        from app.core.dependencies.users import CurrentAdminOrApiKey
+
+        payload = _user_payload(user_id=admin_user_tenant_a.id)
+        dep = CurrentAdminOrApiKey("attendees:read")
+        result = dep(token_payload=payload, db=db)
+
+        assert result.role in (UserRole.ADMIN, UserRole.SUPERADMIN)
+
+    def test_jwt_path_viewer_rejected(
+        self,
+        db,
+        viewer_user_tenant_a,
+    ) -> None:
+        """Viewer JWT raises 403 on admin-only endpoint."""
+        from app.core.dependencies.users import CurrentAdminOrApiKey
+
+        payload = _user_payload(user_id=viewer_user_tenant_a.id)
+        dep = CurrentAdminOrApiKey("attendees:read")
+        with pytest.raises(HTTPException) as exc_info:
+            dep(token_payload=payload, db=db)
+        assert exc_info.value.status_code == 403
+
+    def test_api_key_path_matching_scope_succeeds(
+        self,
+        db,
+        admin_api_key_factory,
+        admin_user_tenant_a,
+    ) -> None:
+        """Admin api-key with matching scope returns UserPublic."""
+        from app.core.dependencies.users import CurrentAdminOrApiKey
+
+        _row, _raw = admin_api_key_factory(scopes=["attendees:read"])
+        payload = _user_payload(
+            user_id=admin_user_tenant_a.id,
+            scopes=["attendees:read"],
+            via_api_key=True,
+        )
+        dep = CurrentAdminOrApiKey("attendees:read")
+        result = dep(token_payload=payload, db=db)
+        assert result is not None
+
+    def test_api_key_path_missing_scope_rejected_403(
+        self,
+        db,
+        admin_api_key_factory,
+        admin_user_tenant_a,
+    ) -> None:
+        """Admin api-key without required scope raises 403."""
+        from app.core.dependencies.users import CurrentAdminOrApiKey
+
+        _row, _raw = admin_api_key_factory(scopes=["attendees:read"])
+        payload = _user_payload(
+            user_id=admin_user_tenant_a.id,
+            scopes=["attendees:read"],  # has read but guard requires write
+            via_api_key=True,
+        )
+        dep = CurrentAdminOrApiKey("attendees:write")
+        with pytest.raises(HTTPException) as exc_info:
+            dep(token_payload=payload, db=db)
+        assert exc_info.value.status_code == 403
+
+    def test_human_jwt_rejected(self, db) -> None:
+        """Human JWT raises 403 on admin-only endpoint."""
+        from app.core.dependencies.users import CurrentAdminOrApiKey
+
+        payload = TokenPayload(
+            sub=str(uuid.uuid4()),
+            exp=datetime.now(UTC) + timedelta(minutes=30),
+            token_type="human",
+            scopes=["portal:*"],  # type: ignore[arg-type]
+        )
+        dep = CurrentAdminOrApiKey("attendees:read")
+        with pytest.raises(HTTPException) as exc_info:
+            dep(token_payload=payload, db=db)
+        assert exc_info.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility (grace period + wildcard)
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardsCompatibility:
+    """Explicit tests for REQ-TV-04 and the grace-period backward compat contract."""
+
+    def test_old_token_synthesised_portal_star_passes_all_guards(self) -> None:
+        """Old token (synthesised portal:*) passes all require_human_scope guards."""
+        from app.core.dependencies.users import require_human_scope
+
+        # Mint a legacy-style token (no scopes in the JWT payload).
+        token = create_access_token(subject=uuid.uuid4(), token_type="human")
+        payload = decode_access_token(token)
+
+        # Grace synthesis should have happened.
+        assert "portal:*" in payload.scopes
+
+        # Must pass all three guards.
+        for scope in ("portal:self_read", "portal:directory_read", "portal:api_keys_manage"):
+            guard = require_human_scope(scope)  # type: ignore[arg-type]
+            guard(payload)  # Should not raise
+
+    def test_new_token_with_self_read_only_passes_self_fails_others(self) -> None:
+        """New token with portal:self_read passes self-read, fails directory and api-keys."""
+        from app.core.dependencies.users import require_human_scope
+
+        token = create_access_token(
+            subject=uuid.uuid4(),
+            token_type="human",
+            scopes=["portal:self_read"],
+            issued_via="third_party",
+        )
+        payload = decode_access_token(token)
+
+        # self_read passes
+        guard_self = require_human_scope("portal:self_read")
+        guard_self(payload)
+
+        # directory_read fails
+        guard_dir = require_human_scope("portal:directory_read")
+        with pytest.raises(HTTPException) as exc_info:
+            guard_dir(payload)
+        assert exc_info.value.status_code == 403
+
+        # api_keys_manage fails
+        guard_keys = require_human_scope("portal:api_keys_manage")
+        with pytest.raises(HTTPException) as exc_info:
+            guard_keys(payload)
+        assert exc_info.value.status_code == 403

--- a/backend/tests/core/dependencies/test_tenants.py
+++ b/backend/tests/core/dependencies/test_tenants.py
@@ -50,6 +50,7 @@ def _make_tenant(tenant_id: uuid.UUID = _TENANT_A_ID) -> MagicMock:
     t.custom_domain_active = False
     t.landing_mode = LandingMode.portal
     t.active_popup_slug = None  # computed projection — not a DB column
+    t.third_party_key_prefix = None  # third-party OTP display fragment
     return t
 
 

--- a/backend/tests/core/test_security_scopes.py
+++ b/backend/tests/core/test_security_scopes.py
@@ -1,0 +1,186 @@
+"""Tests for TokenPayload scopes and issued_via fields.
+
+RED-phase tests for Block 2. These validate:
+  - TokenPayload carries scopes and issued_via.
+  - create_access_token encodes them into the JWT payload.
+  - decode_access_token recovers them.
+  - Grace-period synthesis for legacy human tokens.
+  - No grace synthesis for user tokens.
+  - Scope universe disjointness (sanity).
+  - ADMIN_API_KEY_SCOPES excludes the blacklisted domains.
+
+Tests are expected to FAIL until core/security.py is updated.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import get_args
+
+import jwt
+
+from app.core.config import settings
+from app.core.security import (
+    ADMIN_API_KEY_SCOPES,
+    ALGORITHM,
+    THIRD_PARTY_API_KEY_SCOPES,
+    THIRD_PARTY_TOKEN_SCOPES,
+    ApiKeyScope,
+    HumanScope,
+    create_access_token,
+    decode_access_token,
+)
+
+_BLACKLISTED_SCOPES = {
+    "email_templates",
+    "users",
+    "tenants",
+    "popup_reviewers",
+    "payments:write",
+}
+
+
+class TestTokenPayloadCarriesScopesAndIssuedVia:
+    """TokenPayload fields are present and default correctly."""
+
+    def test_token_payload_carries_scopes_and_issued_via(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from app.core.security import TokenPayload
+
+        payload = TokenPayload(
+            sub=str(uuid.uuid4()),
+            exp=datetime.now(UTC) + timedelta(minutes=30),
+            token_type="human",
+            issued_via="portal",
+            scopes=["portal:self_read"],
+        )
+
+        assert payload.issued_via == "portal"
+        assert payload.scopes == ["portal:self_read"]
+
+    def test_token_payload_defaults(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from app.core.security import TokenPayload
+
+        payload = TokenPayload(
+            sub=str(uuid.uuid4()),
+            exp=datetime.now(UTC) + timedelta(minutes=30),
+        )
+
+        assert payload.issued_via == "portal"
+        assert payload.scopes == []
+        assert payload.api_key_tenant_id is None
+
+
+class TestCreateDecodeRoundtrip:
+    """Encode and decode symmetry for new fields."""
+
+    def test_create_decode_roundtrip_third_party_scopes(self) -> None:
+        """create_access_token encodes scopes+issued_via; decode recovers them."""
+        token = create_access_token(
+            subject=uuid.uuid4(),
+            token_type="human",
+            scopes=list(THIRD_PARTY_TOKEN_SCOPES),
+            issued_via="third_party",
+        )
+        payload = decode_access_token(token)
+
+        assert payload.issued_via == "third_party"
+        assert set(payload.scopes) == set(THIRD_PARTY_TOKEN_SCOPES)
+
+    def test_create_decode_roundtrip_default_no_scopes(self) -> None:
+        """Token created without scopes decodes to empty list (not portal:*)."""
+        subject = uuid.uuid4()
+        token = create_access_token(subject=subject, token_type="user")
+        payload = decode_access_token(token)
+
+        assert payload.issued_via == "portal"
+        assert payload.scopes == []  # no grace synth for user tokens
+
+
+class TestGracePeriod:
+    """Legacy human tokens with absent/empty scopes get portal:* synthesised."""
+
+    def test_legacy_human_token_without_scopes_field_decodes_as_portal_star(
+        self,
+    ) -> None:
+        """A JWT with no `scopes` key in the payload (legacy) decodes as portal:*."""
+        # Mint a raw JWT manually without scopes key
+        import datetime as dt
+
+        raw_payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": dt.datetime.now(dt.UTC) + dt.timedelta(minutes=30),
+            "token_type": "human",
+        }
+        token = jwt.encode(raw_payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        payload = decode_access_token(token)
+
+        assert "portal:*" in payload.scopes
+        assert payload.issued_via == "portal"
+
+    def test_human_token_with_empty_scopes_decodes_as_portal_star(self) -> None:
+        """A JWT with scopes=[] is treated the same as absent scopes for humans."""
+        import datetime as dt
+
+        raw_payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": dt.datetime.now(dt.UTC) + dt.timedelta(minutes=30),
+            "token_type": "human",
+            "scopes": [],
+        }
+        token = jwt.encode(raw_payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        payload = decode_access_token(token)
+
+        assert "portal:*" in payload.scopes
+
+    def test_user_token_without_scopes_decodes_with_empty_list(self) -> None:
+        """User (admin) tokens do NOT get the portal:* grace synthesis."""
+        import datetime as dt
+
+        raw_payload = {
+            "sub": str(uuid.uuid4()),
+            "exp": dt.datetime.now(dt.UTC) + dt.timedelta(minutes=30),
+            "token_type": "user",
+        }
+        token = jwt.encode(raw_payload, settings.SECRET_KEY, algorithm=ALGORITHM)
+
+        payload = decode_access_token(token)
+
+        assert "portal:*" not in payload.scopes
+        assert payload.scopes == []
+
+
+class TestScopeUniverses:
+    """Sanity checks on the scope constant sets."""
+
+    def test_third_party_token_scopes_disjoint_from_api_key_universe(
+        self,
+    ) -> None:
+        """THIRD_PARTY_TOKEN_SCOPES (HumanScope) must not overlap ApiKeyScope."""
+        human_scopes = set(get_args(HumanScope))
+        api_key_scopes = set(get_args(ApiKeyScope))
+        overlap = human_scopes & api_key_scopes
+        assert overlap == set(), f"Overlapping scopes: {overlap}"
+
+    def test_admin_api_key_scopes_excludes_blacklist(self) -> None:
+        """ADMIN_API_KEY_SCOPES must not contain any blacklisted domain tokens."""
+        for scope in ADMIN_API_KEY_SCOPES:
+            for blacklisted in _BLACKLISTED_SCOPES:
+                assert not scope.startswith(blacklisted), (
+                    f"Scope '{scope}' looks like a blacklisted domain '{blacklisted}'"
+                )
+
+    def test_third_party_api_key_scopes_is_subset_of_admin_scopes(self) -> None:
+        """THIRD_PARTY_API_KEY_SCOPES is a proper subset of ADMIN_API_KEY_SCOPES."""
+        assert THIRD_PARTY_API_KEY_SCOPES.issubset(ADMIN_API_KEY_SCOPES)
+
+    def test_third_party_token_scopes_all_in_human_scope_literal(self) -> None:
+        """Every value in THIRD_PARTY_TOKEN_SCOPES must be a valid HumanScope."""
+        human_scope_values = set(get_args(HumanScope))
+        for scope in THIRD_PARTY_TOKEN_SCOPES:
+            assert scope in human_scope_values, f"'{scope}' not in HumanScope"

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -14636,7 +14636,8 @@ export const ThirdPartyHumanLoginSchema = {
     title: 'ThirdPartyHumanLogin',
     description: `Request body for POST /auth/human/third-party/login.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyHumanVerifySchema = {
@@ -14659,7 +14660,8 @@ export const ThirdPartyHumanVerifySchema = {
     title: 'ThirdPartyHumanVerify',
     description: `Request body for POST /auth/human/third-party/authenticate.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyKeyRotatedSchema = {

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -76,6 +76,190 @@ export const AbandonedCartPublicSchema = {
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;
 
+export const AdminApiKeyCreateSchema = {
+    properties: {
+        name: {
+            type: 'string',
+            maxLength: 100,
+            minLength: 1,
+            title: 'Name'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            minItems: 1,
+            title: 'Scopes'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        }
+    },
+    type: 'object',
+    required: ['name', 'scopes'],
+    title: 'AdminApiKeyCreate',
+    description: 'Request body for minting a new admin API key.'
+} as const;
+
+export const AdminApiKeyCreatedSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        },
+        raw_key: {
+            type: 'string',
+            title: 'Raw Key'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at', 'raw_key'],
+    title: 'AdminApiKeyCreated',
+    description: `Response returned only at creation.
+
+\`\`raw_key\`\` is the cleartext token shown once and never stored.`
+} as const;
+
+export const AdminApiKeyPublicSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at'],
+    title: 'AdminApiKeyPublic',
+    description: 'Safe representation of an admin API key — never includes the raw secret.'
+} as const;
+
 export const ApiKeyCreateSchema = {
     properties: {
         name: {
@@ -99,7 +283,7 @@ export const ApiKeyCreateSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -129,7 +313,7 @@ export const ApiKeyCreatedSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -205,7 +389,7 @@ export const ApiKeyPublicSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -14315,6 +14499,17 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Active Popup Slug'
+        },
+        third_party_key_prefix: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Third Party Key Prefix'
         }
     },
     type: 'object',
@@ -14426,6 +14621,62 @@ export const TenantUpdateSchema = {
     },
     type: 'object',
     title: 'TenantUpdate'
+} as const;
+
+export const ThirdPartyHumanLoginSchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        }
+    },
+    type: 'object',
+    required: ['email'],
+    title: 'ThirdPartyHumanLogin',
+    description: `Request body for POST /auth/human/third-party/login.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyHumanVerifySchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        },
+        code: {
+            type: 'string',
+            maxLength: 6,
+            minLength: 6,
+            pattern: '^\\d{6}$',
+            title: 'Code'
+        }
+    },
+    type: 'object',
+    required: ['email', 'code'],
+    title: 'ThirdPartyHumanVerify',
+    description: `Request body for POST /auth/human/third-party/authenticate.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyKeyRotatedSchema = {
+    properties: {
+        api_key: {
+            type: 'string',
+            title: 'Api Key'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        }
+    },
+    type: 'object',
+    required: ['api_key', 'prefix'],
+    title: 'ThirdPartyKeyRotated',
+    description: 'Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.'
 } as const;
 
 export const TicketAttendeeSnapshotSchema = {

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -3,7 +3,122 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+import type { AdminApiKeysCreateAdminApiKeyData, AdminApiKeysCreateAdminApiKeyResponse, AdminApiKeysListAdminApiKeysData, AdminApiKeysListAdminApiKeysResponse, AdminApiKeysGetAdminApiKeyData, AdminApiKeysGetAdminApiKeyResponse, AdminApiKeysRevokeAdminApiKeyData, AdminApiKeysRevokeAdminApiKeyResponse, ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, AuthThirdPartyHumanLoginData, AuthThirdPartyHumanLoginResponse, AuthThirdPartyHumanAuthenticateData, AuthThirdPartyHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TenantsRotateThirdPartyKeyData, TenantsRotateThirdPartyKeyResponse, TenantsDeleteThirdPartyKeyData, TenantsDeleteThirdPartyKeyResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+
+export class AdminApiKeysService {
+    /**
+     * Create Admin Api Key
+     * Mint a new admin API key.
+     *
+     * Scopes must be a subset of ADMIN_API_KEY_SCOPES. Any scope outside that
+     * universe returns 422. Write scopes require an expiry date (validated by
+     * the schema).
+     *
+     * The cleartext key is returned once in ``raw_key``; only the hash is stored.
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @param data.xTenantId
+     * @returns AdminApiKeyCreated Successful Response
+     * @throws ApiError
+     */
+    public static createAdminApiKey(data: AdminApiKeysCreateAdminApiKeyData): CancelablePromise<AdminApiKeysCreateAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * List Admin Api Keys
+     * List admin API keys.
+     *
+     * ADMIN sees only their own keys.
+     * SUPERADMIN sees all admin keys in the tenant they are operating on (via
+     * X-Tenant-Id header, already resolved by TenantSession).
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static listAdminApiKeys(data: AdminApiKeysListAdminApiKeysData = {}): CancelablePromise<AdminApiKeysListAdminApiKeysResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Get Admin Api Key
+     * Retrieve a specific admin API key.
+     *
+     * Visibility mirrors the list endpoint: ADMIN sees only own keys; SUPERADMIN
+     * sees any admin key in the tenant. Returns 404 for keys outside the caller's
+     * visibility — never 403, to avoid leaking existence of foreign keys.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static getAdminApiKey(data: AdminApiKeysGetAdminApiKeyData): CancelablePromise<AdminApiKeysGetAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Revoke Admin Api Key
+     * Revoke an admin API key by setting revoked_at.
+     *
+     * ADMIN can only revoke their own keys (403 for foreign keys).
+     * SUPERADMIN can revoke any admin key in their tenant scope.
+     * Non-existent keys return 404.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static revokeAdminApiKey(data: AdminApiKeysRevokeAdminApiKeyData): CancelablePromise<AdminApiKeysRevokeAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
 
 export class ApiKeysService {
     /**
@@ -1332,6 +1447,69 @@ export class AuthService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/auth/human/authenticate',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Login
+     * Initiate OTP login for an EXISTING human via a third-party integration.
+     *
+     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending human
+     * row — the partner is expected to have onboarded the user out-of-band.
+     *
+     * On any validation failure (unknown tenant, feature disabled, wrong key,
+     * unknown email) the response is 401 to prevent existence leakage.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns AuthCodeSentResponse Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanLogin(data: AuthThirdPartyHumanLoginData): CancelablePromise<AuthThirdPartyHumanLoginResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/login',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Authenticate
+     * Verify OTP and mint a third-party JWT for an existing human.
+     *
+     * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
+     * The JWT grants portal:self_read, portal:directory_read, and
+     * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns Token Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanAuthenticate(data: AuthThirdPartyHumanAuthenticateData): CancelablePromise<AuthThirdPartyHumanAuthenticateResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/authenticate',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
@@ -5998,6 +6176,59 @@ export class TenantsService {
             }
         });
     }
+    
+    /**
+     * Rotate Third Party Key
+     * Generate and store a new third-party API key for this tenant.
+     *
+     * The raw key is returned ONCE and never stored; only its peppered SHA-256
+     * hash is persisted. Rotation takes effect on the NEXT login attempt;
+     * in-flight JWTs already issued remain valid until their own expiry.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns ThirdPartyKeyRotated Successful Response
+     * @throws ApiError
+     */
+    public static rotateThirdPartyKey(data: TenantsRotateThirdPartyKeyData): CancelablePromise<TenantsRotateThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key/rotate',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Third Party Key
+     * Disable third-party login for this tenant by clearing the key hash.
+     *
+     * After this call, POST /auth/human/third-party/login returns 401 for this
+     * tenant until a new key is rotated in.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteThirdPartyKey(data: TenantsDeleteThirdPartyKeyData): CancelablePromise<TenantsDeleteThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
 }
 
 export class TicketingStepsService {
@@ -6696,8 +6927,8 @@ export class VenuePropertyTypesService {
     /**
      * Create Property Type
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns VenuePropertyTypePublic Successful Response
      * @throws ApiError
      */

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -1459,14 +1459,15 @@ export class AuthService {
      * Third Party Human Login
      * Initiate OTP login for an EXISTING human via a third-party integration.
      *
-     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
-     * Unlike the portal login endpoint, this surface NEVER creates a pending human
-     * row — the partner is expected to have onboarded the user out-of-band.
+     * The caller supplies only a valid third-party API key in
+     * X-Third-Party-Api-Key; the tenant is resolved server-side from the key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending
+     * human row — the partner is expected to have onboarded the user
+     * out-of-band.
      *
-     * On any validation failure (unknown tenant, feature disabled, wrong key,
-     * unknown email) the response is 401 to prevent existence leakage.
+     * On any validation failure (wrong key, unknown email) the response is 401
+     * to prevent existence leakage.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns AuthCodeSentResponse Successful Response
@@ -1477,7 +1478,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/login',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,
@@ -1492,11 +1492,11 @@ export class AuthService {
      * Third Party Human Authenticate
      * Verify OTP and mint a third-party JWT for an existing human.
      *
+     * The tenant is resolved server-side from the third-party API key alone.
      * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
      * The JWT grants portal:self_read, portal:directory_read, and
      * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns Token Successful Response
@@ -1507,7 +1507,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/authenticate',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2886,7 +2886,8 @@ export type TenantUpdate = {
 /**
  * Request body for POST /auth/human/third-party/login.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanLogin = {
     email: string;
@@ -2895,7 +2896,8 @@ export type ThirdPartyHumanLogin = {
 /**
  * Request body for POST /auth/human/third-party/authenticate.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanVerify = {
     email: string;
@@ -3718,7 +3720,6 @@ export type AuthHumanAuthenticateResponse = (Token);
 
 export type AuthThirdPartyHumanLoginData = {
     requestBody: ThirdPartyHumanLogin;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 
@@ -3726,7 +3727,6 @@ export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
 
 export type AuthThirdPartyHumanAuthenticateData = {
     requestBody: ThirdPartyHumanVerify;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -13,6 +13,46 @@ export type AbandonedCartPublic = {
     payments?: Array<CartPaymentInfo>;
 };
 
+/**
+ * Request body for minting a new admin API key.
+ */
+export type AdminApiKeyCreate = {
+    name: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    expires_at?: (string | null);
+};
+
+/**
+ * Response returned only at creation.
+ *
+ * ``raw_key`` is the cleartext token shown once and never stored.
+ */
+export type AdminApiKeyCreated = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+    raw_key: string;
+};
+
+/**
+ * Safe representation of an admin API key — never includes the raw secret.
+ */
+export type AdminApiKeyPublic = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+};
+
 export type AITranslateRequest = {
     entity_type: string;
     entity_id: string;
@@ -25,7 +65,7 @@ export type AITranslateRequest = {
 export type ApiKeyCreate = {
     name: string;
     expires_at?: (string | null);
-    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
 };
 
 /**
@@ -36,7 +76,7 @@ export type ApiKeyCreated = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -51,7 +91,7 @@ export type ApiKeyPublic = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -2828,6 +2868,7 @@ export type TenantPublic = {
     landing_mode?: LandingMode;
     id: string;
     active_popup_slug?: (string | null);
+    third_party_key_prefix?: (string | null);
 };
 
 export type TenantUpdate = {
@@ -2840,6 +2881,33 @@ export type TenantUpdate = {
     custom_domain?: (string | null);
     custom_domain_active?: (boolean | null);
     landing_mode?: (LandingMode | null);
+};
+
+/**
+ * Request body for POST /auth/human/third-party/login.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanLogin = {
+    email: string;
+};
+
+/**
+ * Request body for POST /auth/human/third-party/authenticate.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanVerify = {
+    email: string;
+    code: string;
+};
+
+/**
+ * Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.
+ */
+export type ThirdPartyKeyRotated = {
+    api_key: string;
+    prefix: string;
 };
 
 /**
@@ -3212,6 +3280,33 @@ export type VenueWeeklyHourRef = {
 export type VenueWeeklyHoursUpdate = {
     hours: Array<VenueWeeklyHourInput>;
 };
+
+export type AdminApiKeysCreateAdminApiKeyData = {
+    requestBody: AdminApiKeyCreate;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysCreateAdminApiKeyResponse = (AdminApiKeyCreated);
+
+export type AdminApiKeysListAdminApiKeysData = {
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysListAdminApiKeysResponse = (Array<AdminApiKeyPublic>);
+
+export type AdminApiKeysGetAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysGetAdminApiKeyResponse = (AdminApiKeyPublic);
+
+export type AdminApiKeysRevokeAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysRevokeAdminApiKeyResponse = (void);
 
 export type ApiKeysListApiKeysResponse = (Array<ApiKeyPublic>);
 
@@ -3620,6 +3715,22 @@ export type AuthHumanAuthenticateData = {
 };
 
 export type AuthHumanAuthenticateResponse = (Token);
+
+export type AuthThirdPartyHumanLoginData = {
+    requestBody: ThirdPartyHumanLogin;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
+
+export type AuthThirdPartyHumanAuthenticateData = {
+    requestBody: ThirdPartyHumanVerify;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanAuthenticateResponse = (Token);
 
 export type BaseFieldConfigsListBaseFieldConfigsData = {
     /**
@@ -5082,6 +5193,18 @@ export type TenantsDeleteCredentialsData = {
 
 export type TenantsDeleteCredentialsResponse = (void);
 
+export type TenantsRotateThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsRotateThirdPartyKeyResponse = (ThirdPartyKeyRotated);
+
+export type TenantsDeleteThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsDeleteThirdPartyKeyResponse = (void);
+
 export type TicketingStepsListPortalTicketingStepsData = {
     popupId: string;
 };
@@ -5332,7 +5455,7 @@ export type VenuePropertyTypesListPropertyTypesResponse = (Array<VenuePropertyTy
 
 export type VenuePropertyTypesCreatePropertyTypeData = {
     requestBody: VenuePropertyTypeCreate;
-    xTenantId: string;
+    xTenantId?: (string | null);
 };
 
 export type VenuePropertyTypesCreatePropertyTypeResponse = (VenuePropertyTypePublic);

--- a/backoffice/src/components/Sidebar/AppSidebar.tsx
+++ b/backoffice/src/components/Sidebar/AppSidebar.tsx
@@ -86,6 +86,12 @@ const agenticItems: Item[] = [
   { icon: KeyRound, title: "API Keys", path: "/api-keys" },
 ]
 
+// Feature flag: surface the Agentic access section in the sidebar.
+// The /api-keys route and CRUD endpoints stay live (admins can still create
+// keys via the API), but the UI entry is hidden until we are ready to expose
+// it to users.
+const SHOW_AGENTIC_ACCESS = false
+
 // Superadmin only items - organizations list view
 const superadminItems: Item[] = [
   { icon: Building2, title: "Organizations", path: "/organizations" },
@@ -195,14 +201,16 @@ export function AppSidebar() {
           </SidebarGroup>
         )}
 
-        {/* Agentic access (API Keys + Docs) — admins and superadmins only */}
-        {(currentUser?.role === "admin" ||
-          currentUser?.role === "superadmin") && (
-          <SidebarGroup>
-            <SidebarGroupLabel>Agentic access</SidebarGroupLabel>
-            <Main items={agenticItems} />
-          </SidebarGroup>
-        )}
+        {/* Agentic access (API Keys + Docs) — admins and superadmins only.
+            Gated behind SHOW_AGENTIC_ACCESS while the feature is hidden. */}
+        {SHOW_AGENTIC_ACCESS &&
+          (currentUser?.role === "admin" ||
+            currentUser?.role === "superadmin") && (
+            <SidebarGroup>
+              <SidebarGroupLabel>Agentic access</SidebarGroupLabel>
+              <Main items={agenticItems} />
+            </SidebarGroup>
+          )}
       </SidebarContent>
       <SidebarFooter>
         <SidebarAppearance />

--- a/backoffice/src/components/Sidebar/AppSidebar.tsx
+++ b/backoffice/src/components/Sidebar/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   FormInput,
   Home,
+  KeyRound,
   LayoutList,
   ListTree,
   Mail,
@@ -79,6 +80,11 @@ const eventItems: Item[] = [
 
 // Admin items (admins and superadmins)
 const adminItems: Item[] = [{ icon: Users, title: "Users", path: "/admin" }]
+
+// Agentic access items (admins and superadmins only)
+const agenticItems: Item[] = [
+  { icon: KeyRound, title: "API Keys", path: "/api-keys" },
+]
 
 // Superadmin only items - organizations list view
 const superadminItems: Item[] = [
@@ -186,6 +192,15 @@ export function AppSidebar() {
             <SidebarGroupLabel>Administration</SidebarGroupLabel>
             <Main items={adminNavigationItems} />
             {isSuperadmin && <Main items={superadminItems} />}
+          </SidebarGroup>
+        )}
+
+        {/* Agentic access (API Keys + Docs) — admins and superadmins only */}
+        {(currentUser?.role === "admin" ||
+          currentUser?.role === "superadmin") && (
+          <SidebarGroup>
+            <SidebarGroupLabel>Agentic access</SidebarGroupLabel>
+            <Main items={agenticItems} />
           </SidebarGroup>
         )}
       </SidebarContent>

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -64,7 +64,7 @@ const PORTAL_DOMAIN = import.meta.env.VITE_PORTAL_DOMAIN ?? ""
 export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { isSuperadmin } = useAuth()
+  const { isAdmin, isSuperadmin } = useAuth()
   const [copied, setCopied] = useState(false)
 
   const cnameTarget =
@@ -530,7 +530,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
         </div>
       )}
 
-      {isEdit && (
+      {isEdit && isAdmin && (
         <div className="mx-auto max-w-2xl">
           <ThirdPartyIntegrationSection
             tenantId={defaultValues.id}

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -23,6 +23,7 @@ import {
 import { DangerZone } from "@/components/Common/DangerZone"
 import { FieldError } from "@/components/Common/FieldError"
 import { TenantCredentialsSection } from "@/components/forms/TenantCredentialsSection"
+import { ThirdPartyIntegrationSection } from "@/components/forms/ThirdPartyIntegrationSection"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -526,6 +527,15 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
       {isEdit && isSuperadmin && (
         <div className="mx-auto max-w-2xl">
           <TenantCredentialsSection tenantId={defaultValues.id} />
+        </div>
+      )}
+
+      {isEdit && (
+        <div className="mx-auto max-w-2xl">
+          <ThirdPartyIntegrationSection
+            tenantId={defaultValues.id}
+            prefix={defaultValues.third_party_key_prefix}
+          />
         </div>
       )}
 

--- a/backoffice/src/components/forms/ThirdPartyIntegrationSection.tsx
+++ b/backoffice/src/components/forms/ThirdPartyIntegrationSection.tsx
@@ -1,0 +1,282 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import {
+  AlertTriangle,
+  Check,
+  Copy,
+  Link2,
+  RefreshCw,
+  Unlink,
+} from "lucide-react"
+import { useState } from "react"
+
+import { TenantsService, type ThirdPartyKeyRotated } from "@/client"
+import { Alert, AlertDescription } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { InlineRow, InlineSection } from "@/components/ui/inline-form"
+import { LoadingButton } from "@/components/ui/loading-button"
+import useCustomToast from "@/hooks/useCustomToast"
+import { createErrorHandler } from "@/utils"
+
+interface ThirdPartyIntegrationSectionProps {
+  tenantId: string
+  /** Prefix is null when third-party integration is not yet configured */
+  prefix: string | null | undefined
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        navigator.clipboard.writeText(value)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
+    >
+      {copied ? (
+        <>
+          <Check className="mr-2 h-4 w-4" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="mr-2 h-4 w-4" />
+          Copy key
+        </>
+      )}
+    </Button>
+  )
+}
+
+function RevealKeyDialog({
+  result,
+  onClose,
+}: {
+  result: ThirdPartyKeyRotated
+  onClose: () => void
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Third-party API key generated</DialogTitle>
+          <DialogDescription>
+            Save this key now. You will not be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-md border bg-muted p-3">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+            <p className="text-xs text-muted-foreground">
+              Distribute this key to your third-party integration partner.
+              Anyone with this key can initiate OTP logins for your portal
+              users. Store it securely and rotate it if it is ever compromised.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-3 font-mono text-sm break-all select-all">
+            {result.api_key}
+          </div>
+          <CopyButton value={result.api_key} />
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>I have saved it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RotateConfirmDialog({
+  onConfirm,
+  onClose,
+  isPending,
+}: {
+  onConfirm: () => void
+  onClose: () => void
+  isPending: boolean
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rotate third-party API key</DialogTitle>
+          <DialogDescription>
+            A new key will be generated and the current key will stop working
+            immediately. All third-party clients must be updated to use the new
+            key.
+          </DialogDescription>
+        </DialogHeader>
+        <Alert>
+          <AlertDescription>
+            In-flight portal sessions that were authenticated before rotation
+            will remain valid until their tokens expire naturally.
+          </AlertDescription>
+        </Alert>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton loading={isPending} onClick={onConfirm}>
+            Rotate key
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DisableConfirmDialog({
+  onConfirm,
+  onClose,
+  isPending,
+}: {
+  onConfirm: () => void
+  onClose: () => void
+  isPending: boolean
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Disable third-party login</DialogTitle>
+          <DialogDescription>
+            Third-party OTP login will be disabled for all users in this tenant.
+            Existing portal sessions remain valid until they expire.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            variant="destructive"
+            loading={isPending}
+            onClick={onConfirm}
+          >
+            Disable
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function ThirdPartyIntegrationSection({
+  tenantId,
+  prefix,
+}: ThirdPartyIntegrationSectionProps) {
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const queryClient = useQueryClient()
+
+  const [rotateDialogOpen, setRotateDialogOpen] = useState(false)
+  const [disableDialogOpen, setDisableDialogOpen] = useState(false)
+  const [revealResult, setRevealResult] = useState<ThirdPartyKeyRotated | null>(
+    null,
+  )
+
+  const rotateMutation = useMutation({
+    mutationFn: () => TenantsService.rotateThirdPartyKey({ tenantId }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["tenants", tenantId] })
+      setRotateDialogOpen(false)
+      setRevealResult(result)
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => TenantsService.deleteThirdPartyKey({ tenantId }),
+    onSuccess: () => {
+      showSuccessToast("Third-party login disabled")
+      queryClient.invalidateQueries({ queryKey: ["tenants", tenantId] })
+      setDisableDialogOpen(false)
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  const isEnabled = !!prefix
+
+  return (
+    <>
+      <InlineSection title="Third-party integration">
+        <InlineRow
+          icon={<Link2 className="h-4 w-4 text-muted-foreground" />}
+          label="Third-party OTP login"
+          description={
+            isEnabled
+              ? `Enabled - prefix: ${prefix}`
+              : "Disabled - generate a key to enable"
+          }
+        >
+          {isEnabled ? (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setRotateDialogOpen(true)}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Rotate key
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                onClick={() => setDisableDialogOpen(true)}
+              >
+                <Unlink className="mr-2 h-4 w-4" />
+                Disable
+              </Button>
+            </div>
+          ) : (
+            <LoadingButton
+              type="button"
+              variant="outline"
+              size="sm"
+              loading={rotateMutation.isPending}
+              onClick={() => rotateMutation.mutate()}
+            >
+              Generate API key
+            </LoadingButton>
+          )}
+        </InlineRow>
+      </InlineSection>
+
+      {rotateDialogOpen && (
+        <RotateConfirmDialog
+          onConfirm={() => rotateMutation.mutate()}
+          onClose={() => setRotateDialogOpen(false)}
+          isPending={rotateMutation.isPending}
+        />
+      )}
+
+      {disableDialogOpen && (
+        <DisableConfirmDialog
+          onConfirm={() => deleteMutation.mutate()}
+          onClose={() => setDisableDialogOpen(false)}
+          isPending={deleteMutation.isPending}
+        />
+      )}
+
+      {revealResult && (
+        <RevealKeyDialog
+          result={revealResult}
+          onClose={() => setRevealResult(null)}
+        />
+      )}
+    </>
+  )
+}

--- a/backoffice/src/routeTree.gen.ts
+++ b/backoffice/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutPaymentsRouteImport } from './routes/_layout/payments'
 import { Route as LayoutCheckInRouteImport } from './routes/_layout/check-in'
 import { Route as LayoutAttendeesRouteImport } from './routes/_layout/attendees'
+import { Route as LayoutApiKeysRouteImport } from './routes/_layout/api-keys'
 import { Route as LayoutAbandonedCartsRouteImport } from './routes/_layout/abandoned-carts'
 import { Route as LayoutTicketingStepsIndexRouteImport } from './routes/_layout/ticketing-steps/index'
 import { Route as LayoutThemeIndexRouteImport } from './routes/_layout/theme/index'
@@ -98,6 +99,11 @@ const LayoutCheckInRoute = LayoutCheckInRouteImport.update({
 const LayoutAttendeesRoute = LayoutAttendeesRouteImport.update({
   id: '/attendees',
   path: '/attendees',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutApiKeysRoute = LayoutApiKeysRouteImport.update({
+  id: '/api-keys',
+  path: '/api-keys',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutAbandonedCartsRoute = LayoutAbandonedCartsRouteImport.update({
@@ -362,6 +368,7 @@ export interface FileRoutesByFullPath {
   '/': typeof LayoutIndexRoute
   '/login': typeof LoginRoute
   '/abandoned-carts': typeof LayoutAbandonedCartsRoute
+  '/api-keys': typeof LayoutApiKeysRoute
   '/attendees': typeof LayoutAttendeesRoute
   '/check-in': typeof LayoutCheckInRoute
   '/payments': typeof LayoutPaymentsRoute
@@ -418,6 +425,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/abandoned-carts': typeof LayoutAbandonedCartsRoute
+  '/api-keys': typeof LayoutApiKeysRoute
   '/attendees': typeof LayoutAttendeesRoute
   '/check-in': typeof LayoutCheckInRoute
   '/payments': typeof LayoutPaymentsRoute
@@ -477,6 +485,7 @@ export interface FileRoutesById {
   '/_layout': typeof LayoutRouteWithChildren
   '/login': typeof LoginRoute
   '/_layout/abandoned-carts': typeof LayoutAbandonedCartsRoute
+  '/_layout/api-keys': typeof LayoutApiKeysRoute
   '/_layout/attendees': typeof LayoutAttendeesRoute
   '/_layout/check-in': typeof LayoutCheckInRoute
   '/_layout/payments': typeof LayoutPaymentsRoute
@@ -537,6 +546,7 @@ export interface FileRouteTypes {
     | '/'
     | '/login'
     | '/abandoned-carts'
+    | '/api-keys'
     | '/attendees'
     | '/check-in'
     | '/payments'
@@ -593,6 +603,7 @@ export interface FileRouteTypes {
   to:
     | '/login'
     | '/abandoned-carts'
+    | '/api-keys'
     | '/attendees'
     | '/check-in'
     | '/payments'
@@ -651,6 +662,7 @@ export interface FileRouteTypes {
     | '/_layout'
     | '/login'
     | '/_layout/abandoned-carts'
+    | '/_layout/api-keys'
     | '/_layout/attendees'
     | '/_layout/check-in'
     | '/_layout/payments'
@@ -760,6 +772,13 @@ declare module '@tanstack/react-router' {
       path: '/attendees'
       fullPath: '/attendees'
       preLoaderRoute: typeof LayoutAttendeesRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/api-keys': {
+      id: '/_layout/api-keys'
+      path: '/api-keys'
+      fullPath: '/api-keys'
+      preLoaderRoute: typeof LayoutApiKeysRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/abandoned-carts': {
@@ -1110,6 +1129,7 @@ declare module '@tanstack/react-router' {
 
 interface LayoutRouteChildren {
   LayoutAbandonedCartsRoute: typeof LayoutAbandonedCartsRoute
+  LayoutApiKeysRoute: typeof LayoutApiKeysRoute
   LayoutAttendeesRoute: typeof LayoutAttendeesRoute
   LayoutCheckInRoute: typeof LayoutCheckInRoute
   LayoutPaymentsRoute: typeof LayoutPaymentsRoute
@@ -1167,6 +1187,7 @@ interface LayoutRouteChildren {
 
 const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAbandonedCartsRoute: LayoutAbandonedCartsRoute,
+  LayoutApiKeysRoute: LayoutApiKeysRoute,
   LayoutAttendeesRoute: LayoutAttendeesRoute,
   LayoutCheckInRoute: LayoutCheckInRoute,
   LayoutPaymentsRoute: LayoutPaymentsRoute,

--- a/backoffice/src/routes/_layout/api-keys.tsx
+++ b/backoffice/src/routes/_layout/api-keys.tsx
@@ -1,0 +1,588 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import type { ColumnDef } from "@tanstack/react-table"
+import { AlertTriangle, Check, Copy, KeyRound, Plus } from "lucide-react"
+import { useState } from "react"
+
+import {
+  type AdminApiKeyCreate,
+  type AdminApiKeyPublic,
+  AdminApiKeysService,
+} from "@/client"
+import { DataTable } from "@/components/Common/DataTable"
+import { EmptyState } from "@/components/Common/EmptyState"
+import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { Skeleton } from "@/components/ui/skeleton"
+import useAuth from "@/hooks/useAuth"
+import useCustomToast from "@/hooks/useCustomToast"
+import { createErrorHandler } from "@/utils"
+
+// Kept in sync with ADMIN_API_KEY_SCOPES in backend core/security.py
+const ADMIN_API_KEY_SCOPES = [
+  "events:read",
+  "events:write",
+  "rsvp:write",
+  "venues:write",
+  "applications:read",
+  "applications:write",
+  "attendees:read",
+  "attendees:write",
+  "humans:read",
+  "humans:write",
+  "groups:read",
+  "groups:write",
+  "products:read",
+  "products:write",
+  "coupons:read",
+  "coupons:write",
+  "forms:read",
+  "forms:write",
+  "payments:read",
+  "tracks:read",
+  "tracks:write",
+  "ticketing_steps:read",
+  "ticketing_steps:write",
+  "translations:read",
+  "translations:write",
+] as const
+
+type AdminApiKeyScope = (typeof ADMIN_API_KEY_SCOPES)[number]
+
+const SCOPE_GROUPS: { label: string; scopes: AdminApiKeyScope[] }[] = [
+  {
+    label: "Events",
+    scopes: ["events:read", "events:write", "rsvp:write", "venues:write"],
+  },
+  {
+    label: "Applications",
+    scopes: ["applications:read", "applications:write"],
+  },
+  {
+    label: "People",
+    scopes: [
+      "attendees:read",
+      "attendees:write",
+      "humans:read",
+      "humans:write",
+      "groups:read",
+      "groups:write",
+    ],
+  },
+  {
+    label: "Catalog",
+    scopes: [
+      "products:read",
+      "products:write",
+      "coupons:read",
+      "coupons:write",
+      "forms:read",
+      "forms:write",
+    ],
+  },
+  { label: "Financial", scopes: ["payments:read"] },
+  {
+    label: "Structure",
+    scopes: [
+      "tracks:read",
+      "tracks:write",
+      "ticketing_steps:read",
+      "ticketing_steps:write",
+      "translations:read",
+      "translations:write",
+    ],
+  },
+]
+
+export const Route = createFileRoute("/_layout/api-keys")({
+  component: ApiKeysPage,
+  head: () => ({
+    meta: [{ title: "API Keys - EdgeOS" }],
+  }),
+})
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "Never"
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        navigator.clipboard.writeText(value)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
+    >
+      {copied ? (
+        <>
+          <Check className="mr-2 h-4 w-4" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Copy className="mr-2 h-4 w-4" />
+          Copy key
+        </>
+      )}
+    </Button>
+  )
+}
+
+function RevealKeyDialog({
+  rawKey,
+  onClose,
+}: {
+  rawKey: string
+  onClose: () => void
+}) {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>API key created</DialogTitle>
+          <DialogDescription>
+            Save this key now. You will not be able to see it again.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 rounded-md border bg-muted p-3">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+            <p className="text-xs text-muted-foreground">
+              Copy the key below and store it securely. Once you close this
+              dialog, the key is gone from this interface.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-3 font-mono text-sm break-all select-all">
+            {rawKey}
+          </div>
+          <CopyButton value={rawKey} />
+        </div>
+        <DialogFooter>
+          <Button onClick={onClose}>I have saved it</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CreateKeyDialog({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void
+  onCreated: (rawKey: string) => void
+}) {
+  const { showErrorToast } = useCustomToast()
+  const queryClient = useQueryClient()
+
+  const [name, setName] = useState("")
+  const [selectedScopes, setSelectedScopes] = useState<AdminApiKeyScope[]>([])
+  const [expiresAt, setExpiresAt] = useState("")
+  const [nameError, setNameError] = useState("")
+  const [scopeError, setScopeError] = useState("")
+  const [expiresError, setExpiresError] = useState("")
+
+  const hasWriteScope = selectedScopes.some((s) => s.endsWith(":write"))
+
+  const createMutation = useMutation({
+    mutationFn: (data: AdminApiKeyCreate) =>
+      AdminApiKeysService.createAdminApiKey({ requestBody: data }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] })
+      onCreated(result.raw_key)
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  function toggleScope(scope: AdminApiKeyScope) {
+    setSelectedScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope],
+    )
+    setScopeError("")
+    setExpiresError("")
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    let valid = true
+    if (!name.trim()) {
+      setNameError("Name is required")
+      valid = false
+    }
+    if (selectedScopes.length === 0) {
+      setScopeError("Select at least one scope")
+      valid = false
+    }
+    if (hasWriteScope && !expiresAt) {
+      setExpiresError(
+        "Expiry date is required when any write scope is selected",
+      )
+      valid = false
+    }
+    if (!valid) return
+
+    createMutation.mutate({
+      name: name.trim(),
+      scopes: selectedScopes,
+      expires_at: expiresAt || null,
+    })
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create API key</DialogTitle>
+            <DialogDescription>
+              Admin API keys let external services call the backoffice API on
+              behalf of this admin account.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-5 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="api-key-name">Name</Label>
+              <Input
+                id="api-key-name"
+                placeholder="e.g. CI pipeline"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  setNameError("")
+                }}
+              />
+              {nameError && (
+                <p className="text-sm text-destructive">{nameError}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label>Scopes</Label>
+              <p className="text-xs text-muted-foreground">
+                Select the permissions this key should have.
+              </p>
+              {scopeError && (
+                <p className="text-sm text-destructive">{scopeError}</p>
+              )}
+              <div className="space-y-4">
+                {SCOPE_GROUPS.map((group) => (
+                  <div key={group.label} className="space-y-2">
+                    <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      {group.label}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {group.scopes.map((scope) => {
+                        const isSelected = selectedScopes.includes(scope)
+                        return (
+                          <button
+                            key={scope}
+                            type="button"
+                            onClick={() => toggleScope(scope)}
+                            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                              isSelected
+                                ? "border-primary bg-primary text-primary-foreground"
+                                : "border-muted-foreground/30 bg-background text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                            }`}
+                          >
+                            {scope}
+                          </button>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="api-key-expires">
+                Expires at
+                {hasWriteScope && (
+                  <span className="ml-1 text-destructive">*</span>
+                )}
+              </Label>
+              {hasWriteScope && (
+                <p className="text-xs text-muted-foreground">
+                  Required when any write scope is selected.
+                </p>
+              )}
+              <Input
+                id="api-key-expires"
+                type="date"
+                value={expiresAt}
+                min={new Date().toISOString().split("T")[0]}
+                onChange={(e) => {
+                  setExpiresAt(e.target.value)
+                  setExpiresError("")
+                }}
+              />
+              {expiresError && (
+                <p className="text-sm text-destructive">{expiresError}</p>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <LoadingButton type="submit" loading={createMutation.isPending}>
+              Create key
+            </LoadingButton>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RevokeKeyDialog({
+  keyId,
+  keyName,
+  onClose,
+}: {
+  keyId: string
+  keyName: string
+  onClose: () => void
+}) {
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+  const queryClient = useQueryClient()
+
+  const revokeMutation = useMutation({
+    mutationFn: () => AdminApiKeysService.revokeAdminApiKey({ keyId }),
+    onSuccess: () => {
+      showSuccessToast("API key revoked")
+      queryClient.invalidateQueries({ queryKey: ["admin-api-keys"] })
+      onClose()
+    },
+    onError: createErrorHandler(showErrorToast),
+  })
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Revoke API key</DialogTitle>
+          <DialogDescription>
+            Revoke &ldquo;{keyName}&rdquo;? Any service using this key will stop
+            working immediately. This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            variant="destructive"
+            loading={revokeMutation.isPending}
+            onClick={() => revokeMutation.mutate()}
+          >
+            Revoke key
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ApiKeysTable() {
+  const [createOpen, setCreateOpen] = useState(false)
+  const [rawKey, setRawKey] = useState<string | null>(null)
+  const [revokeTarget, setRevokeTarget] = useState<AdminApiKeyPublic | null>(
+    null,
+  )
+
+  const { data: keys, isLoading } = useQuery({
+    queryKey: ["admin-api-keys"],
+    queryFn: () => AdminApiKeysService.listAdminApiKeys(),
+  })
+
+  const columns: ColumnDef<AdminApiKeyPublic>[] = [
+    {
+      accessorKey: "name",
+      header: "Name",
+      cell: ({ row }) => (
+        <div>
+          <p className="font-medium">{row.original.name}</p>
+          <p className="text-xs text-muted-foreground font-mono">
+            {row.original.prefix}...
+          </p>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "scopes",
+      header: "Scopes",
+      cell: ({ row }) => (
+        <div className="flex flex-wrap gap-1">
+          {row.original.scopes.slice(0, 3).map((scope) => (
+            <Badge key={scope} variant="secondary" className="text-xs">
+              {scope}
+            </Badge>
+          ))}
+          {row.original.scopes.length > 3 && (
+            <Badge variant="outline" className="text-xs">
+              +{row.original.scopes.length - 3} more
+            </Badge>
+          )}
+        </div>
+      ),
+    },
+    {
+      accessorKey: "expires_at",
+      header: "Expires",
+      cell: ({ row }) => (
+        <span className="text-sm">{formatDate(row.original.expires_at)}</span>
+      ),
+    },
+    {
+      accessorKey: "last_used_at",
+      header: "Last used",
+      cell: ({ row }) => (
+        <span className="text-sm">{formatDate(row.original.last_used_at)}</span>
+      ),
+    },
+    {
+      accessorKey: "revoked_at",
+      header: "Status",
+      cell: ({ row }) =>
+        row.original.revoked_at ? (
+          <Badge variant="destructive">Revoked</Badge>
+        ) : (
+          <Badge variant="secondary">Active</Badge>
+        ),
+    },
+    {
+      id: "actions",
+      cell: ({ row }) =>
+        !row.original.revoked_at ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={(e) => {
+              e.stopPropagation()
+              setRevokeTarget(row.original)
+            }}
+          >
+            Revoke
+          </Button>
+        ) : null,
+    },
+  ]
+
+  if (isLoading) return <Skeleton className="h-64 w-full" />
+  if (!keys) return null
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        data={keys}
+        emptyState={
+          <EmptyState
+            icon={KeyRound}
+            title="No API keys yet"
+            description="Create an API key to get started."
+            action={
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Create new key
+              </Button>
+            }
+          />
+        }
+      />
+
+      {createOpen && (
+        <CreateKeyDialog
+          onClose={() => setCreateOpen(false)}
+          onCreated={(key) => {
+            setCreateOpen(false)
+            setRawKey(key)
+          }}
+        />
+      )}
+
+      {rawKey && (
+        <RevealKeyDialog rawKey={rawKey} onClose={() => setRawKey(null)} />
+      )}
+
+      {revokeTarget && (
+        <RevokeKeyDialog
+          keyId={revokeTarget.id}
+          keyName={revokeTarget.name}
+          onClose={() => setRevokeTarget(null)}
+        />
+      )}
+    </>
+  )
+}
+
+function ApiKeysPage() {
+  const { isAdmin } = useAuth()
+  const [createOpen, setCreateOpen] = useState(false)
+  const [rawKey, setRawKey] = useState<string | null>(null)
+
+  if (!isAdmin) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">API Keys</h1>
+          <p className="text-muted-foreground">
+            Manage admin API keys for programmatic backoffice access
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create new key
+        </Button>
+      </div>
+
+      <QueryErrorBoundary>
+        <ApiKeysTable />
+      </QueryErrorBoundary>
+
+      {createOpen && (
+        <CreateKeyDialog
+          onClose={() => setCreateOpen(false)}
+          onCreated={(key) => {
+            setCreateOpen(false)
+            setRawKey(key)
+          }}
+        />
+      )}
+
+      {rawKey && (
+        <RevealKeyDialog rawKey={rawKey} onClose={() => setRawKey(null)} />
+      )}
+    </div>
+  )
+}

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -14636,7 +14636,8 @@ export const ThirdPartyHumanLoginSchema = {
     title: 'ThirdPartyHumanLogin',
     description: `Request body for POST /auth/human/third-party/login.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyHumanVerifySchema = {
@@ -14659,7 +14660,8 @@ export const ThirdPartyHumanVerifySchema = {
     title: 'ThirdPartyHumanVerify',
     description: `Request body for POST /auth/human/third-party/authenticate.
 
-Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+The API key comes from the X-Third-Party-Api-Key header; the tenant is
+resolved server-side from the key.`
 } as const;
 
 export const ThirdPartyKeyRotatedSchema = {

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -76,6 +76,190 @@ export const AbandonedCartPublicSchema = {
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;
 
+export const AdminApiKeyCreateSchema = {
+    properties: {
+        name: {
+            type: 'string',
+            maxLength: 100,
+            minLength: 1,
+            title: 'Name'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            minItems: 1,
+            title: 'Scopes'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        }
+    },
+    type: 'object',
+    required: ['name', 'scopes'],
+    title: 'AdminApiKeyCreate',
+    description: 'Request body for minting a new admin API key.'
+} as const;
+
+export const AdminApiKeyCreatedSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        },
+        raw_key: {
+            type: 'string',
+            title: 'Raw Key'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at', 'raw_key'],
+    title: 'AdminApiKeyCreated',
+    description: `Response returned only at creation.
+
+\`\`raw_key\`\` is the cleartext token shown once and never stored.`
+} as const;
+
+export const AdminApiKeyPublicSchema = {
+    properties: {
+        id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Id'
+        },
+        name: {
+            type: 'string',
+            title: 'Name'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        },
+        scopes: {
+            items: {
+                type: 'string',
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
+            },
+            type: 'array',
+            title: 'Scopes'
+        },
+        created_at: {
+            type: 'string',
+            format: 'date-time',
+            title: 'Created At'
+        },
+        last_used_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Last Used At'
+        },
+        expires_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Expires At'
+        },
+        revoked_at: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'date-time'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Revoked At'
+        }
+    },
+    type: 'object',
+    required: ['id', 'name', 'prefix', 'scopes', 'created_at'],
+    title: 'AdminApiKeyPublic',
+    description: 'Safe representation of an admin API key — never includes the raw secret.'
+} as const;
+
 export const ApiKeyCreateSchema = {
     properties: {
         name: {
@@ -99,7 +283,7 @@ export const ApiKeyCreateSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -129,7 +313,7 @@ export const ApiKeyCreatedSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -205,7 +389,7 @@ export const ApiKeyPublicSchema = {
         scopes: {
             items: {
                 type: 'string',
-                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write']
+                enum: ['events:read', 'events:write', 'rsvp:write', 'venues:write', 'applications:read', 'applications:write', 'attendees:read', 'attendees:write', 'humans:read', 'humans:write', 'groups:read', 'groups:write', 'products:read', 'products:write', 'coupons:read', 'coupons:write', 'forms:read', 'forms:write', 'payments:read', 'tracks:read', 'tracks:write', 'ticketing_steps:read', 'ticketing_steps:write', 'translations:read', 'translations:write']
             },
             type: 'array',
             title: 'Scopes'
@@ -14315,6 +14499,17 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Active Popup Slug'
+        },
+        third_party_key_prefix: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Third Party Key Prefix'
         }
     },
     type: 'object',
@@ -14426,6 +14621,62 @@ export const TenantUpdateSchema = {
     },
     type: 'object',
     title: 'TenantUpdate'
+} as const;
+
+export const ThirdPartyHumanLoginSchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        }
+    },
+    type: 'object',
+    required: ['email'],
+    title: 'ThirdPartyHumanLogin',
+    description: `Request body for POST /auth/human/third-party/login.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyHumanVerifySchema = {
+    properties: {
+        email: {
+            type: 'string',
+            format: 'email',
+            title: 'Email'
+        },
+        code: {
+            type: 'string',
+            maxLength: 6,
+            minLength: 6,
+            pattern: '^\\d{6}$',
+            title: 'Code'
+        }
+    },
+    type: 'object',
+    required: ['email', 'code'],
+    title: 'ThirdPartyHumanVerify',
+    description: `Request body for POST /auth/human/third-party/authenticate.
+
+Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).`
+} as const;
+
+export const ThirdPartyKeyRotatedSchema = {
+    properties: {
+        api_key: {
+            type: 'string',
+            title: 'Api Key'
+        },
+        prefix: {
+            type: 'string',
+            title: 'Prefix'
+        }
+    },
+    type: 'object',
+    required: ['api_key', 'prefix'],
+    title: 'ThirdPartyKeyRotated',
+    description: 'Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.'
 } as const;
 
 export const TicketAttendeeSnapshotSchema = {

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -3,7 +3,122 @@
 import type { CancelablePromise } from './core/CancelablePromise';
 import { OpenAPI } from './core/OpenAPI';
 import { request as __request } from './core/request';
-import type { ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+import type { AdminApiKeysCreateAdminApiKeyData, AdminApiKeysCreateAdminApiKeyResponse, AdminApiKeysListAdminApiKeysData, AdminApiKeysListAdminApiKeysResponse, AdminApiKeysGetAdminApiKeyData, AdminApiKeysGetAdminApiKeyResponse, AdminApiKeysRevokeAdminApiKeyData, AdminApiKeysRevokeAdminApiKeyResponse, ApiKeysListApiKeysResponse, ApiKeysCreateApiKeyData, ApiKeysCreateApiKeyResponse, ApiKeysRevokeApiKeyData, ApiKeysRevokeApiKeyResponse, ApplicationReviewsListReviewsData, ApplicationReviewsListReviewsResponse, ApplicationReviewsSubmitReviewData, ApplicationReviewsSubmitReviewResponse, ApplicationReviewsGetReviewSummaryData, ApplicationReviewsGetReviewSummaryResponse, ApplicationReviewsListPendingReviewsData, ApplicationReviewsListPendingReviewsResponse, ApplicationReviewsListMyReviewsData, ApplicationReviewsListMyReviewsResponse, ApplicationsListApplicationsData, ApplicationsListApplicationsResponse, ApplicationsCreateApplicationAdminData, ApplicationsCreateApplicationAdminResponse, ApplicationsGetApplicationData, ApplicationsGetApplicationResponse, ApplicationsListMyApplicationsData, ApplicationsListMyApplicationsResponse, ApplicationsListMyTicketsResponse, ApplicationsGetMyParticipationData, ApplicationsGetMyParticipationResponse, ApplicationsGetMyPurchasesData, ApplicationsGetMyPurchasesResponse, ApplicationsGetMyApplicationData, ApplicationsGetMyApplicationResponse, ApplicationsUpdateMyApplicationData, ApplicationsUpdateMyApplicationResponse, ApplicationsDetachCompanionData, ApplicationsDetachCompanionResponse, ApplicationsCreateMyApplicationData, ApplicationsCreateMyApplicationResponse, ApplicationsListAttendeesDirectoryData, ApplicationsListAttendeesDirectoryResponse, ApplicationsExportAttendeesDirectoryCsvData, ApplicationsExportAttendeesDirectoryCsvResponse, ApplicationsAddMyAttendeeData, ApplicationsAddMyAttendeeResponse, ApplicationsUpdateMyAttendeeData, ApplicationsUpdateMyAttendeeResponse, ApplicationsDeleteMyAttendeeData, ApplicationsDeleteMyAttendeeResponse, ApplicationsReviewScholarshipData, ApplicationsReviewScholarshipResponse, ApprovalStrategiesGetApprovalStrategyData, ApprovalStrategiesGetApprovalStrategyResponse, ApprovalStrategiesCreateOrUpdateApprovalStrategyData, ApprovalStrategiesCreateOrUpdateApprovalStrategyResponse, ApprovalStrategiesUpdateApprovalStrategyData, ApprovalStrategiesUpdateApprovalStrategyResponse, ApprovalStrategiesDeleteApprovalStrategyData, ApprovalStrategiesDeleteApprovalStrategyResponse, AttendeeCategoriesListAttendeeCategoriesData, AttendeeCategoriesListAttendeeCategoriesResponse, AttendeeCategoriesListAttendeeCategoriesPortalData, AttendeeCategoriesListAttendeeCategoriesPortalResponse, AttendeeCategoriesCreateAttendeeCategoryData, AttendeeCategoriesCreateAttendeeCategoryResponse, AttendeeCategoriesUpdateAttendeeCategoryData, AttendeeCategoriesUpdateAttendeeCategoryResponse, AttendeeCategoriesDeleteAttendeeCategoryData, AttendeeCategoriesDeleteAttendeeCategoryResponse, AttendeesListMyAttendeesByPopupData, AttendeesListMyAttendeesByPopupResponse, AttendeesCreateMyAttendeeForPopupData, AttendeesCreateMyAttendeeForPopupResponse, AttendeesUpdateMyAttendeeForPopupData, AttendeesUpdateMyAttendeeForPopupResponse, AttendeesDeleteMyAttendeeForPopupData, AttendeesDeleteMyAttendeeForPopupResponse, AttendeesListAttendeesData, AttendeesListAttendeesResponse, AttendeesGetAttendeeData, AttendeesGetAttendeeResponse, AttendeesUpdateAttendeeData, AttendeesUpdateAttendeeResponse, AttendeesDeleteAttendeeData, AttendeesDeleteAttendeeResponse, AttendeesPostCheckInData, AttendeesPostCheckInResponse, AttendeesGetTicketsByEmailData, AttendeesGetTicketsByEmailResponse, AuthUserLoginData, AuthUserLoginResponse, AuthUserAuthenticateData, AuthUserAuthenticateResponse, AuthScannerLoginData, AuthScannerLoginResponse, AuthScannerAuthenticateData, AuthScannerAuthenticateResponse, AuthHumanLoginData, AuthHumanLoginResponse, AuthHumanAuthenticateData, AuthHumanAuthenticateResponse, AuthThirdPartyHumanLoginData, AuthThirdPartyHumanLoginResponse, AuthThirdPartyHumanAuthenticateData, AuthThirdPartyHumanAuthenticateResponse, BaseFieldConfigsListBaseFieldConfigsData, BaseFieldConfigsListBaseFieldConfigsResponse, BaseFieldConfigsUpdateBaseFieldConfigData, BaseFieldConfigsUpdateBaseFieldConfigResponse, CartsListAbandonedCartsData, CartsListAbandonedCartsResponse, CartsGetMyCartData, CartsGetMyCartResponse, CartsUpdateMyCartData, CartsUpdateMyCartResponse, CartsDeleteMyCartData, CartsDeleteMyCartResponse, CheckInGetMyCheckInOptionsData, CheckInGetMyCheckInOptionsResponse, CheckInConfirmMyCheckInData, CheckInConfirmMyCheckInResponse, CheckInListCheckInsData, CheckInListCheckInsResponse, CheckoutGetRuntimeData, CheckoutGetRuntimeResponse, CheckoutPurchaseOpenTicketingData, CheckoutPurchaseOpenTicketingResponse, CouponsValidateCouponPublicData, CouponsValidateCouponPublicResponse, CouponsListCouponsData, CouponsListCouponsResponse, CouponsCreateCouponData, CouponsCreateCouponResponse, CouponsGetCouponData, CouponsGetCouponResponse, CouponsUpdateCouponData, CouponsUpdateCouponResponse, CouponsDeleteCouponData, CouponsDeleteCouponResponse, CouponsValidateCouponData, CouponsValidateCouponResponse, DashboardGetDashboardStatsData, DashboardGetDashboardStatsResponse, DashboardGetEnrichedDashboardData, DashboardGetEnrichedDashboardResponse, EmailTemplatesListTemplateTypesResponse, EmailTemplatesGetDefaultTemplateData, EmailTemplatesGetDefaultTemplateResponse, EmailTemplatesPreviewTemplateData, EmailTemplatesPreviewTemplateResponse, EmailTemplatesSendTestEmailData, EmailTemplatesSendTestEmailResponse, EmailTemplatesListEmailTemplatesData, EmailTemplatesListEmailTemplatesResponse, EmailTemplatesCreateEmailTemplateData, EmailTemplatesCreateEmailTemplateResponse, EmailTemplatesGetEmailTemplateData, EmailTemplatesGetEmailTemplateResponse, EmailTemplatesUpdateEmailTemplateData, EmailTemplatesUpdateEmailTemplateResponse, EmailTemplatesDeleteEmailTemplateData, EmailTemplatesDeleteEmailTemplateResponse, EventParticipantsListParticipantsData, EventParticipantsListParticipantsResponse, EventParticipantsAdminAddParticipantData, EventParticipantsAdminAddParticipantResponse, EventParticipantsUpdateParticipantData, EventParticipantsUpdateParticipantResponse, EventParticipantsDeleteParticipantData, EventParticipantsDeleteParticipantResponse, EventParticipantsListPortalParticipantsData, EventParticipantsListPortalParticipantsResponse, EventParticipantsRegisterForEventData, EventParticipantsRegisterForEventResponse, EventParticipantsCancelRegistrationData, EventParticipantsCancelRegistrationResponse, EventParticipantsCheckInData, EventParticipantsCheckInResponse, EventsListPublicCalendarData, EventsListPublicCalendarResponse, EventsListEventsData, EventsListEventsResponse, EventsCreateEventData, EventsCreateEventResponse, EventsGetEventData, EventsGetEventResponse, EventsUpdateEventData, EventsUpdateEventResponse, EventsDeleteEventData, EventsDeleteEventResponse, EventsCancelEventData, EventsCancelEventResponse, EventsSetRecurrenceData, EventsSetRecurrenceResponse, EventsListOverridesData, EventsListOverridesResponse, EventsDetachOccurrenceData, EventsDetachOccurrenceResponse, EventsDeleteOccurrenceData, EventsDeleteOccurrenceResponse, EventsCheckAvailabilityData, EventsCheckAvailabilityResponse, EventsCheckAvailabilityPortalData, EventsCheckAvailabilityPortalResponse, EventsCheckRecurringAvailabilityData, EventsCheckRecurringAvailabilityResponse, EventsListInvitationsData, EventsListInvitationsResponse, EventsBulkInviteData, EventsBulkInviteResponse, EventsDeleteInvitationData, EventsDeleteInvitationResponse, EventsListPortalInvitationsData, EventsListPortalInvitationsResponse, EventsBulkInvitePortalData, EventsBulkInvitePortalResponse, EventsApproveEventData, EventsApproveEventResponse, EventsRejectEventData, EventsRejectEventResponse, EventsDeletePortalInvitationData, EventsDeletePortalInvitationResponse, EventsExportEventIcsData, EventsExportEventIcsResponse, EventsListPortalEventsData, EventsListPortalEventsResponse, EventsCreatePortalEventData, EventsCreatePortalEventResponse, EventsPortalHiddenEventsCountData, EventsPortalHiddenEventsCountResponse, EventsGetPortalEventData, EventsGetPortalEventResponse, EventsUpdatePortalEventData, EventsUpdatePortalEventResponse, EventsHidePortalEventData, EventsHidePortalEventResponse, EventsUnhidePortalEventData, EventsUnhidePortalEventResponse, EventsCancelPortalEventData, EventsCancelPortalEventResponse, EventsExportPortalEventIcsData, EventsExportPortalEventIcsResponse, EventSettingsGetEventSettingsData, EventSettingsGetEventSettingsResponse, EventSettingsUpsertEventSettingsData, EventSettingsUpsertEventSettingsResponse, EventSettingsUpdateEventSettingsData, EventSettingsUpdateEventSettingsResponse, EventSettingsGetPortalEventSettingsData, EventSettingsGetPortalEventSettingsResponse, EventVenuesListVenuesData, EventVenuesListVenuesResponse, EventVenuesCreateVenueData, EventVenuesCreateVenueResponse, EventVenuesReorderVenuesData, EventVenuesReorderVenuesResponse, EventVenuesGetVenueData, EventVenuesGetVenueResponse, EventVenuesUpdateVenueData, EventVenuesUpdateVenueResponse, EventVenuesDeleteVenueData, EventVenuesDeleteVenueResponse, EventVenuesSetWeeklyHoursData, EventVenuesSetWeeklyHoursResponse, EventVenuesListExceptionsData, EventVenuesListExceptionsResponse, EventVenuesCreateExceptionData, EventVenuesCreateExceptionResponse, EventVenuesUpdateExceptionData, EventVenuesUpdateExceptionResponse, EventVenuesDeleteExceptionData, EventVenuesDeleteExceptionResponse, EventVenuesListPhotosData, EventVenuesListPhotosResponse, EventVenuesAddPhotoData, EventVenuesAddPhotoResponse, EventVenuesUpdatePhotoData, EventVenuesUpdatePhotoResponse, EventVenuesDeletePhotoData, EventVenuesDeletePhotoResponse, EventVenuesGetAvailabilityData, EventVenuesGetAvailabilityResponse, EventVenuesGetPortalAvailabilityData, EventVenuesGetPortalAvailabilityResponse, EventVenuesListPortalVenuesData, EventVenuesListPortalVenuesResponse, EventVenuesCreatePortalVenueData, EventVenuesCreatePortalVenueResponse, EventVenuesUpdatePortalVenueData, EventVenuesUpdatePortalVenueResponse, EventVenuesDeletePortalVenueData, EventVenuesDeletePortalVenueResponse, FormFieldsListFormFieldsData, FormFieldsListFormFieldsResponse, FormFieldsCreateFormFieldData, FormFieldsCreateFormFieldResponse, FormFieldsListAvailableBaseFieldsData, FormFieldsListAvailableBaseFieldsResponse, FormFieldsCreateBaseFieldConfigData, FormFieldsCreateBaseFieldConfigResponse, FormFieldsGetFormFieldData, FormFieldsGetFormFieldResponse, FormFieldsUpdateFormFieldData, FormFieldsUpdateFormFieldResponse, FormFieldsDeleteFormFieldData, FormFieldsDeleteFormFieldResponse, FormFieldsGetApplicationSchemaData, FormFieldsGetApplicationSchemaResponse, FormFieldsGetPortalApplicationSchemaData, FormFieldsGetPortalApplicationSchemaResponse, FormSectionsListFormSectionsData, FormSectionsListFormSectionsResponse, FormSectionsCreateFormSectionData, FormSectionsCreateFormSectionResponse, FormSectionsGetFormSectionData, FormSectionsGetFormSectionResponse, FormSectionsUpdateFormSectionData, FormSectionsUpdateFormSectionResponse, FormSectionsDeleteFormSectionData, FormSectionsDeleteFormSectionResponse, GroupsListGroupsData, GroupsListGroupsResponse, GroupsCreateGroupData, GroupsCreateGroupResponse, GroupsGetGroupData, GroupsGetGroupResponse, GroupsUpdateGroupData, GroupsUpdateGroupResponse, GroupsDeleteGroupData, GroupsDeleteGroupResponse, GroupsListMyGroupsData, GroupsListMyGroupsResponse, GroupsGetMyGroupData, GroupsGetMyGroupResponse, GroupsUpdateMyGroupData, GroupsUpdateMyGroupResponse, GroupsAddGroupMemberData, GroupsAddGroupMemberResponse, GroupsAddGroupMembersBatchData, GroupsAddGroupMembersBatchResponse, GroupsUpdateGroupMemberData, GroupsUpdateGroupMemberResponse, GroupsRemoveGroupMemberData, GroupsRemoveGroupMemberResponse, GroupsGetGroupPublicData, GroupsGetGroupPublicResponse, HumansListHumansData, HumansListHumansResponse, HumansCreateHumanData, HumansCreateHumanResponse, HumansGetCurrentHumanInfoResponse, HumansUpdateCurrentHumanData, HumansUpdateCurrentHumanResponse, HumansGetCurrentHumanProfileStatsResponse, HumansSearchHumansPortalData, HumansSearchHumansPortalResponse, HumansGetHumanData, HumansGetHumanResponse, HumansUpdateHumanData, HumansUpdateHumanResponse, HumansRevokeHumanApiKeysData, HumansRevokeHumanApiKeysResponse, HumansListHumanApiKeysData, HumansListHumanApiKeysResponse, PaymentsListPaymentsData, PaymentsListPaymentsResponse, PaymentsGetPaymentData, PaymentsGetPaymentResponse, PaymentsUpdatePaymentData, PaymentsUpdatePaymentResponse, PaymentsGetPaymentInvoiceData, PaymentsGetPaymentInvoiceResponse, PaymentsCreateMyApplicationFeeData, PaymentsCreateMyApplicationFeeResponse, PaymentsListMyPaymentsByPopupData, PaymentsListMyPaymentsByPopupResponse, PaymentsGetMyLatestPaymentData, PaymentsGetMyLatestPaymentResponse, PaymentsGetMyPaymentStatusData, PaymentsGetMyPaymentStatusResponse, PaymentsListMyPaymentsData, PaymentsListMyPaymentsResponse, PaymentsGetMyInvoiceData, PaymentsGetMyInvoiceResponse, PaymentsPreviewMyPaymentData, PaymentsPreviewMyPaymentResponse, PaymentsCreateMyPaymentData, PaymentsCreateMyPaymentResponse, PaymentsSimplefiWebhookResponse, PopupReviewersListReviewersData, PopupReviewersListReviewersResponse, PopupReviewersAddReviewerData, PopupReviewersAddReviewerResponse, PopupReviewersUpdateReviewerData, PopupReviewersUpdateReviewerResponse, PopupReviewersRemoveReviewerData, PopupReviewersRemoveReviewerResponse, PopupsListPopupsData, PopupsListPopupsResponse, PopupsCreatePopupData, PopupsCreatePopupResponse, PopupsListPublicPopupsData, PopupsListPublicPopupsResponse, PopupsGetPopupData, PopupsGetPopupResponse, PopupsUpdatePopupData, PopupsUpdatePopupResponse, PopupsDeletePopupData, PopupsDeletePopupResponse, PopupsListPortalPopupsData, PopupsListPortalPopupsResponse, PopupsGetPortalPopupData, PopupsGetPortalPopupResponse, PortalGetPopupAccessData, PortalGetPopupAccessResponse, ProductsListProductCategoriesData, ProductsListProductCategoriesResponse, ProductsListProductsData, ProductsListProductsResponse, ProductsCreateProductData, ProductsCreateProductResponse, ProductsCreateProductsBatchData, ProductsCreateProductsBatchResponse, ProductsGetProductData, ProductsGetProductResponse, ProductsUpdateProductData, ProductsUpdateProductResponse, ProductsDeleteProductData, ProductsDeleteProductResponse, ProductsListPortalProductsData, ProductsListPortalProductsResponse, TenantsGetTenantByDomainData, TenantsGetTenantByDomainResponse, TenantsGetTenantBySlugData, TenantsGetTenantBySlugResponse, TenantsListTenantsData, TenantsListTenantsResponse, TenantsCreateTenantData, TenantsCreateTenantResponse, TenantsGetTenantData, TenantsGetTenantResponse, TenantsUpdateTenantData, TenantsUpdateTenantResponse, TenantsDeleteTenantData, TenantsDeleteTenantResponse, TenantsGetCredentialsData, TenantsGetCredentialsResponse, TenantsDeleteCredentialsData, TenantsDeleteCredentialsResponse, TenantsRotateThirdPartyKeyData, TenantsRotateThirdPartyKeyResponse, TenantsDeleteThirdPartyKeyData, TenantsDeleteThirdPartyKeyResponse, TicketingStepsListPortalTicketingStepsData, TicketingStepsListPortalTicketingStepsResponse, TicketingStepsListTicketingStepsData, TicketingStepsListTicketingStepsResponse, TicketingStepsCreateTicketingStepData, TicketingStepsCreateTicketingStepResponse, TicketingStepsGetTicketingStepData, TicketingStepsGetTicketingStepResponse, TicketingStepsUpdateTicketingStepData, TicketingStepsUpdateTicketingStepResponse, TicketingStepsDeleteTicketingStepData, TicketingStepsDeleteTicketingStepResponse, TracksListTracksData, TracksListTracksResponse, TracksCreateTrackData, TracksCreateTrackResponse, TracksGetTrackData, TracksGetTrackResponse, TracksUpdateTrackData, TracksUpdateTrackResponse, TracksDeleteTrackData, TracksDeleteTrackResponse, TracksListTrackEventsData, TracksListTrackEventsResponse, TracksListPortalTracksData, TracksListPortalTracksResponse, TracksGetPortalTrackData, TracksGetPortalTrackResponse, TracksListPortalTrackEventsData, TracksListPortalTrackEventsResponse, TranslationsListTranslationsData, TranslationsListTranslationsResponse, TranslationsUpsertTranslationData, TranslationsUpsertTranslationResponse, TranslationsAiTranslateData, TranslationsAiTranslateResponse, TranslationsDeleteTranslationData, TranslationsDeleteTranslationResponse, UploadsGetPresignedUploadUrlData, UploadsGetPresignedUploadUrlResponse, UploadsGetPresignedUploadUrlPortalData, UploadsGetPresignedUploadUrlPortalResponse, UsersListUsersData, UsersListUsersResponse, UsersCreateUserData, UsersCreateUserResponse, UsersGetCurrentUserInfoResponse, UsersGetUserData, UsersGetUserResponse, UsersUpdateUserData, UsersUpdateUserResponse, UsersDeleteUserData, UsersDeleteUserResponse, UtilsResolveUrlData, UtilsResolveUrlResponse, VenuePropertyTypesListPropertyTypesData, VenuePropertyTypesListPropertyTypesResponse, VenuePropertyTypesCreatePropertyTypeData, VenuePropertyTypesCreatePropertyTypeResponse, VenuePropertyTypesUpdatePropertyTypeData, VenuePropertyTypesUpdatePropertyTypeResponse, VenuePropertyTypesDeletePropertyTypeData, VenuePropertyTypesDeletePropertyTypeResponse, VenuePropertyTypesListPropertyTypesPortalResponse } from './types.gen';
+
+export class AdminApiKeysService {
+    /**
+     * Create Admin Api Key
+     * Mint a new admin API key.
+     *
+     * Scopes must be a subset of ADMIN_API_KEY_SCOPES. Any scope outside that
+     * universe returns 422. Write scopes require an expiry date (validated by
+     * the schema).
+     *
+     * The cleartext key is returned once in ``raw_key``; only the hash is stored.
+     * @param data The data for the request.
+     * @param data.requestBody
+     * @param data.xTenantId
+     * @returns AdminApiKeyCreated Successful Response
+     * @throws ApiError
+     */
+    public static createAdminApiKey(data: AdminApiKeysCreateAdminApiKeyData): CancelablePromise<AdminApiKeysCreateAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * List Admin Api Keys
+     * List admin API keys.
+     *
+     * ADMIN sees only their own keys.
+     * SUPERADMIN sees all admin keys in the tenant they are operating on (via
+     * X-Tenant-Id header, already resolved by TenantSession).
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static listAdminApiKeys(data: AdminApiKeysListAdminApiKeysData = {}): CancelablePromise<AdminApiKeysListAdminApiKeysResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Get Admin Api Key
+     * Retrieve a specific admin API key.
+     *
+     * Visibility mirrors the list endpoint: ADMIN sees only own keys; SUPERADMIN
+     * sees any admin key in the tenant. Returns 404 for keys outside the caller's
+     * visibility — never 403, to avoid leaking existence of foreign keys.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns AdminApiKeyPublic Successful Response
+     * @throws ApiError
+     */
+    public static getAdminApiKey(data: AdminApiKeysGetAdminApiKeyData): CancelablePromise<AdminApiKeysGetAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Revoke Admin Api Key
+     * Revoke an admin API key by setting revoked_at.
+     *
+     * ADMIN can only revoke their own keys (403 for foreign keys).
+     * SUPERADMIN can revoke any admin key in their tenant scope.
+     * Non-existent keys return 404.
+     * @param data The data for the request.
+     * @param data.keyId
+     * @param data.xTenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static revokeAdminApiKey(data: AdminApiKeysRevokeAdminApiKeyData): CancelablePromise<AdminApiKeysRevokeAdminApiKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/backoffice/api-keys/{key_id}',
+            path: {
+                key_id: data.keyId
+            },
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+}
 
 export class ApiKeysService {
     /**
@@ -1332,6 +1447,69 @@ export class AuthService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/auth/human/authenticate',
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Login
+     * Initiate OTP login for an EXISTING human via a third-party integration.
+     *
+     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending human
+     * row — the partner is expected to have onboarded the user out-of-band.
+     *
+     * On any validation failure (unknown tenant, feature disabled, wrong key,
+     * unknown email) the response is 401 to prevent existence leakage.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns AuthCodeSentResponse Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanLogin(data: AuthThirdPartyHumanLoginData): CancelablePromise<AuthThirdPartyHumanLoginResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/login',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
+            body: data.requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Third Party Human Authenticate
+     * Verify OTP and mint a third-party JWT for an existing human.
+     *
+     * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
+     * The JWT grants portal:self_read, portal:directory_read, and
+     * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
+     * @param data The data for the request.
+     * @param data.xTenantId
+     * @param data.xThirdPartyApiKey
+     * @param data.requestBody
+     * @returns Token Successful Response
+     * @throws ApiError
+     */
+    public static thirdPartyHumanAuthenticate(data: AuthThirdPartyHumanAuthenticateData): CancelablePromise<AuthThirdPartyHumanAuthenticateResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/auth/human/third-party/authenticate',
+            headers: {
+                'X-Tenant-Id': data.xTenantId,
+                'X-Third-Party-Api-Key': data.xThirdPartyApiKey
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
@@ -5998,6 +6176,59 @@ export class TenantsService {
             }
         });
     }
+    
+    /**
+     * Rotate Third Party Key
+     * Generate and store a new third-party API key for this tenant.
+     *
+     * The raw key is returned ONCE and never stored; only its peppered SHA-256
+     * hash is persisted. Rotation takes effect on the NEXT login attempt;
+     * in-flight JWTs already issued remain valid until their own expiry.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns ThirdPartyKeyRotated Successful Response
+     * @throws ApiError
+     */
+    public static rotateThirdPartyKey(data: TenantsRotateThirdPartyKeyData): CancelablePromise<TenantsRotateThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key/rotate',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
+    
+    /**
+     * Delete Third Party Key
+     * Disable third-party login for this tenant by clearing the key hash.
+     *
+     * After this call, POST /auth/human/third-party/login returns 401 for this
+     * tenant until a new key is rotated in.
+     *
+     * Only ADMIN (for their own tenant) and SUPERADMIN (any tenant) may call this.
+     * @param data The data for the request.
+     * @param data.tenantId
+     * @returns void Successful Response
+     * @throws ApiError
+     */
+    public static deleteThirdPartyKey(data: TenantsDeleteThirdPartyKeyData): CancelablePromise<TenantsDeleteThirdPartyKeyResponse> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/api/v1/tenants/{tenant_id}/third-party-key',
+            path: {
+                tenant_id: data.tenantId
+            },
+            errors: {
+                422: 'Validation Error'
+            }
+        });
+    }
 }
 
 export class TicketingStepsService {
@@ -6696,8 +6927,8 @@ export class VenuePropertyTypesService {
     /**
      * Create Property Type
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns VenuePropertyTypePublic Successful Response
      * @throws ApiError
      */

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -1459,14 +1459,15 @@ export class AuthService {
      * Third Party Human Login
      * Initiate OTP login for an EXISTING human via a third-party integration.
      *
-     * The caller must supply a valid third-party API key in X-Third-Party-Api-Key.
-     * Unlike the portal login endpoint, this surface NEVER creates a pending human
-     * row — the partner is expected to have onboarded the user out-of-band.
+     * The caller supplies only a valid third-party API key in
+     * X-Third-Party-Api-Key; the tenant is resolved server-side from the key.
+     * Unlike the portal login endpoint, this surface NEVER creates a pending
+     * human row — the partner is expected to have onboarded the user
+     * out-of-band.
      *
-     * On any validation failure (unknown tenant, feature disabled, wrong key,
-     * unknown email) the response is 401 to prevent existence leakage.
+     * On any validation failure (wrong key, unknown email) the response is 401
+     * to prevent existence leakage.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns AuthCodeSentResponse Successful Response
@@ -1477,7 +1478,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/login',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,
@@ -1492,11 +1492,11 @@ export class AuthService {
      * Third Party Human Authenticate
      * Verify OTP and mint a third-party JWT for an existing human.
      *
+     * The tenant is resolved server-side from the third-party API key alone.
      * Returns a JWT with issued_via=third_party and scopes=THIRD_PARTY_TOKEN_SCOPES.
      * The JWT grants portal:self_read, portal:directory_read, and
      * portal:api_keys_manage on the portal surface; it does NOT grant admin access.
      * @param data The data for the request.
-     * @param data.xTenantId
      * @param data.xThirdPartyApiKey
      * @param data.requestBody
      * @returns Token Successful Response
@@ -1507,7 +1507,6 @@ export class AuthService {
             method: 'POST',
             url: '/api/v1/auth/human/third-party/authenticate',
             headers: {
-                'X-Tenant-Id': data.xTenantId,
                 'X-Third-Party-Api-Key': data.xThirdPartyApiKey
             },
             body: data.requestBody,

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2886,7 +2886,8 @@ export type TenantUpdate = {
 /**
  * Request body for POST /auth/human/third-party/login.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanLogin = {
     email: string;
@@ -2895,7 +2896,8 @@ export type ThirdPartyHumanLogin = {
 /**
  * Request body for POST /auth/human/third-party/authenticate.
  *
- * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ * The API key comes from the X-Third-Party-Api-Key header; the tenant is
+ * resolved server-side from the key.
  */
 export type ThirdPartyHumanVerify = {
     email: string;
@@ -3718,7 +3720,6 @@ export type AuthHumanAuthenticateResponse = (Token);
 
 export type AuthThirdPartyHumanLoginData = {
     requestBody: ThirdPartyHumanLogin;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 
@@ -3726,7 +3727,6 @@ export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
 
 export type AuthThirdPartyHumanAuthenticateData = {
     requestBody: ThirdPartyHumanVerify;
-    xTenantId: string;
     xThirdPartyApiKey: string;
 };
 

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -13,6 +13,46 @@ export type AbandonedCartPublic = {
     payments?: Array<CartPaymentInfo>;
 };
 
+/**
+ * Request body for minting a new admin API key.
+ */
+export type AdminApiKeyCreate = {
+    name: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    expires_at?: (string | null);
+};
+
+/**
+ * Response returned only at creation.
+ *
+ * ``raw_key`` is the cleartext token shown once and never stored.
+ */
+export type AdminApiKeyCreated = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+    raw_key: string;
+};
+
+/**
+ * Safe representation of an admin API key — never includes the raw secret.
+ */
+export type AdminApiKeyPublic = {
+    id: string;
+    name: string;
+    prefix: string;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
+    created_at: string;
+    last_used_at?: (string | null);
+    expires_at?: (string | null);
+    revoked_at?: (string | null);
+};
+
 export type AITranslateRequest = {
     entity_type: string;
     entity_id: string;
@@ -25,7 +65,7 @@ export type AITranslateRequest = {
 export type ApiKeyCreate = {
     name: string;
     expires_at?: (string | null);
-    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
 };
 
 /**
@@ -36,7 +76,7 @@ export type ApiKeyCreated = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -51,7 +91,7 @@ export type ApiKeyPublic = {
     id: string;
     name: string;
     prefix: string;
-    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write')>;
+    scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
     expires_at?: (string | null);
@@ -2828,6 +2868,7 @@ export type TenantPublic = {
     landing_mode?: LandingMode;
     id: string;
     active_popup_slug?: (string | null);
+    third_party_key_prefix?: (string | null);
 };
 
 export type TenantUpdate = {
@@ -2840,6 +2881,33 @@ export type TenantUpdate = {
     custom_domain?: (string | null);
     custom_domain_active?: (boolean | null);
     landing_mode?: (LandingMode | null);
+};
+
+/**
+ * Request body for POST /auth/human/third-party/login.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanLogin = {
+    email: string;
+};
+
+/**
+ * Request body for POST /auth/human/third-party/authenticate.
+ *
+ * Tenant ID and API key come from headers (X-Tenant-Id, X-Third-Party-Api-Key).
+ */
+export type ThirdPartyHumanVerify = {
+    email: string;
+    code: string;
+};
+
+/**
+ * Returned by the rotate endpoint. The raw api_key is shown ONCE and never stored.
+ */
+export type ThirdPartyKeyRotated = {
+    api_key: string;
+    prefix: string;
 };
 
 /**
@@ -3212,6 +3280,33 @@ export type VenueWeeklyHourRef = {
 export type VenueWeeklyHoursUpdate = {
     hours: Array<VenueWeeklyHourInput>;
 };
+
+export type AdminApiKeysCreateAdminApiKeyData = {
+    requestBody: AdminApiKeyCreate;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysCreateAdminApiKeyResponse = (AdminApiKeyCreated);
+
+export type AdminApiKeysListAdminApiKeysData = {
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysListAdminApiKeysResponse = (Array<AdminApiKeyPublic>);
+
+export type AdminApiKeysGetAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysGetAdminApiKeyResponse = (AdminApiKeyPublic);
+
+export type AdminApiKeysRevokeAdminApiKeyData = {
+    keyId: string;
+    xTenantId?: (string | null);
+};
+
+export type AdminApiKeysRevokeAdminApiKeyResponse = (void);
 
 export type ApiKeysListApiKeysResponse = (Array<ApiKeyPublic>);
 
@@ -3620,6 +3715,22 @@ export type AuthHumanAuthenticateData = {
 };
 
 export type AuthHumanAuthenticateResponse = (Token);
+
+export type AuthThirdPartyHumanLoginData = {
+    requestBody: ThirdPartyHumanLogin;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanLoginResponse = (AuthCodeSentResponse);
+
+export type AuthThirdPartyHumanAuthenticateData = {
+    requestBody: ThirdPartyHumanVerify;
+    xTenantId: string;
+    xThirdPartyApiKey: string;
+};
+
+export type AuthThirdPartyHumanAuthenticateResponse = (Token);
 
 export type BaseFieldConfigsListBaseFieldConfigsData = {
     /**
@@ -5082,6 +5193,18 @@ export type TenantsDeleteCredentialsData = {
 
 export type TenantsDeleteCredentialsResponse = (void);
 
+export type TenantsRotateThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsRotateThirdPartyKeyResponse = (ThirdPartyKeyRotated);
+
+export type TenantsDeleteThirdPartyKeyData = {
+    tenantId: string;
+};
+
+export type TenantsDeleteThirdPartyKeyResponse = (void);
+
 export type TicketingStepsListPortalTicketingStepsData = {
     popupId: string;
 };
@@ -5332,7 +5455,7 @@ export type VenuePropertyTypesListPropertyTypesResponse = (Array<VenuePropertyTy
 
 export type VenuePropertyTypesCreatePropertyTypeData = {
     requestBody: VenuePropertyTypeCreate;
-    xTenantId: string;
+    xTenantId?: (string | null);
 };
 
 export type VenuePropertyTypesCreatePropertyTypeResponse = (VenuePropertyTypePublic);

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -6,9 +6,10 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
-  resolveMaxQuantity,
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
+import SoldOutBadge from "@/components/ui/SoldOutBadge"
+import { getProductAvailability } from "@/lib/product-availability"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
@@ -229,12 +230,19 @@ function CompactCard({
       : product.compare_price
     : null
   const supportsQty = supportsQuantitySelector(product.max_per_order)
-  const maxQty = resolveMaxQuantity(product)
+  const {
+    state,
+    canSelect,
+    maxAllowedQuantity: maxQty,
+  } = getProductAvailability(product)
+  const soldOut = state === "sold_out"
 
   return (
     <button
       type="button"
+      disabled={!canSelect}
       onClick={() => {
+        if (!canSelect) return
         if (supportsQty && quantity === 0) {
           onIncrement()
         } else {
@@ -246,9 +254,14 @@ function CompactCard({
         isSelected
           ? "border-l-primary bg-primary/10"
           : "border-l-border bg-checkout-card-bg hover:bg-muted",
+        !canSelect && "opacity-60 cursor-not-allowed hover:bg-checkout-card-bg",
       )}
     >
-      {supportsQty ? (
+      {!canSelect ? (
+        soldOut ? (
+          <SoldOutBadge />
+        ) : null
+      ) : supportsQty ? (
         <QuantitySelector
           value={quantity}
           max={maxQty}
@@ -346,12 +359,19 @@ function GridCard({
       : product.compare_price
     : null
   const supportsQty = supportsQuantitySelector(product.max_per_order)
-  const maxQty = resolveMaxQuantity(product)
+  const {
+    state,
+    canSelect,
+    maxAllowedQuantity: maxQty,
+  } = getProductAvailability(product)
+  const soldOut = state === "sold_out"
 
   return (
     <button
       type="button"
+      disabled={!canSelect}
       onClick={() => {
+        if (!canSelect) return
         if (supportsQty && quantity === 0) {
           onIncrement()
         } else {
@@ -363,6 +383,7 @@ function GridCard({
         isSelected
           ? "border-primary ring-2 ring-primary/20"
           : "border-border hover:border-muted-foreground/30",
+        !canSelect && "opacity-60 cursor-not-allowed hover:border-border",
       )}
     >
       {product.image_url ? (
@@ -380,7 +401,13 @@ function GridCard({
         </div>
       )}
 
-      {supportsQty ? (
+      {!canSelect ? (
+        soldOut && (
+          <div className="absolute top-2 right-2">
+            <SoldOutBadge />
+          </div>
+        )
+      ) : supportsQty ? (
         <div className="absolute top-2 right-2 rounded-full bg-background/90 backdrop-blur-sm shadow-sm px-1.5 py-0.5">
           <QuantitySelector
             value={quantity}
@@ -522,14 +549,21 @@ function DefaultSectionCard({
               : product.compare_price
             : null
           const supportsQty = supportsQuantitySelector(product.max_per_order)
-          const maxQty = resolveMaxQuantity(product)
+          const {
+            state,
+            canSelect,
+            maxAllowedQuantity: maxQty,
+          } = getProductAvailability(product)
+          const soldOut = state === "sold_out"
           const quantity = getQuantity(product.id)
 
           return (
             <button
               key={product.id}
               type="button"
+              disabled={!canSelect}
               onClick={() => {
+                if (!canSelect) return
                 if (supportsQty && quantity === 0) {
                   onIncrement(product.id)
                 } else {
@@ -541,10 +575,16 @@ function DefaultSectionCard({
                 isSelected
                   ? "border-primary bg-primary/10"
                   : "border-border bg-muted hover:border-muted-foreground/30",
+                !canSelect &&
+                  "opacity-60 cursor-not-allowed hover:border-border",
               )}
             >
               <div className="flex items-center gap-3 min-w-0">
-                {supportsQty ? (
+                {!canSelect ? (
+                  soldOut ? (
+                    <SoldOutBadge />
+                  ) : null
+                ) : supportsQty ? (
                   <QuantitySelector
                     value={quantity}
                     max={maxQty}
@@ -718,14 +758,21 @@ function ShowcaseSectionCard({
                 : product.compare_price
               : null
             const supportsQty = supportsQuantitySelector(product.max_per_order)
-            const maxQty = resolveMaxQuantity(product)
+            const {
+              state,
+              canSelect,
+              maxAllowedQuantity: maxQty,
+            } = getProductAvailability(product)
+            const soldOut = state === "sold_out"
             const quantity = getQuantity(product.id)
 
             return (
               <button
                 key={product.id}
                 type="button"
+                disabled={!canSelect}
                 onClick={() => {
+                  if (!canSelect) return
                   if (supportsQty && quantity === 0) {
                     onIncrement(product.id)
                   } else {
@@ -737,6 +784,7 @@ function ShowcaseSectionCard({
                   isSelected
                     ? "bg-primary/10 ring-2 ring-primary"
                     : "bg-muted hover:bg-muted/80 ring-1 ring-border",
+                  !canSelect && "opacity-60 cursor-not-allowed hover:bg-muted",
                 )}
               >
                 {product.image_url && (
@@ -786,7 +834,11 @@ function ShowcaseSectionCard({
                   </p>
                 </div>
 
-                {supportsQty ? (
+                {!canSelect ? (
+                  soldOut ? (
+                    <SoldOutBadge />
+                  ) : null
+                ) : supportsQty ? (
                   <QuantitySelector
                     value={quantity}
                     max={maxQty}

--- a/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
@@ -5,9 +5,10 @@ import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
-  resolveMaxQuantity,
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
+import SoldOutBadge from "@/components/ui/SoldOutBadge"
+import { getProductAvailability } from "@/lib/product-availability"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { formatCurrency } from "@/types/checkout"
@@ -33,7 +34,15 @@ function MerchQtyControl({
   onQuantityChange,
 }: MerchQtyControlProps) {
   const showStepper = supportsQuantitySelector(product.max_per_order)
-  const max = resolveMaxQuantity(product)
+  const {
+    state,
+    canSelect,
+    maxAllowedQuantity: max,
+  } = getProductAvailability(product)
+
+  if (!canSelect) {
+    return state === "sold_out" ? <SoldOutBadge /> : null
+  }
 
   if (showStepper) {
     return (
@@ -98,12 +107,14 @@ function MerchDefaultItem({
   const hasQuantity = quantity > 0
   const hasDiscount =
     product.compare_price != null && product.compare_price > product.price
+  const { canSelect } = getProductAvailability(product)
 
   return (
     <div
       className={cn(
         "p-4 transition-colors",
         hasQuantity ? "bg-primary/10" : "",
+        !canSelect && "opacity-60",
       )}
     >
       {/* Desktop layout */}
@@ -276,6 +287,7 @@ function MerchGrid({ products, getQuantity, onQuantityChange }: CardListProps) {
           const hasDiscount =
             product.compare_price != null &&
             product.compare_price > product.price
+          const { canSelect } = getProductAvailability(product)
 
           return (
             <div
@@ -283,6 +295,7 @@ function MerchGrid({ products, getQuantity, onQuantityChange }: CardListProps) {
               className={cn(
                 "rounded-2xl border overflow-hidden bg-checkout-card-bg transition-all",
                 hasQty ? "border-primary/30" : "border-border",
+                !canSelect && "opacity-60",
               )}
             >
               <div className="relative w-full aspect-square bg-muted flex items-center justify-center">
@@ -361,12 +374,15 @@ function MerchCompact({
         const hasQty = qty > 0
         const hasDiscount =
           product.compare_price != null && product.compare_price > product.price
+        const { canSelect } = getProductAvailability(product)
 
         const cardClassName = cn(
           "group relative w-full flex items-center gap-3 rounded-2xl border bg-checkout-card-bg px-3 py-2.5 transition-all",
           hasQty
             ? "border-primary/30 shadow-sm"
             : "border-border cursor-pointer hover:border-muted-foreground/40 hover:shadow-sm",
+          !canSelect &&
+            "opacity-60 cursor-not-allowed hover:border-border hover:shadow-none",
         )
 
         const cardBody = (
@@ -426,7 +442,15 @@ function MerchCompact({
             </div>
 
             <div className="relative shrink-0">
-              {hasQty ? (
+              {!canSelect ? (
+                <MerchQtyControl
+                  product={product}
+                  quantity={qty}
+                  onQuantityChange={(nextQty) =>
+                    onQuantityChange(product.id, nextQty)
+                  }
+                />
+              ) : hasQty ? (
                 <MerchQtyControl
                   product={product}
                   quantity={qty}
@@ -446,7 +470,7 @@ function MerchCompact({
           </>
         )
 
-        return hasQty ? (
+        return hasQty || !canSelect ? (
           <div key={product.id} className={cardClassName}>
             {cardBody}
           </div>

--- a/portal/src/components/ui/QuantitySelector.tsx
+++ b/portal/src/components/ui/QuantitySelector.tsx
@@ -123,7 +123,9 @@ const QuantitySelector = ({
 
   // Empty-slot state: single "+" add button — filled tile CTA, sized larger
   // than the +/- adjustment buttons so it reads as the primary action.
-  if (value === 0 && onAdd && !disabled) {
+  // Skip when max is 0 (sold out / unavailable) so we don't offer an action
+  // the parent will reject.
+  if (value === 0 && onAdd && !disabled && max > 0) {
     const isAccent = tone === "accent"
     const addClasses = cn(
       "transition-all duration-200 ease-out transform hover:scale-110 active:scale-95 flex items-center justify-center rounded-full shadow-sm",

--- a/portal/src/components/ui/SoldOutBadge.tsx
+++ b/portal/src/components/ui/SoldOutBadge.tsx
@@ -1,0 +1,7 @@
+export default function SoldOutBadge() {
+  return (
+    <span className="px-2 py-0.5 text-[10px] font-semibold uppercase rounded tracking-wide border shrink-0 bg-rose-100 text-rose-700 border-rose-200">
+      Sold out
+    </span>
+  )
+}

--- a/portal/src/hooks/checkout/useCartPersistence.ts
+++ b/portal/src/hooks/checkout/useCartPersistence.ts
@@ -1,6 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query"
 import { type MutableRefObject, useCallback, useEffect } from "react"
-import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
 import {
   type CartState,
   useCart,
@@ -8,6 +7,7 @@ import {
   useSaveCart,
 } from "@/hooks/useCartApi"
 import { checkAndClearPurchasePending } from "@/hooks/usePaymentRedirect"
+import { getProductAvailability } from "@/lib/product-availability"
 import { queryKeys } from "@/lib/query-keys"
 import type {
   CheckoutStep,
@@ -192,50 +192,66 @@ export function useCartPersistence({
 
     const { setHousing, setMerch, setPatron, setInsurance } = restorationSetters
 
-    // Restore housing
+    // Restore housing — skip products that are sold_out / ended / upcoming.
     if (savedCart.housing) {
       const product = products.find(
         (p) => p.id === savedCart.housing?.product_id,
       )
       if (product) {
-        const start = new Date(savedCart.housing.check_in)
-        const end = new Date(savedCart.housing.check_out)
-        const nights = Math.max(
-          1,
-          Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)),
-        )
-        const savedQuantity = savedCart.housing.quantity ?? 1
-        const maxQty = resolveMaxQuantity(product)
-        const quantity = Math.max(1, Math.min(savedQuantity, maxQty))
-        const basePrice = housingPricePerDay
-          ? product.price * nights
-          : product.price
-        setHousing({
-          productId: product.id,
-          product,
-          checkIn: savedCart.housing.check_in,
-          checkOut: savedCart.housing.check_out,
-          nights,
-          pricePerNight: product.price,
-          totalPrice: basePrice * quantity,
-          pricePerDay: housingPricePerDay,
-          quantity,
-        })
+        const { canSelect, maxAllowedQuantity } =
+          getProductAvailability(product)
+        if (canSelect) {
+          const start = new Date(savedCart.housing.check_in)
+          const end = new Date(savedCart.housing.check_out)
+          const nights = Math.max(
+            1,
+            Math.ceil(
+              (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+            ),
+          )
+          const savedQuantity = savedCart.housing.quantity ?? 1
+          const quantity = Math.max(
+            1,
+            Math.min(savedQuantity, maxAllowedQuantity),
+          )
+          const basePrice = housingPricePerDay
+            ? product.price * nights
+            : product.price
+          setHousing({
+            productId: product.id,
+            product,
+            checkIn: savedCart.housing.check_in,
+            checkOut: savedCart.housing.check_out,
+            nights,
+            pricePerNight: product.price,
+            totalPrice: basePrice * quantity,
+            pricePerDay: housingPricePerDay,
+            quantity,
+          })
+        }
       }
     }
 
-    // Restore merch
+    // Restore merch — drop items whose product is no longer selectable.
     if (savedCart.merch?.length) {
       const restoredMerch = savedCart.merch.reduce<SelectedMerchItem[]>(
         (acc, saved) => {
           const product = products.find((p) => p.id === saved.product_id)
           if (!product || saved.quantity <= 0) return acc
+          const { canSelect, maxAllowedQuantity } =
+            getProductAvailability(product)
+          if (!canSelect) return acc
+          const quantity =
+            maxAllowedQuantity === Number.POSITIVE_INFINITY
+              ? saved.quantity
+              : Math.min(saved.quantity, maxAllowedQuantity)
+          if (quantity <= 0) return acc
           acc.push({
             productId: product.id,
             product,
-            quantity: saved.quantity,
+            quantity,
             unitPrice: product.price,
-            totalPrice: product.price * saved.quantity,
+            totalPrice: product.price * quantity,
           })
           return acc
         },
@@ -244,12 +260,13 @@ export function useCartPersistence({
       if (restoredMerch.length > 0) setMerch(restoredMerch)
     }
 
-    // Restore patron
+    // Restore patron — donation products are not stock-bound, but still respect
+    // sale-window state (upcoming/ended).
     if (savedCart.patron) {
       const product = products.find(
         (p) => p.id === savedCart.patron?.product_id,
       )
-      if (product) {
+      if (product && getProductAvailability(product).canSelect) {
         setPatron({
           productId: product.id,
           product,

--- a/portal/src/hooks/checkout/useHousingSelection.test.ts
+++ b/portal/src/hooks/checkout/useHousingSelection.test.ts
@@ -66,4 +66,22 @@ describe("useHousingSelection — id-lookup against full active product list", (
 
     expect(result.current.housing!.quantity).toBe(2)
   })
+
+  it("refuses to select a sold-out product (cap set, remaining=0)", () => {
+    const allActiveProducts = [
+      makeProduct({
+        id: "h-sold",
+        category: "housing",
+        total_stock_cap: 1,
+        total_stock_remaining: 0,
+      }),
+    ]
+    const { result } = renderHook(() => useHousingSelection(allActiveProducts))
+
+    act(() => {
+      result.current.selectHousing("h-sold", "2025-01-01", "2025-01-05")
+    })
+
+    expect(result.current.housing).toBeNull()
+  })
 })

--- a/portal/src/hooks/checkout/useHousingSelection.ts
+++ b/portal/src/hooks/checkout/useHousingSelection.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
+import { getProductAvailability } from "@/lib/product-availability"
 import type { SelectedHousingItem } from "@/types/checkout"
 import type { ProductsPass } from "@/types/Products"
 
@@ -21,9 +21,10 @@ function computeBasePrice(
 }
 
 function clampQuantity(product: ProductsPass, quantity: number): number {
-  const max = resolveMaxQuantity(product)
-  if (max === Number.POSITIVE_INFINITY) return Math.max(0, quantity)
-  return Math.max(0, Math.min(quantity, max))
+  const { maxAllowedQuantity } = getProductAvailability(product)
+  if (maxAllowedQuantity === Number.POSITIVE_INFINITY)
+    return Math.max(0, quantity)
+  return Math.max(0, Math.min(quantity, maxAllowedQuantity))
 }
 
 export function useHousingSelection(
@@ -36,6 +37,7 @@ export function useHousingSelection(
     (productId: string, checkIn: string, checkOut: string) => {
       const product = allActiveProducts.find((p) => p.id === productId)
       if (!product) return
+      if (!getProductAvailability(product).canSelect) return
 
       const nights = computeNights(checkIn, checkOut)
       const basePrice = computeBasePrice(product, nights, pricePerDay)
@@ -45,7 +47,8 @@ export function useHousingSelection(
         // (e.g. when the user only changes dates).
         const prevQuantity =
           prev && prev.productId === productId ? prev.quantity : 1
-        const quantity = clampQuantity(product, prevQuantity || 1) || 1
+        const quantity = clampQuantity(product, prevQuantity || 1)
+        if (quantity <= 0) return prev
         return {
           productId,
           product,

--- a/portal/src/hooks/checkout/useMerchSelection.test.ts
+++ b/portal/src/hooks/checkout/useMerchSelection.test.ts
@@ -101,6 +101,21 @@ describe("useMerchSelection — client-side max_per_order cap", () => {
     })
     expect(result.current.merch).toHaveLength(0)
   })
+
+  it("refuses to add a sold-out product (cap set, remaining=0)", () => {
+    const product = makeMerchProduct({
+      id: "merch-sold",
+      total_stock_cap: 1,
+      total_stock_remaining: 0,
+    })
+    const { result } = renderHook(() => useMerchSelection([product]))
+
+    act(() => {
+      result.current.updateMerchQuantity("merch-sold", 1)
+    })
+
+    expect(result.current.merch).toHaveLength(0)
+  })
 })
 
 describe("useMerchSelection — id-lookup against full active product list", () => {

--- a/portal/src/hooks/checkout/useMerchSelection.ts
+++ b/portal/src/hooks/checkout/useMerchSelection.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
+import { getProductAvailability } from "@/lib/product-availability"
 import type { SelectedMerchItem } from "@/types/checkout"
 import type { ProductsPass } from "@/types/Products"
 
@@ -11,11 +11,16 @@ export function useMerchSelection(allActiveProducts: ProductsPass[]) {
       const product = allActiveProducts.find((p) => p.id === productId)
       if (!product) return
 
-      const maxQty = resolveMaxQuantity(product)
+      const { canSelect, maxAllowedQuantity } = getProductAvailability(product)
+      if (!canSelect && quantity > 0) {
+        // Block adding to cart, but still allow clearing existing line.
+        setMerch((prev) => prev.filter((m) => m.productId !== productId))
+        return
+      }
       const clamped =
-        maxQty === Number.POSITIVE_INFINITY
+        maxAllowedQuantity === Number.POSITIVE_INFINITY
           ? Math.max(0, quantity)
-          : Math.max(0, Math.min(quantity, maxQty))
+          : Math.max(0, Math.min(quantity, maxAllowedQuantity))
 
       if (clamped <= 0) {
         setMerch((prev) => prev.filter((m) => m.productId !== productId))

--- a/portal/src/lib/product-availability.test.ts
+++ b/portal/src/lib/product-availability.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+import {
+  getProductAvailability,
+  isProductSoldOut,
+} from "./product-availability"
+
+const baseProduct = {
+  sale_starts_at: null,
+  sale_ends_at: null,
+  total_stock_cap: null,
+  total_stock_remaining: null,
+  max_per_order: null,
+}
+
+describe("getProductAvailability", () => {
+  it("returns on_sale with unlimited quantity when no caps are set", () => {
+    const av = getProductAvailability(baseProduct)
+    expect(av.state).toBe("on_sale")
+    expect(av.canSelect).toBe(true)
+    expect(av.maxAllowedQuantity).toBe(Number.POSITIVE_INFINITY)
+  })
+
+  it("flags sold_out and zeroes the max when remaining is 0 against a non-null cap", () => {
+    const av = getProductAvailability({
+      ...baseProduct,
+      total_stock_cap: 1,
+      total_stock_remaining: 0,
+    })
+    expect(av.state).toBe("sold_out")
+    expect(av.canSelect).toBe(false)
+    expect(av.maxAllowedQuantity).toBe(0)
+  })
+
+  it("blocks selection when the sale window has ended even if stock is available", () => {
+    const av = getProductAvailability(
+      {
+        ...baseProduct,
+        sale_ends_at: "2026-01-01",
+        total_stock_cap: 10,
+        total_stock_remaining: 10,
+      },
+      "2026-02-01",
+    )
+    expect(av.state).toBe("ended")
+    expect(av.canSelect).toBe(false)
+    expect(av.maxAllowedQuantity).toBe(0)
+  })
+
+  it("blocks selection for upcoming products", () => {
+    const av = getProductAvailability(
+      {
+        ...baseProduct,
+        sale_starts_at: "2027-01-01",
+      },
+      "2026-01-01",
+    )
+    expect(av.state).toBe("upcoming")
+    expect(av.canSelect).toBe(false)
+  })
+
+  it("respects max_per_order when on sale", () => {
+    const av = getProductAvailability({
+      ...baseProduct,
+      max_per_order: 3,
+      total_stock_cap: 100,
+      total_stock_remaining: 100,
+    })
+    expect(av.state).toBe("on_sale")
+    expect(av.maxAllowedQuantity).toBe(3)
+  })
+
+  it("uses min(max_per_order, remaining) when both are set", () => {
+    const av = getProductAvailability({
+      ...baseProduct,
+      max_per_order: 10,
+      total_stock_cap: 5,
+      total_stock_remaining: 2,
+    })
+    expect(av.maxAllowedQuantity).toBe(2)
+  })
+})
+
+describe("isProductSoldOut", () => {
+  it("returns true only when the derived state is sold_out", () => {
+    expect(
+      isProductSoldOut({
+        ...baseProduct,
+        total_stock_cap: 1,
+        total_stock_remaining: 0,
+      }),
+    ).toBe(true)
+    expect(isProductSoldOut(baseProduct)).toBe(false)
+    expect(
+      isProductSoldOut({
+        ...baseProduct,
+        sale_ends_at: "2026-01-01",
+      }),
+    ).toBe(false)
+  })
+})

--- a/portal/src/lib/product-availability.ts
+++ b/portal/src/lib/product-availability.ts
@@ -1,0 +1,42 @@
+import type { ProductPublic } from "@/client"
+import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
+import { deriveProductState, type ProductSaleState } from "@/lib/product-state"
+
+export type AvailabilityProduct = Pick<
+  ProductPublic,
+  | "sale_starts_at"
+  | "sale_ends_at"
+  | "total_stock_cap"
+  | "total_stock_remaining"
+  | "max_per_order"
+>
+
+export interface ProductAvailability {
+  state: ProductSaleState
+  canSelect: boolean
+  maxAllowedQuantity: number
+}
+
+/**
+ * Single source of truth for whether a product can be added to the cart and
+ * how many units the UI is allowed to offer. Combines the derived sale state
+ * (upcoming / ended / sold_out / on_sale) with the per-order + remaining-stock
+ * caps so every variant and every cart hook gates the user identically.
+ *
+ * - `canSelect = false` for any state other than `on_sale` (covers sold_out,
+ *   upcoming, ended).
+ * - `maxAllowedQuantity = 0` whenever the product can't be selected.
+ */
+export function getProductAvailability(
+  product: AvailabilityProduct,
+  today?: string,
+): ProductAvailability {
+  const state = deriveProductState(product, today)
+  const canSelect = state === "on_sale"
+  const maxAllowedQuantity = canSelect ? resolveMaxQuantity(product) : 0
+  return { state, canSelect, maxAllowedQuantity }
+}
+
+export function isProductSoldOut(product: AvailabilityProduct): boolean {
+  return getProductAvailability(product).state === "sold_out"
+}


### PR DESCRIPTION
## Summary

Promotes the third-party OTP scoped auth feature from `dev` to `main`. Delivered as 6 chained PRs (#164 → #169), all merged to `dev` and now consolidated here.

## What lands

- **Third-party OTP login surface**: `POST /auth/human/third-party/{login,authenticate}` mints a scoped JWT for attendees acting via a registered third-party client (e.g. Openclaw). Tenant resolved server-side from the API key alone — no `X-Tenant-Id` header.
- **Tenant third-party key management**: `POST /tenants/{id}/third-party-key/rotate` + `DELETE` for ADMIN/SUPERADMIN. Backoffice panel for self-service rotation gated by `isAdmin`.
- **Scope catalog (platform policy, in code)**:
  - `THIRD_PARTY_TOKEN_SCOPES` — `portal:self_read`, `portal:directory_read`, `portal:api_keys_manage`.
  - `THIRD_PARTY_API_KEY_SCOPES` — `events:read`, `rsvp:write`.
  - `ADMIN_API_KEY_SCOPES` — events, attendees, applications, humans, groups, products, coupons, forms, payments (read-only), tracks, ticketing_steps, translations, rsvp, venues.
  - Explicitly excluded: `email_templates`, `users`, `tenants`, `tenants:credentials`, `popup_reviewers`, `payments:write`.
- **Admin API Keys**: new `POST/GET/DELETE /backoffice/api-keys` for ADMIN/SUPERADMIN. Admin keys validate via `_resolve_api_key` and authenticate the dual-auth admin endpoints across 14 domains.
- **Dual-auth sweep**: `CurrentAdminOrApiKey(scope)` applied to events, event_participants, event_venues, applications, attendees, humans, groups, products, coupons, forms (fields + sections), payments (read-only), tracks, ticketing_steps, translations. JWT path keeps existing role gates; api-key path enforces scope.
- **OTP origin tagging**: `humans.auth_code_origin` column + Redis key segmentation per flow. Closes a cross-flow escalation gap (third-party code can no longer be redeemed via portal `/authenticate` to obtain a `portal:*` JWT).
- **Frontend**: backoffice admin api keys management page + third-party integration panel (gated by feature flag `SHOW_AGENTIC_ACCESS = false` for the sidebar entry; route stays live).

## Migrations

Two new alembic revisions land in this PR:

1. `5e5739582c92` (on top of `d8f2e4a9c1b6` lowercase_emails) — adds `tenants.third_party_api_key_hash`, `tenants.third_party_key_prefix`, partial unique index on the hash, `api_keys.user_id`, makes `api_keys.human_id` nullable, XOR CHECK constraint on api_keys ownership.
2. `3e8f4a2b1c5d` — adds `humans.auth_code_origin`.

Single head after merge: `3e8f4a2b1c5d`. Apply with `cd backend && uv run alembic upgrade head`.

## Verification (already run against the chain tip on `dev`)

- ✅ `cd backend && uv run pytest -q` → 1027 passed, 1 skipped (pre-existing flaky).
- ✅ `cd backend && uv run ruff check .` → clean.
- ✅ `pnpm --filter backoffice run build` → clean.
- ✅ `pnpm --filter portal run build` → clean.
- ✅ Live: end-to-end third-party login (login → OTP → authenticate → scoped JWT) verified against staging-equivalent.
- ✅ Live: cross-flow OTP rejection verified (third-party OTP → portal `/authenticate` returns 401).
- ✅ Live: admin api key with `events:read` returns 200 on `GET /events`; same key returns 403 on `GET /attendees` with "API key lacks required scope" message.
- ✅ Live: scope subset enforcement on portal `/api-keys` mint — third-party JWT requesting `venues:write` returns 403.

## Source PRs

1. #164 — feat(backend): scope catalog, dual-owner api keys, and token payload foundations
2. #165 — feat(backend): portal scope guards and CurrentAdminOrApiKey dependency
3. #166 — feat(backend): third-party OTP login with scoped JWT issuance
4. #167 — feat(backend): admin api keys CRUD module under /backoffice/api-keys
5. #168 — feat(backend): dual-auth sweep across 14 admin domains
6. #169 — feat(backoffice): admin api keys page and third-party integration panel

## Deployment notes

- Apply migrations before restarting backend (column references in `api_keys` and `tenants` are new).
- Redis OTP keys pre-deploy get orphaned (key prefix changes to per-origin segmentation); users mid-login at deploy time need to re-trigger. Low impact, single retry resolves.
- Backoffice "Agentic access" sidebar entry stays hidden via feature flag. To expose admin api keys management UI, flip `SHOW_AGENTIC_ACCESS` to `true` in `backoffice/src/components/Sidebar/AppSidebar.tsx`.