### PR TITLE
Merge dev into main

### DIFF
--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -151,16 +151,17 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
 
         The window MUST already include the caller's setup/teardown buffer.
         Overlap rule: existing.start < window_end AND existing.end > window_start.
-        Cancelled events are ignored (they free the slot).
+        Cancelled and rejected events are ignored (they free the slot).
         """
         # Pull all potentially-relevant rows. Non-recurring rows can be
         # filtered directly. Recurring masters (rrule IS NOT NULL) need to
         # be expanded on-the-fly since their start_time only marks the
         # first occurrence.
+        freed_statuses = [EventStatus.CANCELLED, EventStatus.REJECTED]
         non_recurring = (
             select(Events)
             .where(Events.venue_id == venue_id)
-            .where(Events.status != EventStatus.CANCELLED)
+            .where(col(Events.status).notin_(freed_statuses))
             .where(Events.rrule.is_(None))  # type: ignore[union-attr]
             .where(Events.start_time < window_end)
             .where(Events.end_time > window_start)
@@ -172,7 +173,7 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
         recurring = (
             select(Events)
             .where(Events.venue_id == venue_id)
-            .where(Events.status != EventStatus.CANCELLED)
+            .where(col(Events.status).notin_(freed_statuses))
             .where(Events.rrule.is_not(None))  # type: ignore[union-attr]
         )
         if exclude_event_id is not None:

--- a/backend/tests/test_recurrence_conflicts.py
+++ b/backend/tests/test_recurrence_conflicts.py
@@ -174,6 +174,48 @@ class TestRecurrenceConflictMessage:
         assert resp.json()["detail"] == "Venue already booked (conflicts: Lunch)"
 
 
+class TestFreedStatusesDoNotConflict:
+    """CANCELLED and REJECTED events must release their venue slot."""
+
+    def test_rejected_event_does_not_block_new_booking(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        venue = _make_venue(db, tenant_a, popup)
+
+        slot = datetime(2026, 8, 4, 15, 0, tzinfo=UTC)
+        rejected = _make_event(
+            db,
+            tenant_a,
+            popup,
+            start=slot,
+            venue_id=venue.id,
+            title="Rejected Request",
+        )
+        rejected.status = EventStatus.REJECTED
+        db.add(rejected)
+        db.commit()
+
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "popup_id": str(popup.id),
+                "title": "Replacement",
+                "start_time": slot.isoformat(),
+                "end_time": (slot + timedelta(hours=1)).isoformat(),
+                "timezone": "UTC",
+                "venue_id": str(venue.id),
+            },
+        )
+
+        assert resp.status_code == 201, resp.text
+
+
 class TestFormatOccurrenceLabel:
     """Direct coverage for the locale-independent label formatter."""
 

--- a/packages/shared-form-ui/src/components/Form/PhoneInputForm.tsx
+++ b/packages/shared-form-ui/src/components/Form/PhoneInputForm.tsx
@@ -76,7 +76,9 @@ export const PhoneInputForm = ({
         placeholder={placeholder}
         disabled={disabled}
         className={cn(
-          "flex w-full rounded-md border border-input bg-white px-3 py-2 text-sm [&_.PhoneInputInput]:bg-white [&_.PhoneInputInput]:outline-none [&_.PhoneInputInput]:border-0",
+          "flex h-9 w-full items-center rounded-md border border-input bg-transparent px-3 text-base shadow-sm transition-colors focus-within:ring-1 focus-within:ring-ring md:text-sm",
+          "[&_.PhoneInputInput]:bg-transparent [&_.PhoneInputInput]:text-foreground [&_.PhoneInputInput]:outline-none [&_.PhoneInputInput]:border-0 [&_.PhoneInputInput]:placeholder:text-muted-foreground",
+          disabled && "bg-muted border-muted-foreground/50 cursor-not-allowed opacity-50",
           error && "border-red-500",
         )}
       />


### PR DESCRIPTION
## Summary
- `fix(events)`: treat rejected events as freeing the venue slot
- `style(shared-form-ui)`: align PhoneInputForm styling with standard input

## Test plan
- [ ] Verify rejected events release their venue slot in the calendar/availability view
- [ ] Verify PhoneInputForm renders consistently with other form inputs (height, border, focus ring, disabled state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)