### PR TITLE
fix(ci): unbreak release dev → main

### DIFF
--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -150,19 +150,24 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
         ``only_published_public=True`` matches the public-calendar visibility
         so anonymous users don't see tags that only exist in drafts.
         """
+        # ``status`` and ``visibility`` are stored as the Python ``Enum``
+        # NAMES (uppercase) via SQLAlchemy's native Enum, not the lowercase
+        # values exposed in the schema. Filter against the stored form.
         sql = """
             SELECT DISTINCT btrim(tag) AS tag
             FROM events,
                  jsonb_array_elements_text(events.tags) AS tag
             WHERE events.popup_id = :popup_id
-              AND events.status != 'cancelled'
+              AND events.status != 'CANCELLED'
         """
         if only_published_public:
-            sql += " AND events.status = 'published' AND events.visibility = 'public'"
+            sql += " AND events.status = 'PUBLISHED' AND events.visibility = 'PUBLIC'"
         rows = db.exec(text(sql).bindparams(popup_id=popup_id)).all()
         tags: list[str] = []
         for row in rows:
-            value = row[0] if isinstance(row, tuple) else row
+            # SQLAlchemy 2.x ``Row`` is tuple-like but not a ``tuple``
+            # subclass; index the first column directly.
+            value = row[0]
             if value is None:
                 continue
             cleaned = str(value).strip()

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime, timedelta
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
@@ -15,6 +16,13 @@ from app.api.event_settings.schemas import PublishPermission
 from app.api.human.models import Humans
 from app.api.popup.models import Popups
 from app.api.tenant.models import Tenants
+
+# POST /api/v1/events/portal/events is temporarily disabled for API keys
+# (see ``_PAT_ROUTE_POLICIES`` in ``app/core/security.py``). When the route
+# is restored, remove this marker from the affected tests.
+_post_events_disabled = pytest.mark.skip(
+    reason="POST /events disabled for API keys until week 2 of Edge City rollout",
+)
 
 
 def _pat_auth(raw_key: str) -> dict[str, str]:
@@ -141,6 +149,7 @@ class TestApiKeyPolicy:
         assert resp.status_code == 403, resp.text
         assert "restricted to approved event automation routes" in resp.json()["detail"]
 
+    @_post_events_disabled
     def test_pat_event_respects_event_settings_approval(
         self,
         client: TestClient,
@@ -174,6 +183,7 @@ class TestApiKeyPolicy:
         assert row.status == EventStatus.PENDING_APPROVAL
         assert row.visibility == EventVisibility.UNLISTED
 
+    @_post_events_disabled
     def test_pat_event_does_not_require_approval_when_settings_disabled(
         self,
         client: TestClient,
@@ -207,6 +217,7 @@ class TestApiKeyPolicy:
         assert row.status == EventStatus.PUBLISHED
         assert row.visibility == EventVisibility.PUBLIC
 
+    @_post_events_disabled
     def test_pat_without_write_scope_cannot_create_event(
         self,
         client: TestClient,
@@ -281,7 +292,9 @@ class TestApiKeyPolicy:
         )
 
         assert resp.status_code == 403, resp.text
-        assert resp.json()["detail"] == "Blocked humans cannot create or manage API keys."
+        assert (
+            resp.json()["detail"] == "Blocked humans cannot create or manage API keys."
+        )
 
     def test_write_scope_api_key_requires_expiry(
         self,
@@ -295,9 +308,9 @@ class TestApiKeyPolicy:
         token = create_access_token(subject=human.id, token_type="human")
 
         resp = client.post(
-          "/api/v1/api-keys",
-          headers={"Authorization": f"Bearer {token}"},
-          json={"name": "writer", "scopes": ["events:read", "events:write"]},
+            "/api/v1/api-keys",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"name": "writer", "scopes": ["events:read", "events:write"]},
         )
 
         assert resp.status_code == 422, resp.text
@@ -344,9 +357,7 @@ class TestApiKeyPolicy:
         assert resp.status_code == 204, resp.text
 
         db.expire_all()
-        rows = list(
-            db.exec(select(ApiKeys).where(ApiKeys.human_id == human.id)).all()
-        )
+        rows = list(db.exec(select(ApiKeys).where(ApiKeys.human_id == human.id)).all())
         assert rows
         assert all(row.revoked_at is not None for row in rows)
 
@@ -766,9 +777,7 @@ class TestApiKeyPolicy:
         assert resp.json()["red_flag"] is True
 
         db.expire_all()
-        rows = list(
-            db.exec(select(ApiKeys).where(ApiKeys.human_id == human.id)).all()
-        )
+        rows = list(db.exec(select(ApiKeys).where(ApiKeys.human_id == human.id)).all())
         assert rows
         assert all(row.revoked_at is not None for row in rows)
 

--- a/portal/src/app/portal/agentic-access/page.tsx
+++ b/portal/src/app/portal/agentic-access/page.tsx
@@ -155,9 +155,7 @@ function ApiKeysSection() {
       selectedScopes.includes("venues:write")
     const expiresAt = requiresExpiry
       ? new Date(
-          Date.now() +
-            WRITE_SCOPE_LIFETIME_DAYS * 24 * 60 * 60 * 1000 -
-            60_000,
+          Date.now() + WRITE_SCOPE_LIFETIME_DAYS * 24 * 60 * 60 * 1000 - 60_000,
         ).toISOString()
       : null
     try {


### PR DESCRIPTION
Surfaced by the failing checks on #197.

## What broke

1. **\`list_distinct_tags\` returned wrong results silently**
   The SQL filtered on lowercase enum values (\`'cancelled'\`, \`'published'\`, \`'public'\`), but the events table stores enum **names** (uppercase: \`'CANCELLED'\`, \`'PUBLISHED'\`, \`'PUBLIC'\`) because SQLModel's native Enum is name-based by default. The \`!=\` filter happened to let everything through (no row is stored as \`'cancelled'\`), so \`only_published_public=False\` worked by accident. \`only_published_public=True\` always returned an empty list.
   Fixed by aligning the SQL literals with the stored form.

   Also removed the \`isinstance(row, tuple)\` branch: SQLAlchemy 2.x \`Row\` is tuple-like but not a \`tuple\` subclass, so the check fell through and the rendered list was \`["('experimento-2026',)", ...]\`. \`row[0]\` works for both shapes.

2. **3 \`test_api_key_policy\` tests asserted POST /events behaviour**
   \`b9b57f97\` removed \`POST /api/v1/events/portal/events\` from \`_PAT_ROUTE_POLICIES\` until week 2 of the Edge City rollout. The three tests that exercised that path now hit the generic route-block error. Marked with \`@_post_events_disabled\` pointing back to the comment in \`security.py\`. When the route is restored, removing the marker re-enables them.

3. **\`agentic-access/page.tsx\` biome format**
   Multi-line \`Date.now() + WRITE_SCOPE_LIFETIME_DAYS * ...\` expression that biome wants on one line.

## Verification

- \`uv run pytest tests/test_api_key_policy.py tests/test_event_distinct_tags.py\` → 19 passed, 3 skipped
- \`bash backend/scripts/lint.sh\` → exit 0
- \`pnpm --filter portal exec biome ci .\` → no errors (1 pre-existing warning in \`VariantPatronPreset.tsx\`)

Once this merges to dev, #197 will pick it up automatically.