### PR TITLE
perf(backend): eliminate N+1 queries in list endpoints

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -80,6 +80,9 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 selectinload(Applications.attendees)  # type: ignore[arg-type]
                 .selectinload(Attendees.attendee_products)  # type: ignore[arg-type]
                 .selectinload(AttendeeProducts.product),  # type: ignore[arg-type]
+                selectinload(Applications.attendees).selectinload(  # type: ignore[arg-type]
+                    Attendees.category_ref  # type: ignore[arg-type]
+                ),
                 selectinload(Applications.human),  # type: ignore[arg-type]
             )
             .order_by(desc(Applications.created_at))  # type: ignore[arg-type]
@@ -139,6 +142,9 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 selectinload(Applications.attendees)  # type: ignore[arg-type]
                 .selectinload(Attendees.attendee_products)  # type: ignore[arg-type]
                 .selectinload(AttendeeProducts.product),  # type: ignore[arg-type]
+                selectinload(Applications.attendees).selectinload(  # type: ignore[arg-type]
+                    Attendees.category_ref  # type: ignore[arg-type]
+                ),
                 selectinload(Applications.human),  # type: ignore[arg-type]
             )
             .order_by(desc(Applications.created_at))  # type: ignore[arg-type]
@@ -173,6 +179,9 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 selectinload(Applications.attendees)  # type: ignore[arg-type]
                 .selectinload(Attendees.attendee_products)  # type: ignore[arg-type]
                 .selectinload(AttendeeProducts.product),  # type: ignore[arg-type]
+                selectinload(Applications.attendees).selectinload(  # type: ignore[arg-type]
+                    Attendees.category_ref  # type: ignore[arg-type]
+                ),
                 selectinload(Applications.human),  # type: ignore[arg-type]
             )
             .order_by(desc(Applications.created_at))  # type: ignore[arg-type]
@@ -244,6 +253,9 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 selectinload(Applications.attendees)  # type: ignore[arg-type]
                 .selectinload(Attendees.attendee_products)  # type: ignore[arg-type]
                 .selectinload(AttendeeProducts.product),  # type: ignore[arg-type]
+                selectinload(Applications.attendees).selectinload(  # type: ignore[arg-type]
+                    Attendees.category_ref  # type: ignore[arg-type]
+                ),
                 selectinload(Applications.human),  # type: ignore[arg-type]
             )
             .order_by(desc(Applications.created_at))  # type: ignore[arg-type]

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -491,7 +491,6 @@ async def get_my_application(
             ),
         },
     },
-
     dependencies=[needs("portal:applications:write")],
 )
 async def detach_companion(

--- a/backend/app/api/application_review/router.py
+++ b/backend/app/api/application_review/router.py
@@ -270,13 +270,12 @@ async def list_pending_reviews(
             limit=1000,
         )
 
-    pending_apps = []
-    for app in candidates:
-        existing_review = application_reviews_crud.get_by_application_reviewer(
-            db, app.id, current_user.id
+    reviewed_ids = set(
+        application_reviews_crud.get_decisions_by_reviewer_for_applications(
+            db, current_user.id, [c.id for c in candidates]
         )
-        if not existing_review:
-            pending_apps.append(app)
+    )
+    pending_apps = [a for a in candidates if a.id not in reviewed_ids]
 
     total = len(pending_apps)
     paginated = pending_apps[skip : skip + limit]

--- a/backend/app/api/attendee/crud.py
+++ b/backend/app/api/attendee/crud.py
@@ -77,7 +77,16 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.offset(skip).limit(limit)
+        statement = (
+            statement.options(
+                selectinload(Attendees.attendee_products).selectinload(  # type: ignore[arg-type]
+                    AttendeeProducts.product  # ty: ignore[invalid-argument-type]
+                ),
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
+            )
+            .offset(skip)
+            .limit(limit)
+        )
         results = list(session.exec(statement).all())
 
         return results, total
@@ -115,6 +124,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                     AttendeeProducts.product  # ty: ignore[invalid-argument-type]
                 ),
                 selectinload(Attendees.application),  # type: ignore[arg-type]
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
             )
             .offset(skip)
             .limit(limit)
@@ -339,6 +349,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                     Applications.popup  # ty: ignore[invalid-argument-type]
                 ),
                 selectinload(Attendees.popup),  # type: ignore[arg-type]
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
             )
             .offset(skip)
             .limit(limit)
@@ -376,6 +387,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                 selectinload(Attendees.attendee_products).selectinload(  # type: ignore[arg-type]
                     AttendeeProducts.product  # ty: ignore[invalid-argument-type]
                 ),
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
             )
             .limit(1)
         )
@@ -449,6 +461,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                     AttendeeProducts.product  # ty: ignore[invalid-argument-type]
                 ),
                 selectinload(Attendees.payment_products),  # type: ignore[arg-type]
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
             )
             .offset(skip)
             .limit(limit)
@@ -477,6 +490,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                 selectinload(Attendees.attendee_products).selectinload(  # type: ignore[arg-type]
                     AttendeeProducts.product  # ty: ignore[invalid-argument-type]
                 ),
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
             )
         )
         return list(session.exec(statement).all())

--- a/backend/app/api/attendee/models.py
+++ b/backend/app/api/attendee/models.py
@@ -10,6 +10,7 @@ from app.api.attendee.schemas import AttendeeBase, AttendeeProductsBase
 
 if TYPE_CHECKING:
     from app.api.application.models import Applications
+    from app.api.attendee_category.models import AttendeeCategories
     from app.api.human.models import Humans
     from app.api.payment.models import PaymentProducts
     from app.api.popup.models import Popups
@@ -72,32 +73,22 @@ class Attendees(AttendeeBase, table=True):
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )
     payment_products: list["PaymentProducts"] = Relationship(back_populates="attendee")
+    category_ref: Optional["AttendeeCategories"] = Relationship(
+        sa_relationship_kwargs={"foreign_keys": "Attendees.category_id"},
+    )
 
     @property
     def category(self) -> str:
         """Backwards-compat accessor: return the category key from the FK relationship.
 
-        Reads category_id → AttendeeCategories.key if the relationship is
-        loaded. Falls back to "main" when the relationship is not loaded or
-        the category is missing (direct-sale attendee without a category).
+        Listing endpoints must eager-load `category_ref` (selectinload) so this
+        access does not trigger an extra query per attendee. When the
+        relationship is not loaded SQLAlchemy lazy-loads it via the bound
+        session, mirroring the pre-relationship behaviour.
         """
-        from app.api.attendee_category.models import (
-            AttendeeCategories as ACModel,  # noqa: PLC0415
-        )
-
         if self.category_id is None:
             return "main"
-        # If SQLAlchemy has already resolved the relationship, read from it.
-        # This avoids an extra query when the session is not available.
-        # AttendeeCategories is accessed via the FK — note: this is a lazy
-        # lookup that requires a live session. For schemas that need the full
-        # nested object, use the category_id FK directly via relationship.
-        from sqlalchemy.orm import object_session  # noqa: PLC0415
-
-        sess = object_session(self)
-        if sess is None:
-            return "unknown"
-        cat = sess.get(ACModel, self.category_id)
+        cat = self.category_ref
         return cat.key if cat else "unknown"
 
     @property

--- a/backend/app/api/event_venue/crud.py
+++ b/backend/app/api/event_venue/crud.py
@@ -1,10 +1,21 @@
 import uuid
+from typing import Any
 
-from sqlmodel import Session, col, func, select
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, col, func, or_, select
 
 from app.api.event_venue.models import EventVenues
 from app.api.event_venue.schemas import EventVenueCreate, EventVenueUpdate
 from app.api.shared.crud import BaseCRUD
+
+
+def _eager_load_options() -> tuple:
+    """Relationships fetched alongside every EventVenues list query.
+
+    EventVenuePublic includes weekly_hours, so without eager loading every
+    listing endpoint issues one SELECT per venue (Sentry N+1 alert).
+    """
+    return (selectinload(EventVenues.weekly_hours),)  # type: ignore[arg-type]
 
 
 class EventVenuesCRUD(BaseCRUD[EventVenues, EventVenueCreate, EventVenueUpdate]):
@@ -33,8 +44,49 @@ class EventVenuesCRUD(BaseCRUD[EventVenues, EventVenueCreate, EventVenueUpdate])
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.order_by(EventVenues.display_order, EventVenues.title)
-        statement = statement.offset(skip).limit(limit)
+        statement = (
+            statement.options(*_eager_load_options())
+            .order_by(EventVenues.display_order, EventVenues.title)
+            .offset(skip)
+            .limit(limit)
+        )
+        results = list(session.exec(statement).all())
+
+        return results, total
+
+    def find(
+        self,
+        session: Session,
+        skip: int = 0,
+        limit: int = 100,
+        search: str | None = None,
+        search_fields: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+        **filters: Any,
+    ) -> tuple[list[EventVenues], int]:
+        """Override BaseCRUD.find to eager-load weekly_hours."""
+        statement = select(EventVenues)
+
+        for field, value in filters.items():
+            if value is not None:
+                statement = statement.where(getattr(EventVenues, field) == value)
+
+        if search and search_fields:
+            term = f"%{search}%"
+            search_conditions = [
+                getattr(EventVenues, field).ilike(term)
+                for field in search_fields
+                if hasattr(EventVenues, field)
+            ]
+            if search_conditions:
+                statement = statement.where(or_(*search_conditions))
+
+        count_statement = select(func.count()).select_from(statement.subquery())
+        total = session.exec(count_statement).one()
+
+        statement = self._apply_sorting(statement, sort_by, sort_order)
+        statement = statement.options(*_eager_load_options()).offset(skip).limit(limit)
         results = list(session.exec(statement).all())
 
         return results, total

--- a/backend/app/api/group/crud.py
+++ b/backend/app/api/group/crud.py
@@ -1,10 +1,11 @@
 import secrets
 import uuid
+from typing import Any
 
 from fastapi import HTTPException, status
 from sqlalchemy import desc
 from sqlalchemy.orm import selectinload
-from sqlmodel import Session, col, func, select
+from sqlmodel import Session, col, func, or_, select
 
 from app.api.group.models import (
     GroupLeaders,
@@ -19,6 +20,15 @@ from app.api.shared.crud import BaseCRUD
 def generate_random_slug() -> str:
     """Generate a random hex string for slug (8 characters)."""
     return secrets.token_hex(4)
+
+
+def _list_eager_load() -> tuple:
+    """Relationships fetched alongside every Groups list query.
+
+    GroupPublic exposes whitelisted_emails — without eager loading each row in
+    the list triggers a SELECT against group_whitelisted_emails.
+    """
+    return (selectinload(Groups.whitelisted_emails),)  # type: ignore[arg-type]
 
 
 class GroupsCRUD(BaseCRUD[Groups, GroupCreate, GroupUpdate]):
@@ -82,8 +92,12 @@ class GroupsCRUD(BaseCRUD[Groups, GroupCreate, GroupUpdate]):
         total = session.exec(count_statement).one()
 
         # Apply pagination and ordering
-        statement = statement.order_by(desc(Groups.created_at))  # type: ignore[arg-type]
-        statement = statement.offset(skip).limit(limit)
+        statement = (
+            statement.options(*_list_eager_load())
+            .order_by(desc(Groups.created_at))  # type: ignore[arg-type]
+            .offset(skip)
+            .limit(limit)
+        )
         results = list(session.exec(statement).all())
 
         return results, total
@@ -107,8 +121,49 @@ class GroupsCRUD(BaseCRUD[Groups, GroupCreate, GroupUpdate]):
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.order_by(desc(Groups.created_at))  # type: ignore[arg-type]
-        statement = statement.offset(skip).limit(limit)
+        statement = (
+            statement.options(*_list_eager_load())
+            .order_by(desc(Groups.created_at))  # type: ignore[arg-type]
+            .offset(skip)
+            .limit(limit)
+        )
+        results = list(session.exec(statement).all())
+
+        return results, total
+
+    def find(
+        self,
+        session: Session,
+        skip: int = 0,
+        limit: int = 100,
+        search: str | None = None,
+        search_fields: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+        **filters: Any,
+    ) -> tuple[list[Groups], int]:
+        """Override BaseCRUD.find to eager-load whitelisted_emails."""
+        statement = select(Groups)
+
+        for field, value in filters.items():
+            if value is not None:
+                statement = statement.where(getattr(Groups, field) == value)
+
+        if search and search_fields:
+            term = f"%{search}%"
+            search_conditions = [
+                getattr(Groups, field).ilike(term)
+                for field in search_fields
+                if hasattr(Groups, field)
+            ]
+            if search_conditions:
+                statement = statement.where(or_(*search_conditions))
+
+        count_statement = select(func.count()).select_from(statement.subquery())
+        total = session.exec(count_statement).one()
+
+        statement = self._apply_sorting(statement, sort_by, sort_order)
+        statement = statement.options(*_list_eager_load()).offset(skip).limit(limit)
         results = list(session.exec(statement).all())
 
         return results, total

--- a/backend/app/api/popup_reviewer/router.py
+++ b/backend/app/api/popup_reviewer/router.py
@@ -1,7 +1,8 @@
 import uuid
 
 from fastapi import APIRouter, HTTPException, status
-from sqlmodel import Session
+from sqlalchemy import Column
+from sqlmodel import Session, select
 
 from app.api.popup_reviewer.crud import popup_reviewers_crud
 from app.api.popup_reviewer.models import PopupReviewers
@@ -12,6 +13,7 @@ from app.api.popup_reviewer.schemas import (
 )
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
+from app.api.user.models import Users
 from app.core.dependencies.users import (
     CurrentAdmin,
     CurrentWriter,
@@ -23,14 +25,10 @@ router = APIRouter(prefix="/popups", tags=["popup-reviewers"])
 
 
 def _reviewer_to_public(
-    reviewer: PopupReviewers, session: Session
+    reviewer: PopupReviewers,
+    user: Users | None,
 ) -> PopupReviewerPublic:
-    """Convert reviewer to public schema with user details."""
-    from app.api.user.crud import users_crud
-
-    # Fetch user details from main session (not tenant session)
-    user = users_crud.get(session, reviewer.user_id)
-
+    """Convert reviewer to public schema with pre-fetched user details."""
     return PopupReviewerPublic(
         id=reviewer.id,
         popup_id=reviewer.popup_id,
@@ -42,6 +40,20 @@ def _reviewer_to_public(
         user_email=user.email if user else None,
         user_full_name=user.full_name if user else None,
     )
+
+
+def _fetch_users_by_ids(
+    session: Session, user_ids: list[uuid.UUID]
+) -> dict[uuid.UUID, Users]:
+    """Fetch users by id in a single query, returning a {user_id: user} map.
+
+    Users table is not tenant-scoped — use the main session.
+    """
+    if not user_ids:
+        return {}
+    id_col: Column = Users.id  # ty:ignore[invalid-assignment]
+    statement = select(Users).where(id_col.in_(user_ids))
+    return {u.id: u for u in session.exec(statement).all()}
 
 
 @router.get("/{popup_id}/reviewers", response_model=ListModel[PopupReviewerPublic])
@@ -66,8 +78,10 @@ async def list_reviewers(
 
     reviewers, total = popup_reviewers_crud.find_by_popup(db, popup_id, skip, limit)
 
+    users_by_id = _fetch_users_by_ids(session, [r.user_id for r in reviewers])
+
     return ListModel[PopupReviewerPublic](
-        results=[_reviewer_to_public(r, session) for r in reviewers],
+        results=[_reviewer_to_public(r, users_by_id.get(r.user_id)) for r in reviewers],
         paging=Paging(offset=skip, limit=limit, total=total),
     )
 
@@ -129,7 +143,7 @@ async def add_reviewer(
         db, popup_id, popup.tenant_id, reviewer_in
     )
 
-    return _reviewer_to_public(reviewer, session)
+    return _reviewer_to_public(reviewer, user)
 
 
 @router.patch("/{popup_id}/reviewers/{user_id}", response_model=PopupReviewerPublic)
@@ -143,6 +157,7 @@ async def update_reviewer(
 ) -> PopupReviewerPublic:
     """Update a reviewer's settings."""
     from app.api.popup.crud import popups_crud
+    from app.api.user.crud import users_crud
 
     # Verify popup exists
     popup = popups_crud.get(db, popup_id)
@@ -160,7 +175,8 @@ async def update_reviewer(
         )
 
     reviewer = popup_reviewers_crud.update(db, reviewer, reviewer_in)
-    return _reviewer_to_public(reviewer, session)
+    user = users_crud.get(session, reviewer.user_id)
+    return _reviewer_to_public(reviewer, user)
 
 
 @router.delete(

--- a/backend/tests/api/product/test_enforcement_wiring.py
+++ b/backend/tests/api/product/test_enforcement_wiring.py
@@ -24,7 +24,7 @@ from decimal import Decimal
 
 import pytest
 from fastapi import HTTPException
-from sqlmodel import Session, select
+from sqlmodel import Session
 
 from app.api.application.models import Applications
 from app.api.attendee.crud import attendees_crud
@@ -92,34 +92,34 @@ def _get_or_create_application(
     tenant: Tenants,
     popup: Popups,
 ) -> Applications:
-    """Get an existing application or create one for tests."""
-    app = db.exec(
-        select(Applications).where(
-            Applications.tenant_id == tenant.id,
-            Applications.popup_id == popup.id,
-        )
-    ).first()
-    if app is None:
-        from app.api.human.models import Humans
-        human = Humans(
-            tenant_id=tenant.id,
-            email=f"enf-human-{uuid.uuid4().hex[:8]}@test.com",
-            first_name="Enf",
-            last_name="Test",
-        )
-        db.add(human)
-        db.flush()
-        from app.api.application.schemas import ApplicationStatus
+    """Create a fresh ACCEPTED application for tests.
 
-        app = Applications(
-            tenant_id=tenant.id,
-            popup_id=popup.id,
-            human_id=human.id,
-            status=ApplicationStatus.ACCEPTED.value,
-        )
-        db.add(app)
-        db.commit()
-        db.refresh(app)
+    Always creates a new (human, application) pair so prior tests that mutate
+    application status (e.g. via the approval calculator) cannot leak into the
+    enforcement assertions. The Applications uniqueness constraint is on
+    (human_id, popup_id), which a fresh human per call satisfies.
+    """
+    from app.api.application.schemas import ApplicationStatus
+    from app.api.human.models import Humans
+
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"enf-human-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Enf",
+        last_name="Test",
+    )
+    db.add(human)
+    db.flush()
+
+    app = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
     return app
 
 
@@ -139,7 +139,9 @@ class TestAddProductEnforcement:
     ) -> None:
         """add_product on product with total_stock_remaining=0 → 409."""
         product = _make_product(
-            db, tenant_a, popup_tenant_a,
+            db,
+            tenant_a,
+            popup_tenant_a,
             total_stock_cap=1,
             total_stock_remaining=0,
         )
@@ -158,7 +160,9 @@ class TestAddProductEnforcement:
     ) -> None:
         """add_product call decrements 1 unit of total_stock_remaining."""
         product = _make_product(
-            db, tenant_a, popup_tenant_a,
+            db,
+            tenant_a,
+            popup_tenant_a,
             total_stock_cap=5,
             total_stock_remaining=5,
         )
@@ -183,7 +187,9 @@ class TestAddProductEnforcement:
     ) -> None:
         """add_product with NULL stock (unlimited) → succeeds without decrement."""
         product = _make_product(
-            db, tenant_a, popup_tenant_a,
+            db,
+            tenant_a,
+            popup_tenant_a,
             total_stock_cap=None,
             total_stock_remaining=None,
         )
@@ -247,7 +253,9 @@ class TestAddProductEnforcement:
         from sqlmodel import Session as SyncSession
 
         product = _make_product(
-            db, tenant_a, popup_tenant_a,
+            db,
+            tenant_a,
+            popup_tenant_a,
             total_stock_cap=1,
             total_stock_remaining=1,
         )
@@ -347,7 +355,6 @@ def _make_ot_product(
     max_per_order: int | None = None,
     price: str = "100.00",
 ) -> Products:
-
     product = Products(
         tenant_id=popup.tenant_id,
         popup_id=popup.id,
@@ -402,7 +409,8 @@ class TestOpenTicketingPaymentEnforcement:
 
         popup = _make_ot_popup(db, tenant_a)
         product = _make_ot_product(
-            db, popup,
+            db,
+            popup,
             total_stock_cap=1,
             total_stock_remaining=0,
         )
@@ -429,7 +437,8 @@ class TestOpenTicketingPaymentEnforcement:
 
         popup = _make_ot_popup(db, tenant_a)
         product = _make_ot_product(
-            db, popup,
+            db,
+            popup,
             total_stock_cap=10,
             total_stock_remaining=10,
         )
@@ -464,7 +473,8 @@ class TestOpenTicketingPaymentEnforcement:
 
         popup = _make_ot_popup(db, tenant_a)
         product = _make_ot_product(
-            db, popup,
+            db,
+            popup,
             total_stock_cap=None,
             total_stock_remaining=None,
         )
@@ -497,7 +507,8 @@ class TestOpenTicketingPaymentEnforcement:
 
         popup = _make_ot_popup(db, tenant_a)
         product = _make_ot_product(
-            db, popup,
+            db,
+            popup,
             total_stock_cap=100,
             total_stock_remaining=100,
             max_per_order=2,
@@ -525,7 +536,8 @@ class TestOpenTicketingPaymentEnforcement:
 
         popup = _make_ot_popup(db, tenant_a)
         product = _make_ot_product(
-            db, popup,
+            db,
+            popup,
             total_stock_cap=1,
             total_stock_remaining=1,
         )
@@ -542,8 +554,12 @@ class TestOpenTicketingPaymentEnforcement:
                 checkout_url="https://simplefi.test/checkout/conc",
             )
             with SyncSession(test_engine) as session:
-                with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
-                    mock_get_client.return_value.create_payment.return_value = simplefi_response
+                with patch(
+                    "app.services.simplefi.get_simplefi_client"
+                ) as mock_get_client:
+                    mock_get_client.return_value.create_payment.return_value = (
+                        simplefi_response
+                    )
                     try:
                         payments_crud.create_open_ticketing_payment(
                             session, obj=obj, popup=popup, tenant=tenant_a
@@ -590,7 +606,9 @@ class TestCreatePaymentEnforcement:
         from app.api.payment.schemas import PaymentCreate, PaymentProductRequest
 
         product = _make_product(
-            db, tenant_a, popup_tenant_a,
+            db,
+            tenant_a,
+            popup_tenant_a,
             total_stock_cap=1,
             total_stock_remaining=0,
         )
@@ -624,7 +642,9 @@ class TestCreatePaymentEnforcement:
         from app.api.payment.schemas import PaymentCreate, PaymentProductRequest
 
         product = _make_product(
-            db, tenant_a, popup_tenant_a,
+            db,
+            tenant_a,
+            popup_tenant_a,
             total_stock_cap=100,
             total_stock_remaining=100,
             max_per_order=2,


### PR DESCRIPTION
## Summary

Fixes seven N+1 query patterns flagged by Sentry across the most-trafficked list endpoints, plus a flaky payment-enforcement test exposed while validating the changes.

## N+1 Fixes

| Endpoint | Root cause | Fix |
|---|---|---|
| `GET /attendees`, `GET /applications`, `GET /applications/my/directory/{popup_id}` | `Attendees.category` was a `@property` doing `session.get(AttendeeCategories, self.category_id)` per row | Added `category_ref` Relationship and chained `selectinload(Attendees.category_ref)` in attendee/application listing CRUDs |
| `GET /applications/pending-review` | Per-application `get_by_application_reviewer` inside the candidate loop | Single batch lookup via `get_decisions_by_reviewer_for_applications` |
| `GET /popups/{popup_id}/reviewers` | `users_crud.get` per reviewer to hydrate user details | Batched fetch into a `{user_id: Users}` map before rendering |
| `GET /event-venues` | `EventVenuePublic.weekly_hours` lazy-loaded per venue | `selectinload(EventVenues.weekly_hours)` added to `find_by_popup` and an overridden `find()` |
| `GET /groups`, `GET /groups/my/groups` | `GroupPublic.whitelisted_emails` lazy-loaded per group | `selectinload(Groups.whitelisted_emails)` added to `find_by_popup`, `find_by_leader`, and an overridden `find()` |

## Test Fix

`TestCreatePaymentEnforcement::test_sold_out_product_raises_409` and `test_max_per_order_exceeded_raises_422` were intermittently failing with a 403 \"Application must be accepted\" instead of the expected 409/422. The `_get_or_create_application` helper reused a session-scoped (tenant_a, popup_tenant_a) Application whose status had been mutated by earlier tests. The helper now always creates a fresh ACCEPTED application with a unique human, so the enforcement assertions are deterministic.

## Files Changed

| File | Change |
|------|--------|
| `backend/app/api/attendee/models.py` | New `category_ref` Relationship; `category` property now reads from it |
| `backend/app/api/attendee/crud.py` | Added `selectinload(Attendees.category_ref)` to six listing methods |
| `backend/app/api/application/crud.py` | Chained `Applications.attendees → Attendees.category_ref` in four listing methods |
| `backend/app/api/application/router.py` | Whitespace only (ruff format) |
| `backend/app/api/application_review/router.py` | Replaced per-candidate review lookup with batch query |
| `backend/app/api/event_venue/crud.py` | Added `weekly_hours` eager loading and overrode `find()` |
| `backend/app/api/group/crud.py` | Added `whitelisted_emails` eager loading and overrode `find()` |
| `backend/app/api/popup_reviewer/router.py` | Batched users fetch; `_reviewer_to_public` now takes a pre-fetched user |
| `backend/tests/api/product/test_enforcement_wiring.py` | `_get_or_create_application` always creates a fresh application |

## Test Plan

- [x] \`uv run ruff check app/\` passes
- [x] \`uv run ruff format --check\` passes on all modified files
- [x] \`uv run pytest tests/\`: 1191 passed, 8 skipped (zero failures — the two formerly-flaky enforcement tests now pass deterministically)
- [x] \`alembic heads\`: single head (no migration needed; the new relationship reuses the existing `category_id` FK)