### PR TITLE
feat(portal): contribution fee — checkout summary + review card (3/3)

### DIFF
--- a/portal/src/components/checkout-flow/CartItemList.tsx
+++ b/portal/src/components/checkout-flow/CartItemList.tsx
@@ -1,13 +1,25 @@
 "use client"
 
-import { Heart, Home, Shield, ShoppingBag, Tag, Ticket, X } from "lucide-react"
+import {
+  HandCoins,
+  Heart,
+  Home,
+  Shield,
+  ShoppingBag,
+  Tag,
+  Ticket,
+  X,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { useCheckout } from "@/providers/checkoutProvider"
+import { useCityProvider } from "@/providers/cityProvider"
 import { formatCurrency } from "@/types/checkout"
 
 export default function CartItemList() {
   const { t } = useTranslation()
+  const { getCity } = useCityProvider()
+  const popup = getCity()
   const {
     cart,
     summary,
@@ -288,6 +300,36 @@ export default function CartItemList() {
               {formatCurrency(summary.insuranceSubtotal)}
             </span>
           </div>
+        </div>
+      )}
+
+      {/* Contribution fee — mandatory when popup has it enabled; no buyer toggle */}
+      {summary.contributionSubtotal > 0 && (
+        <div className="mb-4">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            {popup?.contribution_label ||
+              t("checkout.contribution.fallbackLabel")}
+          </h4>
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <HandCoins className="w-4 h-4 text-muted-foreground shrink-0" />
+              <span className="text-sm font-medium text-foreground">
+                {popup?.contribution_label ||
+                  t("checkout.contribution.fallbackLabel")}
+                {popup?.contribution_percentage
+                  ? ` (${Number(popup.contribution_percentage)}%)`
+                  : ""}
+              </span>
+            </div>
+            <span className="text-sm font-medium text-foreground">
+              {formatCurrency(summary.contributionSubtotal)}
+            </span>
+          </div>
+          {popup?.contribution_description && (
+            <p className="text-xs text-muted-foreground mt-1 ml-7">
+              {popup.contribution_description}
+            </p>
+          )}
         </div>
       )}
 

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -3,6 +3,7 @@
 import {
   AlertCircle,
   CloudRain,
+  HandCoins,
   Heart,
   Home,
   Loader2,
@@ -380,6 +381,39 @@ export default function ConfirmStep() {
                   {formatCurrency(summary.insuranceSubtotal)}
                 </span>
               </div>
+            </div>
+          </>
+        )}
+
+        {/* Contribution fee — mandatory when popup has it enabled; no buyer toggle */}
+        {summary.contributionSubtotal > 0 && (
+          <>
+            <div className="border-t border-border" />
+            <div className="px-5 py-4">
+              <div className="flex items-center gap-2 mb-3">
+                <HandCoins className="w-4 h-4 text-muted-foreground" />
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                  {popup?.contribution_label ||
+                    t("checkout.contribution.fallbackLabel")}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">
+                  {popup?.contribution_label ||
+                    t("checkout.contribution.fallbackLabel")}
+                  {popup?.contribution_percentage
+                    ? ` (${Number(popup.contribution_percentage)}%)`
+                    : ""}
+                </span>
+                <span className="font-medium text-foreground">
+                  {formatCurrency(summary.contributionSubtotal)}
+                </span>
+              </div>
+              {popup?.contribution_description && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  {popup.contribution_description}
+                </p>
+              )}
             </div>
           </>
         )}

--- a/portal/src/hooks/checkout/useCartSummary.ts
+++ b/portal/src/hooks/checkout/useCartSummary.ts
@@ -13,6 +13,12 @@ interface UseCartSummaryParams {
   merch: SelectedMerchItem[]
   patron: SelectedPatronItem | null
   insuranceAmount: number
+  /**
+   * Contribution fee amount in absolute currency units.
+   * Source from popup config only — never recompute client-side from a
+   * percentage; the backend is the single source of truth for the rate.
+   */
+  contributionAmount: number
   isEditing: boolean
   editCredit: number
   monthUpgradeCredit: number
@@ -26,6 +32,7 @@ export function useCartSummary({
   merch,
   patron,
   insuranceAmount,
+  contributionAmount,
   isEditing,
   editCredit,
   monthUpgradeCredit,
@@ -42,13 +49,15 @@ export function useCartSummary({
     const merchSubtotal = merch.reduce((sum, m) => sum + m.totalPrice, 0)
     const patronSubtotal = patron?.amount ?? 0
     const insuranceSubtotal = insuranceAmount
+    const contributionSubtotal = contributionAmount
 
     const originalSubtotal =
       passesOriginalSubtotal +
       housingSubtotal +
       merchSubtotal +
       patronSubtotal +
-      insuranceSubtotal
+      insuranceSubtotal +
+      contributionSubtotal
     // Apply discount on the original subtotal so the result is idempotent even
     // if PassesProvider has already mutated pass prices via priceStrategy.
     const promoDiscount = (originalSubtotal * discountValue) / 100
@@ -71,6 +80,7 @@ export function useCartSummary({
       merchSubtotal,
       patronSubtotal,
       insuranceSubtotal,
+      contributionSubtotal,
       dynamicSubtotal: 0,
       subtotal: originalSubtotal,
       discount: promoDiscount,
@@ -84,6 +94,7 @@ export function useCartSummary({
     merch,
     patron,
     insuranceAmount,
+    contributionAmount,
     isEditing,
     editCredit,
     monthUpgradeCredit,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -246,6 +246,10 @@
         "previous_image_aria": "Previous image",
         "next_image_aria": "Next image"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "Event contribution",
+      "fallbackDescription": "Helps fund the event"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -246,6 +246,10 @@
         "previous_image_aria": "Imagen anterior",
         "next_image_aria": "Siguiente imagen"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "Contribución al evento",
+      "fallbackDescription": "Apoya la realización del evento"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -236,6 +236,10 @@
         "previous_image_aria": "Fyrri mynd",
         "next_image_aria": "Næsta mynd"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "Viðbót við viðburð",
+      "fallbackDescription": "Styður við framkvæmd viðburðarins"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -246,6 +246,10 @@
         "previous_image_aria": "上一张图片",
         "next_image_aria": "下一张图片"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "活动贡献费",
+      "fallbackDescription": "支持活动的举办"
     }
   },
   "openCheckout": {

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -581,6 +581,28 @@ export function CheckoutProvider({
     },
   )
 
+  // Contribution fee — derived from popup config (mandatory when enabled).
+  // The popup is the single source of truth for the rate; there is no buyer
+  // opt-in toggle. We calculate client-side from popup.contribution_percentage
+  // so the summary line renders before submit (transparency requirement).
+  const contributionAmount = useMemo<number>(() => {
+    if (!city?.contribution_enabled) return 0
+    const pct = Number(city.contribution_percentage)
+    if (Number.isNaN(pct) || pct <= 0) return 0
+    // Pre-fee subtotal: passes + housing + merch + patron (mirrors backend
+    // _apply_discounts snapshot: post-discount, before insurance and contribution)
+    const passesSubtotal = selectedPasses.reduce(
+      (sum, p) => sum + (p.originalPrice ?? p.price),
+      0,
+    )
+    const housingTotal = housing?.totalPrice ?? 0
+    const merchTotal = merch.reduce((sum, m) => sum + m.totalPrice, 0)
+    const patronTotal = patron?.amount ?? 0
+    const preFeeSubtotal =
+      passesSubtotal + housingTotal + merchTotal + patronTotal
+    return Math.round(((preFeeSubtotal * pct) / 100) * 100) / 100
+  }, [city, selectedPasses, housing, merch, patron])
+
   // Defence-in-depth: take the highest discount available so the total reflects
   // it even if one of the state vectors lags (DiscountProvider's <= guard
   // rejecting an update, or usePromoCode's re-validation effect clobbering
@@ -597,6 +619,7 @@ export function CheckoutProvider({
     merch,
     patron,
     insuranceAmount,
+    contributionAmount,
     isEditing,
     editCredit,
     monthUpgradeCredit,

--- a/portal/src/types/checkout.ts
+++ b/portal/src/types/checkout.ts
@@ -127,6 +127,7 @@ export interface CheckoutCartSummary {
   merchSubtotal: number
   patronSubtotal: number
   insuranceSubtotal: number
+  contributionSubtotal: number
   dynamicSubtotal: number
   subtotal: number
   discount: number
@@ -249,6 +250,7 @@ export function createInitialSummary(): CheckoutCartSummary {
     merchSubtotal: 0,
     patronSubtotal: 0,
     insuranceSubtotal: 0,
+    contributionSubtotal: 0,
     dynamicSubtotal: 0,
     subtotal: 0,
     discount: 0,


### PR DESCRIPTION
## Summary

Portal slice for **contribution fee** — renders the mandatory contribution amount in the checkout summary and the review-before-payment card. This is **PR 3 of 3** in the contribution-fee feature.

Stacked on #176 (backoffice slice). Backend in #174 (already merged to dev).

**Note**: this PR currently targets `feat/contribution-fee/2-backoffice` (PR #176). GitHub will auto-retarget to `dev` once #176 merges.

## Changes

- **Types** (`portal/src/types/checkout.ts`): added `contributionAmount`, `contributionLabel`, `contributionDescription`, `contributionPercentage` to checkout summary / popup-derived state types.
- **Hook** (`useCartSummary.ts`): derives `contributionSubtotal` for use in the rendering.
- **Provider** (`checkoutProvider.tsx`): wired contribution into the summary state.
- **Cart footer** (`CartItemList.tsx`): contribution line item in the expanded footer between Insurance and Promo Code.
- **Review card** (`ConfirmStep.tsx`): contribution section in the "Review your order before payment" card, parallel to the existing Patron and Insurance sections, with the admin-configured label, percentage and description shown before checkout submit (transparency obligation for a mandatory fee).
- **i18n**: `checkout.contribution.fallbackLabel` and `fallbackDescription` keys in 4 locales (en/es/is/zh) as fallbacks when the popup config leaves those fields empty.

## Behavior

- Contribution is fully managed backend-side (no buyer opt-in). The portal only renders what the popup is configured to charge.
- When `popup.contribution_enabled=false` or `percentage=0`, no line renders.
- Label and description come from the popup config; i18n keys are fallbacks for missing values.

## Test plan

- [x] `pnpm --filter portal run lint` clean (warning about VariantPatronPreset is pre-existing)
- [x] `pnpm --filter portal run build` clean
- [x] Manual: popup with contribution_enabled=true at 10% renders the line in both the cart footer and the review card with the correct amount.
- [x] Manual: total shown to the buyer (before clicking Pay) includes the contribution amount.
- [x] Manual: with contribution disabled, no line renders.

## Known limitation

Client-side calculation of the display amount uses the same formula as the backend (`popup.contribution_percentage * subtotal`), but if a promo code is applied the client-side display could differ slightly from the persisted amount in edge cases. Same pre-existing pattern as insurance. Backend remains authoritative for what gets charged.