### PR TITLE
fix(humans): drop deleted human's cached queries before invalidating list

### DIFF
--- a/backoffice/src/routes/_layout/humans/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/humans/$id.edit.tsx
@@ -44,7 +44,10 @@ function EditHumanContent({ humanId }: { humanId: string }) {
     mutationFn: () => HumansService.deleteHuman({ humanId }),
     onSuccess: () => {
       showSuccessToast("Human deleted")
-      queryClient.invalidateQueries({ queryKey: ["humans"] })
+      // Drop cached detail + api-keys subqueries first so the list invalidation
+      // below doesn't refetch the now-deleted human and 404.
+      queryClient.removeQueries({ queryKey: ["humans", humanId] })
+      queryClient.invalidateQueries({ queryKey: ["humans"], exact: true })
       navigate(getHumansNavigationTarget())
     },
     onError: createErrorHandler(showErrorToast),


### PR DESCRIPTION
## Summary
After deleting a Human via the new superadmin DELETE endpoint, the broad `invalidateQueries({ queryKey: ["humans"] })` prefix-matched three keys: the list (`["humans"]`), the detail (`["humans", humanId]`), and the api-keys subquery (`["humans", humanId, "api-keys"]`). The detail and api-keys queries were still mounted while React navigated away, so React Query refetched them and both returned 404 — harmless but ugly in Network and confusing to anyone watching.

Fix: remove the deleted human's entire subtree from cache first, then invalidate just the list query (`exact: true`).

## Why
Reported on dev after the first successful delete — two stale 404 requests showing up in DevTools Network. No functional impact (the row IS gone), purely a cache-hygiene fix.

## Test plan
- [ ] Delete a human in dev → Network tab shows only the DELETE (200), no follow-up 404s on `/humans/{id}` or `/humans/{id}/api-keys`.
- [ ] List view refreshes and the row disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)