### PR TITLE
fix(backend): drop incorrect global unique on users.email and normalize humans email casing

### DIFF
--- a/backend/app/alembic/versions/d8f2e4a9c1b6_lowercase_emails.py
+++ b/backend/app/alembic/versions/d8f2e4a9c1b6_lowercase_emails.py
@@ -73,6 +73,16 @@ def upgrade() -> None:
     _assert_no_collisions(conn, "humans", ["tenant_id"])
     _assert_no_collisions(conn, "pending_humans", ["tenant_id"])
 
+    # Drop the legacy global unique index on users.email. It is incorrect in
+    # this multi-tenant system: uniqueness is already enforced per active
+    # (tenant_id, email) by the partial index uq_user_email_tenant_id_active,
+    # and soft-deleted rows must be allowed to share an email with active or
+    # other soft-deleted rows. The global unique index also blocks this
+    # backfill when two rows differ only by casing (one soft-deleted, one
+    # active) because their lowercased forms collide.
+    op.drop_index("ix_users_email", table_name="users")
+    op.create_index("ix_users_email", "users", ["email"], unique=False)
+
     op.execute(
         "UPDATE users SET email = LOWER(email) WHERE email <> LOWER(email)"
     )

--- a/backend/app/api/auth/pending_human_models.py
+++ b/backend/app/api/auth/pending_human_models.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime
 
+from pydantic import field_validator
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Column, DateTime, Field, SQLModel
@@ -30,3 +31,8 @@ class PendingHumans(SQLModel, table=True):
 
     picture_url: str | None = Field(default=None, max_length=500)
     red_flag: bool = Field(default=False)
+
+    @field_validator("email", mode="after")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return v.lower().strip()

--- a/backend/app/api/human/schemas.py
+++ b/backend/app/api/human/schemas.py
@@ -37,6 +37,11 @@ class HumanBase(SQLModel):
     # current OTP so the verify path can reject cross-flow redemption.
     auth_code_origin: str | None = Field(default=None, max_length=20)
 
+    @field_validator("email", mode="after")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return v.lower().strip()
+
 
 class HumanPublic(BaseModel):
     """Human schema for API responses."""

--- a/backend/app/api/user/schemas.py
+++ b/backend/app/api/user/schemas.py
@@ -8,7 +8,7 @@ from app.api.shared.enums import UserRole
 
 
 class UserBase(SQLModel):
-    email: EmailStr = Field(unique=True, index=True, max_length=255)
+    email: EmailStr = Field(index=True, max_length=255)
     full_name: str | None = Field(default=None, max_length=255)
     role: UserRole
     deleted: bool = False


### PR DESCRIPTION
## Summary

- Drops the legacy global unique constraint `ix_users_email` and recreates it as a non-unique index inside the lowercase-emails migration. The constraint contradicts the per-tenant partial unique `uq_user_email_tenant_id_active` and was blocking the backfill when active and soft-deleted rows differed only by casing (e.g. `Michael@...` soft-deleted + `michael@...` active in the same tenant).
- Removes `unique=True` from `UserBase.email` so future Alembic autogenerate runs do not recreate the incorrect global constraint.
- Adds the existing `normalize_email` validator to `HumanBase` and `PendingHumans` so every email entry path lowercases input, matching the case-sensitive equality lookups across `auth/crud.py`, `user/crud.py`, and `human/crud.py`.

## Why this matters

In a multi-tenant system, two distinct tenants can legitimately have a user with the same email, and a soft-deleted row must not block reuse of its email — that is exactly what `uq_user_email_tenant_id_active` (partial unique on `(email, tenant_id) WHERE deleted = false`) already enforces. The legacy `ix_users_email` unique-on-`email`-alone is a leftover that was silently invalid and only surfaced when the lowercase backfill collided two rows that differed only by casing.

## Test plan

- [ ] Run the migration in staging against a tenant DB with case-only duplicates between active and soft-deleted rows; expect the backfill to succeed.
- [ ] Confirm `alembic heads` returns a single head before deploy.
- [ ] Verify creating a Human/PendingHuman with mixed-case email persists lowercase.
- [ ] Smoke test login (User and Human OTP flows) post-deploy to confirm case-sensitive lookups still match.