### PR TITLE
feat(portal): clarify which items the coupon applies to in cart review

### DIFF
--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -134,6 +134,24 @@ export default function ConfirmStep() {
   // can type a code, see "Code applied!", and watch the total stay the same.
   const hasDiscountableItems = summary.discountableSubtotal > 0
 
+  // Mirror of useCartSummary's helper — anything an admin flagged as
+  // non-discountable (patreon donations are coerced to this on write).
+  const isNonDiscountable = (product?: {
+    discountable?: boolean | null
+  }) => product?.discountable === false
+
+  // When the cart mixes discountable and non-discountable items AND a discount
+  // is applied, the bare "Promo Discount" label hides why the discount is
+  // smaller than the full subtotal. Append "(eligible items)" to clarify.
+  const nonDiscountableTotal =
+    summary.subtotal -
+    summary.discountableSubtotal -
+    summary.insuranceSubtotal -
+    summary.contributionSubtotal
+  const showEligibleQualifier =
+    summary.discount > 0 && nonDiscountableTotal > 0
+  const notEligibleCaption = t("checkout.discount.not_eligible_caption")
+
   // Extract template_config from the confirm step's nested 'insurance' sub-config
   const confirmStep = stepConfigs.find((s) => s.step_type === "confirm")
   const insuranceTemplateConfig =
@@ -216,16 +234,23 @@ export default function ConfirmStep() {
                   {passes.map((pass) => (
                     <div
                       key={pass.productId}
-                      className="flex items-center justify-between text-sm py-0.5"
+                      className="flex items-start justify-between text-sm py-0.5"
                     >
-                      <span className="text-muted-foreground">
-                        {pass.quantity > 1 && (
-                          <span className="text-muted-foreground">
-                            {pass.quantity} ×{" "}
+                      <div className="flex flex-col">
+                        <span className="text-muted-foreground">
+                          {pass.quantity > 1 && (
+                            <span className="text-muted-foreground">
+                              {pass.quantity} ×{" "}
+                            </span>
+                          )}
+                          {pass.product.name}
+                        </span>
+                        {isNonDiscountable(pass.product) && (
+                          <span className="text-xs text-muted-foreground/70">
+                            {notEligibleCaption}
                           </span>
                         )}
-                        {pass.product.name}
-                      </span>
+                      </div>
                       <span className="font-medium text-foreground">
                         {formatCurrency(pass.originalPrice ?? pass.price)}
                       </span>
@@ -258,16 +283,23 @@ export default function ConfirmStep() {
                     {items.map((item) => (
                       <div
                         key={item.productId}
-                        className="flex items-center justify-between text-sm"
+                        className="flex items-start justify-between text-sm"
                       >
-                        <span className="text-muted-foreground">
-                          {item.quantity > 1 && (
-                            <span className="text-muted-foreground">
-                              {item.quantity} ×{" "}
+                        <div className="flex flex-col">
+                          <span className="text-muted-foreground">
+                            {item.quantity > 1 && (
+                              <span className="text-muted-foreground">
+                                {item.quantity} ×{" "}
+                              </span>
+                            )}
+                            {item.product.name}
+                          </span>
+                          {isNonDiscountable(item.product) && (
+                            <span className="text-xs text-muted-foreground/70">
+                              {notEligibleCaption}
                             </span>
                           )}
-                          {item.product.name}
-                        </span>
+                        </div>
                         <span className="font-medium text-foreground">
                           {formatCurrency(item.price)}
                         </span>
@@ -310,6 +342,11 @@ export default function ConfirmStep() {
                     {formatCheckoutDate(cart.housing.checkIn)} –{" "}
                     {formatCheckoutDate(cart.housing.checkOut)}
                   </p>
+                  {isNonDiscountable(cart.housing.product) && (
+                    <p className="text-xs text-muted-foreground/70">
+                      {notEligibleCaption}
+                    </p>
+                  )}
                 </div>
                 <span className="font-medium text-foreground text-sm">
                   {formatCurrency(cart.housing.totalPrice)}
@@ -334,16 +371,23 @@ export default function ConfirmStep() {
                 {cart.merch.map((item) => (
                   <div
                     key={item.productId}
-                    className="flex items-center justify-between text-sm"
+                    className="flex items-start justify-between text-sm"
                   >
-                    <span className="text-muted-foreground">
-                      {item.quantity > 1 && (
-                        <span className="text-muted-foreground">
-                          {item.quantity} ×{" "}
+                    <div className="flex flex-col">
+                      <span className="text-muted-foreground">
+                        {item.quantity > 1 && (
+                          <span className="text-muted-foreground">
+                            {item.quantity} ×{" "}
+                          </span>
+                        )}
+                        {item.product.name}
+                      </span>
+                      {isNonDiscountable(item.product) && (
+                        <span className="text-xs text-muted-foreground/70">
+                          {notEligibleCaption}
                         </span>
                       )}
-                      {item.product.name}
-                    </span>
+                    </div>
                     <span className="font-medium text-foreground">
                       {formatCurrency(item.totalPrice)}
                     </span>
@@ -365,10 +409,15 @@ export default function ConfirmStep() {
                   Patron
                 </span>
               </div>
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground">
-                  Community contribution
-                </span>
+              <div className="flex items-start justify-between text-sm">
+                <div className="flex flex-col">
+                  <span className="text-muted-foreground">
+                    Community contribution
+                  </span>
+                  <span className="text-xs text-muted-foreground/70">
+                    {notEligibleCaption}
+                  </span>
+                </div>
                 <span className="font-medium text-foreground">
                   {formatCurrency(cart.patron.amount)}
                 </span>
@@ -403,6 +452,11 @@ export default function ConfirmStep() {
                       <p className="text-xs text-muted-foreground truncate">
                         {mp.product.name}
                       </p>
+                      {isNonDiscountable(mp.product) && (
+                        <p className="text-xs text-muted-foreground/70">
+                          {notEligibleCaption}
+                        </p>
+                      )}
                     </div>
                     <div className="flex items-center gap-2 shrink-0">
                       <span className="font-medium text-foreground">
@@ -600,7 +654,11 @@ export default function ConfirmStep() {
           )}
           {summary.discount > 0 && (
             <div className="flex justify-between text-sm text-green-600 mb-2">
-              <span>Promo Discount</span>
+              <span>
+                {showEligibleQualifier
+                  ? t("checkout.discount.promo_discount_eligible_label")
+                  : "Promo Discount"}
+              </span>
               <span>-{formatCurrency(summary.discount)}</span>
             </div>
           )}

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -136,9 +136,8 @@ export default function ConfirmStep() {
 
   // Mirror of useCartSummary's helper — anything an admin flagged as
   // non-discountable (patreon donations are coerced to this on write).
-  const isNonDiscountable = (product?: {
-    discountable?: boolean | null
-  }) => product?.discountable === false
+  const isNonDiscountable = (product?: { discountable?: boolean | null }) =>
+    product?.discountable === false
 
   // When the cart mixes discountable and non-discountable items AND a discount
   // is applied, the bare "Promo Discount" label hides why the discount is
@@ -148,8 +147,7 @@ export default function ConfirmStep() {
     summary.discountableSubtotal -
     summary.insuranceSubtotal -
     summary.contributionSubtotal
-  const showEligibleQualifier =
-    summary.discount > 0 && nonDiscountableTotal > 0
+  const showEligibleQualifier = summary.discount > 0 && nonDiscountableTotal > 0
   const notEligibleCaption = t("checkout.discount.not_eligible_caption")
 
   // Extract template_config from the confirm step's nested 'insurance' sub-config

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -250,6 +250,10 @@
     "contribution": {
       "fallbackLabel": "Event contribution",
       "fallbackDescription": "Helps fund the event"
+    },
+    "discount": {
+      "not_eligible_caption": "Not eligible for discount",
+      "promo_discount_eligible_label": "Promo Discount (eligible items)"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -250,6 +250,10 @@
     "contribution": {
       "fallbackLabel": "Contribución al evento",
       "fallbackDescription": "Apoya la realización del evento"
+    },
+    "discount": {
+      "not_eligible_caption": "No aplica descuento",
+      "promo_discount_eligible_label": "Descuento (items elegibles)"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -240,6 +240,10 @@
     "contribution": {
       "fallbackLabel": "Viðbót við viðburð",
       "fallbackDescription": "Styður við framkvæmd viðburðarins"
+    },
+    "discount": {
+      "not_eligible_caption": "Ekki gjaldgengt fyrir afslátt",
+      "promo_discount_eligible_label": "Afsláttur (gjaldgengar vörur)"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -250,6 +250,10 @@
     "contribution": {
       "fallbackLabel": "活动贡献费",
       "fallbackDescription": "支持活动的举办"
+    },
+    "discount": {
+      "not_eligible_caption": "不符合折扣条件",
+      "promo_discount_eligible_label": "促销折扣（符合条件的商品）"
     }
   },
   "openCheckout": {


### PR DESCRIPTION
## Chain (3 of 3)

\`\`\`
dev
└── 01-legacy-cleanup (#190)
    └── 02-coupon-rules-and-discountable (#191)
        └── 📌 03-ux-captions  ← this PR
\`\`\`

**Base**: \`feat/checkout-discount-rules--02-coupon-rules-and-discountable\`. When #191 merges, GitHub auto-updates this PR's base to \`dev\` (after #190 lands first).

## What this PR does

When the cart mixes discountable and non-discountable items (patreon donations, mandatory meal plans, etc.) and a coupon is applied, the buyer used to see \`Promo Discount -\$50\` on a \$5,100 subtotal and suspect a bug. Adds inline copy so the math is self-explanatory.

## Changes

- Small "Not eligible for discount" caption under non-discountable items in every cart section:
  - Passes
  - Dynamic items (templated steps)
  - Housing
  - Merch
  - Patron (shown unconditionally — donations are inherently non-discountable)
  - Meal plans
- "Promo Discount (eligible items)" qualifier on the summary line when the cart contains non-discountable items AND a coupon is applied. Falls back to plain "Promo Discount" when every item is discountable.
- All strings in i18n: \`en\`, \`es\`, \`is\`, \`zh\`.

## Visual

Before:
\`\`\`
PATRON
  Community contribution    \$5,000
Subtotal:                   \$5,100
Promo Discount:               -\$50  ← "why so small?"
Total:                      \$5,050
\`\`\`

After:
\`\`\`
PATRON
  Community contribution    \$5,000
  Not eligible for discount   ← caption sutil
Subtotal:                   \$5,100
Promo Discount (eligible items):  -\$50
Total:                      \$5,050
\`\`\`

## Verification

- [x] Portal builds clean
- [x] 223 portal vitest pass
- [x] All 4 locales updated
- [ ] Visual QA in 4 languages

## Out of scope

- Coupon math and \`Product.discountable\` ship in #191
- Legacy cleanup ships in #190