### PR TITLE
release: dev → main (split event update/cancel emails)

### DIFF
--- a/backend/app/api/email_template/schemas.py
+++ b/backend/app/api/email_template/schemas.py
@@ -22,6 +22,8 @@ class EmailTemplateType(StrEnum):
     ABANDONED_CART = "abandoned_cart"
     EDIT_PASSES_CONFIRMED = "edit_passes_confirmed"
     EVENT_INVITATION = "event_invitation"
+    EVENT_UPDATED = "event_updated"
+    EVENT_CANCELLED = "event_cancelled"
     EVENT_APPROVAL_APPROVED = "event_approval_approved"
     EVENT_APPROVAL_REJECTED = "event_approval_rejected"
 

--- a/backend/app/services/email/__init__.py
+++ b/backend/app/services/email/__init__.py
@@ -16,7 +16,9 @@ from app.services.email.templates import (
     EmailTemplates,
     EventApprovalApprovedContext,
     EventApprovalRejectedContext,
+    EventCancelledContext,
     EventInvitationContext,
+    EventUpdatedContext,
     LoginCodeHumanContext,
     LoginCodeUserContext,
     PaymentAttendeeItem,
@@ -47,6 +49,8 @@ __all__ = [
     "PaymentAttendeeItem",
     # Event contexts
     "EventInvitationContext",
+    "EventUpdatedContext",
+    "EventCancelledContext",
     "EventApprovalApprovedContext",
     "EventApprovalRejectedContext",
     # Helpers

--- a/backend/app/services/email/service.py
+++ b/backend/app/services/email/service.py
@@ -31,7 +31,9 @@ from app.services.email.templates import (
     EmailTemplates,
     EventApprovalApprovedContext,
     EventApprovalRejectedContext,
+    EventCancelledContext,
     EventInvitationContext,
+    EventUpdatedContext,
     LoginCodeHumanContext,
     LoginCodeUserContext,
     PaymentConfirmedContext,
@@ -693,6 +695,62 @@ class EmailService:
             attachments=attachments,
             ical_body=ical_body,
             ical_method=ical_method,
+        )
+
+    async def send_event_updated(
+        self,
+        to: str,
+        subject: str,
+        context: EventUpdatedContext,
+        from_address: str | None = None,
+        from_name: str | None = None,
+        popup_id: uuid.UUID | None = None,
+        db_session: Session | None = None,
+        attachments: list[EmailAttachment] | None = None,
+        ical_body: str | None = None,
+    ) -> bool:
+        """Send event update notification with optional inline iTIP body."""
+        return await self._send_with_fallback(
+            to=to,
+            subject=subject,
+            template_type=EmailTemplateType.EVENT_UPDATED,
+            template_name=EmailTemplates.EVENT_UPDATED,
+            context=context.model_dump(exclude_none=True),
+            from_address=from_address,
+            from_name=from_name,
+            popup_id=popup_id,
+            db_session=db_session,
+            attachments=attachments,
+            ical_body=ical_body,
+            ical_method="REQUEST",
+        )
+
+    async def send_event_cancelled(
+        self,
+        to: str,
+        subject: str,
+        context: EventCancelledContext,
+        from_address: str | None = None,
+        from_name: str | None = None,
+        popup_id: uuid.UUID | None = None,
+        db_session: Session | None = None,
+        attachments: list[EmailAttachment] | None = None,
+        ical_body: str | None = None,
+    ) -> bool:
+        """Send event cancellation notice with optional inline iTIP body."""
+        return await self._send_with_fallback(
+            to=to,
+            subject=subject,
+            template_type=EmailTemplateType.EVENT_CANCELLED,
+            template_name=EmailTemplates.EVENT_CANCELLED,
+            context=context.model_dump(exclude_none=True),
+            from_address=from_address,
+            from_name=from_name,
+            popup_id=popup_id,
+            db_session=db_session,
+            attachments=attachments,
+            ical_body=ical_body,
+            ical_method="CANCEL",
         )
 
     async def send_event_approval_approved(

--- a/backend/app/services/email/templates.py
+++ b/backend/app/services/email/templates.py
@@ -184,20 +184,11 @@ class EditPassesConfirmedContext(BaseModel):
     portal_url: str | None = None
 
 
-class EventChangeRow(BaseModel):
-    """Before/after pair surfaced as an inline diff in update emails."""
-
-    before: str
-    after: str
-
-
 class EventInvitationContext(BaseModel):
     """Context for event/invitation.html template.
 
-    Re-used for four flows: organiser-side invitations (default),
-    self-RSVP confirmations (``is_self_rsvp``), event-update
-    notifications (``is_update`` + ``changes``), and cancellations
-    (``is_cancelled``).
+    Used for organiser-side invitations and self-RSVP confirmations.
+    Update/cancel flows have their own dedicated templates.
     """
 
     first_name: str = ""
@@ -208,13 +199,35 @@ class EventInvitationContext(BaseModel):
     event_when: str = ""
     venue_title: str = ""
     event_url: str = ""
-    is_self_rsvp: bool = False
-    is_update: bool = False
-    is_cancelled: bool = False
-    # Mapping from canonical row key ("event", "time", "location") to the
-    # before/after pair, populated only on update emails so the matching
-    # row in the metadata block renders the inline diff.
+
+
+class EventChangeRow(BaseModel):
+    """Before/after pair surfaced as an inline diff in update emails."""
+
+    before: str
+    after: str
+
+
+class EventUpdatedContext(BaseModel):
+    """Context for event/updated.html — change notification with before/after diff."""
+
+    first_name: str = ""
+    event_title: str
+    popup_name: str = ""
+    event_when: str = ""
+    venue_title: str = ""
+    event_url: str = ""
     changes: dict[str, EventChangeRow] = {}
+
+
+class EventCancelledContext(BaseModel):
+    """Context for event/cancelled.html — cancellation notice."""
+
+    first_name: str = ""
+    event_title: str
+    popup_name: str = ""
+    event_when: str = ""
+    venue_title: str = ""
 
 
 class EventApprovalApprovedContext(BaseModel):
@@ -268,6 +281,8 @@ class EmailTemplates:
 
     # Event
     EVENT_INVITATION = "event/invitation.html"
+    EVENT_UPDATED = "event/updated.html"
+    EVENT_CANCELLED = "event/cancelled.html"
     EVENT_APPROVAL_APPROVED = "event/approval_approved.html"
     EVENT_APPROVAL_REJECTED = "event/approval_rejected.html"
 
@@ -285,6 +300,8 @@ TEMPLATE_TYPE_TO_FILE: dict[EmailTemplateType, str] = {
     EmailTemplateType.ABANDONED_CART: "payment/abandoned_cart.html",
     EmailTemplateType.EDIT_PASSES_CONFIRMED: "payment/edit_passes_confirmed.html",
     EmailTemplateType.EVENT_INVITATION: "event/invitation.html",
+    EmailTemplateType.EVENT_UPDATED: "event/updated.html",
+    EmailTemplateType.EVENT_CANCELLED: "event/cancelled.html",
     EmailTemplateType.EVENT_APPROVAL_APPROVED: "event/approval_approved.html",
     EmailTemplateType.EVENT_APPROVAL_REJECTED: "event/approval_rejected.html",
 }
@@ -974,27 +991,53 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "required": False,
                 "group": "Event",
             },
+            *_POPUP_EVENT_VARIABLES,
+        ],
+    },
+    {
+        "type": EmailTemplateType.EVENT_UPDATED,
+        "label": "Event Updated",
+        "description": "Sent when an event the recipient is invited to or RSVPd to is updated.",
+        "category": "Event",
+        "default_subject": "The event has been updated: {{ event_title }}",
+        "variables": [
             {
-                "name": "is_self_rsvp",
-                "label": "Self-RSVP confirmation",
-                "type": "boolean",
-                "description": "True when this is the confirmation sent after the recipient RSVPed themselves (not an organiser invitation)",
+                "name": "first_name",
+                "label": "First Name",
+                "type": "string",
+                "description": "Recipient's first name",
+                "required": False,
+                "group": "Recipient",
+            },
+            {
+                "name": "event_title",
+                "label": "Event Title",
+                "type": "string",
+                "description": "Title of the event",
+                "required": True,
+                "group": "Event",
+            },
+            {
+                "name": "event_when",
+                "label": "When",
+                "type": "string",
+                "description": "Formatted start date/time",
                 "required": False,
                 "group": "Event",
             },
             {
-                "name": "is_update",
-                "label": "Event update notification",
-                "type": "boolean",
-                "description": "True when this email is announcing a change to an existing event",
+                "name": "venue_title",
+                "label": "Venue",
+                "type": "string",
+                "description": "Venue name (may be empty)",
                 "required": False,
                 "group": "Event",
             },
             {
-                "name": "is_cancelled",
-                "label": "Event cancellation notification",
-                "type": "boolean",
-                "description": "True when this email is announcing that the event was cancelled",
+                "name": "event_url",
+                "label": "Event URL",
+                "type": "string",
+                "description": "Deep link to the event page in the portal",
                 "required": False,
                 "group": "Event",
             },
@@ -1002,7 +1045,49 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "name": "changes",
                 "label": "Changes",
                 "type": "object",
-                "description": "Mapping from row key ('event', 'time', 'location') to {before, after} describing what changed (only set when is_update=true)",
+                "description": "Mapping from row key ('event', 'time', 'location') to {before, after} describing what changed",
+                "required": False,
+                "group": "Event",
+            },
+            *_POPUP_EVENT_VARIABLES,
+        ],
+    },
+    {
+        "type": EmailTemplateType.EVENT_CANCELLED,
+        "label": "Event Cancelled",
+        "description": "Sent when an event the recipient is invited to or RSVPd to is cancelled.",
+        "category": "Event",
+        "default_subject": "Event cancelled: {{ event_title }}",
+        "variables": [
+            {
+                "name": "first_name",
+                "label": "First Name",
+                "type": "string",
+                "description": "Recipient's first name",
+                "required": False,
+                "group": "Recipient",
+            },
+            {
+                "name": "event_title",
+                "label": "Event Title",
+                "type": "string",
+                "description": "Title of the event",
+                "required": True,
+                "group": "Event",
+            },
+            {
+                "name": "event_when",
+                "label": "When",
+                "type": "string",
+                "description": "Formatted start date/time",
+                "required": False,
+                "group": "Event",
+            },
+            {
+                "name": "venue_title",
+                "label": "Venue",
+                "type": "string",
+                "description": "Venue name (may be empty)",
                 "required": False,
                 "group": "Event",
             },

--- a/backend/app/services/event_itip.py
+++ b/backend/app/services/event_itip.py
@@ -14,9 +14,12 @@ from loguru import logger
 
 from app.core.config import settings
 from app.services.email import (
+    EventCancelledContext,
     EventInvitationContext,
+    EventUpdatedContext,
     get_email_service,
 )
+from app.services.email.templates import EventChangeRow
 from app.services.ical import build_event_ics
 
 
@@ -198,18 +201,6 @@ async def send_event_itip(
             when = _format_when(recipient_occurrence)
         else:
             when = _format_time_range(event.start_time, event.end_time)
-        context = EventInvitationContext(
-            first_name=r["first_name"],
-            event_title=event.title or "",
-            popup_name=popup_name,
-            event_when=when,
-            venue_title=venue_title,
-            event_url=event_url,
-            is_self_rsvp=is_self_rsvp,
-            is_update=is_update,
-            is_cancelled=is_cancelled,
-            changes=changes or {},
-        )
         try:
             ics_body = build_event_ics(
                 event,
@@ -232,17 +223,63 @@ async def send_event_itip(
             ics_body = None
 
         try:
-            await service.send_event_invitation(
-                to=r["email"],
-                subject=subject,
-                context=context,
-                from_address=from_address,
-                from_name=from_name,
-                popup_id=event.popup_id,
-                db_session=db,
-                ical_body=ics_body,
-                ical_method=method,
-            )
+            if is_cancelled:
+                await service.send_event_cancelled(
+                    to=r["email"],
+                    subject=subject,
+                    context=EventCancelledContext(
+                        first_name=r["first_name"],
+                        event_title=event.title or "",
+                        popup_name=popup_name,
+                        event_when=when,
+                        venue_title=venue_title,
+                    ),
+                    from_address=from_address,
+                    from_name=from_name,
+                    popup_id=event.popup_id,
+                    db_session=db,
+                    ical_body=ics_body,
+                )
+            elif is_update:
+                await service.send_event_updated(
+                    to=r["email"],
+                    subject=subject,
+                    context=EventUpdatedContext(
+                        first_name=r["first_name"],
+                        event_title=event.title or "",
+                        popup_name=popup_name,
+                        event_when=when,
+                        venue_title=venue_title,
+                        event_url=event_url,
+                        changes={
+                            k: EventChangeRow(**v) for k, v in (changes or {}).items()
+                        },
+                    ),
+                    from_address=from_address,
+                    from_name=from_name,
+                    popup_id=event.popup_id,
+                    db_session=db,
+                    ical_body=ics_body,
+                )
+            else:
+                await service.send_event_invitation(
+                    to=r["email"],
+                    subject=subject,
+                    context=EventInvitationContext(
+                        first_name=r["first_name"],
+                        event_title=event.title or "",
+                        popup_name=popup_name,
+                        event_when=when,
+                        venue_title=venue_title,
+                        event_url=event_url,
+                    ),
+                    from_address=from_address,
+                    from_name=from_name,
+                    popup_id=event.popup_id,
+                    db_session=db,
+                    ical_body=ics_body,
+                    ical_method=method,
+                )
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("Failed to send iTIP {} to {}: {}", method, r["email"], exc)
 

--- a/backend/app/templates/emails/event/cancelled.html
+++ b/backend/app/templates/emails/event/cancelled.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %}Event cancelled: {{ event_title }}{% endblock %}
+
+{% block content %}
+<h1>This event was cancelled</h1>
+
+<p>Hi {{ first_name or "there" }},</p>
+
+<p>
+    The event below has been cancelled and the entry has been removed from your calendar.
+</p>
+
+<div style="background-color: #f8f9fa; border-radius: 8px; padding: 20px; margin: 20px 0;">
+    <table style="width: 100%; border-collapse: collapse;">
+        <tr>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top; width: 110px;">Event:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">{{ event_title }}</td>
+        </tr>
+        {% if event_when %}
+        <tr>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Time:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">{{ event_when }}</td>
+        </tr>
+        {% endif %}
+        {% if venue_title %}
+        <tr>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Location:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">{{ venue_title }}</td>
+        </tr>
+        {% endif %}
+    </table>
+</div>
+{% endblock %}

--- a/backend/app/templates/emails/event/invitation.html
+++ b/backend/app/templates/emails/event/invitation.html
@@ -1,98 +1,39 @@
 {% extends "base.html" %}
 
-{% block title %}{% if is_cancelled %}Event cancelled: {{ event_title }}{% elif is_update %}Event updated: {{ event_title }}{% elif is_self_rsvp %}You're in! {{ event_title }}{% else %}You're invited to {{ event_title }}{% endif %}{% endblock %}
+{% block title %}You're invited to {{ event_title }}{% endblock %}
 
 {% block content %}
-{% if is_cancelled %}
-<h1>This event was cancelled</h1>
-
-<p>Hi {{ first_name or "there" }},</p>
-
-<p>
-    The event below has been cancelled and the entry has been removed from your calendar.
-</p>
-{% elif is_update %}
-<h1>This event was updated</h1>
-
-<p>Hi {{ first_name or "there" }},</p>
-
-<p>
-    The event below has been updated. Highlighted rows show what changed.
-</p>
-{% elif is_self_rsvp %}
-<h1>You're in!</h1>
-
-<p>Hi {{ first_name or "there" }},</p>
-
-<p>
-    You're going to the event below{% if popup_name %} at <strong>{{ popup_name }}</strong>{% endif %}.
-</p>
-{% else %}
 <h1>You're invited!</h1>
 
 <p>Hi {{ first_name or "there" }},</p>
 
 <p>
-    You have been invited to the event below{% if popup_name %} at <strong>{{ popup_name }}</strong>{% endif %}.
+    You have been invited to <strong>{{ event_title }}</strong>{% if popup_name %}
+    at <strong>{{ popup_name }}</strong>{% endif %}.
 </p>
-{% endif %}
 
-{% set highlight_style = "background-color: #fff3cd;" %}
-{% set diff_old_style = "color: #999; text-decoration: line-through;" %}
-{% set diff_arrow_style = "color: #999;" %}
 <div style="background-color: #f8f9fa; border-radius: 8px; padding: 20px; margin: 20px 0;">
     <table style="width: 100%; border-collapse: collapse;">
-        {% set event_change = changes.event if changes else None %}
-        <tr {% if event_change %}style="{{ highlight_style }}"{% endif %}>
-            <td style="padding: 8px 12px; color: #666; vertical-align: top; width: 110px;">Event:</td>
-            <td style="padding: 8px 12px; font-weight: 600;">
-                {% if event_change %}
-                <span style="{{ diff_old_style }}">{{ event_change.before }}</span>
-                <span style="{{ diff_arrow_style }}"> → </span>
-                <strong>{{ event_change.after }}</strong>
-                {% else %}
-                {{ event_title }}
-                {% endif %}
-            </td>
-        </tr>
-        {% set time_change = changes.time if changes else None %}
-        {% if time_change or event_when %}
-        <tr {% if time_change %}style="{{ highlight_style }}"{% endif %}>
-            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Time:</td>
-            <td style="padding: 8px 12px; font-weight: 600;">
-                {% if time_change %}
-                <span style="{{ diff_old_style }}">{{ time_change.before }}</span>
-                <span style="{{ diff_arrow_style }}"> → </span>
-                <strong>{{ time_change.after }}</strong>
-                {% else %}
-                {{ event_when }}
-                {% endif %}
-            </td>
+        {% if event_when %}
+        <tr>
+            <td style="padding: 8px 0; color: #666;">When</td>
+            <td style="padding: 8px 0; font-weight: 600;">{{ event_when }}</td>
         </tr>
         {% endif %}
-        {% set location_change = changes.location if changes else None %}
-        {% if location_change or venue_title %}
-        <tr {% if location_change %}style="{{ highlight_style }}"{% endif %}>
-            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Location:</td>
-            <td style="padding: 8px 12px; font-weight: 600;">
-                {% if location_change %}
-                <span style="{{ diff_old_style }}">{{ location_change.before }}</span>
-                <span style="{{ diff_arrow_style }}"> → </span>
-                <strong>{{ location_change.after }}</strong>
-                {% else %}
-                {{ venue_title }}
-                {% endif %}
-            </td>
+        {% if venue_title %}
+        <tr>
+            <td style="padding: 8px 0; color: #666;">Venue</td>
+            <td style="padding: 8px 0; font-weight: 600;">{{ venue_title }}</td>
         </tr>
         {% endif %}
     </table>
 </div>
 
-{% if event_url and not is_cancelled %}
+{% if event_url %}
 <p class="text-center">
-    <a href="{{ event_url }}" class="button">{% if is_update or is_self_rsvp %}View event details{% else %}View event &amp; RSVP{% endif %}</a>
+    <a href="{{ event_url }}" class="button">View event &amp; RSVP</a>
 </p>
 {% endif %}
 
-{% if not is_cancelled %}<p>See you there!</p>{% endif %}
+<p>See you there!</p>
 {% endblock %}

--- a/backend/app/templates/emails/event/updated.html
+++ b/backend/app/templates/emails/event/updated.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}The event has been updated: {{ event_title }}{% endblock %}
+
+{% block content %}
+<h1>This event was updated</h1>
+
+<p>Hi {{ first_name or "there" }},</p>
+
+<p>
+    The event below has been updated. Highlighted rows show what changed.
+</p>
+
+{% set highlight_style = "background-color: #fff3cd;" %}
+{% set diff_old_style = "color: #999; text-decoration: line-through;" %}
+{% set diff_arrow_style = "color: #999;" %}
+<div style="background-color: #f8f9fa; border-radius: 8px; padding: 20px; margin: 20px 0;">
+    <table style="width: 100%; border-collapse: collapse;">
+        {% set event_change = changes.event if changes else None %}
+        <tr {% if event_change %}style="{{ highlight_style }}"{% endif %}>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top; width: 110px;">Event:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">
+                {% if event_change %}
+                <span style="{{ diff_old_style }}">{{ event_change.before }}</span>
+                <span style="{{ diff_arrow_style }}"> &rarr; </span>
+                <strong>{{ event_change.after }}</strong>
+                {% else %}
+                {{ event_title }}
+                {% endif %}
+            </td>
+        </tr>
+        {% set time_change = changes.time if changes else None %}
+        {% if time_change or event_when %}
+        <tr {% if time_change %}style="{{ highlight_style }}"{% endif %}>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Time:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">
+                {% if time_change %}
+                <span style="{{ diff_old_style }}">{{ time_change.before }}</span>
+                <span style="{{ diff_arrow_style }}"> &rarr; </span>
+                <strong>{{ time_change.after }}</strong>
+                {% else %}
+                {{ event_when }}
+                {% endif %}
+            </td>
+        </tr>
+        {% endif %}
+        {% set location_change = changes.location if changes else None %}
+        {% if location_change or venue_title %}
+        <tr {% if location_change %}style="{{ highlight_style }}"{% endif %}>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Location:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">
+                {% if location_change %}
+                <span style="{{ diff_old_style }}">{{ location_change.before }}</span>
+                <span style="{{ diff_arrow_style }}"> &rarr; </span>
+                <strong>{{ location_change.after }}</strong>
+                {% else %}
+                {{ venue_title }}
+                {% endif %}
+            </td>
+        </tr>
+        {% endif %}
+    </table>
+</div>
+
+{% if event_url %}
+<p class="text-center">
+    <a href="{{ event_url }}" class="button">View event details</a>
+</p>
+{% endif %}
+{% endblock %}

--- a/backend/tests/test_event_itip.py
+++ b/backend/tests/test_event_itip.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 from zoneinfo import ZoneInfo
 
 from fastapi.testclient import TestClient
@@ -155,6 +155,40 @@ def _patch_send_everywhere(mock: AsyncMock):
     stack.enter_context(patch(_PATCH_SEND_SERVICE, new=mock))
     stack.enter_context(patch(_PATCH_SEND_ROUTER, new=mock))
     return stack
+
+
+def _patch_email_service():
+    """Let ``send_event_itip`` run; capture the per-template method calls.
+
+    Returns ``(stack, service)`` — enter ``stack`` as a context manager and
+    inspect ``service.send_event_updated`` / ``service.send_event_cancelled``
+    / ``service.send_event_invitation`` afterwards.
+    """
+    from contextlib import ExitStack
+
+    from app.core.config import settings
+
+    service = MagicMock()
+    service.send_event_invitation = AsyncMock(return_value=True)
+    service.send_event_updated = AsyncMock(return_value=True)
+    service.send_event_cancelled = AsyncMock(return_value=True)
+
+    stack = ExitStack()
+    stack.enter_context(
+        patch("app.services.event_itip.get_email_service", return_value=service)
+    )
+    # ``emails_enabled`` is a computed @property on the Settings class — patch
+    # at the class level so the early-return guard in ``send_event_itip``
+    # passes during the test.
+    stack.enter_context(
+        patch.object(
+            type(settings),
+            "emails_enabled",
+            new_callable=PropertyMock,
+            return_value=True,
+        )
+    )
+    return stack, service
 
 
 # ---------------------------------------------------------------------------
@@ -653,6 +687,40 @@ class TestPatchBumpsSequenceAndDispatches:
             "rsvped@test.com",
         }
 
+    def test_patch_routes_to_send_event_updated(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """PATCH → ``bump_and_dispatch_update`` → ``service.send_event_updated``.
+
+        Guards against the ``invitation.html`` regression where a title/time
+        change was rendered with the generic "You're invited" template.
+        """
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        _invite(db, event, _make_human(db, tenant_a, email="updated@test.com"))
+
+        stack, service = _patch_email_service()
+        with stack:
+            resp = client.patch(
+                f"/api/v1/events/{event.id}",
+                headers=_auth(admin_token_tenant_a),
+                json={"title": "Renamed Event"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        service.send_event_updated.assert_awaited_once()
+        service.send_event_invitation.assert_not_awaited()
+        service.send_event_cancelled.assert_not_awaited()
+        context = service.send_event_updated.await_args.kwargs["context"]
+        # Title change must surface in the diff so the template can highlight
+        # the "Event:" row.
+        assert "event" in context.changes
+        assert context.changes["event"].after == "Renamed Event"
+
 
 class TestCancelAndDeleteDispatchCancel:
     """/cancel endpoint and DELETE both emit iTIP CANCEL with SEQUENCE+1."""
@@ -683,6 +751,30 @@ class TestCancelAndDeleteDispatchCancel:
         assert refreshed.ical_sequence == before_sequence + 1
         assert send_mock.await_count == 1
         assert send_mock.await_args.kwargs["method"] == "CANCEL"
+
+    def test_cancel_endpoint_routes_to_send_event_cancelled(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """/cancel → ``bump_and_dispatch_cancel`` → ``service.send_event_cancelled``."""
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        _invite(db, event, _make_human(db, tenant_a, email="cancelled@test.com"))
+
+        stack, service = _patch_email_service()
+        with stack:
+            resp = client.post(
+                f"/api/v1/events/{event.id}/cancel",
+                headers=_auth(admin_token_tenant_a),
+            )
+
+        assert resp.status_code == 200, resp.text
+        service.send_event_cancelled.assert_awaited_once()
+        service.send_event_invitation.assert_not_awaited()
+        service.send_event_updated.assert_not_awaited()
 
     def test_double_cancel_returns_400(
         self,


### PR DESCRIPTION
## Summary
Single feature shipping from dev → main: split event update and cancellation emails into dedicated templates so update and cancel mails stop going out as generic "You're invited" copy (latent bug after the `d2896c4b` revert).

Includes (#200):
- New `event/updated.html` template with before/after diff for title / time / location.
- New `event/cancelled.html` template (clean cancellation notice, no CTA).
- New `EventUpdatedContext` / `EventCancelledContext` Pydantic models and matching `send_event_updated` / `send_event_cancelled` service methods.
- `send_event_itip` now routes per `(method, is_update)` to the correct template.
- New `EVENT_UPDATED` / `EVENT_CANCELLED` entries in `EmailTemplateType` and `TEMPLATE_TYPE_METADATA` — both surface in the backoffice template editor with per-popup overrides.
- iTIP plumbing (`ical.py`, SEQUENCE bumping, UID stability) untouched; calendar update/cancel behaviour is regression-only.

## Test plan
- [x] `uv run pytest tests/test_event_itip.py -v` — 29/29 pass, with new routing assertions covering update + cancel paths.
- [x] Related suites pass (`test_email_template_contracts`, `test_event_participants`, `test_events_approval`, `test_tenant_login_email_templates`) — 41/41.
- [x] `ruff check` / `ruff format --check` clean on touched files; `ty check` introduces no new diagnostics.
- [ ] Manual mailpit pass post-deploy: invite → edit title/time/venue → cancel; confirm 3 distinct templates and that Gmail/Apple Mail patches the existing calendar entry on update and removes it on cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)