### PR TITLE
feat(backoffice): contribution fee — admin config + payments breakdown (2/3)

### DIFF
--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -1210,7 +1210,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                         onBlur={field.handleBlur}
                         onChange={(e) => field.handleChange(e.target.value)}
                         disabled={readOnly || !contributionEnabled}
-                        className="max-w-xs text-sm"
+                        className="w-80 max-w-xs text-sm field-sizing-fixed"
                         rows={3}
                       />
                     </InlineRow>

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Globe,
   GraduationCap,
+  HandCoins,
   Image,
   Key,
   Languages,
@@ -61,6 +62,7 @@ import {
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import {
@@ -219,6 +221,11 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
       insurance_enabled: defaultValues?.insurance_enabled ?? false,
       insurance_percentage:
         defaultValues?.insurance_percentage?.toString() ?? "",
+      contribution_enabled: defaultValues?.contribution_enabled ?? false,
+      contribution_percentage:
+        defaultValues?.contribution_percentage?.toString() ?? "",
+      contribution_label: defaultValues?.contribution_label ?? "",
+      contribution_description: defaultValues?.contribution_description ?? "",
       events_enabled: defaultValues?.events_enabled ?? true,
       self_check_in_enabled: defaultValues?.self_check_in_enabled ?? false,
       show_attendee_directory: defaultValues?.show_attendee_directory ?? false,
@@ -262,6 +269,16 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
         insurance_enabled: value.insurance_enabled,
         insurance_percentage: value.insurance_enabled
           ? value.insurance_percentage || null
+          : null,
+        contribution_enabled: value.contribution_enabled,
+        contribution_percentage: value.contribution_enabled
+          ? value.contribution_percentage || null
+          : null,
+        contribution_label: value.contribution_enabled
+          ? value.contribution_label || null
+          : null,
+        contribution_description: value.contribution_enabled
+          ? value.contribution_description || null
           : null,
         events_enabled: value.events_enabled,
         self_check_in_enabled: value.self_check_in_enabled,
@@ -1080,6 +1097,126 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                   </div>
                 )}
               </form.Field>
+            )}
+          </form.Subscribe>
+        </InlineSection>
+
+        <Separator />
+
+        {/* Contribution fee */}
+        <InlineSection title="Contribution">
+          <form.Field name="contribution_enabled">
+            {(field) => (
+              <InlineRow
+                icon={<HandCoins className="h-4 w-4 text-muted-foreground" />}
+                label="Enable Contribution"
+                description="Add an optional contribution fee to orders at checkout"
+              >
+                <Switch
+                  id="contribution_enabled"
+                  checked={field.state.value}
+                  onCheckedChange={(checked) => field.handleChange(checked)}
+                  disabled={readOnly}
+                />
+              </InlineRow>
+            )}
+          </form.Field>
+
+          <form.Subscribe
+            selector={(state) => state.values.contribution_enabled}
+          >
+            {(contributionEnabled) => (
+              <>
+                <form.Field
+                  name="contribution_percentage"
+                  validators={{
+                    onBlur: ({ value }) => {
+                      if (readOnly || !contributionEnabled) return undefined
+                      const num = Number.parseFloat(value)
+                      if (!value || Number.isNaN(num) || num < 0) {
+                        return "Contribution percentage must be 0 or greater when contribution is enabled"
+                      }
+                      if (num > 100) {
+                        return "Contribution percentage cannot exceed 100"
+                      }
+                      return undefined
+                    },
+                  }}
+                >
+                  {(field) => (
+                    <div>
+                      <InlineRow
+                        icon={
+                          <HandCoins className="h-4 w-4 text-muted-foreground" />
+                        }
+                        label="Contribution Rate (%)"
+                        description="Percentage of the total order applied as a contribution fee"
+                      >
+                        <Input
+                          id="contribution_percentage"
+                          type="number"
+                          min="0"
+                          max="100"
+                          step="0.01"
+                          placeholder="e.g. 2.50"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          disabled={readOnly || !contributionEnabled}
+                          className="max-w-[120px] text-sm"
+                        />
+                      </InlineRow>
+                      <FieldError errors={field.state.meta.errors} />
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Field name="contribution_label">
+                  {(field) => (
+                    <InlineRow
+                      icon={
+                        <HandCoins className="h-4 w-4 text-muted-foreground" />
+                      }
+                      label="Contribution Label"
+                      description="Short name shown as the line item in the checkout summary"
+                    >
+                      <Input
+                        id="contribution_label"
+                        type="text"
+                        placeholder="e.g. Event support contribution"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        disabled={readOnly || !contributionEnabled}
+                        className="max-w-xs text-sm"
+                      />
+                    </InlineRow>
+                  )}
+                </form.Field>
+
+                <form.Field name="contribution_description">
+                  {(field) => (
+                    <InlineRow
+                      icon={
+                        <HandCoins className="h-4 w-4 text-muted-foreground" />
+                      }
+                      label="Contribution Description"
+                      description="Longer explanation shown under the line item in the portal order summary"
+                    >
+                      <Textarea
+                        id="contribution_description"
+                        placeholder="e.g. This contribution helps fund scholarships and community programs."
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        disabled={readOnly || !contributionEnabled}
+                        className="max-w-xs text-sm"
+                        rows={3}
+                      />
+                    </InlineRow>
+                  )}
+                </form.Field>
+              </>
             )}
           </form.Subscribe>
         </InlineSection>

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -297,6 +297,19 @@ function getColumns(hasInvoice: boolean): ColumnDef<PaymentPublic>[] {
       },
     },
     {
+      accessorKey: "contribution_amount",
+      header: "Contribution",
+      cell: ({ row }) => {
+        const val = row.original.contribution_amount
+        const num = Number(val)
+        return num > 0 ? (
+          <span className="font-mono">${val}</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )
+      },
+    },
+    {
       accessorKey: "coupon_code",
       header: "Coupon",
       cell: ({ row }) =>
@@ -396,8 +409,13 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
     0,
   )
   const total = Number(payment.amount)
-  const discountAmount = subtotal - total
+  const insuranceAmount = Number(payment.insurance_amount ?? 0)
+  const contributionAmount = Number(payment.contribution_amount ?? 0)
+  const discountAmount = subtotal + insuranceAmount + contributionAmount - total
   const hasDiscount = discountAmount > 0.01
+  const hasInsurance = insuranceAmount > 0.01
+  const hasContribution = contributionAmount > 0.01
+  const hasBreakdown = hasDiscount || hasInsurance || hasContribution
 
   let discountLabel = "Discount"
   if (payment.coupon_code) {
@@ -460,33 +478,56 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
           ))}
         </tbody>
         <tfoot className="text-sm">
-          {hasDiscount && (
-            <>
-              <tr className="border-t border-border/40">
-                <td
-                  colSpan={4}
-                  className="pt-2 text-right text-muted-foreground"
-                >
-                  Subtotal
-                </td>
-                <td className="pt-2 pl-4 text-right font-mono tabular-nums text-muted-foreground">
-                  ${subtotal.toFixed(2)}
-                </td>
-              </tr>
-              <tr>
-                <td
-                  colSpan={4}
-                  className="py-0.5 text-right text-muted-foreground"
-                >
-                  {discountLabel}
-                </td>
-                <td className="py-0.5 pl-4 text-right font-mono tabular-nums text-green-600">
-                  -${discountAmount.toFixed(2)}
-                </td>
-              </tr>
-            </>
+          {hasBreakdown && (
+            <tr className="border-t border-border/40">
+              <td colSpan={4} className="pt-2 text-right text-muted-foreground">
+                Subtotal
+              </td>
+              <td className="pt-2 pl-4 text-right font-mono tabular-nums text-muted-foreground">
+                ${subtotal.toFixed(2)}
+              </td>
+            </tr>
           )}
-          <tr className={hasDiscount ? "" : "border-t border-border/40"}>
+          {hasDiscount && (
+            <tr>
+              <td
+                colSpan={4}
+                className="py-0.5 text-right text-muted-foreground"
+              >
+                {discountLabel}
+              </td>
+              <td className="py-0.5 pl-4 text-right font-mono tabular-nums text-green-600">
+                -${discountAmount.toFixed(2)}
+              </td>
+            </tr>
+          )}
+          {hasInsurance && (
+            <tr>
+              <td
+                colSpan={4}
+                className="py-0.5 text-right text-muted-foreground"
+              >
+                Insurance
+              </td>
+              <td className="py-0.5 pl-4 text-right font-mono tabular-nums">
+                +${insuranceAmount.toFixed(2)}
+              </td>
+            </tr>
+          )}
+          {hasContribution && (
+            <tr>
+              <td
+                colSpan={4}
+                className="py-0.5 text-right text-muted-foreground"
+              >
+                Contribution
+              </td>
+              <td className="py-0.5 pl-4 text-right font-mono tabular-nums">
+                +${contributionAmount.toFixed(2)}
+              </td>
+            </tr>
+          )}
+          <tr className={hasBreakdown ? "" : "border-t border-border/40"}>
             <td colSpan={4} className="pt-1.5 text-right font-semibold">
               Total
             </td>
@@ -548,6 +589,7 @@ function PaymentsTableContent() {
       hiddenOnMobile={[
         "source",
         "insurance_amount",
+        "contribution_amount",
         "coupon_code",
         "created_at",
         "products",
@@ -611,6 +653,7 @@ function Payments() {
         { key: "status", label: "Status" },
         { key: "source", label: "Source" },
         { key: "insurance_amount", label: "Insurance" },
+        { key: "contribution_amount", label: "Contribution" },
         { key: "coupon_code", label: "Coupon" },
         { key: "created_at", label: "Date", type: "date" },
       ])


### PR DESCRIPTION
## Summary

Backoffice slice for **contribution fee** (admin-configured, mandatory percentage fee on order total, distinct from insurance/patron). This is **PR 2 of 3** in the contribution-fee feature.

Backend landed in #174. Portal UI is in #177 (stacked on this).

## Changes

- **PopupForm**: new `InlineSection "Contribution"` with 4 fields (Switch + numeric + text + textarea). Conditional visibility mirrors the existing Insurance section.
- **Textarea width fix**: the description Textarea uses `field-sizing-fixed` so its width stays stable while typing (the base component's `field-sizing-content` was causing the input to shrink with empty content and grow with text).
- **Payments list — new `Contribution` column** between INSURANCE and COUPON (also added to CSV export and hidden-on-mobile list).
- **Payments expanded subrow — full fee breakdown**: Subtotal / Discount / Insurance / Contribution / Total. Previously the discount math ignored fees, so when contribution or insurance was present the discount line never rendered and admins couldn't see where the extra amount in Total came from. The fix is symmetric for insurance too.

## Test plan

- [x] `pnpm --filter backoffice run lint` clean
- [x] `pnpm --filter backoffice run build` clean
- [x] Manual: created popup with contribution_enabled=true at 10%, verified the form renders, save round-trips, percentage validator (0..100) works.
- [x] Manual: payments list shows new Contribution column with values from the contribution_amount field; expanded subrow shows the full breakdown including the Contribution line.
- [x] Textarea description width is stable while typing.

## Follow-ups

- Stacked PR #177 adds the portal-side rendering (contribution line in cart footer + review-card section).