### PR TITLE
fix(payment): make checkout submit idempotent

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -1,11 +1,11 @@
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 from loguru import logger
-from sqlalchemy import desc, or_
+from sqlalchemy import desc, or_, text
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, func, select
 
@@ -1344,6 +1344,53 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
 
         return self._apply_discounts(session, obj, application)
 
+    def _find_recent_duplicate_payment(
+        self,
+        session: Session,
+        application_id: uuid.UUID,
+        obj: PaymentCreate,
+        preview: PaymentPreview,
+    ) -> Payments | None:
+        """Return a recently-approved payment whose products and amount match
+        the incoming request, or None.
+
+        Used as an idempotency guard against double-submits, bfcache restores,
+        and browser/network retries that re-fire an already-processed checkout.
+        A legitimate second purchase by the same buyer (different products or
+        outside the window) is left alone.
+        """
+        window_start = datetime.now(tz=UTC) - timedelta(
+            seconds=self._DUPLICATE_WINDOW_SECONDS
+        )
+
+        incoming_fingerprint = sorted(
+            (p.product_id, p.attendee_id, p.quantity) for p in obj.products
+        )
+
+        candidates = list(
+            session.exec(
+                select(Payments)
+                .where(
+                    Payments.application_id == application_id,
+                    Payments.status == PaymentStatus.APPROVED.value,
+                    Payments.created_at >= window_start,
+                    Payments.amount == preview.amount,
+                )
+                .options(selectinload(Payments.products_snapshot))  # type: ignore[arg-type]
+                .order_by(desc(Payments.created_at))
+            ).all()
+        )
+
+        for candidate in candidates:
+            snapshot = sorted(
+                (pp.product_id, pp.attendee_id, pp.quantity)
+                for pp in candidate.products_snapshot
+            )
+            if snapshot == incoming_fingerprint:
+                return candidate
+
+        return None
+
     def _get_application_with_products(
         self, session: Session, application_id: uuid.UUID
     ) -> Applications | None:
@@ -1366,6 +1413,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         )
         return session.exec(statement).first()
 
+    # Idempotency window for duplicate-submit detection. Anything outside
+    # this window is treated as a legitimate new purchase intent.
+    _DUPLICATE_WINDOW_SECONDS = 300
+
     def create_payment(
         self,
         session: Session,
@@ -1376,8 +1427,38 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
 
         For zero-amount payments, auto-approves and adds products directly.
         For paid payments, returns payment with checkout info from SimpleFI.
+
+        Concurrent submissions for the same application are serialized via
+        a row-level lock, and a request matching a recently-approved payment
+        is short-circuited to that existing payment.
         """
+        application_id = _require_application_id(obj.application_id)
+
+        # Serialize concurrent payment attempts for the same application.
+        # Without this, double-submits and browser retries can produce
+        # duplicate Payments + AttendeeProducts (see PR #182 follow-up).
+        session.execute(
+            text("SELECT id FROM applications WHERE id = :id FOR UPDATE"),
+            {"id": application_id},
+        )
+
         preview = self.preview_payment(session, obj)
+
+        # Idempotency short-circuit: if we just approved a payment with the
+        # same products and amount for this application, return that one
+        # instead of creating a duplicate. Stock counters, snapshot rows and
+        # ticket inserts have already happened for the original.
+        existing = self._find_recent_duplicate_payment(
+            session, application_id, obj, preview
+        )
+        if existing is not None:
+            logger.info(
+                "Duplicate payment submit short-circuited: "
+                "application={} matched existing payment={}",
+                application_id,
+                existing.id,
+            )
+            return existing, preview
 
         # Fetch products once for both validation and decrement helpers.
         product_ids = [p.product_id for p in obj.products]

--- a/backend/tests/api/payment/test_payment_idempotency.py
+++ b/backend/tests/api/payment/test_payment_idempotency.py
@@ -1,0 +1,227 @@
+"""Idempotency tests for PaymentsCRUD.create_payment.
+
+The endpoint that backs `POST /payments/my` previously had no guard against
+double-submits, browser retries, or bfcache-induced replays. For $0 / fully
+credited payments that auto-approve synchronously, each replay produced a
+duplicate Payments row + a duplicate set of AttendeeProducts. These tests
+pin the contract that a recent matching submission is short-circuited to
+the existing payment instead.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import AttendeeProducts, Attendees
+from app.api.human.models import Humans
+from app.api.payment.crud import payments_crud
+from app.api.payment.models import Payments
+from app.api.payment.schemas import (
+    PaymentCreate,
+    PaymentProductRequest,
+    PaymentStatus,
+)
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name="Idempotency Test",
+        slug=f"idem-{uuid.uuid4().hex[:8]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        simplefi_api_key="sf_test",
+        currency="USD",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_free_product(db: Session, popup: Popups) -> Products:
+    product = Products(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        name=f"Free Pass {uuid.uuid4().hex[:6]}",
+        slug=f"free-{uuid.uuid4().hex[:8]}",
+        price=Decimal("0"),
+        category="ticket",
+        is_active=True,
+    )
+    db.add(product)
+    db.flush()
+    return product
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        email=f"idem-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Idem",
+        last_name="Tester",
+    )
+    db.add(human)
+    db.flush()
+    return human
+
+
+def _make_app_and_attendee(
+    db: Session, popup: Popups, human: Humans
+) -> tuple[Applications, Attendees]:
+    app = Applications(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(app)
+    db.flush()
+    attendee = Attendees(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        application_id=app.id,
+        name="Idem Attendee",
+        email=human.email,
+        category="main",
+    )
+    db.add(attendee)
+    db.flush()
+    return app, attendee
+
+
+def test_duplicate_submit_within_window_returns_existing_payment(
+    db: Session, tenant_a: Tenants
+) -> None:
+    """Same payload, second time inside the dedup window → same Payment row."""
+    popup = _make_popup(db, tenant_a)
+    product = _make_free_product(db, popup)
+    human = _make_human(db, tenant_a)
+    app, attendee = _make_app_and_attendee(db, popup, human)
+    db.commit()
+
+    obj = PaymentCreate(
+        application_id=app.id,
+        products=[
+            PaymentProductRequest(
+                product_id=product.id,
+                attendee_id=attendee.id,
+                quantity=1,
+            )
+        ],
+    )
+
+    payment1, _ = payments_crud.create_payment(db, obj)
+    payment2, _ = payments_crud.create_payment(db, obj)
+
+    assert payment1.id == payment2.id, (
+        "Second submit must return the existing Payment, not a duplicate."
+    )
+
+    payments = list(
+        db.exec(select(Payments).where(Payments.application_id == app.id)).all()
+    )
+    assert len(payments) == 1, (
+        f"Exactly one Payment should exist for the application, found {len(payments)}"
+    )
+
+    tickets = list(
+        db.exec(
+            select(AttendeeProducts).where(AttendeeProducts.attendee_id == attendee.id)
+        ).all()
+    )
+    assert len(tickets) == 1, (
+        f"Exactly one AttendeeProducts row should exist, found {len(tickets)}"
+    )
+
+
+def test_different_products_within_window_creates_new_payment(
+    db: Session, tenant_a: Tenants
+) -> None:
+    """Different product set → not a duplicate, new payment is created."""
+    popup = _make_popup(db, tenant_a)
+    product_a = _make_free_product(db, popup)
+    product_b = _make_free_product(db, popup)
+    human = _make_human(db, tenant_a)
+    app, attendee = _make_app_and_attendee(db, popup, human)
+    db.commit()
+
+    obj_a = PaymentCreate(
+        application_id=app.id,
+        products=[
+            PaymentProductRequest(
+                product_id=product_a.id,
+                attendee_id=attendee.id,
+                quantity=1,
+            )
+        ],
+    )
+    obj_b = PaymentCreate(
+        application_id=app.id,
+        products=[
+            PaymentProductRequest(
+                product_id=product_b.id,
+                attendee_id=attendee.id,
+                quantity=1,
+            )
+        ],
+    )
+
+    payment1, _ = payments_crud.create_payment(db, obj_a)
+    payment2, _ = payments_crud.create_payment(db, obj_b)
+
+    assert payment1.id != payment2.id, (
+        "Different products are a legitimate second purchase, not a duplicate."
+    )
+
+
+def test_old_approved_payment_outside_window_does_not_match(
+    db: Session, tenant_a: Tenants
+) -> None:
+    """Existing matching payment older than the dedup window → new payment created."""
+    popup = _make_popup(db, tenant_a)
+    product = _make_free_product(db, popup)
+    human = _make_human(db, tenant_a)
+    app, attendee = _make_app_and_attendee(db, popup, human)
+    db.commit()
+
+    obj = PaymentCreate(
+        application_id=app.id,
+        products=[
+            PaymentProductRequest(
+                product_id=product.id,
+                attendee_id=attendee.id,
+                quantity=1,
+            )
+        ],
+    )
+
+    payment1, _ = payments_crud.create_payment(db, obj)
+
+    # Backdate the first payment to put it outside the dedup window.
+    payment1.created_at = datetime.now(tz=UTC) - timedelta(
+        seconds=payments_crud._DUPLICATE_WINDOW_SECONDS + 60
+    )
+    db.add(payment1)
+    db.commit()
+
+    payment2, _ = payments_crud.create_payment(db, obj)
+
+    assert payment2.id != payment1.id, (
+        "A purchase outside the dedup window is treated as a new, legitimate "
+        "purchase intent."
+    )
+    assert payment2.status == PaymentStatus.APPROVED.value

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -99,6 +99,14 @@ export function usePaymentSubmit({
   }, [])
 
   const submitPayment = useCallback(async (): Promise<PaymentSubmitResult> => {
+    // Guard against double-submits that bypass the disabled-button state:
+    // bfcache restore resets isSubmitting to false, and the post-success
+    // reset can race the redirect. Without this, the same checkout can be
+    // re-posted from the same browser session.
+    if (isSubmitting || paymentCompleteRef.current) {
+      return { success: false, error: "Payment already submitted" }
+    }
+
     if (submitMode === "application" && !applicationId) {
       return { success: false, error: "Application not available" }
     }
@@ -300,6 +308,7 @@ export function usePaymentSubmit({
     submitMode,
     router,
     creditsEnabled,
+    isSubmitting,
   ])
 
   return { submitPayment, isSubmitting }


### PR DESCRIPTION
Follow-up del hotfix #182. Cierra el bug \"double-approval para pagos \$0\" que detectamos al revisar los 29 ambiguous rows en producción (7 buyers en edge-esmeralda-2026 + 5 en mushanghai, todos con approveds creados 11-188s aparte por double-submits / browser retries).

## Backend (`backend/app/api/payment/crud.py`)

\`create_payment\` ahora:

1. **Lock pesimista** sobre la application al inicio (\`SELECT id FROM applications WHERE id = :id FOR UPDATE\`). Serializa requests concurrentes para el mismo buyer.
2. **Dedup window de 5 min**: nuevo helper \`_find_recent_duplicate_payment\` compara el request entrante contra payments aprobados recientes con los mismos products + amount. Si matchea, devuelve el payment existente en lugar de crear uno nuevo.

Compras legítimas separadas (productos distintos o fuera de ventana) siguen funcionando — verificado con Anuke-style scenario en \`test_different_products_within_window_creates_new_payment\` y \`test_old_approved_payment_outside_window_does_not_match\`.

## Frontend (\`portal/src/hooks/checkout/usePaymentSubmit.ts\`)

Guard al inicio de \`submitPayment\`:

\`\`\`tsx
if (isSubmitting || paymentCompleteRef.current) {
  return { success: false, error: \"Payment already submitted\" }
}
\`\`\`

Cierra los 3 gaps que dejan el botón habilitado a pesar del state \`isSubmitting\`:
- **bfcache restore** resetea \`isSubmitting\` cuando el buyer vuelve atrás.
- **\`paymentCompleteRef\`** se setea en éxito pero el código nunca la consultaba.
- **Race del reset post-success**: \`router.replace\` es no-bloqueante y \`setIsSubmitting(false)\` corre antes que la navegación.

\`isSubmitting\` agregado a las deps del useCallback para que el closure vea el valor actualizado.

## Test plan

- [x] \`ruff check\` + \`ruff format --check\` en archivos backend tocados
- [x] \`pnpm --filter portal run lint\` + \`run build\` — pasa sin errores TS nuevos
- [x] 3 nuevos tests en \`test_payment_idempotency.py\` pasan
- [x] 99 tests del payment suite siguen pasando (sin regresión)
- [ ] CI green

## Out of scope (follow-ups)

- Cleanup de los 29 ambiguous rows en producción — decisión de producto/ops, no técnica.
- Extender el dedup a payments en estado \`pending\` (evita double-checkout-url en flujos pagos via SimpleFI). Mejora separada.