### PR TITLE
feat(portal+backend): respect product sold-out state end-to-end

### DIFF
--- a/backend/app/api/product/crud.py
+++ b/backend/app/api/product/crud.py
@@ -194,6 +194,27 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
         session.refresh(db_obj)
         return db_obj
 
+    def _count_active_sales(
+        self, session: Session, product_id: uuid.UUID
+    ) -> int:
+        """Sum quantities of units currently holding stock for this product.
+
+        Counts payment_products rows whose payment is in a stock-holding
+        status — mirrors the same set of statuses that gate decrement /
+        restore (pending = reserved, approved = paid). Rejected / expired /
+        cancelled payments are excluded because they release stock.
+        """
+        result = session.execute(
+            text(
+                "SELECT COALESCE(SUM(pp.quantity), 0) "
+                "FROM payment_products pp "
+                "JOIN payments p ON p.id = pp.payment_id "
+                "WHERE pp.product_id = :pid "
+                "AND p.status IN ('pending', 'approved')"
+            ).bindparams(pid=product_id)
+        ).scalar()
+        return int(result or 0)
+
     def update(
         self,
         session: Session,
@@ -203,9 +224,18 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
         """Update product fields.
 
         When `total_stock_cap` changes without an explicit `total_stock_remaining`,
-        recompute remaining to preserve `sold = old_cap - old_remaining`. Otherwise
-        the CHECK constraint `total_stock_remaining <= total_stock_cap` rejects
-        any cap reduction below the stale remaining.
+        recompute remaining so that the existing sold count is preserved. Two
+        cases:
+
+        1. `old_cap` and `old_remaining` are both tracked → derive sold from the
+           counter (`old_cap - old_remaining`).
+        2. Either was NULL (product was unlimited, or never seeded) → count real
+           sales from `payment_products` to avoid losing prior sales when a cap
+           is added after the fact.
+
+        Without this, the CHECK constraint `total_stock_remaining <= total_stock_cap`
+        rejects cap reductions, and (worse) sales made while the product was
+        unlimited get silently dropped when the cap is added later.
         """
         update_data = sale_dates_to_persistence(obj_in.model_dump(exclude_unset=True))
 
@@ -227,7 +257,11 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
             if new_cap is None:
                 update_data["total_stock_remaining"] = None
             elif old_cap is None or old_remaining is None:
-                update_data["total_stock_remaining"] = new_cap
+                # Product was unlimited (or never seeded) — any prior sales
+                # weren't tracked in the counter. Pull sold from payment_products
+                # so we don't silently grant extra inventory.
+                sold = self._count_active_sales(session, db_obj.id)
+                update_data["total_stock_remaining"] = max(0, new_cap - sold)
             else:
                 sold = old_cap - old_remaining
                 update_data["total_stock_remaining"] = max(0, new_cap - sold)

--- a/backend/tests/api/product/test_cap_seed_from_real_sales.py
+++ b/backend/tests/api/product/test_cap_seed_from_real_sales.py
@@ -1,0 +1,228 @@
+"""Regression: setting a cap on a previously-unlimited product must count real
+sales from payment_products, not silently seed remaining=cap.
+
+Reproduces the bug where a Conference T-Shirt with cap=NULL had 1 unit sold,
+then admin set cap=1, and remaining was seeded to 1 — letting a second buyer
+exceed the cap.
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.payment.models import PaymentProducts, Payments
+from app.api.payment.schemas import PaymentStatus
+from app.api.popup.models import Popups
+from app.api.product.crud import products_crud
+from app.api.product.models import Products
+from app.api.product.schemas import ProductUpdate
+from app.api.tenant.models import Tenants
+
+
+def _make_unlimited_product(
+    db: Session, tenant: Tenants, popup: Popups
+) -> Products:
+    suffix = uuid.uuid4().hex[:8]
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"unlimited-{suffix}",
+        slug=f"unlimited-{suffix}",
+        price=Decimal("35"),
+        category="merch",
+        total_stock_cap=None,
+        total_stock_remaining=None,
+        is_active=True,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _record_sale(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    product: Products,
+    qty: int,
+    status: PaymentStatus = PaymentStatus.APPROVED,
+) -> Payments:
+    """Create a payment + payment_products snapshot mimicking a real sale.
+
+    Mirrors the helpers in tests/api/payment/test_stock_restoration.py — kept
+    self-contained here so this regression test doesn't cross-import.
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+    from app.api.attendee.models import Attendees
+    from app.api.human.models import Humans
+
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"sale-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Sale",
+        last_name="Test",
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.flush()
+
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        name="Sale Attendee",
+        category="main",
+        email=f"att-{uuid.uuid4().hex[:8]}@test.com",
+        check_in_code=f"S{uuid.uuid4().hex[:4].upper()}",
+    )
+    db.add(attendee)
+    db.flush()
+
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        status=status.value,
+        amount=Decimal(str(product.price * qty)),
+        currency="ARS",
+        external_id=f"sf-{uuid.uuid4().hex[:16]}",
+    )
+    db.add(payment)
+    db.flush()
+
+    pp = PaymentProducts(
+        tenant_id=tenant.id,
+        payment_id=payment.id,
+        product_id=product.id,
+        attendee_id=attendee.id,
+        quantity=qty,
+        product_name=product.name,
+        product_description=None,
+        product_price=product.price,
+        product_category=product.category or "merch",
+        product_currency="ARS",
+    )
+    db.add(pp)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def test_setting_cap_on_unlimited_product_counts_real_sales(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """cap=NULL with 1 APPROVED sale → PATCH cap=1 → remaining=0 (sold preserved)."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(db, tenant_a, popup_tenant_a, product, qty=1)
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=1))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_cap == 1
+    assert refreshed.total_stock_remaining == 0, (
+        "Expected remaining=0 because 1 unit was already sold while the "
+        "product was unlimited. Got "
+        f"{refreshed.total_stock_remaining} — sold count was silently dropped."
+    )
+
+
+def test_setting_cap_on_unlimited_product_counts_pending_sales(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """Pending payments hold stock too — they must count toward sold."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=2, status=PaymentStatus.PENDING
+    )
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=5))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_remaining == 3, (
+        "Pending sales hold stock until the payment expires — they must be "
+        "counted when seeding remaining from a fresh cap."
+    )
+
+
+def test_setting_cap_excludes_cancelled_and_expired_sales(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """Cancelled / expired / rejected payments released stock — must NOT count."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=1, status=PaymentStatus.CANCELLED
+    )
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=1, status=PaymentStatus.EXPIRED
+    )
+    _record_sale(
+        db, tenant_a, popup_tenant_a, product, qty=1, status=PaymentStatus.REJECTED
+    )
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=5))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_remaining == 5, (
+        "Released payments must not count as sold. Got "
+        f"{refreshed.total_stock_remaining}."
+    )
+
+
+def test_setting_cap_below_real_sold_clamps_to_zero(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """If sold > new_cap (admin underprovisioned), remaining clamps to 0."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(db, tenant_a, popup_tenant_a, product, qty=10)
+
+    products_crud.update(db, product, ProductUpdate(total_stock_cap=3))
+
+    db.expire_all()
+    refreshed = db.get(Products, product.id)
+    assert refreshed.total_stock_cap == 3
+    assert refreshed.total_stock_remaining == 0
+
+
+def test_api_patch_cap_on_unlimited_with_sales(
+    client: TestClient,
+    db: Session,
+    admin_token_tenant_a: str,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """End-to-end: PATCH via admin endpoint also counts real sales."""
+    product = _make_unlimited_product(db, tenant_a, popup_tenant_a)
+    _record_sale(db, tenant_a, popup_tenant_a, product, qty=1)
+
+    resp = client.patch(
+        f"/api/v1/products/{product.id}",
+        headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
+        json={"total_stock_cap": 1},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total_stock_cap"] == 1
+    assert data["total_stock_remaining"] == 0

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -6,9 +6,10 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
-  resolveMaxQuantity,
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
+import SoldOutBadge from "@/components/ui/SoldOutBadge"
+import { getProductAvailability } from "@/lib/product-availability"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
@@ -229,12 +230,19 @@ function CompactCard({
       : product.compare_price
     : null
   const supportsQty = supportsQuantitySelector(product.max_per_order)
-  const maxQty = resolveMaxQuantity(product)
+  const {
+    state,
+    canSelect,
+    maxAllowedQuantity: maxQty,
+  } = getProductAvailability(product)
+  const soldOut = state === "sold_out"
 
   return (
     <button
       type="button"
+      disabled={!canSelect}
       onClick={() => {
+        if (!canSelect) return
         if (supportsQty && quantity === 0) {
           onIncrement()
         } else {
@@ -246,9 +254,14 @@ function CompactCard({
         isSelected
           ? "border-l-primary bg-primary/10"
           : "border-l-border bg-checkout-card-bg hover:bg-muted",
+        !canSelect && "opacity-60 cursor-not-allowed hover:bg-checkout-card-bg",
       )}
     >
-      {supportsQty ? (
+      {!canSelect ? (
+        soldOut ? (
+          <SoldOutBadge />
+        ) : null
+      ) : supportsQty ? (
         <QuantitySelector
           value={quantity}
           max={maxQty}
@@ -346,12 +359,19 @@ function GridCard({
       : product.compare_price
     : null
   const supportsQty = supportsQuantitySelector(product.max_per_order)
-  const maxQty = resolveMaxQuantity(product)
+  const {
+    state,
+    canSelect,
+    maxAllowedQuantity: maxQty,
+  } = getProductAvailability(product)
+  const soldOut = state === "sold_out"
 
   return (
     <button
       type="button"
+      disabled={!canSelect}
       onClick={() => {
+        if (!canSelect) return
         if (supportsQty && quantity === 0) {
           onIncrement()
         } else {
@@ -363,6 +383,7 @@ function GridCard({
         isSelected
           ? "border-primary ring-2 ring-primary/20"
           : "border-border hover:border-muted-foreground/30",
+        !canSelect && "opacity-60 cursor-not-allowed hover:border-border",
       )}
     >
       {product.image_url ? (
@@ -380,7 +401,13 @@ function GridCard({
         </div>
       )}
 
-      {supportsQty ? (
+      {!canSelect ? (
+        soldOut && (
+          <div className="absolute top-2 right-2">
+            <SoldOutBadge />
+          </div>
+        )
+      ) : supportsQty ? (
         <div className="absolute top-2 right-2 rounded-full bg-background/90 backdrop-blur-sm shadow-sm px-1.5 py-0.5">
           <QuantitySelector
             value={quantity}
@@ -522,14 +549,21 @@ function DefaultSectionCard({
               : product.compare_price
             : null
           const supportsQty = supportsQuantitySelector(product.max_per_order)
-          const maxQty = resolveMaxQuantity(product)
+          const {
+            state,
+            canSelect,
+            maxAllowedQuantity: maxQty,
+          } = getProductAvailability(product)
+          const soldOut = state === "sold_out"
           const quantity = getQuantity(product.id)
 
           return (
             <button
               key={product.id}
               type="button"
+              disabled={!canSelect}
               onClick={() => {
+                if (!canSelect) return
                 if (supportsQty && quantity === 0) {
                   onIncrement(product.id)
                 } else {
@@ -541,10 +575,16 @@ function DefaultSectionCard({
                 isSelected
                   ? "border-primary bg-primary/10"
                   : "border-border bg-muted hover:border-muted-foreground/30",
+                !canSelect &&
+                  "opacity-60 cursor-not-allowed hover:border-border",
               )}
             >
               <div className="flex items-center gap-3 min-w-0">
-                {supportsQty ? (
+                {!canSelect ? (
+                  soldOut ? (
+                    <SoldOutBadge />
+                  ) : null
+                ) : supportsQty ? (
                   <QuantitySelector
                     value={quantity}
                     max={maxQty}
@@ -718,14 +758,21 @@ function ShowcaseSectionCard({
                 : product.compare_price
               : null
             const supportsQty = supportsQuantitySelector(product.max_per_order)
-            const maxQty = resolveMaxQuantity(product)
+            const {
+              state,
+              canSelect,
+              maxAllowedQuantity: maxQty,
+            } = getProductAvailability(product)
+            const soldOut = state === "sold_out"
             const quantity = getQuantity(product.id)
 
             return (
               <button
                 key={product.id}
                 type="button"
+                disabled={!canSelect}
                 onClick={() => {
+                  if (!canSelect) return
                   if (supportsQty && quantity === 0) {
                     onIncrement(product.id)
                   } else {
@@ -737,6 +784,7 @@ function ShowcaseSectionCard({
                   isSelected
                     ? "bg-primary/10 ring-2 ring-primary"
                     : "bg-muted hover:bg-muted/80 ring-1 ring-border",
+                  !canSelect && "opacity-60 cursor-not-allowed hover:bg-muted",
                 )}
               >
                 {product.image_url && (
@@ -786,7 +834,11 @@ function ShowcaseSectionCard({
                   </p>
                 </div>
 
-                {supportsQty ? (
+                {!canSelect ? (
+                  soldOut ? (
+                    <SoldOutBadge />
+                  ) : null
+                ) : supportsQty ? (
                   <QuantitySelector
                     value={quantity}
                     max={maxQty}

--- a/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
@@ -5,9 +5,10 @@ import Image from "next/image"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
-  resolveMaxQuantity,
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
+import SoldOutBadge from "@/components/ui/SoldOutBadge"
+import { getProductAvailability } from "@/lib/product-availability"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { formatCurrency } from "@/types/checkout"
@@ -33,7 +34,15 @@ function MerchQtyControl({
   onQuantityChange,
 }: MerchQtyControlProps) {
   const showStepper = supportsQuantitySelector(product.max_per_order)
-  const max = resolveMaxQuantity(product)
+  const {
+    state,
+    canSelect,
+    maxAllowedQuantity: max,
+  } = getProductAvailability(product)
+
+  if (!canSelect) {
+    return state === "sold_out" ? <SoldOutBadge /> : null
+  }
 
   if (showStepper) {
     return (
@@ -98,12 +107,14 @@ function MerchDefaultItem({
   const hasQuantity = quantity > 0
   const hasDiscount =
     product.compare_price != null && product.compare_price > product.price
+  const { canSelect } = getProductAvailability(product)
 
   return (
     <div
       className={cn(
         "p-4 transition-colors",
         hasQuantity ? "bg-primary/10" : "",
+        !canSelect && "opacity-60",
       )}
     >
       {/* Desktop layout */}
@@ -276,6 +287,7 @@ function MerchGrid({ products, getQuantity, onQuantityChange }: CardListProps) {
           const hasDiscount =
             product.compare_price != null &&
             product.compare_price > product.price
+          const { canSelect } = getProductAvailability(product)
 
           return (
             <div
@@ -283,6 +295,7 @@ function MerchGrid({ products, getQuantity, onQuantityChange }: CardListProps) {
               className={cn(
                 "rounded-2xl border overflow-hidden bg-checkout-card-bg transition-all",
                 hasQty ? "border-primary/30" : "border-border",
+                !canSelect && "opacity-60",
               )}
             >
               <div className="relative w-full aspect-square bg-muted flex items-center justify-center">
@@ -361,12 +374,15 @@ function MerchCompact({
         const hasQty = qty > 0
         const hasDiscount =
           product.compare_price != null && product.compare_price > product.price
+        const { canSelect } = getProductAvailability(product)
 
         const cardClassName = cn(
           "group relative w-full flex items-center gap-3 rounded-2xl border bg-checkout-card-bg px-3 py-2.5 transition-all",
           hasQty
             ? "border-primary/30 shadow-sm"
             : "border-border cursor-pointer hover:border-muted-foreground/40 hover:shadow-sm",
+          !canSelect &&
+            "opacity-60 cursor-not-allowed hover:border-border hover:shadow-none",
         )
 
         const cardBody = (
@@ -426,7 +442,15 @@ function MerchCompact({
             </div>
 
             <div className="relative shrink-0">
-              {hasQty ? (
+              {!canSelect ? (
+                <MerchQtyControl
+                  product={product}
+                  quantity={qty}
+                  onQuantityChange={(nextQty) =>
+                    onQuantityChange(product.id, nextQty)
+                  }
+                />
+              ) : hasQty ? (
                 <MerchQtyControl
                   product={product}
                   quantity={qty}
@@ -446,7 +470,7 @@ function MerchCompact({
           </>
         )
 
-        return hasQty ? (
+        return hasQty || !canSelect ? (
           <div key={product.id} className={cardClassName}>
             {cardBody}
           </div>

--- a/portal/src/components/ui/QuantitySelector.tsx
+++ b/portal/src/components/ui/QuantitySelector.tsx
@@ -123,7 +123,9 @@ const QuantitySelector = ({
 
   // Empty-slot state: single "+" add button — filled tile CTA, sized larger
   // than the +/- adjustment buttons so it reads as the primary action.
-  if (value === 0 && onAdd && !disabled) {
+  // Skip when max is 0 (sold out / unavailable) so we don't offer an action
+  // the parent will reject.
+  if (value === 0 && onAdd && !disabled && max > 0) {
     const isAccent = tone === "accent"
     const addClasses = cn(
       "transition-all duration-200 ease-out transform hover:scale-110 active:scale-95 flex items-center justify-center rounded-full shadow-sm",

--- a/portal/src/components/ui/SoldOutBadge.tsx
+++ b/portal/src/components/ui/SoldOutBadge.tsx
@@ -1,0 +1,7 @@
+export default function SoldOutBadge() {
+  return (
+    <span className="px-2 py-0.5 text-[10px] font-semibold uppercase rounded tracking-wide border shrink-0 bg-rose-100 text-rose-700 border-rose-200">
+      Sold out
+    </span>
+  )
+}

--- a/portal/src/hooks/checkout/useCartPersistence.ts
+++ b/portal/src/hooks/checkout/useCartPersistence.ts
@@ -1,6 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query"
 import { type MutableRefObject, useCallback, useEffect } from "react"
-import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
 import {
   type CartState,
   useCart,
@@ -8,6 +7,7 @@ import {
   useSaveCart,
 } from "@/hooks/useCartApi"
 import { checkAndClearPurchasePending } from "@/hooks/usePaymentRedirect"
+import { getProductAvailability } from "@/lib/product-availability"
 import { queryKeys } from "@/lib/query-keys"
 import type {
   CheckoutStep,
@@ -192,50 +192,66 @@ export function useCartPersistence({
 
     const { setHousing, setMerch, setPatron, setInsurance } = restorationSetters
 
-    // Restore housing
+    // Restore housing — skip products that are sold_out / ended / upcoming.
     if (savedCart.housing) {
       const product = products.find(
         (p) => p.id === savedCart.housing?.product_id,
       )
       if (product) {
-        const start = new Date(savedCart.housing.check_in)
-        const end = new Date(savedCart.housing.check_out)
-        const nights = Math.max(
-          1,
-          Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)),
-        )
-        const savedQuantity = savedCart.housing.quantity ?? 1
-        const maxQty = resolveMaxQuantity(product)
-        const quantity = Math.max(1, Math.min(savedQuantity, maxQty))
-        const basePrice = housingPricePerDay
-          ? product.price * nights
-          : product.price
-        setHousing({
-          productId: product.id,
-          product,
-          checkIn: savedCart.housing.check_in,
-          checkOut: savedCart.housing.check_out,
-          nights,
-          pricePerNight: product.price,
-          totalPrice: basePrice * quantity,
-          pricePerDay: housingPricePerDay,
-          quantity,
-        })
+        const { canSelect, maxAllowedQuantity } =
+          getProductAvailability(product)
+        if (canSelect) {
+          const start = new Date(savedCart.housing.check_in)
+          const end = new Date(savedCart.housing.check_out)
+          const nights = Math.max(
+            1,
+            Math.ceil(
+              (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24),
+            ),
+          )
+          const savedQuantity = savedCart.housing.quantity ?? 1
+          const quantity = Math.max(
+            1,
+            Math.min(savedQuantity, maxAllowedQuantity),
+          )
+          const basePrice = housingPricePerDay
+            ? product.price * nights
+            : product.price
+          setHousing({
+            productId: product.id,
+            product,
+            checkIn: savedCart.housing.check_in,
+            checkOut: savedCart.housing.check_out,
+            nights,
+            pricePerNight: product.price,
+            totalPrice: basePrice * quantity,
+            pricePerDay: housingPricePerDay,
+            quantity,
+          })
+        }
       }
     }
 
-    // Restore merch
+    // Restore merch — drop items whose product is no longer selectable.
     if (savedCart.merch?.length) {
       const restoredMerch = savedCart.merch.reduce<SelectedMerchItem[]>(
         (acc, saved) => {
           const product = products.find((p) => p.id === saved.product_id)
           if (!product || saved.quantity <= 0) return acc
+          const { canSelect, maxAllowedQuantity } =
+            getProductAvailability(product)
+          if (!canSelect) return acc
+          const quantity =
+            maxAllowedQuantity === Number.POSITIVE_INFINITY
+              ? saved.quantity
+              : Math.min(saved.quantity, maxAllowedQuantity)
+          if (quantity <= 0) return acc
           acc.push({
             productId: product.id,
             product,
-            quantity: saved.quantity,
+            quantity,
             unitPrice: product.price,
-            totalPrice: product.price * saved.quantity,
+            totalPrice: product.price * quantity,
           })
           return acc
         },
@@ -244,12 +260,13 @@ export function useCartPersistence({
       if (restoredMerch.length > 0) setMerch(restoredMerch)
     }
 
-    // Restore patron
+    // Restore patron — donation products are not stock-bound, but still respect
+    // sale-window state (upcoming/ended).
     if (savedCart.patron) {
       const product = products.find(
         (p) => p.id === savedCart.patron?.product_id,
       )
-      if (product) {
+      if (product && getProductAvailability(product).canSelect) {
         setPatron({
           productId: product.id,
           product,

--- a/portal/src/hooks/checkout/useHousingSelection.test.ts
+++ b/portal/src/hooks/checkout/useHousingSelection.test.ts
@@ -66,4 +66,22 @@ describe("useHousingSelection — id-lookup against full active product list", (
 
     expect(result.current.housing!.quantity).toBe(2)
   })
+
+  it("refuses to select a sold-out product (cap set, remaining=0)", () => {
+    const allActiveProducts = [
+      makeProduct({
+        id: "h-sold",
+        category: "housing",
+        total_stock_cap: 1,
+        total_stock_remaining: 0,
+      }),
+    ]
+    const { result } = renderHook(() => useHousingSelection(allActiveProducts))
+
+    act(() => {
+      result.current.selectHousing("h-sold", "2025-01-01", "2025-01-05")
+    })
+
+    expect(result.current.housing).toBeNull()
+  })
 })

--- a/portal/src/hooks/checkout/useHousingSelection.ts
+++ b/portal/src/hooks/checkout/useHousingSelection.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
+import { getProductAvailability } from "@/lib/product-availability"
 import type { SelectedHousingItem } from "@/types/checkout"
 import type { ProductsPass } from "@/types/Products"
 
@@ -21,9 +21,10 @@ function computeBasePrice(
 }
 
 function clampQuantity(product: ProductsPass, quantity: number): number {
-  const max = resolveMaxQuantity(product)
-  if (max === Number.POSITIVE_INFINITY) return Math.max(0, quantity)
-  return Math.max(0, Math.min(quantity, max))
+  const { maxAllowedQuantity } = getProductAvailability(product)
+  if (maxAllowedQuantity === Number.POSITIVE_INFINITY)
+    return Math.max(0, quantity)
+  return Math.max(0, Math.min(quantity, maxAllowedQuantity))
 }
 
 export function useHousingSelection(
@@ -36,6 +37,7 @@ export function useHousingSelection(
     (productId: string, checkIn: string, checkOut: string) => {
       const product = allActiveProducts.find((p) => p.id === productId)
       if (!product) return
+      if (!getProductAvailability(product).canSelect) return
 
       const nights = computeNights(checkIn, checkOut)
       const basePrice = computeBasePrice(product, nights, pricePerDay)
@@ -45,7 +47,8 @@ export function useHousingSelection(
         // (e.g. when the user only changes dates).
         const prevQuantity =
           prev && prev.productId === productId ? prev.quantity : 1
-        const quantity = clampQuantity(product, prevQuantity || 1) || 1
+        const quantity = clampQuantity(product, prevQuantity || 1)
+        if (quantity <= 0) return prev
         return {
           productId,
           product,

--- a/portal/src/hooks/checkout/useMerchSelection.test.ts
+++ b/portal/src/hooks/checkout/useMerchSelection.test.ts
@@ -101,6 +101,21 @@ describe("useMerchSelection — client-side max_per_order cap", () => {
     })
     expect(result.current.merch).toHaveLength(0)
   })
+
+  it("refuses to add a sold-out product (cap set, remaining=0)", () => {
+    const product = makeMerchProduct({
+      id: "merch-sold",
+      total_stock_cap: 1,
+      total_stock_remaining: 0,
+    })
+    const { result } = renderHook(() => useMerchSelection([product]))
+
+    act(() => {
+      result.current.updateMerchQuantity("merch-sold", 1)
+    })
+
+    expect(result.current.merch).toHaveLength(0)
+  })
 })
 
 describe("useMerchSelection — id-lookup against full active product list", () => {

--- a/portal/src/hooks/checkout/useMerchSelection.ts
+++ b/portal/src/hooks/checkout/useMerchSelection.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
+import { getProductAvailability } from "@/lib/product-availability"
 import type { SelectedMerchItem } from "@/types/checkout"
 import type { ProductsPass } from "@/types/Products"
 
@@ -11,11 +11,16 @@ export function useMerchSelection(allActiveProducts: ProductsPass[]) {
       const product = allActiveProducts.find((p) => p.id === productId)
       if (!product) return
 
-      const maxQty = resolveMaxQuantity(product)
+      const { canSelect, maxAllowedQuantity } = getProductAvailability(product)
+      if (!canSelect && quantity > 0) {
+        // Block adding to cart, but still allow clearing existing line.
+        setMerch((prev) => prev.filter((m) => m.productId !== productId))
+        return
+      }
       const clamped =
-        maxQty === Number.POSITIVE_INFINITY
+        maxAllowedQuantity === Number.POSITIVE_INFINITY
           ? Math.max(0, quantity)
-          : Math.max(0, Math.min(quantity, maxQty))
+          : Math.max(0, Math.min(quantity, maxAllowedQuantity))
 
       if (clamped <= 0) {
         setMerch((prev) => prev.filter((m) => m.productId !== productId))

--- a/portal/src/lib/product-availability.test.ts
+++ b/portal/src/lib/product-availability.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+import {
+  getProductAvailability,
+  isProductSoldOut,
+} from "./product-availability"
+
+const baseProduct = {
+  sale_starts_at: null,
+  sale_ends_at: null,
+  total_stock_cap: null,
+  total_stock_remaining: null,
+  max_per_order: null,
+}
+
+describe("getProductAvailability", () => {
+  it("returns on_sale with unlimited quantity when no caps are set", () => {
+    const av = getProductAvailability(baseProduct)
+    expect(av.state).toBe("on_sale")
+    expect(av.canSelect).toBe(true)
+    expect(av.maxAllowedQuantity).toBe(Number.POSITIVE_INFINITY)
+  })
+
+  it("flags sold_out and zeroes the max when remaining is 0 against a non-null cap", () => {
+    const av = getProductAvailability({
+      ...baseProduct,
+      total_stock_cap: 1,
+      total_stock_remaining: 0,
+    })
+    expect(av.state).toBe("sold_out")
+    expect(av.canSelect).toBe(false)
+    expect(av.maxAllowedQuantity).toBe(0)
+  })
+
+  it("blocks selection when the sale window has ended even if stock is available", () => {
+    const av = getProductAvailability(
+      {
+        ...baseProduct,
+        sale_ends_at: "2026-01-01",
+        total_stock_cap: 10,
+        total_stock_remaining: 10,
+      },
+      "2026-02-01",
+    )
+    expect(av.state).toBe("ended")
+    expect(av.canSelect).toBe(false)
+    expect(av.maxAllowedQuantity).toBe(0)
+  })
+
+  it("blocks selection for upcoming products", () => {
+    const av = getProductAvailability(
+      {
+        ...baseProduct,
+        sale_starts_at: "2027-01-01",
+      },
+      "2026-01-01",
+    )
+    expect(av.state).toBe("upcoming")
+    expect(av.canSelect).toBe(false)
+  })
+
+  it("respects max_per_order when on sale", () => {
+    const av = getProductAvailability({
+      ...baseProduct,
+      max_per_order: 3,
+      total_stock_cap: 100,
+      total_stock_remaining: 100,
+    })
+    expect(av.state).toBe("on_sale")
+    expect(av.maxAllowedQuantity).toBe(3)
+  })
+
+  it("uses min(max_per_order, remaining) when both are set", () => {
+    const av = getProductAvailability({
+      ...baseProduct,
+      max_per_order: 10,
+      total_stock_cap: 5,
+      total_stock_remaining: 2,
+    })
+    expect(av.maxAllowedQuantity).toBe(2)
+  })
+})
+
+describe("isProductSoldOut", () => {
+  it("returns true only when the derived state is sold_out", () => {
+    expect(
+      isProductSoldOut({
+        ...baseProduct,
+        total_stock_cap: 1,
+        total_stock_remaining: 0,
+      }),
+    ).toBe(true)
+    expect(isProductSoldOut(baseProduct)).toBe(false)
+    expect(
+      isProductSoldOut({
+        ...baseProduct,
+        sale_ends_at: "2026-01-01",
+      }),
+    ).toBe(false)
+  })
+})

--- a/portal/src/lib/product-availability.ts
+++ b/portal/src/lib/product-availability.ts
@@ -1,0 +1,42 @@
+import type { ProductPublic } from "@/client"
+import { resolveMaxQuantity } from "@/components/ui/QuantitySelector"
+import { deriveProductState, type ProductSaleState } from "@/lib/product-state"
+
+export type AvailabilityProduct = Pick<
+  ProductPublic,
+  | "sale_starts_at"
+  | "sale_ends_at"
+  | "total_stock_cap"
+  | "total_stock_remaining"
+  | "max_per_order"
+>
+
+export interface ProductAvailability {
+  state: ProductSaleState
+  canSelect: boolean
+  maxAllowedQuantity: number
+}
+
+/**
+ * Single source of truth for whether a product can be added to the cart and
+ * how many units the UI is allowed to offer. Combines the derived sale state
+ * (upcoming / ended / sold_out / on_sale) with the per-order + remaining-stock
+ * caps so every variant and every cart hook gates the user identically.
+ *
+ * - `canSelect = false` for any state other than `on_sale` (covers sold_out,
+ *   upcoming, ended).
+ * - `maxAllowedQuantity = 0` whenever the product can't be selected.
+ */
+export function getProductAvailability(
+  product: AvailabilityProduct,
+  today?: string,
+): ProductAvailability {
+  const state = deriveProductState(product, today)
+  const canSelect = state === "on_sale"
+  const maxAllowedQuantity = canSelect ? resolveMaxQuantity(product) : 0
+  return { state, canSelect, maxAllowedQuantity }
+}
+
+export function isProductSoldOut(product: AvailabilityProduct): boolean {
+  return getProductAvailability(product).state === "sold_out"
+}


### PR DESCRIPTION
## Summary

- **Frontend**: Centralized product availability gate (`portal/src/lib/product-availability.ts`) used by every cart hook and checkout variant. Housing and merch now render a "Sold out" badge and block selection when `total_stock_remaining <= 0`, matching what tickets already did. Cart rehydration drops sold-out items so localStorage can't resurrect them. `QuantitySelector` hides the empty-slot "+" CTA when `max === 0`.
- **Backend**: `products_crud.update()` previously seeded `total_stock_remaining = cap` when transitioning from `cap=NULL` to a concrete cap — silently dropping any sales recorded while the product was unlimited. Now it counts active `payment_products` (PENDING + APPROVED) so cap enforcement reflects real sold units.

Bug originally surfaced as a housing product (cap=1, remaining=0) rendering with an active "+" button in checkout, and a merch product (cap=NULL → cap=1) showing remaining=1 after a unit was already sold.

## Changes

| File | Change |
|------|--------|
| `portal/src/lib/product-availability.ts` (new) | Single source of truth — combines `deriveProductState` + `resolveMaxQuantity`. Returns `{state, canSelect, maxAllowedQuantity}`. |
| `portal/src/lib/product-availability.test.ts` (new) | 7 cases covering sold_out, ended, upcoming, max_per_order, min(cap,remaining). |
| `portal/src/components/ui/SoldOutBadge.tsx` (new) | Shared rose badge — same visual as `VariantTicketSelect` sold_out tile. |
| `portal/src/components/ui/QuantitySelector.tsx` | Skip empty-slot "+" CTA when `max <= 0`. |
| `portal/src/components/checkout-flow/variants/VariantHousingDate.tsx` | All four card layouts (Compact, Grid, DefaultSection, ShowcaseSection) consume the helper; render badge + disable button when sold out. |
| `portal/src/components/checkout-flow/variants/VariantMerchImage.tsx` | `MerchQtyControl` returns the badge directly when not selectable; all three layouts dim sold-out cards. |
| `portal/src/hooks/checkout/useHousingSelection.ts` | Reject `selectHousing` when product not selectable. Removed `\|\| 1` fallback that resurrected qty=1 from a zero clamp. |
| `portal/src/hooks/checkout/useMerchSelection.ts` | Reject increments when product not selectable; clears existing line if present. |
| `portal/src/hooks/checkout/useCartPersistence.ts` | Filter sold-out housing/merch/patron items during rehydration. |
| `portal/src/hooks/checkout/useHousingSelection.test.ts` | New case: sold-out product cannot be selected. |
| `portal/src/hooks/checkout/useMerchSelection.test.ts` | New case: sold-out product cannot be added. |
| `backend/app/api/product/crud.py` | New `_count_active_sales()`. `update()` uses it on the NULL → capped branch so seeded remaining = max(0, cap - real_sold). |
| `backend/tests/api/product/test_cap_seed_from_real_sales.py` (new) | 5 cases: approved counted, pending counted, cancelled/expired/rejected excluded, clamp to 0, end-to-end PATCH. |

## Test plan

- [x] `pnpm vitest run src/hooks/checkout/ src/lib/` → 52/52 pass.
- [x] `pnpm biome check` on all changed files → clean.
- [x] `cd backend && uv run pytest tests/api/product/` → 85/85 pass.
- [x] `cd backend && uv run pytest tests/api/payment/test_stock_restoration.py tests/api/payment/test_integration_stock_lifecycle.py` → 17/17 pass.
- [x] `uv run ruff check` on changed backend files → clean.
- [ ] **Reviewer smoke test**:
  - Backoffice → set a housing/merch product to `cap=1` after a sale → checkout should render it as "Sold out", disabled.
  - Verify existing tickets still render their own sold_out tile (no regression in `VariantTicketSelect`).

## Notes

This fix addresses the immediate symptoms. The deeper architectural fix (replace `total_stock_remaining` counter with monotonic `total_stock_sold`, derive remaining at read time) remains as deferred refactor #1353 — agreed to defer per scope discussion in this session.

Existing records that already drifted (e.g. products created with `cap=NULL`, sold N units, then admin set `cap`) are NOT auto-repaired by this fix. To recover them, either re-trigger the seed via `PATCH {total_stock_cap: null}` → `PATCH {total_stock_cap: N}`, or `UPDATE products SET total_stock_remaining = ...` manually. Detection query available in session notes.