### PR TITLE
feat(backend): contribution fee — popup config + payment wiring (1/3)

### DIFF
--- a/backend/app/alembic/versions/f6c1f50160ef_popup_contribution_fee.py
+++ b/backend/app/alembic/versions/f6c1f50160ef_popup_contribution_fee.py
@@ -1,0 +1,83 @@
+"""popup contribution fee
+
+Adds four contribution_* config columns to popups and contribution_amount
+persistence column to payments. Single atomic migration for this feature.
+
+Column-length rationale:
+- contribution_label VARCHAR(255): matches popup string field convention
+  (e.g., name: max_length=255 in PopupCreate).
+- contribution_description TEXT: admin-authored copy, length-unbounded —
+  matches PaymentProductBase.product_description: sa_type=Text() precedent.
+
+No RLS changes: both tables already have RLS (existing tenant tables).
+PostgreSQL 11+ handles ADD COLUMN ... NOT NULL DEFAULT <constant> without
+a table rewrite for booleans, and nullable additions are always instant.
+
+Revision ID: f6c1f50160ef
+Revises: 3e8f4a2b1c5d
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "f6c1f50160ef"
+down_revision: str = "3e8f4a2b1c5d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Popup contribution config
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_percentage",
+            sa.Numeric(precision=5, scale=2),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_label",
+            sa.String(length=255),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_description",
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+
+    # Payment persistence
+    op.add_column(
+        "payments",
+        sa.Column(
+            "contribution_amount",
+            sa.Numeric(precision=10, scale=2),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("payments", "contribution_amount")
+    op.drop_column("popups", "contribution_description")
+    op.drop_column("popups", "contribution_label")
+    op.drop_column("popups", "contribution_percentage")
+    op.drop_column("popups", "contribution_enabled")

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -1296,12 +1296,25 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 response.group_id = None
                 response.scholarship_discount = True
 
+        # Capture pre-fee snapshot BEFORE any fees are added.
+        # Both insurance and contribution must read from the same pre-fee baseline
+        # so neither fee compounds the other (see design ADR-2).
+        pre_fee_amount = response.amount
+
         # Calculate insurance if requested (application-flow only — POPUP-6)
         if obj.insurance:
             popup = application.popup if application else None
             insurance_amount = self._calculate_insurance(session, obj.products, popup)
             response.insurance_amount = insurance_amount
             response.amount += insurance_amount
+
+        # Calculate contribution fee (mandatory when popup enables it — no buyer opt-in).
+        # Uses the pre-fee snapshot so contribution base does not include insurance.
+        popup = application.popup if application else None
+        if popup and popup.contribution_enabled and popup.contribution_percentage:
+            contribution_amount = calculate_contribution_amount(popup, pre_fee_amount)
+            response.contribution_amount = contribution_amount
+            response.amount += contribution_amount
 
         return response
 
@@ -1477,6 +1490,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 status=PaymentStatus.APPROVED.value,
                 amount=preview.amount,
                 insurance_amount=preview.insurance_amount,
+                contribution_amount=preview.contribution_amount,
                 currency=preview.currency,
                 coupon_id=preview.coupon_id,
                 coupon_code=preview.coupon_code,
@@ -1616,6 +1630,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             status=simplefi_response.status,
             amount=preview.amount,
             insurance_amount=preview.insurance_amount,
+            contribution_amount=preview.contribution_amount,
             currency=preview.currency,
             coupon_id=preview.coupon_id,
             coupon_code=preview.coupon_code,

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -138,6 +138,36 @@ def calculate_insurance_amount(
     )
 
 
+def calculate_contribution_amount(
+    popup: "Any",
+    products_subtotal: Decimal,
+) -> Decimal:
+    """Pure function: compute contribution amount from popup settings + pre-fee subtotal.
+
+    Contribution is MANDATORY when enabled at popup level — there is no buyer opt-in
+    flag. Mirrors `calculate_insurance_amount` shape but drops the per-product
+    eligibility filter (contribution applies over the full pre-fee order subtotal).
+
+    Args:
+        popup: Object with .contribution_enabled (bool) and
+            .contribution_percentage (Decimal|None).
+        products_subtotal: Pre-fee snapshot of the order amount
+            (post-discount, pre-insurance, pre-contribution).
+
+    Returns:
+        Contribution amount rounded to 2 decimal places.
+        Returns Decimal("0") if contribution is disabled or percentage is None.
+    """
+    if not popup.contribution_enabled:
+        return Decimal("0")
+    if popup.contribution_percentage is None:
+        return Decimal("0")
+
+    return (products_subtotal * popup.contribution_percentage / 100).quantize(
+        MONEY_PRECISION, rounding=ROUND_HALF_UP
+    )
+
+
 def _require_application_id(application_id: uuid.UUID | None) -> uuid.UUID:
     """Narrow optional application ids for application-based flows."""
     if application_id is None:

--- a/backend/app/api/payment/schemas.py
+++ b/backend/app/api/payment/schemas.py
@@ -88,6 +88,10 @@ class PaymentBase(SQLModel):
         default=Decimal("0"),
         sa_column=Column(Numeric(10, 2), nullable=False, server_default="0"),
     )
+    contribution_amount: Decimal = Field(
+        default=Decimal("0"),
+        sa_column=Column(Numeric(10, 2), nullable=False, server_default="0"),
+    )
     currency: str = Field(default="USD")
     settlement_currency: str | None = Field(
         default=None,
@@ -204,6 +208,7 @@ class PaymentPreview(BaseModel):
     original_amount: Decimal
     amount: Decimal
     insurance_amount: Decimal = Decimal("0")
+    contribution_amount: Decimal = Decimal("0")
     currency: str = "USD"
     edit_passes: bool = False
 

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -5,7 +5,7 @@ from enum import StrEnum
 from typing import Self
 
 from pydantic import ConfigDict, field_validator, model_validator
-from sqlalchemy import Boolean, Column, Numeric
+from sqlalchemy import Boolean, Column, Numeric, Text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlmodel import Field, SQLModel, String
 
@@ -32,6 +32,23 @@ def validate_popup_insurance_config(enabled: bool, pct: "Decimal | None") -> Non
     if pct > 100:
         raise ValueError(
             "insurance_percentage must be <= 100 (it represents a percentage)"
+        )
+
+
+def validate_popup_contribution_config(enabled: bool, pct: "Decimal | None") -> None:
+    """Validate contribution_percentage bounds when contribution is enabled.
+
+    Raises ValueError if enabled=True and pct is None, <= 0, or > 100.
+    """
+    if not enabled:
+        return
+    if pct is None or pct <= 0:
+        raise ValueError(
+            "contribution_percentage must be > 0 when contribution_enabled is True"
+        )
+    if pct > 100:
+        raise ValueError(
+            "contribution_percentage must be <= 100 (it represents a percentage)"
         )
 
 
@@ -127,6 +144,19 @@ class PopupBase(SQLModel):
         default=None,
         sa_column=Column(Numeric(5, 2), nullable=True),
     )
+    contribution_enabled: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
+    contribution_percentage: Decimal | None = Field(
+        default=None,
+        sa_column=Column(Numeric(5, 2), nullable=True),
+    )
+    contribution_label: str | None = Field(default=None, max_length=255)
+    contribution_description: str | None = Field(
+        default=None,
+        sa_column=Column(Text(), nullable=True),
+    )
     application_layout: ApplicationLayout = Field(
         default=ApplicationLayout.single_page,
         sa_column=Column(String, nullable=False, server_default="single_page"),
@@ -188,6 +218,10 @@ class PopupCreate(SQLModel):
     supported_languages: list[str] = ["en"]
     insurance_enabled: bool = False
     insurance_percentage: Decimal | None = None
+    contribution_enabled: bool = False
+    contribution_percentage: Decimal | None = None
+    contribution_label: str | None = None
+    contribution_description: str | None = None
     application_layout: ApplicationLayout = ApplicationLayout.single_page
     events_enabled: bool = True
     self_check_in_enabled: bool = False
@@ -211,6 +245,9 @@ class PopupCreate(SQLModel):
             )
         validate_popup_insurance_config(
             self.insurance_enabled, self.insurance_percentage
+        )
+        validate_popup_contribution_config(
+            self.contribution_enabled, self.contribution_percentage
         )
         return self
 
@@ -252,6 +289,10 @@ class PopupUpdate(SQLModel):
     supported_languages: list[str] | None = None
     insurance_enabled: bool | None = None
     insurance_percentage: Decimal | None = None
+    contribution_enabled: bool | None = None
+    contribution_percentage: Decimal | None = None
+    contribution_label: str | None = None
+    contribution_description: str | None = None
     application_layout: ApplicationLayout | None = None
     events_enabled: bool | None = None
     self_check_in_enabled: bool | None = None
@@ -283,6 +324,9 @@ class PopupUpdate(SQLModel):
         # Validate insurance only when insurance_enabled is explicitly set to True
         if self.insurance_enabled is True:
             validate_popup_insurance_config(True, self.insurance_percentage)
+        # Validate contribution only when contribution_enabled is explicitly set to True
+        if self.contribution_enabled is True:
+            validate_popup_contribution_config(True, self.contribution_percentage)
         return self
 
 
@@ -318,6 +362,10 @@ class PopupPublic(SQLModel):
     supported_languages: list[str] = ["en"]
     insurance_enabled: bool = False
     insurance_percentage: Decimal | None = None
+    contribution_enabled: bool = False
+    contribution_percentage: Decimal | None = None
+    contribution_label: str | None = None
+    contribution_description: str | None = None
     application_layout: ApplicationLayout = ApplicationLayout.single_page
     events_enabled: bool = True
     show_attendee_directory: bool = False

--- a/backend/tests/api/payment/test_contribution_calculation.py
+++ b/backend/tests/api/payment/test_contribution_calculation.py
@@ -1,0 +1,85 @@
+"""Unit tests for calculate_contribution_amount (TDD — RED first).
+
+Scenarios covered:
+  - SCN-05: enabled + round subtotal → exact result
+  - SCN-06: enabled + fractional subtotal → half-up rounding
+  - SCN-04: enabled + null percentage → 0
+  - SCN-02: disabled popup → 0
+  - Edge: zero subtotal → 0
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.api.payment.crud import calculate_contribution_amount
+
+
+class _FakePopup:
+    """Minimal popup stand-in for pure-function tests."""
+
+    def __init__(
+        self,
+        *,
+        contribution_enabled: bool,
+        contribution_percentage: str | None,
+    ) -> None:
+        self.contribution_enabled = contribution_enabled
+        self.contribution_percentage = (
+            Decimal(contribution_percentage)
+            if contribution_percentage is not None
+            else None
+        )
+
+
+class TestCalculateContributionAmount:
+    def test_enabled_round_subtotal_returns_exact_amount(self) -> None:
+        """SCN-05: 5% of $100.00 = $5.00 exactly."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        assert result == Decimal("5.00")
+
+    def test_enabled_fractional_subtotal_rounds_half_up(self) -> None:
+        """SCN-06: 5% of $33.33 = $1.6665 → rounds half-up to $1.67."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("33.33"))
+        assert result == Decimal("1.67")
+
+    def test_enabled_null_percentage_returns_zero(self) -> None:
+        """SCN-04: enabled=True, percentage=null → 0 (not configured)."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage=None
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        assert result == Decimal("0")
+
+    def test_disabled_popup_returns_zero(self) -> None:
+        """SCN-02: contribution_enabled=False → 0 regardless of subtotal."""
+        popup = _FakePopup(
+            contribution_enabled=False, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        assert result == Decimal("0")
+
+    def test_zero_subtotal_returns_zero(self) -> None:
+        """Edge: subtotal=0, enabled → contribution is 0."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("0"))
+        assert result == Decimal("0")
+
+    def test_result_precision_is_two_decimal_places(self) -> None:
+        """Calculation result always has exactly 2 decimal places."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="3.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        # 3% of 100 = 3.00 — verify it's Decimal with proper precision
+        assert result == Decimal("3.00")
+        # Ensure the exponent represents 2 decimal places
+        assert result == result.quantize(Decimal("0.01"))

--- a/backend/tests/api/payment/test_contribution_calculation.py
+++ b/backend/tests/api/payment/test_contribution_calculation.py
@@ -10,8 +10,6 @@ Scenarios covered:
 
 from decimal import Decimal
 
-import pytest
-
 from app.api.payment.crud import calculate_contribution_amount
 
 
@@ -35,49 +33,37 @@ class _FakePopup:
 class TestCalculateContributionAmount:
     def test_enabled_round_subtotal_returns_exact_amount(self) -> None:
         """SCN-05: 5% of $100.00 = $5.00 exactly."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         assert result == Decimal("5.00")
 
     def test_enabled_fractional_subtotal_rounds_half_up(self) -> None:
         """SCN-06: 5% of $33.33 = $1.6665 → rounds half-up to $1.67."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("33.33"))
         assert result == Decimal("1.67")
 
     def test_enabled_null_percentage_returns_zero(self) -> None:
         """SCN-04: enabled=True, percentage=null → 0 (not configured)."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage=None
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage=None)
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         assert result == Decimal("0")
 
     def test_disabled_popup_returns_zero(self) -> None:
         """SCN-02: contribution_enabled=False → 0 regardless of subtotal."""
-        popup = _FakePopup(
-            contribution_enabled=False, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=False, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         assert result == Decimal("0")
 
     def test_zero_subtotal_returns_zero(self) -> None:
         """Edge: subtotal=0, enabled → contribution is 0."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("0"))
         assert result == Decimal("0")
 
     def test_result_precision_is_two_decimal_places(self) -> None:
         """Calculation result always has exactly 2 decimal places."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="3.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="3.00")
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         # 3% of 100 = 3.00 — verify it's Decimal with proper precision
         assert result == Decimal("3.00")

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -1,0 +1,316 @@
+"""Integration tests for contribution fee wiring in _apply_discounts (TDD — RED first).
+
+Scenarios covered:
+  - SCN-01: contribution enabled → preview includes non-zero contribution_amount
+  - SCN-02: contribution disabled → preview has contribution_amount=0
+  - SCN-04: enabled + null percentage → contribution_amount=0
+  - SCN-07: insurance + contribution both enabled → parallel fees, no compounding
+  - SCN-08: direct-sale (sale_type=direct) → contribution NOT applied
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import Attendees
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_popup(
+    db: Session,
+    tenant: Tenants,
+    *,
+    contribution_enabled: bool = False,
+    contribution_percentage: str | None = None,
+    insurance_enabled: bool = False,
+    insurance_percentage: str | None = None,
+    sale_type: SaleType = SaleType.application,
+) -> Popups:
+    popup = Popups(
+        name=f"Contribution Integration {uuid.uuid4().hex[:8]}",
+        slug=f"contribution-integration-{uuid.uuid4().hex[:8]}",
+        tenant_id=tenant.id,
+        contribution_enabled=contribution_enabled,
+        contribution_percentage=Decimal(contribution_percentage) if contribution_percentage else None,
+        insurance_enabled=insurance_enabled,
+        insurance_percentage=Decimal(insurance_percentage) if insurance_percentage else None,
+        sale_type=sale_type,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_product(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    price: str,
+    insurance_eligible: bool = True,
+) -> "Popups":
+    from app.api.product.models import Products
+
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Product {uuid.uuid4().hex[:6]}",
+        slug=f"product-{uuid.uuid4().hex[:6]}",
+        price=Decimal(price),
+        category="ticket",
+        insurance_eligible=insurance_eligible,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"contribution-int-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Contribution",
+        last_name="Tester",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _make_application(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    human: Humans,
+) -> Applications:
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _make_attendee(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    application: Applications,
+    human: Humans,
+) -> Attendees:
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        name="Contribution Tester",
+        category="main",
+        email=human.email,
+        check_in_code=f"CTR{uuid.uuid4().hex[:6].upper()}",
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+    return attendee
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContributionInApplyDiscounts:
+    """Integration tests via POST /api/v1/payments/my/preview."""
+
+    def test_contribution_enabled_preview_includes_contribution_amount(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-01: popup.contribution_enabled=True, 5%, product=$100 → contribution_amount=5.00."""
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=True,
+            contribution_percentage="5.00",
+        )
+        product = _make_product(db, tenant_a, popup, price="100.00")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["contribution_amount"]) == Decimal("5.00"), (
+            f"Expected contribution_amount=5.00, got {data.get('contribution_amount')}"
+        )
+
+    def test_contribution_disabled_preview_has_zero_contribution_amount(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-02: popup.contribution_enabled=False → contribution_amount=0."""
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=False,
+        )
+        product = _make_product(db, tenant_a, popup, price="100.00")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["contribution_amount"]) == Decimal("0"), (
+            f"Expected contribution_amount=0, got {data.get('contribution_amount')}"
+        )
+
+    def test_contribution_enabled_null_percentage_returns_zero(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-04: enabled=True, percentage=null → contribution_amount=0."""
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=True,
+            contribution_percentage=None,
+        )
+        product = _make_product(db, tenant_a, popup, price="100.00")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["contribution_amount"]) == Decimal("0"), (
+            f"Expected contribution_amount=0 with null percentage, got {data.get('contribution_amount')}"
+        )
+
+    def test_insurance_and_contribution_do_not_compound(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-07: Both insurance (5%) and contribution (3%) on $100 pre-fee snapshot.
+
+        insurance_amount = 5% × 100 = 5.00 (eligible product × pct)
+        contribution_amount = 3% × 100 = 3.00 (pre-fee snapshot × pct)
+        grand total = 100 + 5 + 3 = 108.00
+        Neither fee base includes the other fee.
+        """
+        popup = _make_popup(
+            db,
+            tenant_a,
+            insurance_enabled=True,
+            insurance_percentage="5.00",
+            contribution_enabled=True,
+            contribution_percentage="3.00",
+        )
+        # insurance_eligible=True so insurance also applies over the full product price
+        product = _make_product(
+            db, tenant_a, popup, price="100.00", insurance_eligible=True
+        )
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+                "insurance": True,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["insurance_amount"]) == Decimal("5.00"), (
+            f"Expected insurance_amount=5.00, got {data.get('insurance_amount')}"
+        )
+        assert Decimal(data["contribution_amount"]) == Decimal("3.00"), (
+            f"Expected contribution_amount=3.00, got {data.get('contribution_amount')}"
+        )
+        assert Decimal(data["amount"]) == Decimal("108.00"), (
+            f"Expected grand total=108.00, got {data.get('amount')}"
+        )

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -24,6 +24,7 @@ from app.api.application.schemas import ApplicationStatus
 from app.api.attendee.models import Attendees
 from app.api.human.models import Humans
 from app.api.popup.models import Popups
+from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 from app.core.security import create_access_token
@@ -70,9 +71,7 @@ def _make_product(
     *,
     price: str,
     insurance_eligible: bool = True,
-) -> "Popups":
-    from app.api.product.models import Products
-
+) -> Products:
     product = Products(
         tenant_id=tenant.id,
         popup_id=popup.id,

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -28,7 +28,6 @@ from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 from app.core.security import create_access_token
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -49,9 +48,13 @@ def _make_popup(
         slug=f"contribution-integration-{uuid.uuid4().hex[:8]}",
         tenant_id=tenant.id,
         contribution_enabled=contribution_enabled,
-        contribution_percentage=Decimal(contribution_percentage) if contribution_percentage else None,
+        contribution_percentage=Decimal(contribution_percentage)
+        if contribution_percentage
+        else None,
         insurance_enabled=insurance_enabled,
-        insurance_percentage=Decimal(insurance_percentage) if insurance_percentage else None,
+        insurance_percentage=Decimal(insurance_percentage)
+        if insurance_percentage
+        else None,
         sale_type=sale_type,
     )
     db.add(popup)

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -6,6 +6,11 @@ Scenarios covered:
   - SCN-04: enabled + null percentage → contribution_amount=0
   - SCN-07: insurance + contribution both enabled → parallel fees, no compounding
   - SCN-08: direct-sale (sale_type=direct) → contribution NOT applied
+
+SCN-08 note: The direct-sale flow uses create_open_ticketing_payment, which does
+NOT call _apply_discounts — it builds Payments directly with amount=0 and no
+contribution. Contribution is naturally excluded from the direct-sale path
+because it runs through a completely separate code path.
 """
 
 import uuid
@@ -313,4 +318,53 @@ class TestContributionInApplyDiscounts:
         )
         assert Decimal(data["amount"]) == Decimal("108.00"), (
             f"Expected grand total=108.00, got {data.get('amount')}"
+        )
+
+
+class TestDirectSaleExclusion:
+    """SCN-08: Direct-sale flow excludes contribution (different code path).
+
+    The create_open_ticketing_payment path does not call _apply_discounts,
+    so contribution is naturally excluded. We verify the Payments model
+    has contribution_amount=0 default when no calculation runs.
+    """
+
+    def test_payments_model_has_zero_contribution_amount_by_default(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-08: Payments created without contribution_amount → defaults to 0.
+
+        This validates the column default and that the direct-sale path
+        (which never calls calculate_contribution_amount) yields 0 on the row.
+        """
+        from app.api.payment.models import Payments
+        from app.api.payment.schemas import PaymentStatus
+
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=True,
+            contribution_percentage="5.00",
+            sale_type=SaleType.direct,
+        )
+
+        # Simulate what create_open_ticketing_payment does: build Payments
+        # WITHOUT passing contribution_amount — the server_default kicks in.
+        payment = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.PENDING.value,
+            amount=Decimal("100.00"),
+            currency="USD",
+        )
+        db.add(payment)
+        db.commit()
+        db.refresh(payment)
+
+        # contribution_amount must be 0 — not computed in direct-sale path
+        assert payment.contribution_amount == Decimal("0"), (
+            f"Direct-sale Payments row should have contribution_amount=0, "
+            f"got {payment.contribution_amount}"
         )

--- a/backend/tests/api/popup/test_popup_contribution_patch.py
+++ b/backend/tests/api/popup/test_popup_contribution_patch.py
@@ -1,0 +1,116 @@
+"""Integration tests for contribution fields in PopupUpdate PATCH (TDD — RED first).
+
+SCN-09: PopupUpdate schema accepts contribution fields without 422.
+Also exercises the extra="forbid" regression guard.
+
+Scenarios:
+  - PATCH with all 4 contribution fields + enabled=true → 200
+  - PATCH with contribution_enabled=true + null percentage → 422
+  - PATCH with contribution_enabled=false + null percentage → 200 (disabled is ok)
+  - PATCH with only contribution_label (no enabled flag) → 200 (partial update)
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_popup(client: TestClient, token: str) -> dict:
+    response = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(token),
+        json={"name": f"Contribution Test Popup {uuid.uuid4().hex[:8]}"},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+class TestPopupContributionPatch:
+    def test_patch_all_contribution_fields_enabled_returns_200(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """SCN-09: PATCH with all 4 contribution fields and enabled=true → 200."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={
+                "contribution_enabled": True,
+                "contribution_percentage": "5.00",
+                "contribution_label": "Climate fund",
+                "contribution_description": "Supports the event sustainability",
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["contribution_enabled"] is True
+        assert Decimal(data["contribution_percentage"]) == Decimal("5.00")
+        assert data["contribution_label"] == "Climate fund"
+        assert data["contribution_description"] == "Supports the event sustainability"
+
+    def test_patch_enabled_true_null_percentage_returns_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """contribution_enabled=True + null percentage → 422 (validator rejects)."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={
+                "contribution_enabled": True,
+                "contribution_percentage": None,
+            },
+        )
+        assert response.status_code == 422
+        assert "contribution_percentage" in response.text
+
+    def test_patch_enabled_false_null_percentage_returns_200(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """contribution_enabled=False with null percentage → 200 (disabled is fine)."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={
+                "contribution_enabled": False,
+                "contribution_percentage": None,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["contribution_enabled"] is False
+
+    def test_patch_contribution_label_only_returns_200(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Partial update with only contribution_label → 200 (extra=forbid guard)."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"contribution_label": "New label"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["contribution_label"] == "New label"

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -10080,6 +10080,12 @@ export const PaymentPreviewSchema = {
             title: 'Insurance Amount',
             default: '0'
         },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
+            default: '0'
+        },
         currency: {
             type: 'string',
             title: 'Currency',
@@ -10386,6 +10392,12 @@ export const PaymentPublicSchema = {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             title: 'Insurance Amount',
+            default: '0'
+        },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
             default: '0'
         },
         currency: {
@@ -11095,6 +11107,46 @@ export const PopupAdminSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11458,6 +11510,48 @@ export const PopupCreateSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11740,6 +11834,45 @@ export const PopupPublicSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
@@ -12263,6 +12396,54 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Enabled'
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             anyOf: [

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2081,6 +2081,7 @@ export type PaymentPreview = {
     original_amount: string;
     amount: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     edit_passes?: boolean;
     coupon_id?: (string | null);
@@ -2141,6 +2142,7 @@ export type PaymentPublic = {
     status?: string;
     amount?: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     settlement_currency?: (string | null);
     rate?: (string | null);
@@ -2265,6 +2267,10 @@ export type PopupAdmin = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2309,6 +2315,10 @@ export type PopupCreate = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2351,6 +2361,10 @@ export type PopupPublic = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     show_attendee_directory?: boolean;
@@ -2426,6 +2440,10 @@ export type PopupUpdate = {
     supported_languages?: (Array<(string)> | null);
     insurance_enabled?: (boolean | null);
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: (boolean | null);
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: (ApplicationLayout | null);
     events_enabled?: (boolean | null);
     self_check_in_enabled?: (boolean | null);

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -10080,6 +10080,12 @@ export const PaymentPreviewSchema = {
             title: 'Insurance Amount',
             default: '0'
         },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
+            default: '0'
+        },
         currency: {
             type: 'string',
             title: 'Currency',
@@ -10386,6 +10392,12 @@ export const PaymentPublicSchema = {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             title: 'Insurance Amount',
+            default: '0'
+        },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
             default: '0'
         },
         currency: {
@@ -11095,6 +11107,46 @@ export const PopupAdminSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11458,6 +11510,48 @@ export const PopupCreateSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11740,6 +11834,45 @@ export const PopupPublicSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
@@ -12263,6 +12396,54 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Enabled'
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             anyOf: [

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2081,6 +2081,7 @@ export type PaymentPreview = {
     original_amount: string;
     amount: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     edit_passes?: boolean;
     coupon_id?: (string | null);
@@ -2141,6 +2142,7 @@ export type PaymentPublic = {
     status?: string;
     amount?: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     settlement_currency?: (string | null);
     rate?: (string | null);
@@ -2265,6 +2267,10 @@ export type PopupAdmin = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2309,6 +2315,10 @@ export type PopupCreate = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2351,6 +2361,10 @@ export type PopupPublic = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     show_attendee_directory?: boolean;
@@ -2426,6 +2440,10 @@ export type PopupUpdate = {
     supported_languages?: (Array<(string)> | null);
     insurance_enabled?: (boolean | null);
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: (boolean | null);
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: (ApplicationLayout | null);
     events_enabled?: (boolean | null);
     self_check_in_enabled?: (boolean | null);


### PR DESCRIPTION
## Summary

Adds **contribution fee** — an admin-configured, mandatory percentage fee applied to the order total when enabled on a popup. Distinct from `insurance` (which protects products) and `patron` (fixed-amount donation product): contribution supports the event itself via a percentage of the full order.

- **Model**: 4 new columns on `popups` (`contribution_enabled`, `contribution_percentage`, `contribution_label`, `contribution_description`) + 1 column on `payments` (`contribution_amount`).
- **Calculation**: pure function `calculate_contribution_amount(popup, subtotal)` in `payment/crud.py`, wired into `_apply_discounts` using a shared pre-fee snapshot so insurance and contribution never compound.
- **No buyer opt-in**: when the admin enables contribution on a popup, every payment automatically includes it. Direct-sale (open-ticketing) flow excluded by design.
- **Persistence**: `Payments.contribution_amount` stored on every payment for reporting.

This is **PR 1 of 3** chained PRs. PR-2 adds the backoffice config UI, PR-3 adds the portal summary line + i18n.

## Changes

- Migration `f6c1f50160ef_popup_contribution_fee.py` (5 columns total, all additive, no backfill).
- `PopupBase` / `PopupCreate` / `PopupUpdate` (explicit listing for `extra="forbid"`) / `PopupPublic` schemas updated.
- Range validator (0..100) on percentage; explicit `Text()` for `contribution_description`.
- `PaymentPreview` exposes `contribution_amount` for frontend rendering.
- 16 new tests (unit + integration) covering SCN-01..08.
- OpenAPI client regenerated for both `backoffice/src/client/` and `portal/src/client/` (consumed by PR-2 and PR-3).

## Test plan

- [x] `bash scripts/test.sh` → 1043 passed, 0 failures
- [x] `bash scripts/lint.sh` ruff → clean (8 pre-existing ty errors in `admin_api_key`, `api_key` unrelated to this change)
- [x] `uv run alembic heads` → single head `f6c1f50160ef`
- [x] Migration upgrade + downgrade verified via testcontainers session
- [x] OpenAPI client diff verified in `backoffice/src/client/` and `portal/src/client/`

## Follow-ups (non-blocking, deferred to follow-up issues)

- W-01: end-to-end test for SCN-03 (PATCH percentage → preview reflects new rate)
- W-02: HTTP test for SCN-10 (PopupPublic JSON response includes all 4 fields)
- W-03: HTTP test for SCN-08 direct-sale exclusion (currently asserted at DB level only)