### PR TITLE
release: contribution fee + events draft/publish + RSVP feedback

### DIFF
--- a/backend/app/alembic/versions/f6c1f50160ef_popup_contribution_fee.py
+++ b/backend/app/alembic/versions/f6c1f50160ef_popup_contribution_fee.py
@@ -1,0 +1,83 @@
+"""popup contribution fee
+
+Adds four contribution_* config columns to popups and contribution_amount
+persistence column to payments. Single atomic migration for this feature.
+
+Column-length rationale:
+- contribution_label VARCHAR(255): matches popup string field convention
+  (e.g., name: max_length=255 in PopupCreate).
+- contribution_description TEXT: admin-authored copy, length-unbounded —
+  matches PaymentProductBase.product_description: sa_type=Text() precedent.
+
+No RLS changes: both tables already have RLS (existing tenant tables).
+PostgreSQL 11+ handles ADD COLUMN ... NOT NULL DEFAULT <constant> without
+a table rewrite for booleans, and nullable additions are always instant.
+
+Revision ID: f6c1f50160ef
+Revises: 3e8f4a2b1c5d
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "f6c1f50160ef"
+down_revision: str = "3e8f4a2b1c5d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Popup contribution config
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_percentage",
+            sa.Numeric(precision=5, scale=2),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_label",
+            sa.String(length=255),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "popups",
+        sa.Column(
+            "contribution_description",
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+
+    # Payment persistence
+    op.add_column(
+        "payments",
+        sa.Column(
+            "contribution_amount",
+            sa.Numeric(precision=10, scale=2),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("payments", "contribution_amount")
+    op.drop_column("popups", "contribution_description")
+    op.drop_column("popups", "contribution_label")
+    op.drop_column("popups", "contribution_percentage")
+    op.drop_column("popups", "contribution_enabled")

--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -151,13 +151,17 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
 
         The window MUST already include the caller's setup/teardown buffer.
         Overlap rule: existing.start < window_end AND existing.end > window_start.
-        Cancelled and rejected events are ignored (they free the slot).
+        Draft, cancelled and rejected events are ignored (they free the slot).
         """
         # Pull all potentially-relevant rows. Non-recurring rows can be
         # filtered directly. Recurring masters (rrule IS NOT NULL) need to
         # be expanded on-the-fly since their start_time only marks the
         # first occurrence.
-        freed_statuses = [EventStatus.CANCELLED, EventStatus.REJECTED]
+        freed_statuses = [
+            EventStatus.DRAFT,
+            EventStatus.CANCELLED,
+            EventStatus.REJECTED,
+        ]
         non_recurring = (
             select(Events)
             .where(Events.venue_id == venue_id)

--- a/backend/app/api/event_venue/router.py
+++ b/backend/app/api/event_venue/router.py
@@ -564,12 +564,17 @@ def _compute_availability(
     tz = ZoneInfo(tz_name)
 
     # --- Busy from events (+ setup/teardown) and closed exceptions --------
-    # Cancelled and rejected events no longer hold their slot; treat them
-    # as freed availability so calendars don't show ghost blocks.
+    # Drafts, cancelled and rejected events no longer hold their slot; treat
+    # them as freed availability so calendars don't show ghost blocks and
+    # draft proposals don't lock the venue against other bookings.
     events_query = (
         select(Events)
         .where(Events.venue_id == venue.id)
-        .where(Events.status.notin_([EventStatus.CANCELLED, EventStatus.REJECTED]))
+        .where(
+            Events.status.notin_(
+                [EventStatus.DRAFT, EventStatus.CANCELLED, EventStatus.REJECTED]
+            )
+        )
         .where(Events.start_time < end)
         .where(Events.end_time > start)
     )

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -1296,12 +1296,25 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 response.group_id = None
                 response.scholarship_discount = True
 
+        # Capture pre-fee snapshot BEFORE any fees are added.
+        # Both insurance and contribution must read from the same pre-fee baseline
+        # so neither fee compounds the other (see design ADR-2).
+        pre_fee_amount = response.amount
+
         # Calculate insurance if requested (application-flow only — POPUP-6)
         if obj.insurance:
             popup = application.popup if application else None
             insurance_amount = self._calculate_insurance(session, obj.products, popup)
             response.insurance_amount = insurance_amount
             response.amount += insurance_amount
+
+        # Calculate contribution fee (mandatory when popup enables it — no buyer opt-in).
+        # Uses the pre-fee snapshot so contribution base does not include insurance.
+        popup = application.popup if application else None
+        if popup and popup.contribution_enabled and popup.contribution_percentage:
+            contribution_amount = calculate_contribution_amount(popup, pre_fee_amount)
+            response.contribution_amount = contribution_amount
+            response.amount += contribution_amount
 
         return response
 
@@ -1477,6 +1490,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 status=PaymentStatus.APPROVED.value,
                 amount=preview.amount,
                 insurance_amount=preview.insurance_amount,
+                contribution_amount=preview.contribution_amount,
                 currency=preview.currency,
                 coupon_id=preview.coupon_id,
                 coupon_code=preview.coupon_code,
@@ -1616,6 +1630,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             status=simplefi_response.status,
             amount=preview.amount,
             insurance_amount=preview.insurance_amount,
+            contribution_amount=preview.contribution_amount,
             currency=preview.currency,
             coupon_id=preview.coupon_id,
             coupon_code=preview.coupon_code,

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -138,6 +138,36 @@ def calculate_insurance_amount(
     )
 
 
+def calculate_contribution_amount(
+    popup: "Any",
+    products_subtotal: Decimal,
+) -> Decimal:
+    """Pure function: compute contribution amount from popup settings + pre-fee subtotal.
+
+    Contribution is MANDATORY when enabled at popup level — there is no buyer opt-in
+    flag. Mirrors `calculate_insurance_amount` shape but drops the per-product
+    eligibility filter (contribution applies over the full pre-fee order subtotal).
+
+    Args:
+        popup: Object with .contribution_enabled (bool) and
+            .contribution_percentage (Decimal|None).
+        products_subtotal: Pre-fee snapshot of the order amount
+            (post-discount, pre-insurance, pre-contribution).
+
+    Returns:
+        Contribution amount rounded to 2 decimal places.
+        Returns Decimal("0") if contribution is disabled or percentage is None.
+    """
+    if not popup.contribution_enabled:
+        return Decimal("0")
+    if popup.contribution_percentage is None:
+        return Decimal("0")
+
+    return (products_subtotal * popup.contribution_percentage / 100).quantize(
+        MONEY_PRECISION, rounding=ROUND_HALF_UP
+    )
+
+
 def _require_application_id(application_id: uuid.UUID | None) -> uuid.UUID:
     """Narrow optional application ids for application-based flows."""
     if application_id is None:

--- a/backend/app/api/payment/schemas.py
+++ b/backend/app/api/payment/schemas.py
@@ -88,6 +88,10 @@ class PaymentBase(SQLModel):
         default=Decimal("0"),
         sa_column=Column(Numeric(10, 2), nullable=False, server_default="0"),
     )
+    contribution_amount: Decimal = Field(
+        default=Decimal("0"),
+        sa_column=Column(Numeric(10, 2), nullable=False, server_default="0"),
+    )
     currency: str = Field(default="USD")
     settlement_currency: str | None = Field(
         default=None,
@@ -204,6 +208,7 @@ class PaymentPreview(BaseModel):
     original_amount: Decimal
     amount: Decimal
     insurance_amount: Decimal = Decimal("0")
+    contribution_amount: Decimal = Decimal("0")
     currency: str = "USD"
     edit_passes: bool = False
 

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -5,7 +5,7 @@ from enum import StrEnum
 from typing import Self
 
 from pydantic import ConfigDict, field_validator, model_validator
-from sqlalchemy import Boolean, Column, Numeric
+from sqlalchemy import Boolean, Column, Numeric, Text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlmodel import Field, SQLModel, String
 
@@ -32,6 +32,23 @@ def validate_popup_insurance_config(enabled: bool, pct: "Decimal | None") -> Non
     if pct > 100:
         raise ValueError(
             "insurance_percentage must be <= 100 (it represents a percentage)"
+        )
+
+
+def validate_popup_contribution_config(enabled: bool, pct: "Decimal | None") -> None:
+    """Validate contribution_percentage bounds when contribution is enabled.
+
+    Raises ValueError if enabled=True and pct is None, <= 0, or > 100.
+    """
+    if not enabled:
+        return
+    if pct is None or pct <= 0:
+        raise ValueError(
+            "contribution_percentage must be > 0 when contribution_enabled is True"
+        )
+    if pct > 100:
+        raise ValueError(
+            "contribution_percentage must be <= 100 (it represents a percentage)"
         )
 
 
@@ -127,6 +144,19 @@ class PopupBase(SQLModel):
         default=None,
         sa_column=Column(Numeric(5, 2), nullable=True),
     )
+    contribution_enabled: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
+    contribution_percentage: Decimal | None = Field(
+        default=None,
+        sa_column=Column(Numeric(5, 2), nullable=True),
+    )
+    contribution_label: str | None = Field(default=None, max_length=255)
+    contribution_description: str | None = Field(
+        default=None,
+        sa_column=Column(Text(), nullable=True),
+    )
     application_layout: ApplicationLayout = Field(
         default=ApplicationLayout.single_page,
         sa_column=Column(String, nullable=False, server_default="single_page"),
@@ -188,6 +218,10 @@ class PopupCreate(SQLModel):
     supported_languages: list[str] = ["en"]
     insurance_enabled: bool = False
     insurance_percentage: Decimal | None = None
+    contribution_enabled: bool = False
+    contribution_percentage: Decimal | None = None
+    contribution_label: str | None = None
+    contribution_description: str | None = None
     application_layout: ApplicationLayout = ApplicationLayout.single_page
     events_enabled: bool = True
     self_check_in_enabled: bool = False
@@ -211,6 +245,9 @@ class PopupCreate(SQLModel):
             )
         validate_popup_insurance_config(
             self.insurance_enabled, self.insurance_percentage
+        )
+        validate_popup_contribution_config(
+            self.contribution_enabled, self.contribution_percentage
         )
         return self
 
@@ -252,6 +289,10 @@ class PopupUpdate(SQLModel):
     supported_languages: list[str] | None = None
     insurance_enabled: bool | None = None
     insurance_percentage: Decimal | None = None
+    contribution_enabled: bool | None = None
+    contribution_percentage: Decimal | None = None
+    contribution_label: str | None = None
+    contribution_description: str | None = None
     application_layout: ApplicationLayout | None = None
     events_enabled: bool | None = None
     self_check_in_enabled: bool | None = None
@@ -283,6 +324,9 @@ class PopupUpdate(SQLModel):
         # Validate insurance only when insurance_enabled is explicitly set to True
         if self.insurance_enabled is True:
             validate_popup_insurance_config(True, self.insurance_percentage)
+        # Validate contribution only when contribution_enabled is explicitly set to True
+        if self.contribution_enabled is True:
+            validate_popup_contribution_config(True, self.contribution_percentage)
         return self
 
 
@@ -318,6 +362,10 @@ class PopupPublic(SQLModel):
     supported_languages: list[str] = ["en"]
     insurance_enabled: bool = False
     insurance_percentage: Decimal | None = None
+    contribution_enabled: bool = False
+    contribution_percentage: Decimal | None = None
+    contribution_label: str | None = None
+    contribution_description: str | None = None
     application_layout: ApplicationLayout = ApplicationLayout.single_page
     events_enabled: bool = True
     show_attendee_directory: bool = False

--- a/backend/tests/api/payment/test_contribution_calculation.py
+++ b/backend/tests/api/payment/test_contribution_calculation.py
@@ -1,0 +1,85 @@
+"""Unit tests for calculate_contribution_amount (TDD — RED first).
+
+Scenarios covered:
+  - SCN-05: enabled + round subtotal → exact result
+  - SCN-06: enabled + fractional subtotal → half-up rounding
+  - SCN-04: enabled + null percentage → 0
+  - SCN-02: disabled popup → 0
+  - Edge: zero subtotal → 0
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.api.payment.crud import calculate_contribution_amount
+
+
+class _FakePopup:
+    """Minimal popup stand-in for pure-function tests."""
+
+    def __init__(
+        self,
+        *,
+        contribution_enabled: bool,
+        contribution_percentage: str | None,
+    ) -> None:
+        self.contribution_enabled = contribution_enabled
+        self.contribution_percentage = (
+            Decimal(contribution_percentage)
+            if contribution_percentage is not None
+            else None
+        )
+
+
+class TestCalculateContributionAmount:
+    def test_enabled_round_subtotal_returns_exact_amount(self) -> None:
+        """SCN-05: 5% of $100.00 = $5.00 exactly."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        assert result == Decimal("5.00")
+
+    def test_enabled_fractional_subtotal_rounds_half_up(self) -> None:
+        """SCN-06: 5% of $33.33 = $1.6665 → rounds half-up to $1.67."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("33.33"))
+        assert result == Decimal("1.67")
+
+    def test_enabled_null_percentage_returns_zero(self) -> None:
+        """SCN-04: enabled=True, percentage=null → 0 (not configured)."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage=None
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        assert result == Decimal("0")
+
+    def test_disabled_popup_returns_zero(self) -> None:
+        """SCN-02: contribution_enabled=False → 0 regardless of subtotal."""
+        popup = _FakePopup(
+            contribution_enabled=False, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        assert result == Decimal("0")
+
+    def test_zero_subtotal_returns_zero(self) -> None:
+        """Edge: subtotal=0, enabled → contribution is 0."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="5.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("0"))
+        assert result == Decimal("0")
+
+    def test_result_precision_is_two_decimal_places(self) -> None:
+        """Calculation result always has exactly 2 decimal places."""
+        popup = _FakePopup(
+            contribution_enabled=True, contribution_percentage="3.00"
+        )
+        result = calculate_contribution_amount(popup, Decimal("100.00"))
+        # 3% of 100 = 3.00 — verify it's Decimal with proper precision
+        assert result == Decimal("3.00")
+        # Ensure the exponent represents 2 decimal places
+        assert result == result.quantize(Decimal("0.01"))

--- a/backend/tests/api/payment/test_contribution_calculation.py
+++ b/backend/tests/api/payment/test_contribution_calculation.py
@@ -10,8 +10,6 @@ Scenarios covered:
 
 from decimal import Decimal
 
-import pytest
-
 from app.api.payment.crud import calculate_contribution_amount
 
 
@@ -35,49 +33,37 @@ class _FakePopup:
 class TestCalculateContributionAmount:
     def test_enabled_round_subtotal_returns_exact_amount(self) -> None:
         """SCN-05: 5% of $100.00 = $5.00 exactly."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         assert result == Decimal("5.00")
 
     def test_enabled_fractional_subtotal_rounds_half_up(self) -> None:
         """SCN-06: 5% of $33.33 = $1.6665 → rounds half-up to $1.67."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("33.33"))
         assert result == Decimal("1.67")
 
     def test_enabled_null_percentage_returns_zero(self) -> None:
         """SCN-04: enabled=True, percentage=null → 0 (not configured)."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage=None
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage=None)
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         assert result == Decimal("0")
 
     def test_disabled_popup_returns_zero(self) -> None:
         """SCN-02: contribution_enabled=False → 0 regardless of subtotal."""
-        popup = _FakePopup(
-            contribution_enabled=False, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=False, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         assert result == Decimal("0")
 
     def test_zero_subtotal_returns_zero(self) -> None:
         """Edge: subtotal=0, enabled → contribution is 0."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="5.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="5.00")
         result = calculate_contribution_amount(popup, Decimal("0"))
         assert result == Decimal("0")
 
     def test_result_precision_is_two_decimal_places(self) -> None:
         """Calculation result always has exactly 2 decimal places."""
-        popup = _FakePopup(
-            contribution_enabled=True, contribution_percentage="3.00"
-        )
+        popup = _FakePopup(contribution_enabled=True, contribution_percentage="3.00")
         result = calculate_contribution_amount(popup, Decimal("100.00"))
         # 3% of 100 = 3.00 — verify it's Decimal with proper precision
         assert result == Decimal("3.00")

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -1,0 +1,316 @@
+"""Integration tests for contribution fee wiring in _apply_discounts (TDD — RED first).
+
+Scenarios covered:
+  - SCN-01: contribution enabled → preview includes non-zero contribution_amount
+  - SCN-02: contribution disabled → preview has contribution_amount=0
+  - SCN-04: enabled + null percentage → contribution_amount=0
+  - SCN-07: insurance + contribution both enabled → parallel fees, no compounding
+  - SCN-08: direct-sale (sale_type=direct) → contribution NOT applied
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import Attendees
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_popup(
+    db: Session,
+    tenant: Tenants,
+    *,
+    contribution_enabled: bool = False,
+    contribution_percentage: str | None = None,
+    insurance_enabled: bool = False,
+    insurance_percentage: str | None = None,
+    sale_type: SaleType = SaleType.application,
+) -> Popups:
+    popup = Popups(
+        name=f"Contribution Integration {uuid.uuid4().hex[:8]}",
+        slug=f"contribution-integration-{uuid.uuid4().hex[:8]}",
+        tenant_id=tenant.id,
+        contribution_enabled=contribution_enabled,
+        contribution_percentage=Decimal(contribution_percentage) if contribution_percentage else None,
+        insurance_enabled=insurance_enabled,
+        insurance_percentage=Decimal(insurance_percentage) if insurance_percentage else None,
+        sale_type=sale_type,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_product(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    price: str,
+    insurance_eligible: bool = True,
+) -> "Popups":
+    from app.api.product.models import Products
+
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Product {uuid.uuid4().hex[:6]}",
+        slug=f"product-{uuid.uuid4().hex[:6]}",
+        price=Decimal(price),
+        category="ticket",
+        insurance_eligible=insurance_eligible,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"contribution-int-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Contribution",
+        last_name="Tester",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _make_application(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    human: Humans,
+) -> Applications:
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _make_attendee(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    application: Applications,
+    human: Humans,
+) -> Attendees:
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        name="Contribution Tester",
+        category="main",
+        email=human.email,
+        check_in_code=f"CTR{uuid.uuid4().hex[:6].upper()}",
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+    return attendee
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestContributionInApplyDiscounts:
+    """Integration tests via POST /api/v1/payments/my/preview."""
+
+    def test_contribution_enabled_preview_includes_contribution_amount(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-01: popup.contribution_enabled=True, 5%, product=$100 → contribution_amount=5.00."""
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=True,
+            contribution_percentage="5.00",
+        )
+        product = _make_product(db, tenant_a, popup, price="100.00")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["contribution_amount"]) == Decimal("5.00"), (
+            f"Expected contribution_amount=5.00, got {data.get('contribution_amount')}"
+        )
+
+    def test_contribution_disabled_preview_has_zero_contribution_amount(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-02: popup.contribution_enabled=False → contribution_amount=0."""
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=False,
+        )
+        product = _make_product(db, tenant_a, popup, price="100.00")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["contribution_amount"]) == Decimal("0"), (
+            f"Expected contribution_amount=0, got {data.get('contribution_amount')}"
+        )
+
+    def test_contribution_enabled_null_percentage_returns_zero(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-04: enabled=True, percentage=null → contribution_amount=0."""
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=True,
+            contribution_percentage=None,
+        )
+        product = _make_product(db, tenant_a, popup, price="100.00")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["contribution_amount"]) == Decimal("0"), (
+            f"Expected contribution_amount=0 with null percentage, got {data.get('contribution_amount')}"
+        )
+
+    def test_insurance_and_contribution_do_not_compound(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-07: Both insurance (5%) and contribution (3%) on $100 pre-fee snapshot.
+
+        insurance_amount = 5% × 100 = 5.00 (eligible product × pct)
+        contribution_amount = 3% × 100 = 3.00 (pre-fee snapshot × pct)
+        grand total = 100 + 5 + 3 = 108.00
+        Neither fee base includes the other fee.
+        """
+        popup = _make_popup(
+            db,
+            tenant_a,
+            insurance_enabled=True,
+            insurance_percentage="5.00",
+            contribution_enabled=True,
+            contribution_percentage="3.00",
+        )
+        # insurance_eligible=True so insurance also applies over the full product price
+        product = _make_product(
+            db, tenant_a, popup, price="100.00", insurance_eligible=True
+        )
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        attendee = _make_attendee(db, tenant_a, popup, application, human)
+
+        token = create_access_token(subject=human.id, token_type="human")
+        response = client.post(
+            "/api/v1/payments/my/preview",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(product.id),
+                        "attendee_id": str(attendee.id),
+                        "quantity": 1,
+                    }
+                ],
+                "insurance": True,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert Decimal(data["insurance_amount"]) == Decimal("5.00"), (
+            f"Expected insurance_amount=5.00, got {data.get('insurance_amount')}"
+        )
+        assert Decimal(data["contribution_amount"]) == Decimal("3.00"), (
+            f"Expected contribution_amount=3.00, got {data.get('contribution_amount')}"
+        )
+        assert Decimal(data["amount"]) == Decimal("108.00"), (
+            f"Expected grand total=108.00, got {data.get('amount')}"
+        )

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -24,6 +24,7 @@ from app.api.application.schemas import ApplicationStatus
 from app.api.attendee.models import Attendees
 from app.api.human.models import Humans
 from app.api.popup.models import Popups
+from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 from app.core.security import create_access_token
@@ -70,9 +71,7 @@ def _make_product(
     *,
     price: str,
     insurance_eligible: bool = True,
-) -> "Popups":
-    from app.api.product.models import Products
-
+) -> Products:
     product = Products(
         tenant_id=tenant.id,
         popup_id=popup.id,

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -28,7 +28,6 @@ from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 from app.core.security import create_access_token
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -49,9 +48,13 @@ def _make_popup(
         slug=f"contribution-integration-{uuid.uuid4().hex[:8]}",
         tenant_id=tenant.id,
         contribution_enabled=contribution_enabled,
-        contribution_percentage=Decimal(contribution_percentage) if contribution_percentage else None,
+        contribution_percentage=Decimal(contribution_percentage)
+        if contribution_percentage
+        else None,
         insurance_enabled=insurance_enabled,
-        insurance_percentage=Decimal(insurance_percentage) if insurance_percentage else None,
+        insurance_percentage=Decimal(insurance_percentage)
+        if insurance_percentage
+        else None,
         sale_type=sale_type,
     )
     db.add(popup)

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -6,6 +6,11 @@ Scenarios covered:
   - SCN-04: enabled + null percentage → contribution_amount=0
   - SCN-07: insurance + contribution both enabled → parallel fees, no compounding
   - SCN-08: direct-sale (sale_type=direct) → contribution NOT applied
+
+SCN-08 note: The direct-sale flow uses create_open_ticketing_payment, which does
+NOT call _apply_discounts — it builds Payments directly with amount=0 and no
+contribution. Contribution is naturally excluded from the direct-sale path
+because it runs through a completely separate code path.
 """
 
 import uuid
@@ -313,4 +318,53 @@ class TestContributionInApplyDiscounts:
         )
         assert Decimal(data["amount"]) == Decimal("108.00"), (
             f"Expected grand total=108.00, got {data.get('amount')}"
+        )
+
+
+class TestDirectSaleExclusion:
+    """SCN-08: Direct-sale flow excludes contribution (different code path).
+
+    The create_open_ticketing_payment path does not call _apply_discounts,
+    so contribution is naturally excluded. We verify the Payments model
+    has contribution_amount=0 default when no calculation runs.
+    """
+
+    def test_payments_model_has_zero_contribution_amount_by_default(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SCN-08: Payments created without contribution_amount → defaults to 0.
+
+        This validates the column default and that the direct-sale path
+        (which never calls calculate_contribution_amount) yields 0 on the row.
+        """
+        from app.api.payment.models import Payments
+        from app.api.payment.schemas import PaymentStatus
+
+        popup = _make_popup(
+            db,
+            tenant_a,
+            contribution_enabled=True,
+            contribution_percentage="5.00",
+            sale_type=SaleType.direct,
+        )
+
+        # Simulate what create_open_ticketing_payment does: build Payments
+        # WITHOUT passing contribution_amount — the server_default kicks in.
+        payment = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.PENDING.value,
+            amount=Decimal("100.00"),
+            currency="USD",
+        )
+        db.add(payment)
+        db.commit()
+        db.refresh(payment)
+
+        # contribution_amount must be 0 — not computed in direct-sale path
+        assert payment.contribution_amount == Decimal("0"), (
+            f"Direct-sale Payments row should have contribution_amount=0, "
+            f"got {payment.contribution_amount}"
         )

--- a/backend/tests/api/popup/test_popup_contribution_patch.py
+++ b/backend/tests/api/popup/test_popup_contribution_patch.py
@@ -1,0 +1,116 @@
+"""Integration tests for contribution fields in PopupUpdate PATCH (TDD — RED first).
+
+SCN-09: PopupUpdate schema accepts contribution fields without 422.
+Also exercises the extra="forbid" regression guard.
+
+Scenarios:
+  - PATCH with all 4 contribution fields + enabled=true → 200
+  - PATCH with contribution_enabled=true + null percentage → 422
+  - PATCH with contribution_enabled=false + null percentage → 200 (disabled is ok)
+  - PATCH with only contribution_label (no enabled flag) → 200 (partial update)
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_popup(client: TestClient, token: str) -> dict:
+    response = client.post(
+        "/api/v1/popups",
+        headers=_admin_headers(token),
+        json={"name": f"Contribution Test Popup {uuid.uuid4().hex[:8]}"},
+    )
+    assert response.status_code == 201
+    return response.json()
+
+
+class TestPopupContributionPatch:
+    def test_patch_all_contribution_fields_enabled_returns_200(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """SCN-09: PATCH with all 4 contribution fields and enabled=true → 200."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={
+                "contribution_enabled": True,
+                "contribution_percentage": "5.00",
+                "contribution_label": "Climate fund",
+                "contribution_description": "Supports the event sustainability",
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["contribution_enabled"] is True
+        assert Decimal(data["contribution_percentage"]) == Decimal("5.00")
+        assert data["contribution_label"] == "Climate fund"
+        assert data["contribution_description"] == "Supports the event sustainability"
+
+    def test_patch_enabled_true_null_percentage_returns_422(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """contribution_enabled=True + null percentage → 422 (validator rejects)."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={
+                "contribution_enabled": True,
+                "contribution_percentage": None,
+            },
+        )
+        assert response.status_code == 422
+        assert "contribution_percentage" in response.text
+
+    def test_patch_enabled_false_null_percentage_returns_200(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """contribution_enabled=False with null percentage → 200 (disabled is fine)."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={
+                "contribution_enabled": False,
+                "contribution_percentage": None,
+            },
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data["contribution_enabled"] is False
+
+    def test_patch_contribution_label_only_returns_200(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Partial update with only contribution_label → 200 (extra=forbid guard)."""
+        popup = _create_popup(client, admin_token_tenant_a)
+        popup_id = popup["id"]
+
+        response = client.patch(
+            f"/api/v1/popups/{popup_id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"contribution_label": "New label"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["contribution_label"] == "New label"

--- a/backend/tests/test_recurrence_conflicts.py
+++ b/backend/tests/test_recurrence_conflicts.py
@@ -175,7 +175,7 @@ class TestRecurrenceConflictMessage:
 
 
 class TestFreedStatusesDoNotConflict:
-    """CANCELLED and REJECTED events must release their venue slot."""
+    """DRAFT, CANCELLED and REJECTED events must release their venue slot."""
 
     def test_rejected_event_does_not_block_new_booking(
         self,
@@ -206,6 +206,44 @@ class TestFreedStatusesDoNotConflict:
             json={
                 "popup_id": str(popup.id),
                 "title": "Replacement",
+                "start_time": slot.isoformat(),
+                "end_time": (slot + timedelta(hours=1)).isoformat(),
+                "timezone": "UTC",
+                "venue_id": str(venue.id),
+            },
+        )
+
+        assert resp.status_code == 201, resp.text
+
+    def test_draft_event_does_not_block_new_booking(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        venue = _make_venue(db, tenant_a, popup)
+
+        slot = datetime(2026, 9, 2, 10, 0, tzinfo=UTC)
+        draft = _make_event(
+            db,
+            tenant_a,
+            popup,
+            start=slot,
+            venue_id=venue.id,
+            title="Draft Idea",
+        )
+        draft.status = EventStatus.DRAFT
+        db.add(draft)
+        db.commit()
+
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "popup_id": str(popup.id),
+                "title": "Real Booking",
                 "start_time": slot.isoformat(),
                 "end_time": (slot + timedelta(hours=1)).isoformat(),
                 "timezone": "UTC",

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -10080,6 +10080,12 @@ export const PaymentPreviewSchema = {
             title: 'Insurance Amount',
             default: '0'
         },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
+            default: '0'
+        },
         currency: {
             type: 'string',
             title: 'Currency',
@@ -10386,6 +10392,12 @@ export const PaymentPublicSchema = {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             title: 'Insurance Amount',
+            default: '0'
+        },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
             default: '0'
         },
         currency: {
@@ -11095,6 +11107,46 @@ export const PopupAdminSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11458,6 +11510,48 @@ export const PopupCreateSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11740,6 +11834,45 @@ export const PopupPublicSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
@@ -12263,6 +12396,54 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Enabled'
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             anyOf: [

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2081,6 +2081,7 @@ export type PaymentPreview = {
     original_amount: string;
     amount: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     edit_passes?: boolean;
     coupon_id?: (string | null);
@@ -2141,6 +2142,7 @@ export type PaymentPublic = {
     status?: string;
     amount?: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     settlement_currency?: (string | null);
     rate?: (string | null);
@@ -2265,6 +2267,10 @@ export type PopupAdmin = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2309,6 +2315,10 @@ export type PopupCreate = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2351,6 +2361,10 @@ export type PopupPublic = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     show_attendee_directory?: boolean;
@@ -2426,6 +2440,10 @@ export type PopupUpdate = {
     supported_languages?: (Array<(string)> | null);
     insurance_enabled?: (boolean | null);
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: (boolean | null);
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: (ApplicationLayout | null);
     events_enabled?: (boolean | null);
     self_check_in_enabled?: (boolean | null);

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -25,7 +25,6 @@ import {
 } from "@/client"
 import { DangerZone } from "@/components/Common/DangerZone"
 import { FieldError } from "@/components/Common/FieldError"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { DatePicker } from "@/components/ui/date-picker"
 import { ImageUpload } from "@/components/ui/image-upload"
@@ -83,11 +82,6 @@ interface EventFormProps {
   initialStartIso?: string
   onSuccess: () => void
 }
-
-const EVENT_STATUSES = [
-  { value: "draft", label: "Draft" },
-  { value: "published", label: "Public" },
-] as const
 
 const VISIBILITY_OPTIONS = [
   {
@@ -343,7 +337,6 @@ export function EventForm({
       require_approval: false,
       highlighted: defaultValues?.highlighted ?? false,
       host_display_name: defaultValues?.host_display_name ?? "",
-      status: defaultValues?.status ?? "draft",
       tags: defaultValues?.tags ?? [],
     },
     onSubmit: ({ value }) => {
@@ -391,6 +384,9 @@ export function EventForm({
 
       const hostDisplayName = value.host_display_name.trim() || null
 
+      const finalStatus =
+        submitActionRef.current === "draft" ? "draft" : "published"
+
       if (isEdit) {
         const payload: EventUpdate = {
           title: value.title,
@@ -412,7 +408,7 @@ export function EventForm({
           visibility: value.visibility,
           require_approval: value.require_approval,
           highlighted: value.highlighted,
-          status: value.status,
+          status: finalStatus,
           tags,
         }
         updateMutation.mutate(payload)
@@ -438,7 +434,7 @@ export function EventForm({
           visibility: value.visibility,
           require_approval: value.require_approval,
           highlighted: value.highlighted,
-          status: value.status,
+          status: finalStatus,
           tags,
           recurrence: buildRecurrence(repeat, value.timezone || "UTC"),
         }
@@ -446,6 +442,8 @@ export function EventForm({
       }
     },
   })
+
+  const submitActionRef = useRef<"draft" | "publish">("publish")
 
   const isPending = createMutation.isPending || updateMutation.isPending
 
@@ -1014,6 +1012,7 @@ export function EventForm({
           )
           return
         }
+        submitActionRef.current = "publish"
         form.handleSubmit().catch((err: unknown) => {
           showErrorToast(
             err instanceof Error ? err.message : "Error submitting form",
@@ -1042,57 +1041,6 @@ export function EventForm({
               disabled={readOnly}
             />
             <FieldError errors={field.state.meta.errors} />
-            <div className="mt-3">
-              <form.Field name="status">
-                {(statusField) => (
-                  <div className="flex items-center gap-2">
-                    <Select
-                      value={statusField.state.value}
-                      onValueChange={(v) =>
-                        statusField.handleChange(
-                          v as (typeof EVENT_STATUSES)[number]["value"],
-                        )
-                      }
-                      disabled={readOnly}
-                    >
-                      <SelectTrigger className="w-auto border-0 bg-transparent p-0 shadow-none focus:ring-0">
-                        {statusField.state.value === "published" ? (
-                          <Badge
-                            variant={
-                              visibilityValue === "unlisted"
-                                ? "secondary"
-                                : "outline"
-                            }
-                            className={
-                              visibilityValue === "private"
-                                ? "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-transparent"
-                                : undefined
-                            }
-                          >
-                            {visibilityValue === "unlisted"
-                              ? "Unlisted"
-                              : visibilityValue === "private"
-                                ? "Private"
-                                : "Public"}
-                          </Badge>
-                        ) : (
-                          <Badge variant="secondary">
-                            <SelectValue />
-                          </Badge>
-                        )}
-                      </SelectTrigger>
-                      <SelectContent>
-                        {EVENT_STATUSES.map((s) => (
-                          <SelectItem key={s.value} value={s.value}>
-                            {s.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                )}
-              </form.Field>
-            </div>
           </div>
         )}
       </form.Field>
@@ -1852,7 +1800,7 @@ export function EventForm({
         </InlineSection>
       )}
 
-      <div className="flex gap-4">
+      <div className="flex items-center justify-between gap-4">
         <Button
           type="button"
           variant="outline"
@@ -1861,25 +1809,44 @@ export function EventForm({
           {readOnly ? "Back" : "Cancel"}
         </Button>
         {!readOnly && (
-          <div className="flex flex-col items-start gap-1">
-            <LoadingButton
-              type="submit"
-              loading={isPending}
-              disabled={
-                effectiveAvailability.status === "unavailable" ||
-                effectiveAvailability.status === "partially-unavailable"
-              }
-            >
-              {isEdit ? "Save Changes" : "Create Event"}
-            </LoadingButton>
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex gap-2">
+              <LoadingButton
+                type="button"
+                variant="outline"
+                loading={isPending && submitActionRef.current === "draft"}
+                disabled={isPending}
+                onClick={() => {
+                  submitActionRef.current = "draft"
+                  form.handleSubmit()
+                }}
+              >
+                Save as Draft
+              </LoadingButton>
+              <LoadingButton
+                type="button"
+                loading={isPending && submitActionRef.current === "publish"}
+                disabled={
+                  isPending ||
+                  effectiveAvailability.status === "unavailable" ||
+                  effectiveAvailability.status === "partially-unavailable"
+                }
+                onClick={() => {
+                  submitActionRef.current = "publish"
+                  form.handleSubmit()
+                }}
+              >
+                Publish Event
+              </LoadingButton>
+            </div>
             {effectiveAvailability.status === "unavailable" && (
               <p className="text-xs text-destructive">
-                Pick a time the venue is open and free before submitting.
+                Pick a time the venue is open and free before publishing.
               </p>
             )}
             {effectiveAvailability.status === "partially-unavailable" && (
               <p className="text-xs text-destructive">
-                Resolve the conflicting occurrences before submitting.
+                Resolve the conflicting occurrences before publishing.
               </p>
             )}
           </div>

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -1210,7 +1210,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                         onBlur={field.handleBlur}
                         onChange={(e) => field.handleChange(e.target.value)}
                         disabled={readOnly || !contributionEnabled}
-                        className="max-w-xs text-sm"
+                        className="w-80 max-w-xs text-sm field-sizing-fixed"
                         rows={3}
                       />
                     </InlineRow>

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Globe,
   GraduationCap,
+  HandCoins,
   Image,
   Key,
   Languages,
@@ -61,6 +62,7 @@ import {
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
+import { Textarea } from "@/components/ui/textarea"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import {
@@ -219,6 +221,11 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
       insurance_enabled: defaultValues?.insurance_enabled ?? false,
       insurance_percentage:
         defaultValues?.insurance_percentage?.toString() ?? "",
+      contribution_enabled: defaultValues?.contribution_enabled ?? false,
+      contribution_percentage:
+        defaultValues?.contribution_percentage?.toString() ?? "",
+      contribution_label: defaultValues?.contribution_label ?? "",
+      contribution_description: defaultValues?.contribution_description ?? "",
       events_enabled: defaultValues?.events_enabled ?? true,
       self_check_in_enabled: defaultValues?.self_check_in_enabled ?? false,
       show_attendee_directory: defaultValues?.show_attendee_directory ?? false,
@@ -262,6 +269,16 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
         insurance_enabled: value.insurance_enabled,
         insurance_percentage: value.insurance_enabled
           ? value.insurance_percentage || null
+          : null,
+        contribution_enabled: value.contribution_enabled,
+        contribution_percentage: value.contribution_enabled
+          ? value.contribution_percentage || null
+          : null,
+        contribution_label: value.contribution_enabled
+          ? value.contribution_label || null
+          : null,
+        contribution_description: value.contribution_enabled
+          ? value.contribution_description || null
           : null,
         events_enabled: value.events_enabled,
         self_check_in_enabled: value.self_check_in_enabled,
@@ -1080,6 +1097,126 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                   </div>
                 )}
               </form.Field>
+            )}
+          </form.Subscribe>
+        </InlineSection>
+
+        <Separator />
+
+        {/* Contribution fee */}
+        <InlineSection title="Contribution">
+          <form.Field name="contribution_enabled">
+            {(field) => (
+              <InlineRow
+                icon={<HandCoins className="h-4 w-4 text-muted-foreground" />}
+                label="Enable Contribution"
+                description="Add an optional contribution fee to orders at checkout"
+              >
+                <Switch
+                  id="contribution_enabled"
+                  checked={field.state.value}
+                  onCheckedChange={(checked) => field.handleChange(checked)}
+                  disabled={readOnly}
+                />
+              </InlineRow>
+            )}
+          </form.Field>
+
+          <form.Subscribe
+            selector={(state) => state.values.contribution_enabled}
+          >
+            {(contributionEnabled) => (
+              <>
+                <form.Field
+                  name="contribution_percentage"
+                  validators={{
+                    onBlur: ({ value }) => {
+                      if (readOnly || !contributionEnabled) return undefined
+                      const num = Number.parseFloat(value)
+                      if (!value || Number.isNaN(num) || num < 0) {
+                        return "Contribution percentage must be 0 or greater when contribution is enabled"
+                      }
+                      if (num > 100) {
+                        return "Contribution percentage cannot exceed 100"
+                      }
+                      return undefined
+                    },
+                  }}
+                >
+                  {(field) => (
+                    <div>
+                      <InlineRow
+                        icon={
+                          <HandCoins className="h-4 w-4 text-muted-foreground" />
+                        }
+                        label="Contribution Rate (%)"
+                        description="Percentage of the total order applied as a contribution fee"
+                      >
+                        <Input
+                          id="contribution_percentage"
+                          type="number"
+                          min="0"
+                          max="100"
+                          step="0.01"
+                          placeholder="e.g. 2.50"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          disabled={readOnly || !contributionEnabled}
+                          className="max-w-[120px] text-sm"
+                        />
+                      </InlineRow>
+                      <FieldError errors={field.state.meta.errors} />
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Field name="contribution_label">
+                  {(field) => (
+                    <InlineRow
+                      icon={
+                        <HandCoins className="h-4 w-4 text-muted-foreground" />
+                      }
+                      label="Contribution Label"
+                      description="Short name shown as the line item in the checkout summary"
+                    >
+                      <Input
+                        id="contribution_label"
+                        type="text"
+                        placeholder="e.g. Event support contribution"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        disabled={readOnly || !contributionEnabled}
+                        className="max-w-xs text-sm"
+                      />
+                    </InlineRow>
+                  )}
+                </form.Field>
+
+                <form.Field name="contribution_description">
+                  {(field) => (
+                    <InlineRow
+                      icon={
+                        <HandCoins className="h-4 w-4 text-muted-foreground" />
+                      }
+                      label="Contribution Description"
+                      description="Longer explanation shown under the line item in the portal order summary"
+                    >
+                      <Textarea
+                        id="contribution_description"
+                        placeholder="e.g. This contribution helps fund scholarships and community programs."
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        disabled={readOnly || !contributionEnabled}
+                        className="max-w-xs text-sm"
+                        rows={3}
+                      />
+                    </InlineRow>
+                  )}
+                </form.Field>
+              </>
             )}
           </form.Subscribe>
         </InlineSection>

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -297,6 +297,19 @@ function getColumns(hasInvoice: boolean): ColumnDef<PaymentPublic>[] {
       },
     },
     {
+      accessorKey: "contribution_amount",
+      header: "Contribution",
+      cell: ({ row }) => {
+        const val = row.original.contribution_amount
+        const num = Number(val)
+        return num > 0 ? (
+          <span className="font-mono">${val}</span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        )
+      },
+    },
+    {
       accessorKey: "coupon_code",
       header: "Coupon",
       cell: ({ row }) =>
@@ -396,8 +409,13 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
     0,
   )
   const total = Number(payment.amount)
-  const discountAmount = subtotal - total
+  const insuranceAmount = Number(payment.insurance_amount ?? 0)
+  const contributionAmount = Number(payment.contribution_amount ?? 0)
+  const discountAmount = subtotal + insuranceAmount + contributionAmount - total
   const hasDiscount = discountAmount > 0.01
+  const hasInsurance = insuranceAmount > 0.01
+  const hasContribution = contributionAmount > 0.01
+  const hasBreakdown = hasDiscount || hasInsurance || hasContribution
 
   let discountLabel = "Discount"
   if (payment.coupon_code) {
@@ -460,33 +478,56 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
           ))}
         </tbody>
         <tfoot className="text-sm">
-          {hasDiscount && (
-            <>
-              <tr className="border-t border-border/40">
-                <td
-                  colSpan={4}
-                  className="pt-2 text-right text-muted-foreground"
-                >
-                  Subtotal
-                </td>
-                <td className="pt-2 pl-4 text-right font-mono tabular-nums text-muted-foreground">
-                  ${subtotal.toFixed(2)}
-                </td>
-              </tr>
-              <tr>
-                <td
-                  colSpan={4}
-                  className="py-0.5 text-right text-muted-foreground"
-                >
-                  {discountLabel}
-                </td>
-                <td className="py-0.5 pl-4 text-right font-mono tabular-nums text-green-600">
-                  -${discountAmount.toFixed(2)}
-                </td>
-              </tr>
-            </>
+          {hasBreakdown && (
+            <tr className="border-t border-border/40">
+              <td colSpan={4} className="pt-2 text-right text-muted-foreground">
+                Subtotal
+              </td>
+              <td className="pt-2 pl-4 text-right font-mono tabular-nums text-muted-foreground">
+                ${subtotal.toFixed(2)}
+              </td>
+            </tr>
           )}
-          <tr className={hasDiscount ? "" : "border-t border-border/40"}>
+          {hasDiscount && (
+            <tr>
+              <td
+                colSpan={4}
+                className="py-0.5 text-right text-muted-foreground"
+              >
+                {discountLabel}
+              </td>
+              <td className="py-0.5 pl-4 text-right font-mono tabular-nums text-green-600">
+                -${discountAmount.toFixed(2)}
+              </td>
+            </tr>
+          )}
+          {hasInsurance && (
+            <tr>
+              <td
+                colSpan={4}
+                className="py-0.5 text-right text-muted-foreground"
+              >
+                Insurance
+              </td>
+              <td className="py-0.5 pl-4 text-right font-mono tabular-nums">
+                +${insuranceAmount.toFixed(2)}
+              </td>
+            </tr>
+          )}
+          {hasContribution && (
+            <tr>
+              <td
+                colSpan={4}
+                className="py-0.5 text-right text-muted-foreground"
+              >
+                Contribution
+              </td>
+              <td className="py-0.5 pl-4 text-right font-mono tabular-nums">
+                +${contributionAmount.toFixed(2)}
+              </td>
+            </tr>
+          )}
+          <tr className={hasBreakdown ? "" : "border-t border-border/40"}>
             <td colSpan={4} className="pt-1.5 text-right font-semibold">
               Total
             </td>
@@ -548,6 +589,7 @@ function PaymentsTableContent() {
       hiddenOnMobile={[
         "source",
         "insurance_amount",
+        "contribution_amount",
         "coupon_code",
         "created_at",
         "products",
@@ -611,6 +653,7 @@ function Payments() {
         { key: "status", label: "Status" },
         { key: "source", label: "Source" },
         { key: "insurance_amount", label: "Insurance" },
+        { key: "contribution_amount", label: "Contribution" },
         { key: "coupon_code", label: "Coupon" },
         { key: "created_at", label: "Date", type: "date" },
       ])

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -21,6 +21,7 @@ import {
   Clock,
   Crown,
   Layers,
+  Loader2,
   MapPin,
   Repeat,
   Tag,
@@ -29,8 +30,10 @@ import {
 import Link from "next/link"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 import {
+  ApiError,
   EventParticipantsService,
   type EventPublic,
   EventsService,
@@ -168,6 +171,15 @@ export function CalendarBody({
   // must not. Use occurrence_id (set only on virtual occurrences) to decide.
   const rsvpBodyFor = (e: EventPublic) =>
     e.occurrence_id ? { occurrence_start: e.start_time } : undefined
+  const toastRsvpError = (err: unknown) => {
+    const fallback = t("events.rsvp.action_error") as string
+    let detail = fallback
+    if (err instanceof ApiError && err.body && typeof err.body === "object") {
+      const body = err.body as { detail?: unknown }
+      if (typeof body.detail === "string") detail = body.detail
+    }
+    toast.error(detail)
+  }
   const rsvpMutation = useMutation({
     mutationFn: (e: EventPublic) =>
       EventParticipantsService.registerForEvent({
@@ -177,6 +189,7 @@ export function CalendarBody({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["portal-events-calendar"] })
     },
+    onError: toastRsvpError,
   })
   const cancelRsvpMutation = useMutation({
     mutationFn: (e: EventPublic) =>
@@ -187,7 +200,18 @@ export function CalendarBody({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["portal-events-calendar"] })
     },
+    onError: toastRsvpError,
   })
+  // Tracks the in-flight RSVP target so we can pin the spinner to the
+  // specific event (and recurring occurrence) the user clicked instead
+  // of flipping every "Going" button on the day.
+  const pendingRsvpKey: string | null = (() => {
+    const pending =
+      (rsvpMutation.isPending && rsvpMutation.variables) ||
+      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
+      null
+    return pending ? `${pending.id}:${pending.start_time}` : null
+  })()
 
   const events = useOverride ? (eventsOverride ?? []) : (data?.results ?? [])
 
@@ -461,29 +485,48 @@ export function CalendarBody({
                           </div>
                         </div>
                       </Link>
-                      {isAuthed && event.status === "published" && (
-                        <div className="absolute top-2 right-2">
-                          {event.my_rsvp_status &&
-                          event.my_rsvp_status !== "cancelled" ? (
-                            <button
-                              type="button"
-                              onClick={() => cancelRsvpMutation.mutate(event)}
-                              className="inline-flex items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
-                            >
-                              <CheckCircle className="h-3 w-3" />
-                              {t("events.rsvp.going")}
-                            </button>
-                          ) : (
-                            <button
-                              type="button"
-                              onClick={() => rsvpMutation.mutate(event)}
-                              className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs font-medium hover:bg-muted"
-                            >
-                              {t("events.rsvp.rsvp")}
-                            </button>
-                          )}
-                        </div>
-                      )}
+                      {isAuthed &&
+                        event.status === "published" &&
+                        (() => {
+                          const rsvpKey = `${event.id}:${event.start_time}`
+                          const isRsvpPending = pendingRsvpKey === rsvpKey
+                          const isRsvped =
+                            event.my_rsvp_status &&
+                            event.my_rsvp_status !== "cancelled"
+                          return (
+                            <div className="absolute top-2 right-2">
+                              {isRsvped ? (
+                                <button
+                                  type="button"
+                                  disabled={isRsvpPending}
+                                  onClick={() =>
+                                    cancelRsvpMutation.mutate(event)
+                                  }
+                                  className="inline-flex items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
+                                >
+                                  {isRsvpPending ? (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                  ) : (
+                                    <CheckCircle className="h-3 w-3" />
+                                  )}
+                                  {t("events.rsvp.going")}
+                                </button>
+                              ) : (
+                                <button
+                                  type="button"
+                                  disabled={isRsvpPending}
+                                  onClick={() => rsvpMutation.mutate(event)}
+                                  className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                  {isRsvpPending && (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                  )}
+                                  {t("events.rsvp.rsvp")}
+                                </button>
+                              )}
+                            </div>
+                          )
+                        })()}
                     </div>
                   )
                 })}

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -12,6 +12,7 @@ import {
   Crown,
   Home,
   Layers,
+  Loader2,
   Maximize2,
   Minimize2,
   Repeat,
@@ -20,8 +21,10 @@ import {
 import Link from "next/link"
 import { Fragment, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 import {
+  ApiError,
   EventParticipantsService,
   type EventPublic,
   EventsService,
@@ -238,6 +241,15 @@ export function DayBody({
   // must not. Use occurrence_id (set only on virtual occurrences) to decide.
   const rsvpBodyFor = (e: EventPublic) =>
     e.occurrence_id ? { occurrence_start: e.start_time } : undefined
+  const toastRsvpError = (err: unknown) => {
+    const fallback = t("events.rsvp.action_error") as string
+    let detail = fallback
+    if (err instanceof ApiError && err.body && typeof err.body === "object") {
+      const body = err.body as { detail?: unknown }
+      if (typeof body.detail === "string") detail = body.detail
+    }
+    toast.error(detail)
+  }
   const rsvpMutation = useMutation({
     mutationFn: (e: EventPublic) =>
       EventParticipantsService.registerForEvent({
@@ -247,6 +259,7 @@ export function DayBody({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["portal-events-day"] })
     },
+    onError: toastRsvpError,
   })
   const cancelRsvpMutation = useMutation({
     mutationFn: (e: EventPublic) =>
@@ -257,7 +270,17 @@ export function DayBody({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["portal-events-day"] })
     },
+    onError: toastRsvpError,
   })
+  // Tracks the in-flight RSVP target so the spinner stays on the
+  // specific event card (and recurring instance) the user clicked.
+  const pendingRsvpKey: string | null = (() => {
+    const pending =
+      (rsvpMutation.isPending && rsvpMutation.variables) ||
+      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
+      null
+    return pending ? `${pending.id}:${pending.start_time}` : null
+  })()
 
   // "HH:MM" in the popup timezone (24h) -> minutes since 00:00.
   const minutesInTz = useMemo(() => {
@@ -766,36 +789,50 @@ export function DayBody({
                               )}
                             {isAuthed &&
                               !isShort &&
-                              event.status === "published" && (
-                                <div className="absolute bottom-1 right-1">
-                                  {isRsvpd ? (
-                                    <button
-                                      type="button"
-                                      onClick={(e) => {
-                                        e.preventDefault()
-                                        e.stopPropagation()
-                                        cancelRsvpMutation.mutate(event)
-                                      }}
-                                      className="inline-flex items-center gap-0.5 rounded border border-emerald-300 bg-emerald-50 px-1 py-0.5 text-[9px] font-medium text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
-                                    >
-                                      <CheckCircle className="h-2.5 w-2.5" />
-                                      {t("events.rsvp.going")}
-                                    </button>
-                                  ) : (
-                                    <button
-                                      type="button"
-                                      onClick={(e) => {
-                                        e.preventDefault()
-                                        e.stopPropagation()
-                                        rsvpMutation.mutate(event)
-                                      }}
-                                      className="inline-flex items-center rounded border bg-background px-1 py-0.5 text-[9px] font-medium hover:bg-muted"
-                                    >
-                                      {t("events.rsvp.rsvp")}
-                                    </button>
-                                  )}
-                                </div>
-                              )}
+                              event.status === "published" &&
+                              (() => {
+                                const rsvpKey = `${event.id}:${event.start_time}`
+                                const isRsvpPending = pendingRsvpKey === rsvpKey
+                                return (
+                                  <div className="absolute bottom-1 right-1">
+                                    {isRsvpd ? (
+                                      <button
+                                        type="button"
+                                        disabled={isRsvpPending}
+                                        onClick={(e) => {
+                                          e.preventDefault()
+                                          e.stopPropagation()
+                                          cancelRsvpMutation.mutate(event)
+                                        }}
+                                        className="inline-flex items-center gap-0.5 rounded border border-emerald-300 bg-emerald-50 px-1 py-0.5 text-[9px] font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
+                                      >
+                                        {isRsvpPending ? (
+                                          <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                                        ) : (
+                                          <CheckCircle className="h-2.5 w-2.5" />
+                                        )}
+                                        {t("events.rsvp.going")}
+                                      </button>
+                                    ) : (
+                                      <button
+                                        type="button"
+                                        disabled={isRsvpPending}
+                                        onClick={(e) => {
+                                          e.preventDefault()
+                                          e.stopPropagation()
+                                          rsvpMutation.mutate(event)
+                                        }}
+                                        className="inline-flex items-center gap-0.5 rounded border bg-background px-1 py-0.5 text-[9px] font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                                      >
+                                        {isRsvpPending && (
+                                          <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                                        )}
+                                        {t("events.rsvp.rsvp")}
+                                      </button>
+                                    )}
+                                  </div>
+                                )
+                              })()}
                           </Link>
                         )
                       },

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -9,6 +9,7 @@ import {
   EyeOff,
   Filter,
   Layers,
+  Loader2,
   MapPin,
   Pencil,
   Repeat,
@@ -70,6 +71,12 @@ interface ListBodyProps {
   currentHumanId?: string | null
   onRsvp?: (event: EventPublic) => void
   onCancelRsvp?: (event: EventPublic) => void
+  /**
+   * Key (``${event.id}:${event.start_time}``) of the row whose RSVP
+   * mutation is currently in flight. The matching button renders a
+   * spinner and is disabled until the request settles.
+   */
+  pendingRsvpKey?: string | null
   onHide?: (eventId: string) => void
   onUnhide?: (eventId: string) => void
 }
@@ -94,6 +101,7 @@ export function ListBody({
   currentHumanId,
   onRsvp,
   onCancelRsvp,
+  pendingRsvpKey,
   onHide,
   onUnhide,
 }: ListBodyProps) {
@@ -269,33 +277,48 @@ export function ListBody({
                   {isAuthed && (
                     <div className="absolute bottom-2 right-2 flex items-center gap-1.5">
                       {event.status === "published" &&
-                        (event.my_rsvp_status &&
-                        event.my_rsvp_status !== "cancelled" ? (
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.preventDefault()
-                              e.stopPropagation()
-                              onCancelRsvp?.(event)
-                            }}
-                            className="inline-flex h-7 items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 text-xs font-medium text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
-                          >
-                            <CheckCircle className="h-3 w-3" />
-                            {t("events.rsvp.going")}
-                          </button>
-                        ) : (
-                          <button
-                            type="button"
-                            onClick={(e) => {
-                              e.preventDefault()
-                              e.stopPropagation()
-                              onRsvp?.(event)
-                            }}
-                            className="inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2 text-xs font-medium shadow-sm hover:bg-muted"
-                          >
-                            {t("events.rsvp.rsvp")}
-                          </button>
-                        ))}
+                        (() => {
+                          const rsvpKey = `${event.id}:${event.start_time}`
+                          const isRsvpPending = pendingRsvpKey === rsvpKey
+                          const isRsvped =
+                            event.my_rsvp_status &&
+                            event.my_rsvp_status !== "cancelled"
+                          return isRsvped ? (
+                            <button
+                              type="button"
+                              disabled={isRsvpPending}
+                              onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                onCancelRsvp?.(event)
+                              }}
+                              className="inline-flex h-7 items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
+                            >
+                              {isRsvpPending ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                <CheckCircle className="h-3 w-3" />
+                              )}
+                              {t("events.rsvp.going")}
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              disabled={isRsvpPending}
+                              onClick={(e) => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                onRsvp?.(event)
+                              }}
+                              className="inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2 text-xs font-medium shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {isRsvpPending && (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              )}
+                              {t("events.rsvp.rsvp")}
+                            </button>
+                          )
+                        })()}
                       <button
                         type="button"
                         onClick={(e) => {

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -14,8 +14,10 @@ import {
 } from "react"
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
 
 import {
+  ApiError,
   EventParticipantsService,
   type EventPublic,
   EventsService,
@@ -452,6 +454,15 @@ export default function EventsPage() {
   // must not. Use occurrence_id (set only on virtual occurrences) to decide.
   const rsvpBodyFor = (e: EventPublic) =>
     e.occurrence_id ? { occurrence_start: e.start_time } : undefined
+  const toastRsvpError = (err: unknown) => {
+    const fallback = t("events.rsvp.action_error") as string
+    let detail = fallback
+    if (err instanceof ApiError && err.body && typeof err.body === "object") {
+      const body = err.body as { detail?: unknown }
+      if (typeof body.detail === "string") detail = body.detail
+    }
+    toast.error(detail)
+  }
   const rsvpMutation = useMutation({
     mutationFn: (e: EventPublic) =>
       EventParticipantsService.registerForEvent({
@@ -461,6 +472,7 @@ export default function EventsPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["portal-events"] })
     },
+    onError: toastRsvpError,
   })
   const cancelRsvpMutation = useMutation({
     mutationFn: (e: EventPublic) =>
@@ -471,7 +483,20 @@ export default function EventsPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["portal-events"] })
     },
+    onError: toastRsvpError,
   })
+  // The row whose RSVP request is currently in flight, in the
+  // `${id}:${start_time}` format ListBody matches against. Including the
+  // occurrence start in the key keeps the spinner pinned to the specific
+  // recurring instance the user clicked rather than every row sharing
+  // the same event id.
+  const pendingRsvpKey: string | null = (() => {
+    const pending =
+      (rsvpMutation.isPending && rsvpMutation.variables) ||
+      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
+      null
+    return pending ? `${pending.id}:${pending.start_time}` : null
+  })()
 
   const hideMutation = useMutation({
     mutationFn: (eventId: string) => EventsService.hidePortalEvent({ eventId }),
@@ -757,6 +782,7 @@ export default function EventsPage() {
             currentHumanId={currentHuman?.id}
             onRsvp={(e) => rsvpMutation.mutate(e)}
             onCancelRsvp={(e) => cancelRsvpMutation.mutate(e)}
+            pendingRsvpKey={pendingRsvpKey}
             onHide={(id) => hideMutation.mutate(id)}
             onUnhide={(id) => unhideMutation.mutate(id)}
           />

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -10080,6 +10080,12 @@ export const PaymentPreviewSchema = {
             title: 'Insurance Amount',
             default: '0'
         },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
+            default: '0'
+        },
         currency: {
             type: 'string',
             title: 'Currency',
@@ -10386,6 +10392,12 @@ export const PaymentPublicSchema = {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
             title: 'Insurance Amount',
+            default: '0'
+        },
+        contribution_amount: {
+            type: 'string',
+            pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
+            title: 'Contribution Amount',
             default: '0'
         },
         currency: {
@@ -11095,6 +11107,46 @@ export const PopupAdminSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11458,6 +11510,48 @@ export const PopupCreateSchema = {
             ],
             title: 'Insurance Percentage'
         },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
+        },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
             default: 'single_page'
@@ -11740,6 +11834,45 @@ export const PopupPublicSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            type: 'boolean',
+            title: 'Contribution Enabled',
+            default: false
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             '$ref': '#/components/schemas/ApplicationLayout',
@@ -12263,6 +12396,54 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Insurance Percentage'
+        },
+        contribution_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Enabled'
+        },
+        contribution_percentage: {
+            anyOf: [
+                {
+                    type: 'number'
+                },
+                {
+                    type: 'string',
+                    pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Percentage'
+        },
+        contribution_label: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Label'
+        },
+        contribution_description: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Contribution Description'
         },
         application_layout: {
             anyOf: [

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2081,6 +2081,7 @@ export type PaymentPreview = {
     original_amount: string;
     amount: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     edit_passes?: boolean;
     coupon_id?: (string | null);
@@ -2141,6 +2142,7 @@ export type PaymentPublic = {
     status?: string;
     amount?: string;
     insurance_amount?: string;
+    contribution_amount?: string;
     currency?: string;
     settlement_currency?: (string | null);
     rate?: (string | null);
@@ -2265,6 +2267,10 @@ export type PopupAdmin = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2309,6 +2315,10 @@ export type PopupCreate = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     self_check_in_enabled?: boolean;
@@ -2351,6 +2361,10 @@ export type PopupPublic = {
     supported_languages?: Array<(string)>;
     insurance_enabled?: boolean;
     insurance_percentage?: (string | null);
+    contribution_enabled?: boolean;
+    contribution_percentage?: (string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: ApplicationLayout;
     events_enabled?: boolean;
     show_attendee_directory?: boolean;
@@ -2426,6 +2440,10 @@ export type PopupUpdate = {
     supported_languages?: (Array<(string)> | null);
     insurance_enabled?: (boolean | null);
     insurance_percentage?: (number | string | null);
+    contribution_enabled?: (boolean | null);
+    contribution_percentage?: (number | string | null);
+    contribution_label?: (string | null);
+    contribution_description?: (string | null);
     application_layout?: (ApplicationLayout | null);
     events_enabled?: (boolean | null);
     self_check_in_enabled?: (boolean | null);

--- a/portal/src/components/checkout-flow/CartItemList.tsx
+++ b/portal/src/components/checkout-flow/CartItemList.tsx
@@ -1,13 +1,25 @@
 "use client"
 
-import { Heart, Home, Shield, ShoppingBag, Tag, Ticket, X } from "lucide-react"
+import {
+  HandCoins,
+  Heart,
+  Home,
+  Shield,
+  ShoppingBag,
+  Tag,
+  Ticket,
+  X,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { useCheckout } from "@/providers/checkoutProvider"
+import { useCityProvider } from "@/providers/cityProvider"
 import { formatCurrency } from "@/types/checkout"
 
 export default function CartItemList() {
   const { t } = useTranslation()
+  const { getCity } = useCityProvider()
+  const popup = getCity()
   const {
     cart,
     summary,
@@ -288,6 +300,36 @@ export default function CartItemList() {
               {formatCurrency(summary.insuranceSubtotal)}
             </span>
           </div>
+        </div>
+      )}
+
+      {/* Contribution fee — mandatory when popup has it enabled; no buyer toggle */}
+      {summary.contributionSubtotal > 0 && (
+        <div className="mb-4">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            {popup?.contribution_label ||
+              t("checkout.contribution.fallbackLabel")}
+          </h4>
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <HandCoins className="w-4 h-4 text-muted-foreground shrink-0" />
+              <span className="text-sm font-medium text-foreground">
+                {popup?.contribution_label ||
+                  t("checkout.contribution.fallbackLabel")}
+                {popup?.contribution_percentage
+                  ? ` (${Number(popup.contribution_percentage)}%)`
+                  : ""}
+              </span>
+            </div>
+            <span className="text-sm font-medium text-foreground">
+              {formatCurrency(summary.contributionSubtotal)}
+            </span>
+          </div>
+          {popup?.contribution_description && (
+            <p className="text-xs text-muted-foreground mt-1 ml-7">
+              {popup.contribution_description}
+            </p>
+          )}
         </div>
       )}
 

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -3,6 +3,7 @@
 import {
   AlertCircle,
   CloudRain,
+  HandCoins,
   Heart,
   Home,
   Loader2,
@@ -380,6 +381,39 @@ export default function ConfirmStep() {
                   {formatCurrency(summary.insuranceSubtotal)}
                 </span>
               </div>
+            </div>
+          </>
+        )}
+
+        {/* Contribution fee — mandatory when popup has it enabled; no buyer toggle */}
+        {summary.contributionSubtotal > 0 && (
+          <>
+            <div className="border-t border-border" />
+            <div className="px-5 py-4">
+              <div className="flex items-center gap-2 mb-3">
+                <HandCoins className="w-4 h-4 text-muted-foreground" />
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                  {popup?.contribution_label ||
+                    t("checkout.contribution.fallbackLabel")}
+                </span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">
+                  {popup?.contribution_label ||
+                    t("checkout.contribution.fallbackLabel")}
+                  {popup?.contribution_percentage
+                    ? ` (${Number(popup.contribution_percentage)}%)`
+                    : ""}
+                </span>
+                <span className="font-medium text-foreground">
+                  {formatCurrency(summary.contributionSubtotal)}
+                </span>
+              </div>
+              {popup?.contribution_description && (
+                <p className="text-xs text-muted-foreground mt-2">
+                  {popup.contribution_description}
+                </p>
+              )}
             </div>
           </>
         )}

--- a/portal/src/hooks/checkout/useCartSummary.ts
+++ b/portal/src/hooks/checkout/useCartSummary.ts
@@ -13,6 +13,12 @@ interface UseCartSummaryParams {
   merch: SelectedMerchItem[]
   patron: SelectedPatronItem | null
   insuranceAmount: number
+  /**
+   * Contribution fee amount in absolute currency units.
+   * Source from popup config only — never recompute client-side from a
+   * percentage; the backend is the single source of truth for the rate.
+   */
+  contributionAmount: number
   isEditing: boolean
   editCredit: number
   monthUpgradeCredit: number
@@ -26,6 +32,7 @@ export function useCartSummary({
   merch,
   patron,
   insuranceAmount,
+  contributionAmount,
   isEditing,
   editCredit,
   monthUpgradeCredit,
@@ -42,13 +49,15 @@ export function useCartSummary({
     const merchSubtotal = merch.reduce((sum, m) => sum + m.totalPrice, 0)
     const patronSubtotal = patron?.amount ?? 0
     const insuranceSubtotal = insuranceAmount
+    const contributionSubtotal = contributionAmount
 
     const originalSubtotal =
       passesOriginalSubtotal +
       housingSubtotal +
       merchSubtotal +
       patronSubtotal +
-      insuranceSubtotal
+      insuranceSubtotal +
+      contributionSubtotal
     // Apply discount on the original subtotal so the result is idempotent even
     // if PassesProvider has already mutated pass prices via priceStrategy.
     const promoDiscount = (originalSubtotal * discountValue) / 100
@@ -71,6 +80,7 @@ export function useCartSummary({
       merchSubtotal,
       patronSubtotal,
       insuranceSubtotal,
+      contributionSubtotal,
       dynamicSubtotal: 0,
       subtotal: originalSubtotal,
       discount: promoDiscount,
@@ -84,6 +94,7 @@ export function useCartSummary({
     merch,
     patron,
     insuranceAmount,
+    contributionAmount,
     isEditing,
     editCredit,
     monthUpgradeCredit,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -563,7 +563,8 @@
       "check_in": "Check in",
       "check_in_opens_at_start": "Check-in opens at start time",
       "registered": "Registered",
-      "checked_in": "Checked in"
+      "checked_in": "Checked in",
+      "action_error": "Couldn't update your RSVP. Please try again."
     },
     "login_required": {
       "title": "Sign in to view this event",

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -246,6 +246,10 @@
         "previous_image_aria": "Previous image",
         "next_image_aria": "Next image"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "Event contribution",
+      "fallbackDescription": "Helps fund the event"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -246,6 +246,10 @@
         "previous_image_aria": "Imagen anterior",
         "next_image_aria": "Siguiente imagen"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "Contribución al evento",
+      "fallbackDescription": "Apoya la realización del evento"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -563,7 +563,8 @@
       "check_in": "Check-in",
       "check_in_opens_at_start": "El check-in se habilita al comenzar el evento",
       "registered": "Anotado",
-      "checked_in": "Check-in realizado"
+      "checked_in": "Check-in realizado",
+      "action_error": "No pudimos actualizar tu RSVP. Por favor intentá de nuevo."
     },
     "login_required": {
       "title": "Iniciá sesión para ver el evento",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -553,7 +553,8 @@
       "check_in": "Innrita",
       "check_in_opens_at_start": "Innritun opnar á upphafstíma",
       "registered": "Skráður",
-      "checked_in": "Innritaður"
+      "checked_in": "Innritaður",
+      "action_error": "Ekki tókst að uppfæra RSVP. Vinsamlegast reyndu aftur."
     },
     "login_required": {
       "title": "Skráðu þig inn til að sjá þennan viðburð",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -236,6 +236,10 @@
         "previous_image_aria": "Fyrri mynd",
         "next_image_aria": "Næsta mynd"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "Viðbót við viðburð",
+      "fallbackDescription": "Styður við framkvæmd viðburðarins"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -246,6 +246,10 @@
         "previous_image_aria": "上一张图片",
         "next_image_aria": "下一张图片"
       }
+    },
+    "contribution": {
+      "fallbackLabel": "活动贡献费",
+      "fallbackDescription": "支持活动的举办"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -563,7 +563,8 @@
       "check_in": "签到",
       "check_in_opens_at_start": "签到将在活动开始时开放",
       "registered": "已登记",
-      "checked_in": "已签到"
+      "checked_in": "已签到",
+      "action_error": "无法更新你的报名，请稍后重试。"
     },
     "login_required": {
       "title": "登录以查看此活动",

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -581,6 +581,28 @@ export function CheckoutProvider({
     },
   )
 
+  // Contribution fee — derived from popup config (mandatory when enabled).
+  // The popup is the single source of truth for the rate; there is no buyer
+  // opt-in toggle. We calculate client-side from popup.contribution_percentage
+  // so the summary line renders before submit (transparency requirement).
+  const contributionAmount = useMemo<number>(() => {
+    if (!city?.contribution_enabled) return 0
+    const pct = Number(city.contribution_percentage)
+    if (Number.isNaN(pct) || pct <= 0) return 0
+    // Pre-fee subtotal: passes + housing + merch + patron (mirrors backend
+    // _apply_discounts snapshot: post-discount, before insurance and contribution)
+    const passesSubtotal = selectedPasses.reduce(
+      (sum, p) => sum + (p.originalPrice ?? p.price),
+      0,
+    )
+    const housingTotal = housing?.totalPrice ?? 0
+    const merchTotal = merch.reduce((sum, m) => sum + m.totalPrice, 0)
+    const patronTotal = patron?.amount ?? 0
+    const preFeeSubtotal =
+      passesSubtotal + housingTotal + merchTotal + patronTotal
+    return Math.round(((preFeeSubtotal * pct) / 100) * 100) / 100
+  }, [city, selectedPasses, housing, merch, patron])
+
   // Defence-in-depth: take the highest discount available so the total reflects
   // it even if one of the state vectors lags (DiscountProvider's <= guard
   // rejecting an update, or usePromoCode's re-validation effect clobbering
@@ -597,6 +619,7 @@ export function CheckoutProvider({
     merch,
     patron,
     insuranceAmount,
+    contributionAmount,
     isEditing,
     editCredit,
     monthUpgradeCredit,

--- a/portal/src/types/checkout.ts
+++ b/portal/src/types/checkout.ts
@@ -127,6 +127,7 @@ export interface CheckoutCartSummary {
   merchSubtotal: number
   patronSubtotal: number
   insuranceSubtotal: number
+  contributionSubtotal: number
   dynamicSubtotal: number
   subtotal: number
   discount: number
@@ -249,6 +250,7 @@ export function createInitialSummary(): CheckoutCartSummary {
     merchSubtotal: 0,
     patronSubtotal: 0,
     insuranceSubtotal: 0,
+    contributionSubtotal: 0,
     dynamicSubtotal: 0,
     subtotal: 0,
     discount: 0,


### PR DESCRIPTION
## Summary

Release PR rolling up everything merged to \`dev\` since the previous \`main\` cut. 23 commits, +1787 / -194 across 30 files.

## What's included

### Contribution fee (new feature)

Admin-configured percentage fee on the order total, mandatory when enabled on a popup. Distinct from \`insurance\` (product-scoped) and \`patron\` (fixed donation product) — contribution is intended to support event realization.

Shipped via 3 chained PRs:
- **#174** backend: migration \`f6c1f50160ef_popup_contribution_fee.py\` (4 columns on \`popups\` + 1 on \`payments\`), \`calculate_contribution_amount()\` pure function, \`_apply_discounts\` wiring with shared pre-fee snapshot (no compounding with insurance), payment persistence, OpenAPI client regen, 16 new tests.
- **#176** backoffice: PopupForm Contribution InlineSection, payments list new Contribution column + full fee breakdown in expanded subrow (also fixes pre-existing insurance breakdown math bug).
- **#177** portal: contribution line in cart footer + Review-before-payment card section + i18n fallbacks in 4 locales.

### Events: draft/publish workflow refactor

- Replaced the events status dropdown with explicit Save as Draft / Publish Event buttons in backoffice.
- Treat draft events as freeing the venue slot (so a draft doesn't block other events at the same venue).

### Portal events list

- RSVP loading and error feedback states.

### Misc

- Test helper type annotation fix.

## Database migrations

- \`f6c1f50160ef_popup_contribution_fee.py\` — additive only, no backfill, no downtime expected.

## Risks / things to validate before merge

- **Alembic head**: confirm \`f6c1f50160ef\` is the single head on dev before deploy.
- **Known follow-ups deferred** (non-blocking):
  - SCN-03 end-to-end test (PATCH popup percentage → preview reflects new rate)
  - SCN-10 HTTP test (PopupPublic JSON includes the 4 contribution fields)
  - SCN-08 HTTP test (direct-sale exclusion — DB-level coverage only today)
- Pre-existing \`ty check\` errors in \`admin_api_key/*\` and \`api_key/crud.py\` unchanged by this release.

## Test plan

- [x] Backend test suite green on dev (1043 passed)
- [x] Backoffice + portal lint + build green
- [x] Manual end-to-end test of contribution-fee flow performed on local stack before merging the chain to dev
- [ ] Smoke test on staging after deploy