### PR TITLE
feat(api-keys): server-owned write scope lifetime, bump to 90 days

### DIFF
--- a/backend/app/api/admin_api_key/schemas.py
+++ b/backend/app/api/admin_api_key/schemas.py
@@ -4,13 +4,14 @@ from typing import get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
 from app.core.security import ApiKeyScope
 
 # All scope values valid in the ApiKeyScope Literal — used for schema-level
 # validation (unknown scope string → 422 before router-level universe check).
 _ALL_API_KEY_SCOPES: frozenset[str] = frozenset(get_args(ApiKeyScope))
 
-MAX_WRITE_SCOPE_LIFETIME_DAYS = 30
+__all__ = ["MAX_WRITE_SCOPE_LIFETIME_DAYS"]
 
 
 class AdminApiKeyCreate(BaseModel):
@@ -50,10 +51,15 @@ class AdminApiKeyCreate(BaseModel):
         return expires_at
 
     @model_validator(mode="after")
-    def require_expiry_for_write_scope(self) -> "AdminApiKeyCreate":
+    def default_expiry_for_write_scope(self) -> "AdminApiKeyCreate":
+        # Same server-owned lifetime contract as ``ApiKeyCreate``: a write
+        # scope without an explicit ``expires_at`` is defaulted to
+        # ``now + MAX_WRITE_SCOPE_LIFETIME_DAYS``.
         write_scopes = {s for s in self.scopes if s.endswith(":write")}
         if write_scopes and self.expires_at is None:
-            raise ValueError("Write-capable API keys require an expiry date")
+            self.expires_at = datetime.now(UTC) + timedelta(
+                days=MAX_WRITE_SCOPE_LIFETIME_DAYS
+            )
         return self
 
 

--- a/backend/app/api/api_key/schemas.py
+++ b/backend/app/api/api_key/schemas.py
@@ -10,7 +10,10 @@ from app.core.security import ApiKeyScope
 # Any new scope added to ApiKeyScope is immediately accepted here.
 ALLOWED_API_KEY_SCOPES: frozenset[str] = frozenset(get_args(ApiKeyScope))
 DEFAULT_API_KEY_SCOPES: list[ApiKeyScope] = ["events:read"]
-MAX_WRITE_SCOPE_LIFETIME_DAYS = 30
+# Single source of truth for the maximum (and default) lifetime of any
+# write-capable API key. ``admin_api_key.schemas`` re-uses this constant
+# so the limit lives in one place.
+MAX_WRITE_SCOPE_LIFETIME_DAYS = 90
 
 
 class ApiKeyCreate(BaseModel):
@@ -51,11 +54,17 @@ class ApiKeyCreate(BaseModel):
         return expires_at
 
     @model_validator(mode="after")
-    def require_expiry_for_write_scope(self) -> "ApiKeyCreate":
-        # Any scope ending in :write is considered a write scope.
+    def default_expiry_for_write_scope(self) -> "ApiKeyCreate":
+        # Any scope ending in :write is considered a write scope. The server
+        # is the source of truth for the lifetime: when the caller omits
+        # ``expires_at``, default to ``now + MAX_WRITE_SCOPE_LIFETIME_DAYS``
+        # so frontends don't need to duplicate the constant or fight clock
+        # drift against the field validator above.
         write_scopes = {s for s in self.scopes if s.endswith(":write")}
         if write_scopes and self.expires_at is None:
-            raise ValueError("Write-capable API keys require an expiry date")
+            self.expires_at = datetime.now(UTC) + timedelta(
+                days=MAX_WRITE_SCOPE_LIFETIME_DAYS
+            )
         return self
 
 

--- a/backend/tests/api/admin_api_key/test_crud.py
+++ b/backend/tests/api/admin_api_key/test_crud.py
@@ -83,18 +83,26 @@ class TestCreateAdminApiKey:
         )
         assert resp.status_code == 201, resp.text
 
-    def test_write_scope_without_expiry_returns_422(
+    def test_write_scope_without_expiry_defaults_to_policy_lifetime(
         self,
         client: TestClient,
         admin_token_tenant_a: str,
     ) -> None:
-        """Write scope without expires_at returns 422 (schema validation)."""
+        """Write scope without expires_at is created with the server-default
+        lifetime (``now + MAX_WRITE_SCOPE_LIFETIME_DAYS``)."""
+        from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
+
         resp = client.post(
             BASE_URL,
             headers=_bearer(admin_token_tenant_a),
             json={"name": "write-no-expiry", "scopes": ["attendees:write"]},
         )
-        assert resp.status_code == 422, resp.text
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["expires_at"] is not None
+        expires_at = datetime.fromisoformat(body["expires_at"])
+        expected = datetime.now(UTC) + timedelta(days=MAX_WRITE_SCOPE_LIFETIME_DAYS)
+        assert abs((expires_at - expected).total_seconds()) < 60
 
     def test_viewer_cannot_create_admin_api_key(
         self,
@@ -191,7 +199,9 @@ class TestListAdminApiKeys:
         from sqlmodel import select
 
         for item in items:
-            row = db.exec(select(ApiKeys).where(ApiKeys.id == uuid.UUID(item["id"]))).first()
+            row = db.exec(
+                select(ApiKeys).where(ApiKeys.id == uuid.UUID(item["id"]))
+            ).first()
             assert row is not None
             assert row.user_id == admin_user_tenant_a.id
 
@@ -282,7 +292,9 @@ class TestGetAdminApiKey:
         db.commit()
         db.refresh(row_b)
 
-        resp = client.get(f"{BASE_URL}/{row_b.id}", headers=_bearer(admin_token_tenant_a))
+        resp = client.get(
+            f"{BASE_URL}/{row_b.id}", headers=_bearer(admin_token_tenant_a)
+        )
         assert resp.status_code == 404, resp.text
 
         # Cleanup
@@ -295,7 +307,9 @@ class TestGetAdminApiKey:
         admin_token_tenant_a: str,
     ) -> None:
         """Non-existent key_id returns 404."""
-        resp = client.get(f"{BASE_URL}/{uuid.uuid4()}", headers=_bearer(admin_token_tenant_a))
+        resp = client.get(
+            f"{BASE_URL}/{uuid.uuid4()}", headers=_bearer(admin_token_tenant_a)
+        )
         assert resp.status_code == 404, resp.text
 
 
@@ -313,7 +327,9 @@ class TestRevokeAdminApiKey:
 
         row, _ = admin_api_key_factory(scopes=["events:read"])
 
-        resp = client.delete(f"{BASE_URL}/{row.id}", headers=_bearer(admin_token_tenant_a))
+        resp = client.delete(
+            f"{BASE_URL}/{row.id}", headers=_bearer(admin_token_tenant_a)
+        )
         assert resp.status_code == 204, resp.text
 
         db.refresh(row)
@@ -342,7 +358,9 @@ class TestRevokeAdminApiKey:
         db.commit()
         db.refresh(row_b)
 
-        resp = client.delete(f"{BASE_URL}/{row_b.id}", headers=_bearer(admin_token_tenant_a))
+        resp = client.delete(
+            f"{BASE_URL}/{row_b.id}", headers=_bearer(admin_token_tenant_a)
+        )
         assert resp.status_code in (403, 404), resp.text
 
         # Cleanup
@@ -355,7 +373,9 @@ class TestRevokeAdminApiKey:
         admin_token_tenant_a: str,
     ) -> None:
         """Non-existent key_id returns 404."""
-        resp = client.delete(f"{BASE_URL}/{uuid.uuid4()}", headers=_bearer(admin_token_tenant_a))
+        resp = client.delete(
+            f"{BASE_URL}/{uuid.uuid4()}", headers=_bearer(admin_token_tenant_a)
+        )
         assert resp.status_code == 404, resp.text
 
     def test_viewer_cannot_revoke_key(
@@ -366,7 +386,9 @@ class TestRevokeAdminApiKey:
     ) -> None:
         """VIEWER cannot revoke keys — 403."""
         row, _ = admin_api_key_factory(scopes=["events:read"])
-        resp = client.delete(f"{BASE_URL}/{row.id}", headers=_bearer(viewer_token_tenant_a))
+        resp = client.delete(
+            f"{BASE_URL}/{row.id}", headers=_bearer(viewer_token_tenant_a)
+        )
         assert resp.status_code == 403, resp.text
 
     def test_superadmin_can_revoke_any_key_in_tenant(

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -296,12 +296,13 @@ class TestApiKeyPolicy:
             resp.json()["detail"] == "Blocked humans cannot create or manage API keys."
         )
 
-    def test_write_scope_api_key_requires_expiry(
+    def test_write_scope_api_key_defaults_expiry_when_omitted(
         self,
         client: TestClient,
         db: Session,
         tenant_a: Tenants,
     ) -> None:
+        from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
         from app.core.security import create_access_token
 
         human = _make_human(db, tenant_a)
@@ -313,7 +314,14 @@ class TestApiKeyPolicy:
             json={"name": "writer", "scopes": ["events:read", "events:write"]},
         )
 
-        assert resp.status_code == 422, resp.text
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["expires_at"] is not None
+        # Server-owned lifetime: roughly ``now + MAX_WRITE_SCOPE_LIFETIME_DAYS``,
+        # with a small skew tolerance for the round-trip.
+        expires_at = datetime.fromisoformat(body["expires_at"])
+        expected = datetime.now(UTC) + timedelta(days=MAX_WRITE_SCOPE_LIFETIME_DAYS)
+        assert abs((expires_at - expected).total_seconds()) < 60
 
     def test_write_scope_api_key_rejects_long_expiry(
         self,
@@ -321,11 +329,16 @@ class TestApiKeyPolicy:
         db: Session,
         tenant_a: Tenants,
     ) -> None:
+        from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
         from app.core.security import create_access_token
 
         human = _make_human(db, tenant_a)
         token = create_access_token(subject=human.id, token_type="human")
-        expires_at = (datetime.now(UTC) + timedelta(days=45)).isoformat()
+        # Just past the policy max — the field validator must still reject
+        # an explicit value beyond the server's lifetime ceiling.
+        expires_at = (
+            datetime.now(UTC) + timedelta(days=MAX_WRITE_SCOPE_LIFETIME_DAYS + 10)
+        ).isoformat()
 
         resp = client.post(
             "/api/v1/api-keys",

--- a/backend/tests/test_portal_venue_crud.py
+++ b/backend/tests/test_portal_venue_crud.py
@@ -504,12 +504,13 @@ class TestPortalVenueCrudPat:
         assert resp.status_code == 403, resp.text
         assert "owner" in resp.json()["detail"].lower()
 
-    def test_venues_write_api_key_requires_expiry(
+    def test_venues_write_api_key_defaults_expiry_when_omitted(
         self,
         client: TestClient,
         db: Session,
         tenant_a: Tenants,
     ) -> None:
+        from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
         from app.core.security import create_access_token
 
         human = _make_human(db, tenant_a)
@@ -521,7 +522,12 @@ class TestPortalVenueCrudPat:
             json={"name": "venue writer", "scopes": ["venues:write"]},
         )
 
-        assert resp.status_code == 422, resp.text
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["expires_at"] is not None
+        expires_at = datetime.fromisoformat(body["expires_at"])
+        expected = datetime.now(UTC) + timedelta(days=MAX_WRITE_SCOPE_LIFETIME_DAYS)
+        assert abs((expires_at - expected).total_seconds()) < 60
 
     def test_venues_write_api_key_with_expiry_ok(
         self,

--- a/portal/src/app/portal/agentic-access/page.tsx
+++ b/portal/src/app/portal/agentic-access/page.tsx
@@ -33,7 +33,6 @@ import { CopyAgentBrief } from "./CopyAgentBrief"
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
 
 const DEFAULT_SCOPES: ApiKeyScope[] = ["events:read"]
-const WRITE_SCOPE_LIFETIME_DAYS = 30
 
 const scopeKey = (scope: ApiKeyScope) => scope.replace(":", "_")
 
@@ -150,19 +149,14 @@ function ApiKeysSection() {
   const onCreate = async () => {
     const name = newKeyName.trim()
     if (!name) return
-    const requiresExpiry =
-      selectedScopes.includes("events:write") ||
-      selectedScopes.includes("venues:write")
-    const expiresAt = requiresExpiry
-      ? new Date(
-          Date.now() + WRITE_SCOPE_LIFETIME_DAYS * 24 * 60 * 60 * 1000 - 60_000,
-        ).toISOString()
-      : null
     try {
+      // The backend owns the write-scope lifetime: send ``expires_at: null``
+      // and let it fill in the policy default. The created key returned in
+      // the response already carries the final ``expires_at`` for display.
       const created = await createKey({
         name,
         scopes: selectedScopes,
-        expires_at: expiresAt,
+        expires_at: null,
       })
       setCreatedKey(created)
       setNewKeyName("")


### PR DESCRIPTION
> **Stacked on #198.** Merge that first; this PR's diff against \`dev\` will then collapse to just the schema + portal cleanup.

## Why

Today the portal computes \`expires_at = client_now + 30d - 60s\` and ships it to the back, which re-validates it against \`server_now + 30d\`. The \`-60s\` (commit \`188a48e\`) is a band-aid over the underlying issue: the front shouldn't be computing this in the first place. The back already knows the policy, and the constant lives **in three places** (portal page, \`api_key/schemas.py\`, \`admin_api_key/schemas.py\`) so bumping it is a coordinated three-file release with a deploy ordering risk.

We need to bump the policy to **90 days** — perfect moment to fix the underlying duplication.

## What changed

**Back — server is now the source of truth.**

- \`ApiKeyCreate\` and \`AdminApiKeyCreate\` model validators changed from \`require_expiry_for_write_scope\` (raise 422 if missing) to \`default_expiry_for_write_scope\` (fill in \`now + MAX_WRITE_SCOPE_LIFETIME_DAYS\`).
- The field-level \`validate_expiry\` is unchanged — it still rejects **explicit** values past the ceiling, so external callers can't sneak past the policy.
- \`MAX_WRITE_SCOPE_LIFETIME_DAYS\` lives in \`api_key/schemas.py\` only; \`admin_api_key/schemas.py\` imports it. **Bumping the policy is now a one-line, one-deploy change.**
- Bumped from **30 → 90 days**.

**Front — stop doing back's job.**

- Removed local \`WRITE_SCOPE_LIFETIME_DAYS\` constant + the \`Date.now() + ...\` arithmetic.
- \`createKey\` sends \`expires_at: null\` and renders the server-issued value from the response (the response already includes \`expires_at\`, so the UI keeps showing the correct date).

## Migration / backwards compatibility

- **API surface is backwards-compatible.** The \`POST /api/v1/api-keys\` and \`POST /api/v1/backoffice/api-keys\` endpoints continue to accept an explicit \`expires_at\` (validated against the new 90d ceiling) or \`null\`/omitted (server fills in).
- **Old portal builds still work.** They keep sending an explicit \`expires_at\` of \`client_now + 30d - 60s\`, which is well within the new 90d ceiling.
- **No DB migration.** Only request-validation logic changes.

## Verification

- \`uv run pytest tests/test_api_key_policy.py tests/api/admin_api_key/test_crud.py\` → 37 passed, 3 skipped (the 3 skips are the POST /events skips from #198)
- \`uv run ruff check\` + \`ruff format --check\` → clean
- \`pnpm --filter portal run build\` → clean
- \`pnpm --filter portal exec biome ci .\` → clean on changed file

## Future-proofing

If \`MAX_WRITE_SCOPE_LIFETIME_DAYS\` later moves to an env var (or per-tenant config), only \`api_key/schemas.py\` needs to change — front and admin module stay untouched.