### PR TITLE
feat(checkout): coupon rules + Product.discountable flag

### DIFF
--- a/backend/app/alembic/versions/377c2c02fe74_product_discountable.py
+++ b/backend/app/alembic/versions/377c2c02fe74_product_discountable.py
@@ -1,0 +1,47 @@
+"""product_discountable: per-product flag controlling whether discounts apply.
+
+Adds:
+  - products.discountable (bool, NOT NULL, default true)
+
+Defaults to true so existing products keep current behavior. When set to false
+on a specific product, the backend's `_calculate_amounts` routes its amount to
+the non-discountable bucket — same treatment as patreon products — so coupons,
+group discounts, and scholarship discounts never reduce its price.
+
+The portal mirrors the same split when computing `discountableSubtotal`.
+
+Revision ID: 377c2c02fe74
+Revises: 84513cbb2260
+Create Date: 2026-05-23 21:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "377c2c02fe74"
+down_revision: str = "84513cbb2260"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "products",
+        sa.Column(
+            "discountable",
+            sa.Boolean(),
+            nullable=False,
+            server_default="true",
+        ),
+    )
+    # Patreon products are donations and must never be discounted. Backfill so
+    # the new flag captures the existing business rule for legacy rows.
+    op.execute("UPDATE products SET discountable = false WHERE category = 'patreon'")
+
+
+def downgrade() -> None:
+    op.drop_column("products", "discountable")

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -219,11 +219,21 @@ def _get_credit(application: Applications, discount_value: Decimal) -> Decimal:
 def _calculate_amounts(
     session: Session,
     requested_products: list[PaymentProductRequest],
-) -> tuple[Decimal, Decimal, Decimal]:
+) -> tuple[Decimal, Decimal]:
     """
-    Calculate standard, supporter, and patreon amounts.
+    Calculate standard and non-discountable amounts.
 
-    Returns: (standard_amount, supporter_amount, patreon_amount)
+    Buckets:
+      - standard: regular discountable products (coupons / group / scholarship
+        discounts reduce this side only)
+      - non_discountable: products with `discountable=False`, including patreon
+        donations (forced via the schema validator). Charged in full, immune to
+        any discount.
+
+    Patreon products are a sub-case of non-discountable: their stored `price`
+    is 0 and the buyer-chosen donation lives on `unit_price_override`.
+
+    Returns: (standard_amount, non_discountable_amount)
     """
     product_ids = list({rp.product_id for rp in requested_products})
     statement = select(Products).where(
@@ -244,41 +254,38 @@ def _calculate_amounts(
         if attendee_id not in attendees:
             attendees[attendee_id] = {
                 "standard": Decimal("0"),
-                "supporter": Decimal("0"),
-                "patreon": Decimal("0"),
+                "non_discountable": Decimal("0"),
             }
 
-        if product_model.category == "patreon":
-            # Patron donations are independent from ticket prices. The amount
-            # lives on the request's unit_price_override (raw popup currency
-            # units, quantity is always 1). product_model.price is 0 for
-            # patreon products and must not be used to derive the donation
-            # amount. Tickets in the same order are still charged in full.
-            donation_amount = req_prod.unit_price_override or Decimal("0")
-            attendees[attendee_id]["patreon"] += donation_amount
-        elif product_model.category == "supporter":
-            attendees[attendee_id]["supporter"] += product_model.price * quantity
+        if not product_model.discountable:
+            # Patreon donations carry their amount on unit_price_override
+            # (product.price is always 0 for patreon). All other
+            # non-discountable products use the regular price * quantity.
+            if product_model.category == "patreon":
+                line_amount = req_prod.unit_price_override or Decimal("0")
+            else:
+                line_amount = product_model.price * quantity
+            attendees[attendee_id]["non_discountable"] += line_amount
         else:
             attendees[attendee_id]["standard"] += product_model.price * quantity
 
     standard_amount = sum((a["standard"] for a in attendees.values()), Decimal("0"))
-    supporter_amount = sum((a["supporter"] for a in attendees.values()), Decimal("0"))
-    patreon_amount = sum((a["patreon"] for a in attendees.values()), Decimal("0"))
-
-    logger.info(
-        "Amounts calculated - Standard: {}, Supporter: {}, Patreon: {}",
-        standard_amount,
-        supporter_amount,
-        patreon_amount,
+    non_discountable_amount = sum(
+        (a["non_discountable"] for a in attendees.values()), Decimal("0")
     )
 
-    return standard_amount, supporter_amount, patreon_amount
+    logger.info(
+        "Amounts calculated - Standard: {}, NonDiscountable: {}",
+        standard_amount,
+        non_discountable_amount,
+    )
+
+    return standard_amount, non_discountable_amount
 
 
 def _calculate_price(
     standard_amount: Decimal,
-    supporter_amount: Decimal,
-    patreon_amount: Decimal,
+    non_discountable_amount: Decimal,
     discount_value: Decimal,
     application: Applications,
     edit_passes: bool,
@@ -292,7 +299,7 @@ def _calculate_price(
         discounted_standard = _get_discounted_price(standard_amount, discount_value)
     discounted_standard = discounted_standard - credit
 
-    return discounted_standard + supporter_amount + patreon_amount
+    return discounted_standard + non_discountable_amount
 
 
 class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
@@ -480,7 +487,6 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         buyer_name = (
             f"{obj.buyer.first_name} {obj.buyer.last_name}".strip() or obj.buyer.email
         )
-        amount = Decimal("0")
 
         payment = Payments(
             tenant_id=tenant.id,
@@ -506,9 +512,18 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 email=obj.buyer.email,
             )
 
+            # Split products into discountable vs non-discountable buckets so
+            # admin-flagged products (and patreon donations, even though they
+            # don't appear in this flow today) bypass any coupon discount.
+            discountable_amount = Decimal("0")
+            non_discountable_amount = Decimal("0")
             for line in obj.products:
                 product = products_map[line.product_id]
-                amount += product.price * line.quantity
+                line_total = product.price * line.quantity
+                if product.category == "patreon" or not product.discountable:
+                    non_discountable_amount += line_total
+                else:
+                    discountable_amount += line_total
 
                 for _ in range(line.quantity):
                     # One AttendeeProducts row per ticket — Design §2.2
@@ -539,20 +554,30 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         )
                     )
 
-            amount = amount.quantize(MONEY_PRECISION, rounding=ROUND_HALF_UP)
+            discountable_amount = discountable_amount.quantize(
+                MONEY_PRECISION, rounding=ROUND_HALF_UP
+            )
+            non_discountable_amount = non_discountable_amount.quantize(
+                MONEY_PRECISION, rounding=ROUND_HALF_UP
+            )
 
-            if obj.coupon_code:
+            # Skip coupon when there is nothing in the discountable bucket — a
+            # coupon would land with zero effect and waste a single-use code.
+            # Portal hides the input; this guards crafted requests.
+            if obj.coupon_code and discountable_amount > Decimal("0"):
                 coupon = coupons_crud.validate_coupon(
                     session, code=obj.coupon_code, popup_id=popup.id
                 )
                 discount_value = Decimal(str(coupon.discount_value))
-                amount = _get_discounted_price(amount, discount_value)
+                discountable_amount = _get_discounted_price(
+                    discountable_amount, discount_value
+                )
                 payment.coupon_id = coupon.id
                 payment.coupon_code = coupon.code
                 payment.discount_value = discount_value
                 coupons_crud.use_coupon(session, coupon.id)
 
-            payment.amount = amount
+            payment.amount = discountable_amount + non_discountable_amount
 
             if not popup.simplefi_api_key:
                 raise HTTPException(
@@ -591,7 +616,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             }
 
             simplefi_response = simplefi_client.create_payment(
-                amount=amount,
+                amount=payment.amount,
                 popup_slug=popup.slug,
                 tenant_slug=tenant.slug,
                 currency=popup.currency,
@@ -1221,16 +1246,15 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             discount_value=discount_assigned,
         )
 
-        standard_amount, supporter_amount, patreon_amount = _calculate_amounts(
+        standard_amount, non_discountable_amount = _calculate_amounts(
             session,
             obj.products,
         )
 
-        response.original_amount = standard_amount + supporter_amount + patreon_amount
+        response.original_amount = standard_amount + non_discountable_amount
         response.amount = _calculate_price(
             standard_amount=standard_amount,
-            supporter_amount=supporter_amount,
-            patreon_amount=patreon_amount,
+            non_discountable_amount=non_discountable_amount,
             discount_value=discount_assigned,
             application=application,
             edit_passes=obj.edit_passes,
@@ -1242,8 +1266,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             group_discount = application.group.discount_percentage or Decimal("0")
             discounted_amount = _calculate_price(
                 standard_amount=standard_amount,
-                supporter_amount=supporter_amount,
-                patreon_amount=patreon_amount,
+                non_discountable_amount=non_discountable_amount,
                 discount_value=group_discount,
                 application=application,
                 edit_passes=obj.edit_passes,
@@ -1252,8 +1275,11 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 response.amount = discounted_amount
                 response.discount_value = group_discount
 
-        # Check coupon code
-        if obj.coupon_code:
+        # Check coupon code. Skip when there is nothing discountable in the
+        # cart — applying a coupon would be a no-op and risks burning a
+        # single-use coupon for the buyer. Portal hides the input; this guards
+        # crafted requests.
+        if obj.coupon_code and standard_amount > Decimal("0"):
             coupon = coupons_crud.validate_coupon(
                 session,
                 code=obj.coupon_code,
@@ -1262,8 +1288,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             coupon_discount = Decimal(str(coupon.discount_value))
             discounted_amount = _calculate_price(
                 standard_amount=standard_amount,
-                supporter_amount=supporter_amount,
-                patreon_amount=patreon_amount,
+                non_discountable_amount=non_discountable_amount,
                 discount_value=coupon_discount,
                 application=application,
                 edit_passes=obj.edit_passes,
@@ -1282,8 +1307,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             scholarship_discount_pct = Decimal(str(application.discount_percentage))
             discounted_amount = _calculate_price(
                 standard_amount=standard_amount,
-                supporter_amount=supporter_amount,
-                patreon_amount=patreon_amount,
+                non_discountable_amount=non_discountable_amount,
                 discount_value=scholarship_discount_pct,
                 application=application,
                 edit_passes=obj.edit_passes,
@@ -1301,8 +1325,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         # so neither fee compounds the other (see design ADR-2).
         pre_fee_amount = response.amount
 
-        # Calculate insurance if requested (application-flow only — POPUP-6)
-        if obj.insurance:
+        # Calculate insurance if requested (application-flow only — POPUP-6).
+        # If discounts dropped the order to $0, there is nothing left to insure,
+        # so skip the calc even when the toggle was persisted as true.
+        if obj.insurance and pre_fee_amount > Decimal("0"):
             popup = application.popup if application else None
             insurance_amount = self._calculate_insurance(session, obj.products, popup)
             response.insurance_amount = insurance_amount

--- a/backend/app/api/product/schemas.py
+++ b/backend/app/api/product/schemas.py
@@ -86,6 +86,14 @@ class ProductBase(SQLModel):
         default=False,
         sa_column=Column(Boolean, nullable=False, server_default="false"),
     )
+    # Controls whether coupon / group / scholarship discounts reduce this
+    # product's price. Default true. Set false on items that must always be
+    # charged in full (e.g. meal plans for popups that mandate it). Patreon
+    # products are non-discountable by category and ignore this flag.
+    discountable: bool = Field(
+        default=True,
+        sa_column=Column(Boolean, nullable=False, server_default="true"),
+    )
 
 
 class ProductPublic(ProductBase):
@@ -136,6 +144,7 @@ class ProductCreate(BaseModel):
     max_per_order: int | None = Field(default=None, ge=1)
     insurance_eligible: bool = False
     requires_check_in: bool = False
+    discountable: bool = True
 
     model_config = ConfigDict(str_strip_whitespace=True)
 
@@ -147,6 +156,13 @@ class ProductCreate(BaseModel):
                 "Patron products must have a price of 0. "
                 "The donation amount is set by the donor at checkout."
             )
+        return self
+
+    @model_validator(mode="after")
+    def coerce_patreon_discountable(self) -> "ProductCreate":
+        """Patreon products are donations and always non-discountable."""
+        if self.category == "patreon":
+            self.discountable = False
         return self
 
     @model_validator(mode="after")
@@ -209,6 +225,7 @@ class ProductUpdate(BaseModel):
     max_per_order: int | None = Field(default=None, ge=1)
     insurance_eligible: bool | None = None
     requires_check_in: bool | None = None
+    discountable: bool | None = None
 
     @model_validator(mode="after")
     def validate_patreon_price(self) -> "ProductUpdate":
@@ -218,6 +235,13 @@ class ProductUpdate(BaseModel):
                 "Patron products must have a price of 0. "
                 "The donation amount is set by the donor at checkout."
             )
+        return self
+
+    @model_validator(mode="after")
+    def coerce_patreon_discountable(self) -> "ProductUpdate":
+        """When updating to category=patreon, force discountable=false."""
+        if self.category == "patreon":
+            self.discountable = False
         return self
 
     @model_validator(mode="after")
@@ -261,6 +285,7 @@ class ProductBatchItem(BaseModel):
     max_per_order: int | None = Field(default=None, ge=1)
     insurance_eligible: bool = False
     requires_check_in: bool = False
+    discountable: bool = True
 
     model_config = ConfigDict(str_strip_whitespace=True)
 
@@ -270,6 +295,13 @@ class ProductBatchItem(BaseModel):
         if self.category != "ticket":
             if self.duration_type is not None:
                 raise ValueError("duration_type can only be set for ticket products")
+        return self
+
+    @model_validator(mode="after")
+    def coerce_patreon_discountable(self) -> "ProductBatchItem":
+        """Patreon products are donations and always non-discountable."""
+        if self.category == "patreon":
+            self.discountable = False
         return self
 
     @model_validator(mode="after")

--- a/backend/tests/api/payment/test_discountable_product.py
+++ b/backend/tests/api/payment/test_discountable_product.py
@@ -1,0 +1,215 @@
+"""Tests for the per-product `discountable` flag.
+
+Products with `discountable=False` should be routed to the non-discountable
+bucket by `_calculate_amounts`, and `_calculate_price` must charge them at
+full price regardless of the discount value.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import Attendees
+from app.api.human.models import Humans
+from app.api.payment.crud import _calculate_amounts, _calculate_price
+from app.api.payment.schemas import PaymentProductRequest
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+
+
+@pytest.fixture(scope="module")
+def human_for_discountable(db: Session, tenant_a: Tenants) -> Humans:
+    email = f"discountable-test-{uuid.uuid4().hex[:8]}@test.com"
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant_a.id,
+        email=email,
+        first_name="Discountable",
+        last_name="Tester",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name="Discountable Test",
+        slug=f"discountable-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        simplefi_api_key="simplefi_test_key",
+        currency="USD",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_product(
+    db: Session,
+    popup: Popups,
+    *,
+    price: str,
+    discountable: bool,
+    category: str = "ticket",
+) -> Products:
+    product = Products(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        name=f"Product {category}",
+        slug=f"{category}-{uuid.uuid4().hex[:6]}",
+        price=Decimal(price),
+        category=category,
+        is_active=True,
+        discountable=discountable,
+    )
+    db.add(product)
+    db.flush()
+    return product
+
+
+def _make_application_and_attendee(
+    db: Session, popup: Popups, human: Humans
+) -> tuple[Applications, Attendees]:
+    application = Applications(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.flush()
+    attendee = Attendees(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        application_id=application.id,
+        email=human.email,
+        name=f"{human.first_name} {human.last_name}",
+        category="main",
+    )
+    db.add(attendee)
+    db.flush()
+    return application, attendee
+
+
+class TestCalculateAmounts:
+    def test_routes_non_discountable_product_to_dedicated_bucket(
+        self, db: Session, tenant_a: Tenants, human_for_discountable: Humans
+    ) -> None:
+        """Discountable=False products go to non_discountable, not standard."""
+        popup = _make_popup(db, tenant_a)
+        standard_product = _make_product(db, popup, price="100", discountable=True)
+        mandatory_product = _make_product(db, popup, price="50", discountable=False)
+        _, attendee = _make_application_and_attendee(
+            db, popup, human_for_discountable
+        )
+        db.commit()
+        try:
+            requested = [
+                PaymentProductRequest(
+                    product_id=standard_product.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                ),
+                PaymentProductRequest(
+                    product_id=mandatory_product.id,
+                    attendee_id=attendee.id,
+                    quantity=2,
+                ),
+            ]
+            standard, non_discountable = _calculate_amounts(db, requested)
+            assert standard == Decimal("100")
+            assert non_discountable == Decimal("100")  # 50 * 2
+        finally:
+            db.delete(attendee)
+            db.rollback()
+
+    def test_patreon_donation_lands_in_non_discountable_bucket(
+        self, db: Session, tenant_a: Tenants, human_for_discountable: Humans
+    ) -> None:
+        """Patreon donations route through non-discountable (unit_price_override)."""
+        popup = _make_popup(db, tenant_a)
+        # discountable defaults to false on patreon (forced by schema validator).
+        patron = _make_product(
+            db, popup, price="0", discountable=False, category="patreon"
+        )
+        _, attendee = _make_application_and_attendee(
+            db, popup, human_for_discountable
+        )
+        db.commit()
+        try:
+            requested = [
+                PaymentProductRequest(
+                    product_id=patron.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                    unit_price_override=Decimal("1500"),
+                ),
+            ]
+            standard, non_discountable = _calculate_amounts(db, requested)
+            # Donation amount comes from unit_price_override, not product.price.
+            assert non_discountable == Decimal("1500")
+            assert standard == Decimal("0")
+        finally:
+            db.delete(attendee)
+            db.rollback()
+
+
+class TestCalculatePrice:
+    def test_non_discountable_amount_bypasses_discount(self) -> None:
+        """A 100% discount must not reduce the non_discountable bucket."""
+        from types import SimpleNamespace
+
+        application = SimpleNamespace(
+            id=uuid.uuid4(),
+            scholarship_status=None,
+            discount_percentage=None,
+            credit=None,
+            group=None,
+        )
+
+        result = _calculate_price(
+            standard_amount=Decimal("100"),
+            non_discountable_amount=Decimal("50"),
+            discount_value=Decimal("100"),
+            application=application,  # type: ignore[arg-type]
+            edit_passes=False,
+        )
+        # Standard discounted to 0, non_discountable still charged at 50.
+        assert result == Decimal("50")
+
+    def test_partial_discount_only_affects_standard(self) -> None:
+        """50% off the standard side; non_discountable stays full."""
+        from types import SimpleNamespace
+
+        application = SimpleNamespace(
+            id=uuid.uuid4(),
+            scholarship_status=None,
+            discount_percentage=None,
+            credit=None,
+            group=None,
+        )
+
+        result = _calculate_price(
+            standard_amount=Decimal("200"),
+            non_discountable_amount=Decimal("50"),
+            discount_value=Decimal("50"),
+            application=application,  # type: ignore[arg-type]
+            edit_passes=False,
+        )
+        # 200 * 0.5 + 50 = 150
+        assert result == Decimal("150")

--- a/backend/tests/api/payment/test_patron_payment_integration.py
+++ b/backend/tests/api/payment/test_patron_payment_integration.py
@@ -80,6 +80,8 @@ def _make_patreon_product(db: Session, popup: Popups) -> Products:
         price=Decimal("0"),
         category="patreon",
         is_active=True,
+        # Mirrors what the schema validator coerces for any patreon product.
+        discountable=False,
     )
     db.add(product)
     db.flush()
@@ -344,10 +346,11 @@ class TestPatronPaymentCreation:
                     unit_price_override=Decimal("5000"),
                 ),
             ]
-            standard, supporter, patreon = _calculate_amounts(db, requested)
+            standard, non_discountable = _calculate_amounts(db, requested)
             assert standard == Decimal("3000")
-            assert supporter == Decimal("0")
-            assert patreon == Decimal("5000")
+            # Patreon donation rides on the non-discountable bucket alongside
+            # any other `discountable=false` products.
+            assert non_discountable == Decimal("5000")
         finally:
             db.delete(attendee)
             db.delete(application)

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -12980,6 +12980,11 @@ export const ProductBatchItemSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         }
     },
     type: 'object',
@@ -13157,6 +13162,11 @@ export const ProductBatchResultSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         },
         id: {
             type: 'string',
@@ -13395,6 +13405,11 @@ export const ProductCreateSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         }
     },
     type: 'object',
@@ -13592,6 +13607,11 @@ export const ProductPublicSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         },
         id: {
             type: 'string',
@@ -13826,6 +13846,17 @@ export const ProductUpdateSchema = {
                 }
             ],
             title: 'Requires Check In'
+        },
+        discountable: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Discountable'
         }
     },
     type: 'object',
@@ -14002,6 +14033,11 @@ export const ProductWithQuantitySchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         },
         id: {
             type: 'string',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2591,6 +2591,7 @@ export type ProductBatchItem = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
 };
 
 /**
@@ -2618,6 +2619,7 @@ export type ProductBatchResult = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
     id: string;
     success: boolean;
     err_msg?: (string | null);
@@ -2658,6 +2660,7 @@ export type ProductCreate = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
 };
 
 /**
@@ -2698,6 +2701,7 @@ export type ProductPublic = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
     id: string;
 };
 
@@ -2723,6 +2727,7 @@ export type ProductUpdate = {
     max_per_order?: (number | null);
     insurance_eligible?: (boolean | null);
     requires_check_in?: (boolean | null);
+    discountable?: (boolean | null);
 };
 
 /**
@@ -2750,6 +2755,7 @@ export type ProductWithQuantity = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
     id: string;
     quantity?: number;
 };

--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -11,6 +11,7 @@ import {
   QrCode,
   Shield,
   ShieldCheck,
+  TicketPercent,
 } from "lucide-react"
 import { useMemo, useState } from "react"
 import {
@@ -205,6 +206,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
       sale_starts_at: defaultValues?.sale_starts_at ?? "",
       sale_ends_at: defaultValues?.sale_ends_at ?? "",
       insurance_eligible: defaultValues?.insurance_eligible ?? false,
+      discountable: defaultValues?.discountable ?? true,
     },
     onSubmit: ({ value }) => {
       if (readOnly) return
@@ -246,6 +248,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
           total_stock_cap: totalStockCap,
           max_per_order: maxPerOrder,
           insurance_eligible: value.insurance_eligible,
+          discountable: value.discountable,
         })
       } else {
         if (!selectedPopupId) {
@@ -272,6 +275,7 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
           total_stock_cap: totalStockCap ?? undefined,
           max_per_order: maxPerOrder ?? undefined,
           insurance_eligible: value.insurance_eligible,
+          discountable: value.discountable,
         })
       }
     },
@@ -643,6 +647,55 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
               </InlineRow>
             )}
           </form.Field>
+
+          <form.Subscribe selector={(state) => state.values.category}>
+            {(category) => (
+              <form.Field name="discountable">
+                {(field) => {
+                  // Patreon donations are never discountable by policy — the
+                  // backend coerces the field on write, so mirror that in the
+                  // form: force value=false, disable the checkbox, and show
+                  // why.
+                  const isPatreon = category === "patreon"
+                  const isDisabled = readOnly || isPatreon
+                  const effectiveChecked = isPatreon ? false : field.state.value
+
+                  return (
+                    <InlineRow
+                      icon={
+                        <TicketPercent className="h-4 w-4 text-muted-foreground" />
+                      }
+                      label="Discountable"
+                      description={
+                        isPatreon
+                          ? "Patreon donations are never discountable"
+                          : "When off, coupons and group/scholarship discounts never reduce this product's price (e.g. mandatory meal plans)"
+                      }
+                    >
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id="discountable"
+                          checked={effectiveChecked}
+                          onCheckedChange={(checked) =>
+                            field.handleChange(checked === true)
+                          }
+                          disabled={isDisabled}
+                          title={
+                            isPatreon
+                              ? "Patreon donations are never discountable"
+                              : undefined
+                          }
+                        />
+                        <Label htmlFor="discountable" className="text-sm">
+                          Eligible for discounts
+                        </Label>
+                      </div>
+                    </InlineRow>
+                  )
+                }}
+              </form.Field>
+            )}
+          </form.Subscribe>
 
           <form.Field name="requires_check_in">
             {(field) => (

--- a/portal/src/checkout/popupCheckoutPolicy.test.ts
+++ b/portal/src/checkout/popupCheckoutPolicy.test.ts
@@ -46,12 +46,6 @@ describe("getEffectiveCheckoutMode", () => {
     )
   })
 
-  it("returns simple_quantity for supporter regardless of popup mode", () => {
-    expect(
-      getEffectiveCheckoutMode("supporter", CHECKOUT_MODE.PASS_SYSTEM),
-    ).toBe(CHECKOUT_MODE.SIMPLE_QUANTITY)
-  })
-
   it("returns simple_quantity for merch regardless of popup mode", () => {
     expect(getEffectiveCheckoutMode("merch", CHECKOUT_MODE.PASS_SYSTEM)).toBe(
       CHECKOUT_MODE.SIMPLE_QUANTITY,

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -12980,6 +12980,11 @@ export const ProductBatchItemSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         }
     },
     type: 'object',
@@ -13157,6 +13162,11 @@ export const ProductBatchResultSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         },
         id: {
             type: 'string',
@@ -13395,6 +13405,11 @@ export const ProductCreateSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         }
     },
     type: 'object',
@@ -13592,6 +13607,11 @@ export const ProductPublicSchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         },
         id: {
             type: 'string',
@@ -13826,6 +13846,17 @@ export const ProductUpdateSchema = {
                 }
             ],
             title: 'Requires Check In'
+        },
+        discountable: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Discountable'
         }
     },
     type: 'object',
@@ -14002,6 +14033,11 @@ export const ProductWithQuantitySchema = {
             type: 'boolean',
             title: 'Requires Check In',
             default: false
+        },
+        discountable: {
+            type: 'boolean',
+            title: 'Discountable',
+            default: true
         },
         id: {
             type: 'string',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2591,6 +2591,7 @@ export type ProductBatchItem = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
 };
 
 /**
@@ -2618,6 +2619,7 @@ export type ProductBatchResult = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
     id: string;
     success: boolean;
     err_msg?: (string | null);
@@ -2658,6 +2660,7 @@ export type ProductCreate = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
 };
 
 /**
@@ -2698,6 +2701,7 @@ export type ProductPublic = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
     id: string;
 };
 
@@ -2723,6 +2727,7 @@ export type ProductUpdate = {
     max_per_order?: (number | null);
     insurance_eligible?: (boolean | null);
     requires_check_in?: (boolean | null);
+    discountable?: (boolean | null);
 };
 
 /**
@@ -2750,6 +2755,7 @@ export type ProductWithQuantity = {
     max_per_order?: (number | null);
     insurance_eligible?: boolean;
     requires_check_in?: boolean;
+    discountable?: boolean;
     id: string;
     quantity?: number;
 };

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -114,13 +114,25 @@ export default function ConfirmStep() {
     Object.values(cart.dynamicItems).some((items) => items.length > 0) ||
     hasEditChanges
 
-  // Insurance available if popup has insurance enabled with a valid percentage
+  // Insurance available if popup has insurance enabled with a valid percentage.
+  // Gate on the post-discount product subtotal so insurance is hidden whenever
+  // there are no products left to insure — covers coupons that drop it to $0,
+  // group/scholarship discounts of 100%, and patreon zeroing other products.
   const isInsuranceEnabled =
     popup?.insurance_enabled === true && popup?.insurance_percentage != null
+  const discountedProductsSubtotal =
+    summary.discountableSubtotal - summary.discount
   const hasInsurableProducts =
     isInsuranceEnabled &&
     cart.insurancePotentialPrice > 0 &&
-    summary.grandTotal - summary.insuranceSubtotal > 0
+    discountedProductsSubtotal > 0
+
+  // Hide the coupon input when there is nothing in the cart that a discount
+  // could apply to. Covers the patreon-only case naturally (patreon products
+  // are forced `discountable=false` by the backend, so a cart with only a
+  // donation reports `discountableSubtotal === 0`). Without this the buyer
+  // can type a code, see "Code applied!", and watch the total stay the same.
+  const hasDiscountableItems = summary.discountableSubtotal > 0
 
   // Extract template_config from the confirm step's nested 'insurance' sub-config
   const confirmStep = stepConfigs.find((s) => s.step_type === "confirm")
@@ -467,7 +479,7 @@ export default function ConfirmStep() {
         )}
 
         {/* Promo Code Section */}
-        {popup?.allows_coupons && (
+        {popup?.allows_coupons && hasDiscountableItems && (
           <>
             <div className="border-t border-border" />
             <div className="px-4 sm:px-5 py-4">

--- a/portal/src/hooks/checkout/useCartSummary.ts
+++ b/portal/src/hooks/checkout/useCartSummary.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react"
 import type {
   CheckoutCartSummary,
+  SelectedDynamicItem,
   SelectedHousingItem,
   SelectedMealPlanItem,
   SelectedMerchItem,
@@ -8,12 +9,28 @@ import type {
   SelectedPatronItem,
 } from "@/types/checkout"
 
+// Mirror backend `_calculate_amounts` (payment/crud.py): every product is
+// discountable unless the admin set `discountable: false`. Patreon products
+// are forced to `discountable: false` by the backend schema validator, so the
+// single check covers both cases.
+function isNonDiscountableProduct(product: {
+  discountable?: boolean | null
+}): boolean {
+  return product.discountable === false
+}
+
 interface UseCartSummaryParams {
   selectedPasses: SelectedPassItem[]
   housing: SelectedHousingItem | null
   merch: SelectedMerchItem[]
   patron: SelectedPatronItem | null
   mealPlans: SelectedMealPlanItem[]
+  /**
+   * Items added through templated checkout steps (modern popups). Keyed by
+   * step_type; each item carries its product so we can split by category
+   * (patreon items and `discountable=false` products bypass the discount).
+   */
+  dynamicItems: Record<string, SelectedDynamicItem[]>
   insuranceAmount: number
   /**
    * Contribution fee amount in absolute currency units.
@@ -34,6 +51,7 @@ export function useCartSummary({
   merch,
   patron,
   mealPlans,
+  dynamicItems,
   insuranceAmount,
   contributionAmount,
   isEditing,
@@ -48,8 +66,24 @@ export function useCartSummary({
       (sum, p) => sum + (p.originalPrice ?? p.price),
       0,
     )
+    // Split by `isNonDiscountableProduct` so patreon donations and admin-flagged
+    // `discountable: false` products (e.g. mandatory meal plans) skip the
+    // discount and stay at full price.
+    const nonDiscountablePassesSubtotal = selectedPasses
+      .filter((p) => isNonDiscountableProduct(p.product))
+      .reduce((sum, p) => sum + (p.originalPrice ?? p.price), 0)
+    const discountablePassesSubtotal =
+      passesOriginalSubtotal - nonDiscountablePassesSubtotal
+
     const housingSubtotal = housing?.totalPrice ?? 0
+    const housingDiscountable =
+      !housing || !isNonDiscountableProduct(housing.product)
     const merchSubtotal = merch.reduce((sum, m) => sum + m.totalPrice, 0)
+    const nonDiscountableMerchSubtotal = merch
+      .filter((m) => isNonDiscountableProduct(m.product))
+      .reduce((sum, m) => sum + m.totalPrice, 0)
+    const discountableMerchSubtotal =
+      merchSubtotal - nonDiscountableMerchSubtotal
     const patronSubtotal = patron?.amount ?? 0
     // One meal-plan entry = one weekly product purchase. Price already on the
     // resolved product reference; sum across all (attendee × week) entries.
@@ -57,20 +91,52 @@ export function useCartSummary({
       (sum, m) => sum + (m.product?.price ?? 0),
       0,
     )
+    const nonDiscountableMealPlansSubtotal = mealPlans
+      .filter((m) => m.product && isNonDiscountableProduct(m.product))
+      .reduce((sum, m) => sum + (m.product?.price ?? 0), 0)
+    const discountableMealPlansSubtotal =
+      mealPlansSubtotal - nonDiscountableMealPlansSubtotal
+
+    // Items from templated checkout steps. Split the same way.
+    const allDynamicItems = Object.values(dynamicItems).flat()
+    const dynamicSubtotal = allDynamicItems.reduce(
+      (sum, item) => sum + item.price,
+      0,
+    )
+    const nonDiscountableDynamicSubtotal = allDynamicItems
+      .filter((item) => isNonDiscountableProduct(item.product))
+      .reduce((sum, item) => sum + item.price, 0)
+    const discountableDynamicSubtotal =
+      dynamicSubtotal - nonDiscountableDynamicSubtotal
+
     const insuranceSubtotal = insuranceAmount
     const contributionSubtotal = contributionAmount
 
+    // Discount base mirrors backend `standard_amount`: discountable passes +
+    // housing (when not flagged) + discountable merch + discountable meals +
+    // discountable dynamic items. Patron donations, patreon-category items,
+    // and any product with `discountable: false` are charged in full.
+    const discountableSubtotal =
+      discountablePassesSubtotal +
+      (housingDiscountable ? housingSubtotal : 0) +
+      discountableMerchSubtotal +
+      discountableMealPlansSubtotal +
+      discountableDynamicSubtotal
+    const promoDiscount = (discountableSubtotal * discountValue) / 100
+
+    const nonDiscountableTotal =
+      nonDiscountablePassesSubtotal +
+      (housingDiscountable ? 0 : housingSubtotal) +
+      nonDiscountableMerchSubtotal +
+      nonDiscountableMealPlansSubtotal +
+      nonDiscountableDynamicSubtotal +
+      patronSubtotal
+
     const originalSubtotal =
-      passesOriginalSubtotal +
-      housingSubtotal +
-      merchSubtotal +
-      patronSubtotal +
-      mealPlansSubtotal +
+      discountableSubtotal +
+      nonDiscountableTotal +
       insuranceSubtotal +
       contributionSubtotal
-    // Apply discount on the original subtotal so the result is idempotent even
-    // if PassesProvider has already mutated pass prices via priceStrategy.
-    const promoDiscount = (originalSubtotal * discountValue) / 100
     const discountedSubtotal = originalSubtotal - promoDiscount
     const accountCredit = appCredit ? Number(appCredit) : 0
     const credit = isEditing
@@ -83,7 +149,8 @@ export function useCartSummary({
       (housing ? 1 : 0) +
       merch.length +
       (patron ? 1 : 0) +
-      mealPlans.length
+      mealPlans.length +
+      allDynamicItems.length
 
     return {
       passesSubtotal,
@@ -93,7 +160,8 @@ export function useCartSummary({
       mealPlansSubtotal,
       insuranceSubtotal,
       contributionSubtotal,
-      dynamicSubtotal: 0,
+      discountableSubtotal,
+      dynamicSubtotal,
       subtotal: originalSubtotal,
       discount: promoDiscount,
       credit,
@@ -106,6 +174,7 @@ export function useCartSummary({
     merch,
     patron,
     mealPlans,
+    dynamicItems,
     insuranceAmount,
     contributionAmount,
     isEditing,

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -616,28 +616,6 @@ export function CheckoutProvider({
     },
   )
 
-  // Contribution fee — derived from popup config (mandatory when enabled).
-  // The popup is the single source of truth for the rate; there is no buyer
-  // opt-in toggle. We calculate client-side from popup.contribution_percentage
-  // so the summary line renders before submit (transparency requirement).
-  const contributionAmount = useMemo<number>(() => {
-    if (!city?.contribution_enabled) return 0
-    const pct = Number(city.contribution_percentage)
-    if (Number.isNaN(pct) || pct <= 0) return 0
-    // Pre-fee subtotal: passes + housing + merch + patron (mirrors backend
-    // _apply_discounts snapshot: post-discount, before insurance and contribution)
-    const passesSubtotal = selectedPasses.reduce(
-      (sum, p) => sum + (p.originalPrice ?? p.price),
-      0,
-    )
-    const housingTotal = housing?.totalPrice ?? 0
-    const merchTotal = merch.reduce((sum, m) => sum + m.totalPrice, 0)
-    const patronTotal = patron?.amount ?? 0
-    const preFeeSubtotal =
-      passesSubtotal + housingTotal + merchTotal + patronTotal
-    return Math.round(((preFeeSubtotal * pct) / 100) * 100) / 100
-  }, [city, selectedPasses, housing, merch, patron])
-
   // Defence-in-depth: take the highest discount available so the total reflects
   // it even if one of the state vectors lags (DiscountProvider's <= guard
   // rejecting an update, or usePromoCode's re-validation effect clobbering
@@ -647,6 +625,94 @@ export function CheckoutProvider({
     promoCodeDiscount ?? 0,
   )
 
+  // Discount base mirrors backend `_calculate_price` (payment/crud.py): the
+  // discount applies only to items where `product.discountable !== false`.
+  // Patreon products are forced to `discountable=false` by the backend schema
+  // validator, so the single check covers donations too.
+  const discountableProductsSubtotal = useMemo(() => {
+    const isNonDiscountable = (product: { discountable?: boolean | null }) =>
+      product.discountable === false
+    const standardPassesSubtotal = selectedPasses
+      .filter((p) => !isNonDiscountable(p.product))
+      .reduce((sum, p) => sum + (p.originalPrice ?? p.price), 0)
+    const housingTotal =
+      housing && !isNonDiscountable(housing.product) ? housing.totalPrice : 0
+    const merchTotal = merch
+      .filter((m) => !isNonDiscountable(m.product))
+      .reduce((sum, m) => sum + m.totalPrice, 0)
+    const mealPlansTotal = selectedMealPlans
+      .filter((m) => m.product && !isNonDiscountable(m.product))
+      .reduce((sum, m) => sum + (m.product?.price ?? 0), 0)
+    const standardDynamicSubtotal = Object.values(dynamicItems)
+      .flat()
+      .filter((item) => !isNonDiscountable(item.product))
+      .reduce((sum, item) => sum + item.price, 0)
+    return (
+      standardPassesSubtotal +
+      housingTotal +
+      merchTotal +
+      mealPlansTotal +
+      standardDynamicSubtotal
+    )
+  }, [selectedPasses, housing, merch, selectedMealPlans, dynamicItems])
+
+  // Non-discountable products: anything flagged `product.discountable=false`
+  // (patreon products are coerced to this by the backend validator) plus the
+  // patron donation amount. Charged in full alongside the discounted standard
+  // subtotal.
+  const nonDiscountableProductsSubtotal = useMemo(() => {
+    const isNonDiscountable = (product: { discountable?: boolean | null }) =>
+      product.discountable === false
+    const nonDiscountablePasses = selectedPasses
+      .filter((p) => isNonDiscountable(p.product))
+      .reduce((sum, p) => sum + (p.originalPrice ?? p.price), 0)
+    const nonDiscountableHousing =
+      housing && isNonDiscountable(housing.product) ? housing.totalPrice : 0
+    const nonDiscountableMerch = merch
+      .filter((m) => isNonDiscountable(m.product))
+      .reduce((sum, m) => sum + m.totalPrice, 0)
+    const nonDiscountableMealPlans = selectedMealPlans
+      .filter((m) => m.product && isNonDiscountable(m.product))
+      .reduce((sum, m) => sum + (m.product?.price ?? 0), 0)
+    const nonDiscountableDynamic = Object.values(dynamicItems)
+      .flat()
+      .filter((item) => isNonDiscountable(item.product))
+      .reduce((sum, item) => sum + item.price, 0)
+    return (
+      nonDiscountablePasses +
+      nonDiscountableHousing +
+      nonDiscountableMerch +
+      nonDiscountableMealPlans +
+      nonDiscountableDynamic +
+      (patron?.amount ?? 0)
+    )
+  }, [selectedPasses, housing, merch, selectedMealPlans, dynamicItems, patron])
+
+  const discountedProductsAmount = Math.max(
+    0,
+    discountableProductsSubtotal * (1 - effectiveDiscount / 100),
+  )
+
+  // Mirrors backend `pre_fee_amount` (payment/crud.py:1302): post-discount
+  // standard subtotal plus non-discountable items. This is the base both for
+  // contribution and for the "anything left to pay" gate.
+  const preFeeAmount =
+    discountedProductsAmount + nonDiscountableProductsSubtotal
+
+  // Contribution fee — derived from popup config (mandatory when enabled).
+  // The popup is the single source of truth for the rate; there is no buyer
+  // opt-in toggle. We calculate client-side from popup.contribution_percentage
+  // so the summary line renders before submit (transparency requirement).
+  // Base mirrors backend: % of pre_fee_amount (post-discount standard + non
+  // discountable). Zero when there is nothing being charged for products.
+  const contributionAmount = useMemo<number>(() => {
+    if (!city?.contribution_enabled) return 0
+    if (preFeeAmount <= 0) return 0
+    const pct = Number(city.contribution_percentage)
+    if (Number.isNaN(pct) || pct <= 0) return 0
+    return Math.round(((preFeeAmount * pct) / 100) * 100) / 100
+  }, [city, preFeeAmount])
+
   // Cart summary
   const { summary } = useCartSummary({
     selectedPasses,
@@ -654,6 +720,7 @@ export function CheckoutProvider({
     merch,
     patron,
     mealPlans: selectedMealPlans,
+    dynamicItems,
     insuranceAmount,
     contributionAmount,
     isEditing,
@@ -689,6 +756,25 @@ export function CheckoutProvider({
     setPromoCodeValid,
     setPromoCodeDiscount,
   ])
+
+  // If discounts (group, scholarship, or coupon) drop the product subtotal to
+  // $0, force the insurance toggle off so the persisted line item stops
+  // counting even when the InsuranceCard is hidden.
+  useEffect(() => {
+    if (discountedProductsAmount <= 0 && insurance) {
+      setInsurance(false)
+    }
+  }, [discountedProductsAmount, insurance])
+
+  // If the cart has nothing discountable (e.g. only items flagged
+  // `discountable: false`), a coupon code would land with zero effect and the
+  // single-use coupons would be wasted. Drop any applied coupon so the UI
+  // stays consistent with the hidden input below.
+  useEffect(() => {
+    if (discountableProductsSubtotal === 0 && (promoCodeValid || promoCode)) {
+      clearPromoCode()
+    }
+  }, [discountableProductsSubtotal, promoCodeValid, promoCode, clearPromoCode])
 
   // Loading states
   const isLoading = promoIsLoading
@@ -731,15 +817,6 @@ export function CheckoutProvider({
     hasRestoredStepRef.current = true
     setCurrentStep(stepToRestore as CheckoutStep)
   }, [availableSteps, initialStep, setCurrentStep])
-
-  // Dynamic subtotal
-  const dynamicSubtotal = useMemo(
-    () =>
-      Object.values(dynamicItems)
-        .flat()
-        .reduce((sum, item) => sum + item.price, 0),
-    [dynamicItems],
-  )
 
   // Build cart state
   const cart = useMemo<CheckoutCartState>(
@@ -1006,22 +1083,12 @@ export function CheckoutProvider({
         : null,
   })
 
-  const finalSummary = useMemo(
-    () => ({
-      ...summary,
-      dynamicSubtotal,
-      subtotal: summary.subtotal + dynamicSubtotal,
-      grandTotal: summary.grandTotal + dynamicSubtotal,
-    }),
-    [summary, dynamicSubtotal],
-  )
-
   const value: CheckoutContextValue = {
     currentStep,
     availableSteps,
     stepConfigs: effectiveConfiguredSteps,
     cart,
-    summary: finalSummary,
+    summary,
     allProducts: products,
     productsByStepId,
     getProductsForStep,

--- a/portal/src/strategies/PriceStrategy.ts
+++ b/portal/src/strategies/PriceStrategy.ts
@@ -28,8 +28,7 @@ class DefaultPriceStrategy implements PriceStrategy {
     hasPatreonPurchased: boolean,
     discount: number,
   ): number {
-    const isSpecialProduct =
-      product.category === "patreon" || product.category === "supporter"
+    const isSpecialProduct = product.category === "patreon"
     const originalPrice = product.original_price || product.price || 0
     const effective = getEffectiveCheckoutMode(
       product.category,
@@ -45,11 +44,7 @@ class DefaultPriceStrategy implements PriceStrategy {
       return 0
     }
 
-    if (
-      product.category !== "patreon" &&
-      product.category !== "supporter" &&
-      discount > 0
-    ) {
+    if (product.category !== "patreon" && discount > 0) {
       return originalPrice * (1 - discount / 100) * (product.quantity || 1)
       // if (discount.discount_type === 'percentage') {
       //   return originalPrice * (1 - discount.discount_value / 100);

--- a/portal/src/strategies/ProductStrategies.test.ts
+++ b/portal/src/strategies/ProductStrategies.test.ts
@@ -135,20 +135,16 @@ describe("getProductStrategy — category-scoped selection", () => {
     )
   })
 
-  it("supporter under pass_system uses SimpleQuantityProductStrategy (toggles selected)", () => {
-    const supporter = createProduct({
-      id: "s1",
-      category: "supporter",
+  it("non-ticket category under pass_system uses SimpleQuantityProductStrategy (toggles selected)", () => {
+    const merch = createProduct({
+      id: "m1",
+      category: "merch",
       selected: false,
       max_per_order: 1,
     })
-    const attendees = [createAttendee([supporter])]
-    const strategy = getProductStrategy(
-      supporter,
-      false,
-      CHECKOUT_MODE.PASS_SYSTEM,
-    )
-    const result = strategy.handleSelection(attendees, "attendee-1", supporter)
+    const attendees = [createAttendee([merch])]
+    const strategy = getProductStrategy(merch, false, CHECKOUT_MODE.PASS_SYSTEM)
+    const result = strategy.handleSelection(attendees, "attendee-1", merch)
     expect(result[0]?.products[0]?.selected).toBe(true)
   })
 

--- a/portal/src/types/checkout.ts
+++ b/portal/src/types/checkout.ts
@@ -148,6 +148,12 @@ export interface CheckoutCartSummary {
   mealPlansSubtotal: number
   insuranceSubtotal: number
   contributionSubtotal: number
+  /**
+   * Sum of items eligible for discounts (passes + housing + merch + patron +
+   * meal plans). Excludes insurance and contribution — they are charged in
+   * full regardless of any discount applied.
+   */
+  discountableSubtotal: number
   dynamicSubtotal: number
   subtotal: number
   discount: number
@@ -273,6 +279,7 @@ export function createInitialSummary(): CheckoutCartSummary {
     mealPlansSubtotal: 0,
     insuranceSubtotal: 0,
     contributionSubtotal: 0,
+    discountableSubtotal: 0,
     dynamicSubtotal: 0,
     subtotal: 0,
     discount: 0,


### PR DESCRIPTION
## Chain (2 of 3)

\`\`\`
dev
└── 01-legacy-cleanup (#190)
    └── 📌 02-coupon-rules-and-discountable  ← this PR
        └── 03-ux-captions
\`\`\`

**Base**: \`feat/checkout-discount-rules--01-legacy-cleanup\` (so the diff shows only this slice's changes). When PR #190 merges, GitHub auto-updates this PR's base to \`dev\`.

## What this PR does

Aligns frontend and backend on which cart items receive a discount, and adds a per-product flag for admins to mark items as never-discountable (e.g. mandatory meal plans, patreon donations).

## Business rules (both sides)

- Discount (coupon + group + scholarship) applies only to products with \`discountable=true\`. Patreon donations and admin-flagged items bypass the discount and are charged in full.
- Insurance and contribution are charged separately from the discount math. When the discountable subtotal post-discount lands at \$0, both are auto-zeroed.
- Coupon input is hidden when the cart has no discountable items, and any already-applied coupon is auto-cleared. Backend mirrors with a defense-in-depth guard.

## Per-product \`discountable\` flag

- New \`products.discountable BOOLEAN NOT NULL DEFAULT true\` column (Alembic \`377c2c02fe74\`). Migration backfills patreon products to \`discountable=false\`.
- \`ProductCreate\`/\`ProductUpdate\`/\`ProductBatchItem\` Pydantic validators coerce \`discountable=false\` when \`category=patreon\` (defense-in-depth for crafted API calls).
- Backend \`_calculate_amounts\` splits into \`(standard, non_discountable)\` buckets. Patreon donations use the \`unit_price_override\` branch but land in \`non_discountable\`. The dead \`supporter\` bucket is removed.
- Backoffice \`ProductForm\`: new "Discountable" checkbox, disabled and force-false when category=patreon.

## Behavior change (intentional)

Previously: cart with patreon + ticket + coupon → coupon rejected entirely.
Now: cart with patreon + ticket + coupon → coupon applies to the ticket; patreon stays full.

Better UX (donors don't lose their coupon for donating). **Flag in release notes.**

## QA scenarios

- [ ] Coupon 100% on cart with only standard products → total = \$0
- [ ] Cart with patreon \$5000 + ticket \$100 + 50% coupon → total = \$5050 (ticket discounted, patreon full)
- [ ] Cart with only meal plan flagged \`discountable=false\` → coupon input hidden
- [ ] Cart with only patreon donation → coupon input hidden
- [ ] Insurance toggle auto-disables when discountable subtotal post-discount = 0
- [ ] Contribution = \$0 when products post-discount = \$0
- [ ] Admin creates a new product with \`category=patreon\` → \`discountable\` is saved as \`false\` even if the form sends \`true\`

## Verification

- [x] 190 backend tests pass (\`payment/\` + \`product/\`)
- [x] 223 portal vitest pass
- [x] Portal + backoffice builds clean
- [x] Migration: \`alembic heads\` returns single head \`377c2c02fe74\`

## Files

- Backend: \`payment/crud.py\`, \`product/schemas.py\`, migration, tests
- Portal: \`useCartSummary\`, \`checkoutProvider\`, \`ConfirmStep\`, \`PriceStrategy\`, \`popupCheckoutPolicy.test\`, regenerated client
- Backoffice: \`ProductForm\`, regenerated client