### PR TITLE
fix(backend): checkout payment fixes — zero-amount email + duplicate tickets

### DIFF
--- a/backend/app/alembic/versions/94d7d49c3c92_cleanup_duplicate_orphan_attendee_products.py
+++ b/backend/app/alembic/versions/94d7d49c3c92_cleanup_duplicate_orphan_attendee_products.py
@@ -26,6 +26,7 @@ rows in both cases without relying on arbitrary UUID ordering.
 """
 
 from alembic import op
+from sqlalchemy import text
 
 revision = "94d7d49c3c92"
 down_revision = "377c2c02fe74"
@@ -37,7 +38,7 @@ def upgrade() -> None:
     conn = op.get_bind()
 
     # Dry-run: count rows that will be deleted
-    to_delete = conn.execute(
+    to_delete = conn.execute(text(
         """
         SELECT COUNT(*)
         FROM attendee_products ap
@@ -47,7 +48,7 @@ def upgrade() -> None:
           AND p.status IN ('approved', 'expired')
           AND ap.check_in_code LIKE UPPER(LEFT(pu.slug, 3)) || '%'
         """
-    ).scalar()
+    )).scalar()
 
     print(f"\n[94d7d49c3c92] attendee_products cleanup — rows to delete: {to_delete}")
 

--- a/backend/app/alembic/versions/94d7d49c3c92_cleanup_duplicate_orphan_attendee_products.py
+++ b/backend/app/alembic/versions/94d7d49c3c92_cleanup_duplicate_orphan_attendee_products.py
@@ -1,0 +1,76 @@
+"""cleanup duplicate and orphan attendee_products from open-ticketing checkout
+
+Revision ID: 94d7d49c3c92
+Revises: 377c2c02fe74
+Create Date: 2026-05-25
+
+Root cause
+----------
+create_open_ticketing_payment pre-created AttendeeProducts rows while the
+payment was still PENDING. When SimpleFI confirmed the payment, approve_payment
+called _add_products_to_attendees (always-INSERT) creating a second set of rows
+for the same tickets. Two classes of bad data resulted:
+
+1. APPROVED payments (open-ticketing): 2x AttendeeProducts per ticket.
+   Pre-created rows have a popup-slug prefix in their check_in_code
+   (e.g. "SOL..."); approval-created rows have no prefix (shorter codes).
+   Verified: 0 pre-created codes appear in check_ins — safe to delete.
+
+2. EXPIRED payments (open-ticketing): ALL AttendeeProducts are orphans
+   (payment never completed). All have the slug-prefix pattern since
+   approve_payment was never called.
+
+Fix: delete rows where check_in_code LIKE slug_prefix || '%', joined
+to the popup via payments. This is precise — it targets only the pre-created
+rows in both cases without relying on arbitrary UUID ordering.
+"""
+
+from alembic import op
+
+revision = "94d7d49c3c92"
+down_revision = "377c2c02fe74"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Dry-run: count rows that will be deleted
+    to_delete = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM attendee_products ap
+        JOIN payments p ON p.id = ap.payment_id
+        JOIN popups pu ON pu.id = p.popup_id
+        WHERE p.application_id IS NULL
+          AND p.status IN ('approved', 'expired')
+          AND ap.check_in_code LIKE UPPER(LEFT(pu.slug, 3)) || '%'
+        """
+    ).scalar()
+
+    print(f"\n[94d7d49c3c92] attendee_products cleanup — rows to delete: {to_delete}")
+
+    # Delete pre-created AttendeeProducts rows:
+    # - Approved payments: removes the slug-prefixed duplicates, keeps the
+    #   approval-created rows (no prefix) which are the canonical tickets.
+    # - Expired payments: removes all rows (all are slug-prefixed orphans).
+    op.execute(
+        """
+        DELETE FROM attendee_products
+        WHERE id IN (
+            SELECT ap.id
+            FROM attendee_products ap
+            JOIN payments p ON p.id = ap.payment_id
+            JOIN popups pu ON pu.id = p.popup_id
+            WHERE p.application_id IS NULL
+              AND p.status IN ('approved', 'expired')
+              AND ap.check_in_code LIKE UPPER(LEFT(pu.slug, 3)) || '%'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Data-only migration — deleted rows cannot be recovered from schema alone.
+    pass

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -526,19 +526,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     discountable_amount += line_total
 
                 for _ in range(line.quantity):
-                    # One AttendeeProducts row per ticket — Design §2.2
-                    session.add(
-                        AttendeeProducts(
-                            id=uuid.uuid4(),
-                            tenant_id=tenant.id,
-                            attendee_id=attendee.id,
-                            product_id=product.id,
-                            check_in_code=generate_check_in_code(
-                                (popup.slug or "")[:3].upper()
-                            ),
-                            payment_id=payment.id,
-                        )
-                    )
+                    # PaymentProducts snapshot only — AttendeeProducts are created
+                    # by approve_payment via _add_products_to_attendees when the
+                    # webhook confirms the payment. Pre-creating them here caused
+                    # duplicates (double the tickets) on every approved checkout.
                     session.add(
                         PaymentProducts(
                             tenant_id=tenant.id,

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -759,6 +759,9 @@ async def create_my_payment(
 
     payment, _preview = payments_crud.create_payment(db, payment_in)
 
+    if payment.status == PaymentStatus.APPROVED.value:
+        await _send_payment_confirmed_email(payment, db_session=db)
+
     return PaymentPublic.model_validate(payment)
 
 

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -160,7 +160,7 @@ def test_create_open_ticketing_payment_one_attendee_n_tickets(
     db: Session,
     tenant_a: Tenants,
 ) -> None:
-    """quantity=3 → 1 attendee + 3 AttendeeProducts rows.  Design §2.1/§2.2."""
+    """quantity=3 → 1 attendee + 3 PaymentProducts (snapshot). AttendeeProducts are created only on approval. Design §2.1/§2.2."""
     popup = _make_popup(db, tenant_a, slug_prefix="main-comp")
     product = _make_product(db, popup, name="GA", price="120.00")
     section = _make_section(db, popup, label="Buyer Info")
@@ -219,16 +219,13 @@ def test_create_open_ticketing_payment_one_attendee_n_tickets(
     assert attendees[0].category == "main"
     assert attendees[0].email == "buyer@test.com"
 
-    # 3 AttendeeProducts rows, each with unique check_in_code
+    # AttendeeProducts are NOT created at checkout — only when payment is approved.
     attendee_products = list(
         db.exec(
             select(AttendeeProducts).where(AttendeeProducts.product_id == product.id)
         ).all()
     )
-    assert len(attendee_products) == 3
-    codes = {ap.check_in_code for ap in attendee_products}
-    assert len(codes) == 3, "Each ticket must have a distinct check_in_code"
-    assert all(ap.payment_id == payment.id for ap in attendee_products)
+    assert len(attendee_products) == 0
 
     payment_products = list(
         db.exec(
@@ -289,7 +286,7 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
     )
     assert len(attendees) == 1
 
-    # 3 AttendeeProducts rows total (1 + 2)
+    # AttendeeProducts are NOT created at checkout — only when each payment is approved.
     tickets = list(
         db.exec(
             select(AttendeeProducts).where(
@@ -297,7 +294,7 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
             )
         ).all()
     )
-    assert len(tickets) == 3
+    assert len(tickets) == 0
 
 
 def test_create_open_ticketing_payment_does_not_overwrite_existing_human(


### PR DESCRIPTION
## Summary

Two bug fixes for the open-ticketing checkout flow.

## Related Issue

N/A — hotfixes identified via production investigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Zero-amount payment email**: when a 100% coupon makes the total \$0, `create_payment` auto-approves without going through SimpleFI, so no webhook fires. The buyer received no confirmation email. Fixed by sending `PAYMENT_CONFIRMED` immediately after auto-approval in `create_my_payment`.

- **Duplicate tickets in BO attendees table**: `create_open_ticketing_payment` was pre-creating `AttendeeProducts` rows while the payment was still PENDING. On webhook approval, `approve_payment` called `_add_products_to_attendees` (always-INSERT) again, doubling every ticket. Fixed by removing the pre-creation — only `PaymentProducts` (the snapshot) is written at checkout time, consistent with the application flow.

- **Migration `94d7d49c3c92`**: cleans up existing bad data in production. Deletes pre-created rows identified by their slug-prefix `check_in_code` pattern. Verified: 0 affected rows were ever checked in.

## Testing

- [x] Backend linting passes (`bash scripts/lint.sh`)
- [x] Manual testing performed
- [x] Verified against production DB (read-only) before writing migration

## Checklist

- [x] My code follows the project's coding standards
- [x] Database migrations are included if schema changed