### PR TITLE
fix: third-party app legacy scopes + silence backend test warnings

### DIFF
--- a/backend/app/api/third_party_app/models.py
+++ b/backend/app/api/third_party_app/models.py
@@ -11,7 +11,7 @@ cannot express a functional WHERE clause portably.
 """
 
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import Index, text
@@ -69,11 +69,11 @@ class ThirdPartyApps(SQLModel, table=True):
         sa_column=Column(DateTime(timezone=True), nullable=True),
     )
     created_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
     updated_at: datetime = Field(
-        default_factory=datetime.utcnow,
+        default_factory=lambda: datetime.now(UTC),
         sa_column=Column(DateTime(timezone=True), nullable=False),
     )
 

--- a/backend/tests/api/payment/test_patron_payment_integration.py
+++ b/backend/tests/api/payment/test_patron_payment_integration.py
@@ -383,7 +383,6 @@ class TestPatronPaymentCreation:
             assert exc_info.value.status_code == 422
             assert "patron" in exc_info.value.detail.lower()
         finally:
-            db.delete(attendee)
             db.delete(application)
             db.delete(product)
             db.delete(popup)
@@ -415,7 +414,6 @@ class TestPatronPaymentCreation:
                 payments_crud.create_payment(db, obj)
             assert exc_info.value.status_code == 422
         finally:
-            db.delete(attendee)
             db.delete(application)
             db.delete(step)
             db.delete(product)
@@ -446,7 +444,6 @@ class TestPatronPaymentCreation:
                 payments_crud.create_payment(db, obj)
             assert exc_info.value.status_code == 422
         finally:
-            db.delete(attendee)
             db.delete(application)
             db.delete(product)
             db.commit()
@@ -477,7 +474,6 @@ class TestPatronPaymentCreation:
                 payments_crud.create_payment(db, obj)
             assert exc_info.value.status_code == 422
         finally:
-            db.delete(attendee)
             db.delete(application)
             db.delete(step)
             db.delete(product)

--- a/backoffice/src/routes/_layout/third-party-apps.tsx
+++ b/backoffice/src/routes/_layout/third-party-apps.tsx
@@ -309,12 +309,22 @@ function EditAppDialog({
   const { showSuccessToast, showErrorToast } = useCustomToast()
   const queryClient = useQueryClient()
 
-  const [name, setName] = useState(app.name)
-  const [tokenScopes, setTokenScopes] = useState<string[]>(
-    app.allowed_token_scopes,
+  const validTokenScopes = new Set(availableScopes.token_scopes)
+  const validApiKeyScopes = new Set(availableScopes.api_key_scopes)
+
+  const legacyTokenScopes = app.allowed_token_scopes.filter(
+    (s) => !validTokenScopes.has(s),
   )
-  const [apiKeyScopes, setApiKeyScopes] = useState<string[]>(
-    app.allowed_api_key_scopes,
+  const legacyApiKeyScopes = app.allowed_api_key_scopes.filter(
+    (s) => !validApiKeyScopes.has(s),
+  )
+
+  const [name, setName] = useState(app.name)
+  const [tokenScopes, setTokenScopes] = useState<string[]>(() =>
+    app.allowed_token_scopes.filter((s) => validTokenScopes.has(s)),
+  )
+  const [apiKeyScopes, setApiKeyScopes] = useState<string[]>(() =>
+    app.allowed_api_key_scopes.filter((s) => validApiKeyScopes.has(s)),
   )
   const [nameError, setNameError] = useState("")
   const [scopeError, setScopeError] = useState("")
@@ -451,6 +461,26 @@ function EditAppDialog({
                 onToggle={(s) => toggleScope(s, apiKeyScopes, setApiKeyScopes)}
               />
             </div>
+
+            {(legacyTokenScopes.length > 0 ||
+              legacyApiKeyScopes.length > 0) && (
+              <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3">
+                <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500 mt-0.5" />
+                <div className="text-xs text-muted-foreground space-y-1">
+                  <p className="font-medium text-foreground">
+                    Legacy scopes will be removed on save.
+                  </p>
+                  {legacyTokenScopes.length > 0 && (
+                    <p>Token scopes dropped: {legacyTokenScopes.join(", ")}</p>
+                  )}
+                  {legacyApiKeyScopes.length > 0 && (
+                    <p>
+                      API key scopes dropped: {legacyApiKeyScopes.join(", ")}
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
 
             {isExpandingScopes && (
               <div className="flex items-start gap-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3">


### PR DESCRIPTION
## Summary
- **fix(backoffice):** the edit dialog for third-party apps used to re-send legacy scopes (e.g. `portal:self_read`) that no longer exist in the current scope universe. They were invisible in the UI but stuck in state, so PATCH was always rejected. The dialog now filters them out and surfaces a warning listing what the save will drop.
- **chore(backend):** silence two test warnings — replace `datetime.utcnow` with `datetime.now(UTC)` in `ThirdPartyApps` defaults, and drop the redundant explicit attendee delete in patron payment tests (the `Applications.attendees` cascade already handles it).

## Test plan
- [x] Backend lint clean on touched files (`ruff check` + `ruff format --check`).
- [x] Backoffice lint clean (`pnpm run lint`).
- [x] `pytest tests/api/payment/test_patron_payment_integration.py -W error::sqlalchemy.exc.SAWarning` → 9 passed, no SAWarnings.
- [x] `pnpm --filter backoffice run build` → green.
- [ ] Manual: open Edit on a legacy third-party app, verify legacy scopes block appears with the scopes about to be dropped, save persists the new scope set without rotating the key.