### PR TITLE
fix(jobs): bootstrap SQLAlchemy registry in standalone job entrypoints

### DIFF
--- a/backend/app/jobs/__init__.py
+++ b/backend/app/jobs/__init__.py
@@ -1,0 +1,12 @@
+"""Standalone job entrypoints invoked by external schedulers.
+
+Importing ``app.models`` here is a deliberate side-effect: it pulls every
+``SQLModel`` table class into the registry so SQLAlchemy can resolve
+relationship targets that are referenced by string name (e.g. a popup
+relationship pointing at ``"FormFields"``). The HTTP service inherits this
+implicitly via the FastAPI app's import chain; job modules don't, so they
+must opt in here. Without this import the first ORM query against ``Popups``
+fails with ``InvalidRequestError: expression 'FormFields' failed to locate``.
+"""
+
+import app.models  # noqa: F401  (side-effect import: register all mappers)


### PR DESCRIPTION
Caught during the dev smoke run of \`edgeos-dev-checkin-pass-dispatch\`. The task ran but failed with:

\`\`\`
sqlalchemy.exc.InvalidRequestError: When initializing mapper Mapper[Popups(popups)],
expression 'FormFields' failed to locate a name ('FormFields').
\`\`\`

## Root cause

The HTTP service never hit this because FastAPI's import chain pulls in the full models barrel (\`app.models\`), so every \`SQLModel\` table class is registered by the time any ORM query runs. Standalone jobs invoked via \`python -m app.jobs.<name>\` don't traverse that chain - they import only what's on the dispatcher's path. So the mapper for \`Popups\` could not resolve relationships referenced by string name (e.g. \`"FormFields"\`).

## Fix

Side-effect-import \`app.models\` in \`app/jobs/__init__.py\` so every job module inherits a fully configured registry without having to remember to import it themselves.

## Test plan

- [x] \`uv run pytest tests/test_checkin_pass_dispatch.py tests/test_check_in_pass_template.py tests/test_checkin_qr.py tests/test_popup_checkin_pass_lead_days.py\` - 20/20 green
- [x] \`uv run ruff check app/jobs\` - clean
- [ ] After this merges and a new image lands on ECR, re-run \`edgeos-dev-checkin-pass-dispatch\` and confirm exit code 0