### PR TITLE
fix: zero-amount checkout flow for groups and open-ticketing

### DIFF
--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -14,6 +14,8 @@ from app.api.checkout.schemas import (
     OpenTicketingPurchaseResponse,
 )
 from app.api.payment.crud import payments_crud
+from app.api.payment.router import _send_payment_confirmed_email
+from app.api.payment.schemas import PaymentStatus
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import SessionDep
 from app.core.rate_limit import RateLimit
@@ -65,6 +67,9 @@ async def purchase_open_ticketing(
         popup=popup,
         tenant=tenant,
     )
+
+    if payment.status == PaymentStatus.APPROVED.value:
+        await _send_payment_confirmed_email(payment, db_session=db)
 
     return OpenTicketingPurchaseResponse(
         payment_id=payment.id,

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -400,6 +400,27 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             "sections": sections_snapshot,
         }
 
+    def _finalize_zero_amount_payment(
+        self,
+        session: Session,
+        payment: Payments,
+        products: list[PaymentProductRequest],
+    ) -> Payments:
+        """Auto-approve a payment whose discounts zeroed the cart.
+
+        Shared by the authenticated application flow and the anonymous
+        open-ticketing flow: there is no provider charge to confirm, so we
+        mark the payment APPROVED, materialize AttendeeProducts from the
+        request list, and commit. Callers handle flow-specific setup (cart
+        cleanup, edit_passes clearing, coupon usage, etc.) BEFORE invoking
+        this helper so the only shared concern lives here.
+        """
+        payment.status = PaymentStatus.APPROVED.value
+        self._add_products_to_attendees(session, products, payment_id=payment.id)
+        session.commit()
+        session.refresh(payment)
+        return payment
+
     def create_open_ticketing_payment(
         self,
         session: Session,
@@ -517,6 +538,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             # don't appear in this flow today) bypass any coupon discount.
             discountable_amount = Decimal("0")
             non_discountable_amount = Decimal("0")
+            payment_products: list[PaymentProducts] = []
             for line in obj.products:
                 product = products_map[line.product_id]
                 line_total = product.price * line.quantity
@@ -530,20 +552,20 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     # by approve_payment via _add_products_to_attendees when the
                     # webhook confirms the payment. Pre-creating them here caused
                     # duplicates (double the tickets) on every approved checkout.
-                    session.add(
-                        PaymentProducts(
-                            tenant_id=tenant.id,
-                            payment_id=payment.id,
-                            product_id=product.id,
-                            attendee_id=attendee.id,
-                            quantity=1,
-                            product_name=product.name,
-                            product_description=product.description,
-                            product_price=product.price,
-                            product_category=product.category or "",
-                            product_currency=popup.currency,
-                        )
+                    pp = PaymentProducts(
+                        tenant_id=tenant.id,
+                        payment_id=payment.id,
+                        product_id=product.id,
+                        attendee_id=attendee.id,
+                        quantity=1,
+                        product_name=product.name,
+                        product_description=product.description,
+                        product_price=product.price,
+                        product_category=product.category or "",
+                        product_currency=popup.currency,
                     )
+                    session.add(pp)
+                    payment_products.append(pp)
 
             discountable_amount = discountable_amount.quantize(
                 MONEY_PRECISION, rounding=ROUND_HALF_UP
@@ -569,6 +591,27 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 coupons_crud.use_coupon(session, coupon.id)
 
             payment.amount = discountable_amount + non_discountable_amount
+
+            # Zero-amount short-circuit: a 100% coupon zeroed the cart, so
+            # SimpleFI has nothing to charge and would either reject or auto-
+            # approve without firing the webhook. Share the auto-approval path
+            # with the authenticated flow so both stay in lock-step (without
+            # this, the open-ticketing buyer never received tickets nor the
+            # confirmation email).
+            if payment.amount == Decimal("0"):
+                self._finalize_zero_amount_payment(
+                    session,
+                    payment,
+                    [
+                        PaymentProductRequest(
+                            product_id=pp.product_id,
+                            attendee_id=pp.attendee_id,
+                            quantity=pp.quantity,
+                        )
+                        for pp in payment_products
+                    ],
+                )
+                return payment, ""
 
             if not popup.simplefi_api_key:
                 raise HTTPException(
@@ -1589,12 +1632,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             session.add(payment)
             session.flush()
 
-            # Auto-approve and add products directly
-            self._add_products_to_attendees(
-                session, obj.products, payment_id=payment.id
-            )
-
-            # Get product details for snapshot
+            # Build product snapshots before approval so they're available
+            # when AttendeeProducts are materialized in the finalizer.
             product_ids = [p.product_id for p in obj.products]
             prod_statement = select(Products).where(
                 Products.id.in_(product_ids),  # type: ignore[attr-defined]
@@ -1602,7 +1641,6 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             )
             products_map = {p.id: p for p in session.exec(prod_statement).all()}
 
-            # Create product snapshots
             for req_prod in obj.products:
                 product = products_map.get(req_prod.product_id)
                 if product:
@@ -1637,8 +1675,11 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             )
 
             session.add(application)
-            session.commit()
-            session.refresh(payment)
+
+            # Shared finalizer: materializes AttendeeProducts, commits the
+            # session and refreshes the payment. Same code path as the
+            # anonymous open-ticketing flow so they can't drift again.
+            self._finalize_zero_amount_payment(session, payment, obj.products)
 
             # Return payment with approved status
             preview.status = PaymentStatus.APPROVED.value

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -271,14 +271,22 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
         form_data={name_field.name: "Repeat"},
     )
 
-    sf_resp1 = SimpleNamespace(id="sf_reuse_1", status="pending", checkout_url="https://sf.test/1")
-    sf_resp2 = SimpleNamespace(id="sf_reuse_2", status="pending", checkout_url="https://sf.test/2")
+    sf_resp1 = SimpleNamespace(
+        id="sf_reuse_1", status="pending", checkout_url="https://sf.test/1"
+    )
+    sf_resp2 = SimpleNamespace(
+        id="sf_reuse_2", status="pending", checkout_url="https://sf.test/2"
+    )
 
     with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
         mock_get_client.return_value.create_payment.side_effect = [sf_resp1, sf_resp2]
 
-        payments_crud.create_open_ticketing_payment(db, obj=obj1, popup=popup, tenant=tenant_a)
-        payments_crud.create_open_ticketing_payment(db, obj=obj2, popup=popup, tenant=tenant_a)
+        payments_crud.create_open_ticketing_payment(
+            db, obj=obj1, popup=popup, tenant=tenant_a
+        )
+        payments_crud.create_open_ticketing_payment(
+            db, obj=obj2, popup=popup, tenant=tenant_a
+        )
 
     # Still exactly 1 attendee after two purchases
     attendees = list(
@@ -449,6 +457,53 @@ def test_create_open_ticketing_payment_applies_coupon_discount(
     assert coupon.current_uses == 1
 
 
+def test_create_open_ticketing_payment_100_percent_coupon_auto_approves(
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """A 100% coupon zeroes the cart: skip SimpleFI, mark APPROVED, materialize
+    AttendeeProducts so the router can fire the confirmation email."""
+    popup = _make_popup(db, tenant_a, slug_prefix="full-coupon")
+    product = _make_product(db, popup, name="GA", price="75.00")
+    coupon = _make_coupon(db, popup, code="FREEPASS", discount_value=100)
+    db.commit()
+
+    obj = _purchase_create(
+        email="buyer@test.com",
+        first_name="Matias",
+        last_name="Walter",
+        products=[(product, 2)],
+        form_data={},
+        coupon_code="FREEPASS",
+    )
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        payment, checkout_url = payments_crud.create_open_ticketing_payment(
+            db,
+            obj=obj,
+            popup=popup,
+            tenant=tenant_a,
+        )
+
+    mock_get_client.assert_not_called()
+    assert payment.amount == Decimal("0.00")
+    assert payment.status == "approved"
+    assert payment.coupon_id == coupon.id
+    assert payment.discount_value == Decimal("100")
+    assert checkout_url == ""
+
+    attendee_products = list(
+        db.exec(
+            select(AttendeeProducts).where(AttendeeProducts.payment_id == payment.id)
+        ).all()
+    )
+    assert len(attendee_products) == 2
+
+    db.expire(coupon)
+    db.refresh(coupon)
+    assert coupon.current_uses == 1
+
+
 def test_create_open_ticketing_payment_rejects_invalid_coupon(
     db: Session,
     tenant_a: Tenants,
@@ -475,6 +530,5 @@ def test_create_open_ticketing_payment_rejects_invalid_coupon(
     assert exc_info.value.status_code == 404
     mock_get_client.assert_not_called()
     assert (
-        db.exec(select(Payments).where(Payments.popup_id == popup.id)).first()
-        is None
+        db.exec(select(Payments).where(Payments.popup_id == popup.id)).first() is None
     )

--- a/portal/src/app/groups/[groupSlug]/page.tsx
+++ b/portal/src/app/groups/[groupSlug]/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { useParams } from "next/navigation"
+import { useEffect } from "react"
 import { PopupCheckoutContent } from "@/app/checkout/components/PopupCheckoutContent"
 import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import useGetPublicGroup from "@/hooks/useGetPublicGroup"
 import { getCheckoutBackground } from "@/lib/background-image"
 import { useCityProvider } from "@/providers/cityProvider"
+import { useDiscount } from "@/providers/discountProvider"
 
 const LoadingFallback = () => (
   <div className="flex items-center justify-center h-screen">
@@ -15,8 +17,55 @@ const LoadingFallback = () => (
 
 const GroupCheckoutPage = () => {
   const params = useParams<{ groupSlug: string }>()
-  const { getPopups, popupsLoaded } = useCityProvider()
+  const { getCity, getPopups, popupsLoaded, setCityPreselected } =
+    useCityProvider()
   const { group, loading, error } = useGetPublicGroup(params.groupSlug)
+  const { setDiscount, discountApplied } = useDiscount()
+
+  // Pre-select the popup as soon as we know it so the DiscountProvider's
+  // city-reset effect settles on this popup's id BEFORE we seed the discount.
+  useEffect(() => {
+    if (group?.popup_id) {
+      setCityPreselected(group.popup_id)
+    }
+  }, [group?.popup_id, setCityPreselected])
+
+  // The portal's DiscountProvider reads group discounts from /groups/my/groups,
+  // which only lists groups where the user is a leader (find_by_leader). Buyers
+  // arriving via /groups/{slug} are added as members, so that query returns
+  // empty and the cart skips the discount. Seed the discount directly from the
+  // public group payload we already fetched. This is intentionally narrow —
+  // the upcoming groups SDD reworks the membership/discount surfaces.
+  //
+  // We depend on BOTH `discountApplied.discount_value` and `.city_id` so the
+  // effect re-fires in the commit AFTER the DiscountProvider's city-reset
+  // (discountProvider.tsx:39-48) settles. That reset uses setDiscountApplied
+  // directly, bypassing our setDiscount's downgrade guard — if both fired in
+  // the same commit, the reset's "last write wins" wiped our value. Re-firing
+  // once city_id is stable lets our setDiscount land cleanly without further
+  // reset interference.
+  const currentCity = getCity()
+  useEffect(() => {
+    if (!group?.discount_percentage) return
+    if (currentCity?.id !== group.popup_id) return
+    if (discountApplied.city_id !== currentCity.id) return
+    const discountValue = Number(group.discount_percentage)
+    if (!Number.isFinite(discountValue) || discountValue <= 0) return
+    if (discountApplied.discount_value >= discountValue) return
+    setDiscount({
+      discount_value: discountValue,
+      discount_type: "percentage",
+      discount_code: null,
+      city_id: currentCity.id,
+    })
+  }, [
+    group?.discount_percentage,
+    group?.popup_id,
+    currentCity?.id,
+    discountApplied.discount_value,
+    discountApplied.city_id,
+    setDiscount,
+  ])
 
   if (loading || !popupsLoaded) {
     return <LoadingFallback />

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -254,12 +254,18 @@ export function usePaymentSubmit({
             : Promise.resolve(),
         ])
         if (popupSlug) {
-          if (submitMode === "open-ticketing") {
+          // Approved-on-create only happens when the cart was zero-amount and
+          // SimpleFI was bypassed (paid flows return status=pending + a
+          // checkout_url and never hit this branch). Edits are adjustments,
+          // not ceremonies — keep those landing on /passes. For everything
+          // else, the thank-you page provides closure and confirms that the
+          // email was sent, matching the open-ticketing zero-amount path.
+          if (isEditing) {
+            router.replace(`/portal/${popupSlug}/passes`)
+          } else {
             const paymentId = data.id ?? data.payment_id
             const qs = paymentId ? `?payment_id=${paymentId}` : ""
             router.replace(`/checkout/${popupSlug}/thank-you${qs}`)
-          } else {
-            router.replace(`/portal/${popupSlug}/passes`)
           }
         } else {
           // Fallback when slug is unavailable: keep the legacy success step


### PR DESCRIPTION
## Summary

- **Backend**: Auto-approves zero-amount open-ticketing payments (100% coupon), materializes tickets, and fires the confirmation email. Extracts a shared `_finalize_zero_amount_payment` primitive so the authenticated application/groups flow and the anonymous open-ticketing flow stay in lock-step.
- **Portal**: Surfaces the group discount in the cart when a buyer arrives via `/groups/{slug}` invite (was always showing full price because the discount source only listed groups where the buyer is a leader, not a member).
- **Portal**: Routes the approved-on-create branch (zero-amount cart, no SimpleFI redirect) to the thank-you page instead of dropping the buyer straight into `/portal/{slug}/passes`. Edits keep the previous `/passes` landing.

## Background

A buyer entering through a `/groups/{slug}` link with a 100% group discount (or a 100% coupon in any flow) was hitting three coordinated UX gaps:

1. The cart UI showed full price even though the backend charged 0.
2. The anonymous open-ticketing equivalent created the payment but never created tickets nor sent the confirmation email.
3. After the zero-amount approval, the application flow redirected to `/portal/{slug}/passes` with no closure — buyers couldn't tell whether the order actually processed.

This change fixes the three failure modes together.

## Test plan

- [x] `pytest tests/api/payment/test_create_open_ticketing_payment.py` — 7 passed, including new `test_create_open_ticketing_payment_100_percent_coupon_auto_approves`
- [x] `ruff check` and `ruff format --check` on touched backend files
- [x] `biome check` on touched portal files
- [x] `pnpm run build` (portal)
- [ ] Manual: open `/groups/{slug}` (group with discount > 0) as a non-leader and verify the cart shows the discount on review/confirm
- [ ] Manual: complete a 100% discounted purchase via `/groups/{slug}` and verify (a) redirect to thank-you, (b) tickets appear in `/portal/{slug}/passes`, (c) confirmation email arrives
- [ ] Manual: complete a 100% discounted purchase via anonymous open-ticketing (direct-sale popup with a 100% coupon) and verify the same three points
- [ ] Manual: edit passes with a delta of 0 and verify the redirect still lands on `/portal/{slug}/passes` (not thank-you)
- [ ] Manual: paid purchase via SimpleFI still flows through gateway and lands on the existing success URL

## Known follow-ups (out of scope for this PR)

- `/groups/my/groups` only returns groups where the buyer is a leader — the discount surface needs broader rework as part of the upcoming groups SDD.
- `GET /groups/public/{slug}` resolves by slug without `popup_id`, leaving cross-popup collisions within the same tenant non-deterministic. Flagged as a separate concern.