### PR TITLE
fix(payment): link AttendeeProducts to originating payment

### DIFF
--- a/backend/app/alembic/versions/4dffd7a49bef_backfill_attendee_products_payment_id.py
+++ b/backend/app/alembic/versions/4dffd7a49bef_backfill_attendee_products_payment_id.py
@@ -1,0 +1,61 @@
+"""Backfill attendee_products.payment_id from payment_products.
+
+The ticket-as-first-class-entity refactor added the optional payment_id
+column on attendee_products but the three internal call sites of
+PaymentsCRUD._add_products_to_attendees did not forward the payment_id,
+so every ticket created via the approval paths (approve_payment,
+update_status -> APPROVED, and the auto-approve branch of create_payment)
+ended up with payment_id=NULL.
+
+This migration backfills the link wherever it can be done unambiguously:
+for each NULL row, if exactly one APPROVED payment in payment_products
+shares (attendee_id, product_id), set payment_id to that payment.
+
+Ambiguous rows (the attendee has more than one approved payment for the
+same product) are left untouched on purpose — those need product team
+review because they signal a separate idempotency bug where one purchase
+intent created two approved payments and two tickets.
+
+Revision ID: 4dffd7a49bef
+Revises: f6c1f50160ef
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "4dffd7a49bef"
+down_revision: str | Sequence[str] | None = "f6c1f50160ef"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        WITH unique_pp AS (
+            SELECT
+                pp.attendee_id,
+                pp.product_id,
+                (array_agg(DISTINCT pp.payment_id))[1] AS payment_id
+            FROM payment_products pp
+            JOIN payments p ON p.id = pp.payment_id
+            WHERE p.status = 'approved'
+            GROUP BY pp.attendee_id, pp.product_id
+            HAVING COUNT(DISTINCT pp.payment_id) = 1
+        )
+        UPDATE attendee_products ap
+        SET payment_id = u.payment_id
+        FROM unique_pp u
+        WHERE ap.payment_id IS NULL
+          AND ap.attendee_id = u.attendee_id
+          AND ap.product_id  = u.product_id;
+        """
+    )
+
+
+def downgrade() -> None:
+    # No-op: re-NULLing rows would lose information and we can't tell which
+    # rows this migration touched after the fact. Operators who need to
+    # reverse the backfill should restore from snapshot.
+    pass

--- a/backend/app/alembic/versions/6b0327ae7ca7_merge_payment_id_backfill_and_payment_products_metadata.py
+++ b/backend/app/alembic/versions/6b0327ae7ca7_merge_payment_id_backfill_and_payment_products_metadata.py
@@ -1,0 +1,28 @@
+"""Merge: attendee_products payment_id backfill + payment_products metadata.
+
+main shipped `4dffd7a49bef` (backfill attendee_products.payment_id) with
+parent `f6c1f50160ef`. dev independently shipped `d2f5a7c891b3`
+(payment_products.purchase_metadata) which also descends from
+`f6c1f50160ef` via `a1f9c2e8b5d1` and `c0b101dd74e8`. When the backfill
+PR was backported to dev, the two heads coexisted; this no-op merge joins
+them so dev (and the eventual dev -> main merge) has a single head and
+the file content of `4dffd7a49bef_*.py` stays identical to main.
+
+Revision ID: 6b0327ae7ca7
+Revises: 4dffd7a49bef, d2f5a7c891b3
+"""
+
+from collections.abc import Sequence
+
+revision: str = "6b0327ae7ca7"
+down_revision: tuple[str, ...] = ("4dffd7a49bef", "d2f5a7c891b3")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -1471,18 +1471,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     session.delete(ap)
                 session.flush()
 
-            # Auto-approve and add products directly
-            self._add_products_to_attendees(session, obj.products)
-
-            # Get product details for snapshot
-            product_ids = [p.product_id for p in obj.products]
-            prod_statement = select(Products).where(
-                Products.id.in_(product_ids),  # type: ignore[attr-defined]
-                Products.deleted_at.is_(None),  # type: ignore[attr-defined]
-            )
-            products_map = {p.id: p for p in session.exec(prod_statement).all()}
-
-            # Create payment record for audit trail
+            # Create payment record first so AttendeeProducts can link to it.
             payment = Payments(
                 tenant_id=application.tenant_id,
                 application_id=obj.application_id,
@@ -1501,6 +1490,19 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             )
             session.add(payment)
             session.flush()
+
+            # Auto-approve and add products directly
+            self._add_products_to_attendees(
+                session, obj.products, payment_id=payment.id
+            )
+
+            # Get product details for snapshot
+            product_ids = [p.product_id for p in obj.products]
+            prod_statement = select(Products).where(
+                Products.id.in_(product_ids),  # type: ignore[attr-defined]
+                Products.deleted_at.is_(None),  # type: ignore[attr-defined]
+            )
+            products_map = {p.id: p for p in session.exec(prod_statement).all()}
 
             # Create product snapshots
             for req_prod in obj.products:
@@ -1746,7 +1748,9 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 )
                 for pp in payment.products_snapshot
             ]
-            self._add_products_to_attendees(session, products_to_add)
+            self._add_products_to_attendees(
+                session, products_to_add, payment_id=payment.id
+            )
 
             # Create ambassador group if patreon product was purchased.
             # Direct-sale payments have no application — skip ambassador logic
@@ -2011,7 +2015,9 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 )
                 for pp in payment.products_snapshot
             ]
-            self._add_products_to_attendees(session, products_to_add)
+            self._add_products_to_attendees(
+                session, products_to_add, payment_id=payment.id
+            )
 
         session.add(payment)
         session.commit()

--- a/backend/tests/api/payment/test_attendee_products_payment_link.py
+++ b/backend/tests/api/payment/test_attendee_products_payment_link.py
@@ -1,0 +1,211 @@
+"""Regression: AttendeeProducts.payment_id is set when tickets are created
+via the approval paths (approve_payment, update_status -> APPROVED).
+
+Background: the `ticket-as-first-class-entity` refactor added an optional
+`payment_id` kwarg to PaymentsCRUD._add_products_to_attendees. The three
+call sites must forward it so tickets are linked back to their originating
+payment. A regression in May 2026 left production rows with payment_id=NULL,
+breaking refund / cancellation cleanup, profile stats, and product snapshots.
+"""
+
+import uuid
+from decimal import Decimal
+
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import AttendeeProducts, Attendees
+from app.api.human.models import Humans
+from app.api.payment.crud import payments_crud
+from app.api.payment.models import PaymentProducts, Payments
+from app.api.payment.schemas import PaymentProductRequest, PaymentStatus
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.tenant.models import Tenants
+
+
+def _make_product(db: Session, tenant: Tenants, popup: Popups) -> Products:
+    suffix = uuid.uuid4().hex[:8]
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"link-test-{suffix}",
+        slug=f"link-{suffix}",
+        price=Decimal("100"),
+        category="ticket",
+        is_active=True,
+    )
+    db.add(product)
+    db.flush()
+    return product
+
+
+def _make_pending_payment_with_snapshot(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    product_qty_pairs: list[tuple[Products, int]],
+) -> tuple[Payments, Attendees]:
+    """Build a PENDING payment with PaymentProducts snapshot rows + 1 attendee."""
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"link-human-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Link",
+        last_name="Test",
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.flush()
+
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        name="Link Attendee",
+        category="main",
+        email=f"att-{uuid.uuid4().hex[:8]}@test.com",
+        check_in_code=f"L{uuid.uuid4().hex[:4].upper()}",
+    )
+    db.add(attendee)
+    db.flush()
+
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        status=PaymentStatus.PENDING.value,
+        amount=Decimal("100"),
+        currency="USD",
+        external_id=f"sf-link-{uuid.uuid4().hex[:12]}",
+    )
+    db.add(payment)
+    db.flush()
+
+    for product, qty in product_qty_pairs:
+        db.add(
+            PaymentProducts(
+                tenant_id=tenant.id,
+                payment_id=payment.id,
+                product_id=product.id,
+                attendee_id=attendee.id,
+                quantity=qty,
+                product_name=product.name,
+                product_description=None,
+                product_price=product.price,
+                product_category=product.category or "ticket",
+                product_currency="USD",
+            )
+        )
+
+    db.commit()
+    db.refresh(payment)
+    return payment, attendee
+
+
+def test_approve_payment_links_tickets_to_payment(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """approve_payment must set AttendeeProducts.payment_id on every new ticket."""
+    product = _make_product(db, tenant_a, popup_tenant_a)
+    payment, attendee = _make_pending_payment_with_snapshot(
+        db, tenant_a, popup_tenant_a, [(product, 2)]
+    )
+
+    payments_crud.approve_payment(db, payment.id)
+
+    db.expire_all()
+    tickets = list(
+        db.exec(
+            select(AttendeeProducts).where(
+                AttendeeProducts.attendee_id == attendee.id,
+                AttendeeProducts.product_id == product.id,
+            )
+        ).all()
+    )
+    assert len(tickets) == 2
+    assert all(t.payment_id == payment.id for t in tickets), (
+        "approve_payment must link every new AttendeeProducts row to the "
+        "payment that approved it."
+    )
+
+
+def test_update_status_to_approved_links_tickets_to_payment(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """update_status -> APPROVED must set AttendeeProducts.payment_id on every new ticket."""
+    product = _make_product(db, tenant_a, popup_tenant_a)
+    payment, attendee = _make_pending_payment_with_snapshot(
+        db, tenant_a, popup_tenant_a, [(product, 3)]
+    )
+
+    payments_crud.update_status(db, payment.id, PaymentStatus.APPROVED)
+
+    db.expire_all()
+    tickets = list(
+        db.exec(
+            select(AttendeeProducts).where(
+                AttendeeProducts.attendee_id == attendee.id,
+                AttendeeProducts.product_id == product.id,
+            )
+        ).all()
+    )
+    assert len(tickets) == 3
+    assert all(t.payment_id == payment.id for t in tickets), (
+        "update_status -> APPROVED must link every new AttendeeProducts row "
+        "to the payment whose status transitioned."
+    )
+
+
+def test_add_products_to_attendees_forwards_payment_id(
+    db: Session,
+    tenant_a: Tenants,
+    popup_tenant_a: Popups,
+) -> None:
+    """_add_products_to_attendees stamps payment_id when the kwarg is provided.
+
+    Direct contract test that backs up the auto-approve branch of
+    create_payment, which constructs the Payments row, flushes it, and then
+    calls this method with payment_id=payment.id.
+    """
+    product = _make_product(db, tenant_a, popup_tenant_a)
+    payment, attendee = _make_pending_payment_with_snapshot(
+        db, tenant_a, popup_tenant_a, [(product, 1)]
+    )
+
+    payments_crud._add_products_to_attendees(
+        db,
+        [
+            PaymentProductRequest(
+                product_id=product.id,
+                attendee_id=attendee.id,
+                quantity=2,
+            )
+        ],
+        payment_id=payment.id,
+    )
+    db.commit()
+
+    db.expire_all()
+    tickets = list(
+        db.exec(
+            select(AttendeeProducts).where(
+                AttendeeProducts.attendee_id == attendee.id,
+                AttendeeProducts.product_id == product.id,
+            )
+        ).all()
+    )
+    assert len(tickets) == 2
+    assert all(t.payment_id == payment.id for t in tickets)


### PR DESCRIPTION
Backport del hotfix mergeado a main (PR #182) para mantener dev en sync.

## Summary

Los tres call sites internos de `_add_products_to_attendees` (`approve_payment`, `update_status` → APPROVED, y el auto-approve branch de `create_payment`) no forwardeaban el kwarg `payment_id` introducido por el refactor `ticket-as-first-class-entity`, dejando los tickets con `payment_id = NULL`.

Ver PR #182 para diagnóstico completo (3 tenants, 186 NULL rows, 157 backfilleables automáticamente vía migration idempotente).

## Changes

- `backend/app/api/payment/crud.py` — los 3 call sites forwardean `payment_id`; auto-approve branch reordenado para crear `Payments` antes del insert de tickets.
- `backend/app/alembic/versions/4dffd7a49bef_backfill_attendee_products_payment_id.py` — backfill idempotente.
- `backend/tests/api/payment/test_attendee_products_payment_link.py` — 3 tests de regresión.

## Test plan

- [x] Ruff + format check
- [x] `alembic heads` único
- [x] 99 tests de payment passing
- [ ] CI green