### PR TITLE
feat(attendees): ticket filter + event email timezone fix

### DIFF
--- a/backend/app/api/attendee/crud.py
+++ b/backend/app/api/attendee/crud.py
@@ -99,12 +99,18 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
         skip: int = 0,
         limit: int = 100,
         search: str | None = None,
+        has_tickets: bool | None = None,
     ) -> tuple[list[Attendees], int]:
         """Find attendees by popup_id with eager loading.
 
         Queries directly on Attendees.popup_id (denormalized). Covers both
         application-based attendees (popup_id backfilled from application)
         and direct-sale attendees (popup_id set at creation, no application).
+
+        has_tickets filters by whether the attendee owns at least one
+        AttendeeProducts row (a purchased/granted ticket): True keeps only
+        attendees with tickets, False only those without, None disables the
+        filter. Uses a correlated EXISTS so it does not multiply rows.
         """
         base_statement = select(Attendees).where(Attendees.popup_id == popup_id)
 
@@ -112,6 +118,16 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
             search_term = f"%{search}%"
             base_statement = base_statement.where(
                 Attendees.name.ilike(search_term) | Attendees.email.ilike(search_term)  # type: ignore[union-attr]
+            )
+
+        if has_tickets is not None:
+            ticket_exists = (
+                select(AttendeeProducts.id)
+                .where(AttendeeProducts.attendee_id == Attendees.id)
+                .exists()
+            )
+            base_statement = base_statement.where(
+                ticket_exists if has_tickets else ~ticket_exists
             )
 
         # Use proper count query instead of fetching all rows

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -410,6 +410,7 @@ async def list_attendees(
     popup_id: uuid.UUID | None = None,
     email: str | None = None,
     search: str | None = None,
+    has_tickets: bool | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[AttendeeListItem]:
@@ -418,6 +419,9 @@ async def list_attendees(
     Returns AttendeeListItem (ProductWithQuantity shape) for compatibility with
     the existing BO list view. Use GET /attendees/{id} for the full
     AttendeePublic shape with typed AttendeeProductPublic tickets.
+
+    has_tickets (only honored on the popup_id path) keeps attendees with at
+    least one purchased/granted ticket when True, those without when False.
     """
     if application_id:
         attendees = crud.attendees_crud.find_by_application(db, application_id)
@@ -425,7 +429,12 @@ async def list_attendees(
         attendees = attendees[skip : skip + limit]
     elif popup_id:
         attendees, total = crud.attendees_crud.find_by_popup(
-            db, popup_id=popup_id, skip=skip, limit=limit, search=search
+            db,
+            popup_id=popup_id,
+            skip=skip,
+            limit=limit,
+            search=search,
+            has_tickets=has_tickets,
         )
     elif email:
         attendees, total = crud.attendees_crud.find_by_email(

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -47,6 +47,7 @@ from app.core.dependencies.users import (
     SessionDep,
 )
 from app.core.rate_limit import RateLimit
+from app.services.event_datetime import format_event_when
 from app.services.event_itip import (
     bump_and_dispatch_cancel as _bump_and_dispatch_itip_cancel,
 )
@@ -1751,7 +1752,9 @@ async def _send_event_approval_email(
         portal_base = get_portal_url(popup.tenant)
         event_url = f"{portal_base.rstrip('/')}/portal/{popup_slug}/events/{event.id}"
 
-    when = event.start_time.strftime("%b %d, %Y at %H:%M") if event.start_time else ""
+    when = (
+        format_event_when(event.start_time, event.timezone) if event.start_time else ""
+    )
 
     service = get_email_service()
     from_address = popup.tenant.sender_email if popup and popup.tenant else None

--- a/backend/app/services/approval_notify.py
+++ b/backend/app/services/approval_notify.py
@@ -14,6 +14,7 @@ from loguru import logger
 
 from app.core.config import settings as app_settings
 from app.services.email import get_email_service
+from app.services.event_datetime import format_event_when_range
 
 if TYPE_CHECKING:
     from app.api.event.models import Events
@@ -70,8 +71,9 @@ async def notify_event_pending_approval(
         f"<p>A new event has been submitted and is pending approval.</p>"
         f"<ul>"
         f"<li><b>Title:</b> {event.title}</li>"
-        f"<li><b>When:</b> {event.start_time.isoformat()} "
-        f"→ {event.end_time.isoformat()}</li>"
+        f"<li><b>When:</b> "
+        f"{format_event_when_range(event.start_time, event.end_time, event.timezone)}"
+        f"</li>"
         f"<li><b>Reason:</b> {reason}</li>"
         f"<li><b>Event ID:</b> {event.id}</li>"
         f"</ul>"

--- a/backend/app/services/event_datetime.py
+++ b/backend/app/services/event_datetime.py
@@ -1,0 +1,89 @@
+"""Timezone-aware, locale-stable datetime formatting for event emails.
+
+Event datetimes are stored as UTC instants. Email bodies must show the
+*event's* local wall-clock time (e.g. ``Jun 07, 2026 at 18:00 PDT``), not
+UTC, so we convert with the event's IANA ``timezone`` before formatting.
+The ``.ics`` attachment stays UTC per RFC 5545 — only the human-readable
+text is localized here.
+
+``strftime`` codes ``%a``/``%b`` are locale-dependent (notably on Windows
+hosts), so weekday/month names come from fixed English arrays to keep the
+output identical across hosts.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_MONTHS = (
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+)
+
+_PLACEHOLDER = "—"
+
+
+def _to_local(dt: datetime, timezone: str | None) -> datetime:
+    """Convert a UTC instant to the event's local tz.
+
+    Naive datetimes are treated as UTC; unknown IANA names fall back to
+    UTC so a bad ``timezone`` column never raises.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    try:
+        tz = ZoneInfo(timezone or "UTC")
+    except ZoneInfoNotFoundError:
+        tz = UTC
+    return dt.astimezone(tz)
+
+
+def format_event_when(dt: datetime | None, timezone: str | None) -> str:
+    """Render a single instant as ``"Jun 07, 2026 at 18:00 PDT"``.
+
+    ``dt`` is a UTC instant; ``timezone`` an IANA name (e.g.
+    ``America/Los_Angeles``). Returns ``"—"`` when ``dt`` is missing.
+    """
+    if not dt:
+        return _PLACEHOLDER
+    local = _to_local(dt, timezone)
+    month = _MONTHS[local.month - 1]
+    abbr = local.tzname() or ""
+    base = f"{month} {local.day:02d}, {local.year} at {local.strftime('%H:%M')}"
+    return f"{base} {abbr}".rstrip()
+
+
+def format_event_when_range(
+    start: datetime | None,
+    end: datetime | None,
+    timezone: str | None,
+) -> str:
+    """Render a start–end range in the event's local tz.
+
+    Falls back to start-only when ``end`` is missing or equal to start.
+    When both bounds land on the same local date, only the end time is
+    shown after the dash (``"Jun 07, 2026 at 18:00 PDT – 19:00"``);
+    otherwise the full ``"<start> – <end>"`` form is used. Both bounds are
+    localized first so the range never mixes zones.
+    """
+    if not start:
+        return _PLACEHOLDER
+    start_str = format_event_when(start, timezone)
+    if not end or end == start:
+        return start_str
+    local_start = _to_local(start, timezone)
+    local_end = _to_local(end, timezone)
+    if local_end.date() == local_start.date():
+        return f"{start_str} – {local_end.strftime('%H:%M')}"
+    return f"{start_str} – {format_event_when(end, timezone)}"

--- a/backend/app/services/event_itip.py
+++ b/backend/app/services/event_itip.py
@@ -20,6 +20,7 @@ from app.services.email import (
     get_email_service,
 )
 from app.services.email.templates import EventChangeRow
+from app.services.event_datetime import format_event_when, format_event_when_range
 from app.services.ical import build_event_ics
 
 
@@ -193,14 +194,19 @@ async def send_event_itip(
         if recipient_occurrence and event.start_time and event.end_time:
             # For one occurrence of a recurring series, mirror what the ICS
             # does: shift the master duration onto the occurrence start.
+            # The occurrence instant is UTC; the master's tz localizes it.
             duration = event.end_time - event.start_time
-            when = _format_time_range(
-                recipient_occurrence, recipient_occurrence + duration
+            when = format_event_when_range(
+                recipient_occurrence,
+                recipient_occurrence + duration,
+                event.timezone,
             )
         elif recipient_occurrence:
-            when = _format_when(recipient_occurrence)
+            when = format_event_when(recipient_occurrence, event.timezone)
         else:
-            when = _format_time_range(event.start_time, event.end_time)
+            when = format_event_when_range(
+                event.start_time, event.end_time, event.timezone
+            )
         try:
             ics_body = build_event_ics(
                 event,
@@ -312,27 +318,6 @@ async def bump_and_dispatch_update(
     )
 
 
-def _format_when(dt: datetime | None) -> str:
-    return dt.strftime("%b %d, %Y at %H:%M") if dt else "—"
-
-
-def _format_time_range(start: datetime | None, end: datetime | None) -> str:
-    """Render a "Mon, May 5, 2026 at 14:00 – 15:00" style time range.
-
-    Falls back to start-only when end is missing or equal to start, and
-    expands to a full "<start> – <end-date end-time>" form when the event
-    spans multiple days.
-    """
-    if not start:
-        return "—"
-    start_str = _format_when(start)
-    if not end or end == start:
-        return start_str
-    if end.date() == start.date():
-        return f"{start_str} – {end.strftime('%H:%M')}"
-    return f"{start_str} – {_format_when(end)}"
-
-
 def _venue_name(db, venue_id) -> str:
     if venue_id is None:
         return "—"
@@ -371,9 +356,10 @@ def summarize_event_changes(db, before: dict, after) -> dict[str, dict[str, str]
         new_start = getattr(after, "start_time", None)
         new_end = getattr(after, "end_time", None)
         if old_start != new_start or old_end != new_end:
+            tz = getattr(after, "timezone", None)
             changes["time"] = {
-                "before": _format_time_range(old_start, old_end),
-                "after": _format_time_range(new_start, new_end),
+                "before": format_event_when_range(old_start, old_end, tz),
+                "after": format_event_when_range(new_start, new_end, tz),
             }
 
     if "venue_id" in before:

--- a/backend/tests/api/attendee/test_find_by_popup_has_tickets.py
+++ b/backend/tests/api/attendee/test_find_by_popup_has_tickets.py
@@ -1,0 +1,145 @@
+"""Tests for AttendeesCRUD.find_by_popup has_tickets filter.
+
+has_tickets keeps only attendees with at least one AttendeeProducts row when
+True, only those without when False, and disables the filter when None. The
+filter must not multiply rows (correlated EXISTS) nor break the total count.
+
+Each test creates a fresh popup so it is isolated from the session-scoped
+shared fixtures (db / popup_tenant_a have no per-test rollback).
+"""
+
+import uuid
+from decimal import Decimal
+
+from sqlmodel import Session
+
+from app.api.attendee.crud import attendees_crud
+from app.api.attendee.models import AttendeeProducts, Attendees
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.tenant.models import Tenants
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name="HasTickets Popup",
+        slug=f"has-tickets-popup-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_attendee(
+    db: Session, tenant: Tenants, popup: Popups, *, name: str
+) -> Attendees:
+    attendee = Attendees(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=name,
+        category="main",
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+    return attendee
+
+
+def _make_product(db: Session, tenant: Tenants, popup: Popups) -> Products:
+    product = Products(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"HasTickets Product {uuid.uuid4().hex[:6]}",
+        slug=f"has-tickets-prod-{uuid.uuid4().hex[:6]}",
+        price=Decimal("10"),
+        category="ticket",
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _give_ticket(
+    db: Session, tenant: Tenants, attendee: Attendees, product: Products
+) -> AttendeeProducts:
+    ticket = AttendeeProducts(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        attendee_id=attendee.id,
+        product_id=product.id,
+        check_in_code=f"HT{uuid.uuid4().hex[:6].upper()}",
+    )
+    db.add(ticket)
+    db.commit()
+    db.refresh(ticket)
+    return ticket
+
+
+class TestFindByPopupHasTickets:
+    def test_none_returns_all(self, db: Session, tenant_a: Tenants) -> None:
+        popup = _make_popup(db, tenant_a)
+        product = _make_product(db, tenant_a, popup)
+        with_ticket = _make_attendee(db, tenant_a, popup, name="With")
+        _give_ticket(db, tenant_a, with_ticket, product)
+        _make_attendee(db, tenant_a, popup, name="Without")
+
+        results, total = attendees_crud.find_by_popup(db, popup_id=popup.id)
+
+        assert total == 2
+        assert len(results) == 2
+
+    def test_true_returns_only_attendees_with_tickets(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        product = _make_product(db, tenant_a, popup)
+        with_ticket = _make_attendee(db, tenant_a, popup, name="With")
+        _give_ticket(db, tenant_a, with_ticket, product)
+        _make_attendee(db, tenant_a, popup, name="Without")
+
+        results, total = attendees_crud.find_by_popup(
+            db, popup_id=popup.id, has_tickets=True
+        )
+
+        assert total == 1
+        assert [r.id for r in results] == [with_ticket.id]
+
+    def test_true_does_not_multiply_rows_for_multiple_tickets(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        """An attendee with several tickets must appear exactly once."""
+        popup = _make_popup(db, tenant_a)
+        product = _make_product(db, tenant_a, popup)
+        with_ticket = _make_attendee(db, tenant_a, popup, name="Multi")
+        _give_ticket(db, tenant_a, with_ticket, product)
+        _give_ticket(db, tenant_a, with_ticket, product)
+        _give_ticket(db, tenant_a, with_ticket, product)
+
+        results, total = attendees_crud.find_by_popup(
+            db, popup_id=popup.id, has_tickets=True
+        )
+
+        assert total == 1
+        assert len(results) == 1
+
+    def test_false_returns_only_attendees_without_tickets(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        product = _make_product(db, tenant_a, popup)
+        with_ticket = _make_attendee(db, tenant_a, popup, name="With")
+        _give_ticket(db, tenant_a, with_ticket, product)
+        without = _make_attendee(db, tenant_a, popup, name="Without")
+
+        results, total = attendees_crud.find_by_popup(
+            db, popup_id=popup.id, has_tickets=False
+        )
+
+        assert total == 1
+        assert [r.id for r in results] == [without.id]

--- a/backend/tests/test_event_when_format.py
+++ b/backend/tests/test_event_when_format.py
@@ -1,0 +1,62 @@
+"""Unit tests for the timezone-aware email "when" formatter.
+
+Event datetimes are stored as UTC instants; email bodies must show the
+event's *local* wall-clock time. These cover the conversion, the day
+crossing it implies, the invalid-tz fallback, and the start–end range.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.services.event_datetime import format_event_when, format_event_when_range
+
+
+class TestFormatEventWhen:
+    def test_converts_utc_to_la_and_crosses_day(self) -> None:
+        # 01:00Z on Jun 8 is 18:00 PDT on Jun 7 (UTC-7) — the day rolls back.
+        dt = datetime(2026, 6, 8, 1, 0, tzinfo=UTC)
+        assert (
+            format_event_when(dt, "America/Los_Angeles") == "Jun 07, 2026 at 18:00 PDT"
+        )
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        dt = datetime(2026, 6, 8, 1, 0)  # noqa: DTZ001 — intentional naive input
+        assert (
+            format_event_when(dt, "America/Los_Angeles") == "Jun 07, 2026 at 18:00 PDT"
+        )
+
+    def test_invalid_timezone_falls_back_to_utc(self) -> None:
+        dt = datetime(2026, 6, 8, 1, 0, tzinfo=UTC)
+        assert format_event_when(dt, "Not/AZone") == "Jun 08, 2026 at 01:00 UTC"
+
+    def test_none_returns_placeholder(self) -> None:
+        assert format_event_when(None, "America/Los_Angeles") == "—"
+
+
+class TestFormatEventWhenRange:
+    def test_same_local_day_shows_end_time_only(self) -> None:
+        start = datetime(2026, 6, 8, 1, 0, tzinfo=UTC)  # 18:00 PDT Jun 7
+        end = datetime(2026, 6, 8, 2, 0, tzinfo=UTC)  # 19:00 PDT Jun 7
+        assert (
+            format_event_when_range(start, end, "America/Los_Angeles")
+            == "Jun 07, 2026 at 18:00 PDT – 19:00"
+        )
+
+    def test_multi_local_day_shows_full_end(self) -> None:
+        start = datetime(2026, 6, 8, 4, 0, tzinfo=UTC)  # 21:00 PDT Jun 7
+        end = datetime(2026, 6, 8, 8, 0, tzinfo=UTC)  # 01:00 PDT Jun 8
+        assert format_event_when_range(start, end, "America/Los_Angeles") == (
+            "Jun 07, 2026 at 21:00 PDT – Jun 08, 2026 at 01:00 PDT"
+        )
+
+    def test_missing_end_falls_back_to_start(self) -> None:
+        start = datetime(2026, 6, 8, 1, 0, tzinfo=UTC)
+        assert (
+            format_event_when_range(start, None, "America/Los_Angeles")
+            == "Jun 07, 2026 at 18:00 PDT"
+        )
+
+    def test_missing_start_returns_placeholder(self) -> None:
+        end = datetime(2026, 6, 8, 1, 0, tzinfo=UTC)
+        assert format_event_when_range(None, end, "America/Los_Angeles") == "—"

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -1176,11 +1176,15 @@ export class AttendeesService {
      * Returns AttendeeListItem (ProductWithQuantity shape) for compatibility with
      * the existing BO list view. Use GET /attendees/{id} for the full
      * AttendeePublic shape with typed AttendeeProductPublic tickets.
+     *
+     * has_tickets (only honored on the popup_id path) keeps attendees with at
+     * least one purchased/granted ticket when True, those without when False.
      * @param data The data for the request.
      * @param data.applicationId
      * @param data.popupId
      * @param data.email
      * @param data.search
+     * @param data.hasTickets
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -1199,6 +1203,7 @@ export class AttendeesService {
                 popup_id: data.popupId,
                 email: data.email,
                 search: data.search,
+                has_tickets: data.hasTickets,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -3832,6 +3832,7 @@ export type AttendeesDeleteMyAttendeeForPopupResponse = ({
 export type AttendeesListAttendeesData = {
     applicationId?: (string | null);
     email?: (string | null);
+    hasTickets?: (boolean | null);
     /**
      * Maximum number of items to return
      */

--- a/backoffice/src/routes/_layout/attendees.tsx
+++ b/backoffice/src/routes/_layout/attendees.tsx
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
-import { createFileRoute, Link } from "@tanstack/react-router"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import type { ColumnDef } from "@tanstack/react-table"
 import {
   Download,
@@ -40,11 +40,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { InlineRow, InlineSection } from "@/components/ui/inline-form"
+import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
 import {
+  type TableSearchParams,
   useTableSearchParams,
   validateTableSearch,
 } from "@/hooks/useTableSearchParams"
@@ -98,6 +101,7 @@ function getAttendeesQueryOptions(
   page: number,
   pageSize: number,
   search?: string,
+  hasTickets?: boolean,
 ) {
   return {
     queryFn: () =>
@@ -106,14 +110,26 @@ function getAttendeesQueryOptions(
         limit: pageSize,
         popupId: popupId || undefined,
         search: search || undefined,
+        hasTickets: hasTickets || undefined,
       }),
-    queryKey: ["attendees", popupId, { page, pageSize, search }],
+    queryKey: ["attendees", popupId, { page, pageSize, search, hasTickets }],
   }
+}
+
+type AttendeesSearchParams = TableSearchParams & {
+  hasTickets?: boolean
 }
 
 export const Route = createFileRoute("/_layout/attendees")({
   component: Attendees,
-  validateSearch: validateTableSearch,
+  validateSearch: (raw: Record<string, unknown>): AttendeesSearchParams => ({
+    ...validateTableSearch(raw),
+    // Accept both the boolean (default JSON search serialization) and the
+    // "true" string so the param round-trips regardless of how it was encoded.
+    ...(raw.hasTickets === true || raw.hasTickets === "true"
+      ? { hasTickets: true }
+      : {}),
+  }),
   head: () => ({
     meta: [{ title: "Attendees - EdgeOS" }],
   }),
@@ -315,11 +331,25 @@ const columns: ColumnDef<AttendeeListItem>[] = [
 
 function AttendeesTableContent() {
   const { selectedPopupId } = useWorkspace()
+  const navigate = useNavigate()
   const searchParams = Route.useSearch()
   const { search, pagination, setSearch, setPagination } = useTableSearchParams(
     searchParams,
     "/attendees",
   )
+  const hasTickets = searchParams.hasTickets ?? false
+
+  const setHasTickets = (value: boolean) => {
+    navigate({
+      to: "/attendees",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        hasTickets: value || undefined,
+        page: 0,
+      }),
+      replace: true,
+    })
+  }
 
   const { data: attendees } = useQuery({
     ...getAttendeesQueryOptions(
@@ -327,6 +357,7 @@ function AttendeesTableContent() {
       pagination.pageIndex,
       pagination.pageSize,
       search,
+      hasTickets,
     ),
     placeholderData: keepPreviousData,
   })
@@ -341,13 +372,28 @@ function AttendeesTableContent() {
       hiddenOnMobile={["gender", "category"]}
       searchValue={search}
       onSearchChange={setSearch}
+      filterBar={
+        <div className="flex items-center gap-2">
+          <Switch
+            id="attendees-has-tickets"
+            checked={hasTickets}
+            onCheckedChange={(checked) => setHasTickets(checked === true)}
+          />
+          <Label
+            htmlFor="attendees-has-tickets"
+            className="whitespace-nowrap text-sm font-normal text-muted-foreground"
+          >
+            With tickets only
+          </Label>
+        </div>
+      }
       serverPagination={{
         total: attendees.paging.total,
         pagination,
         onPaginationChange: setPagination,
       }}
       emptyState={
-        !search ? (
+        !search && !hasTickets ? (
           <EmptyState
             icon={Users}
             title="No attendees yet"

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -91,7 +91,12 @@ export default function EventDetailPage() {
     ? `/portal/${city?.slug}/events?${fromSearch}&${focusQs}`
     : `/portal/${city?.slug}/events?${focusQs}`
   const queryClient = useQueryClient()
-  const { timezone, formatTime, formatDateFull } = useEventTimezone(city?.id)
+  const {
+    timezone,
+    formatTime,
+    formatDateFull,
+    isLoading: tzLoading,
+  } = useEventTimezone(city?.id)
 
   const {
     data: event,
@@ -290,7 +295,7 @@ export default function EventDetailPage() {
     },
   })
 
-  if (isLoading) {
+  if (isLoading || tzLoading) {
     return (
       <div className="flex items-center justify-center py-20">
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -130,10 +130,12 @@ export function CalendarBody({
     setCurrentMonth(defaultDate)
     setSelectedDate(defaultDate)
   }, [defaultDate])
-  const { formatTime, formatDayKey, formatGridDayKey } = useEventTimezone(
-    popupId,
-    timezoneOverride,
-  )
+  const {
+    formatTime,
+    formatDayKey,
+    formatGridDayKey,
+    isLoading: tzLoading,
+  } = useEventTimezone(popupId, timezoneOverride)
 
   const { data: currentHuman } = useQuery({
     queryKey: ["current-human"],
@@ -269,6 +271,18 @@ export function CalendarBody({
     onEventLinkClick("calendar", selectedDayKey, {
       outer: main?.scrollTop ?? 0,
     })
+  }
+
+  // Defer rendering until the popup timezone resolves. Times *and* which
+  // day-cell an event lands in (``formatDayKey``) depend on it, so painting
+  // with the browser-tz fallback would briefly show events at the wrong
+  // hour/day before snapping to the popup tz once settings load.
+  if (tzLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    )
   }
 
   return (

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -166,10 +166,12 @@ export function DayBody({
     const resolved = typeof next === "function" ? next(selectedDate) : next
     onSelectedDateChange(resolved)
   }
-  const { timezone, formatTime, formatDayKey } = useEventTimezone(
-    popupId,
-    timezoneOverride,
-  )
+  const {
+    timezone,
+    formatTime,
+    formatDayKey,
+    isLoading: tzLoading,
+  } = useEventTimezone(popupId, timezoneOverride)
   const scrollRef = useRef<HTMLDivElement>(null)
   const mobileScrollRef = useRef<HTMLDivElement>(null)
 
@@ -235,7 +237,11 @@ export function DayBody({
       }),
     enabled: isAuthed && !useOverride && !!popupId,
   })
-  const isLoading = useOverride ? false : eventsLoading
+  // Fold the settings-timezone load into the loading state: rendering the
+  // day grid before the popup tz resolves would place events at the wrong
+  // hour (browser-tz fallback) until settings arrive. With an override
+  // (public calendar) the tz is known synchronously, so this stays false.
+  const isLoading = useOverride ? false : eventsLoading || tzLoading
 
   // Recurring events require occurrence_start so the RSVP targets a single
   // instance. That includes both expanded pseudo-rows (have occurrence_id)

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -279,8 +279,13 @@ export default function EventsPage() {
     queryFn: () => HumansService.getCurrentHumanInfo(),
     staleTime: 5 * 60 * 1000,
   })
-  const { timezone, formatTime, formatDateShort, formatDayKey } =
-    useEventTimezone(city?.id)
+  const {
+    timezone,
+    formatTime,
+    formatDateShort,
+    formatDayKey,
+    isLoading: tzLoading,
+  } = useEventTimezone(city?.id)
 
   const { data: eventSettings } = usePortalEventSettings(city?.id)
   const { data: popupTags } = usePopupTags(city?.id)
@@ -777,7 +782,7 @@ export default function EventsPage() {
           <ListBody
             events={events}
             slug={city?.slug}
-            isLoading={isLoading}
+            isLoading={isLoading || tzLoading}
             formatTime={formatTime}
             formatDateShort={formatDateShort}
             formatDayKey={formatDayKey}

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -1176,11 +1176,15 @@ export class AttendeesService {
      * Returns AttendeeListItem (ProductWithQuantity shape) for compatibility with
      * the existing BO list view. Use GET /attendees/{id} for the full
      * AttendeePublic shape with typed AttendeeProductPublic tickets.
+     *
+     * has_tickets (only honored on the popup_id path) keeps attendees with at
+     * least one purchased/granted ticket when True, those without when False.
      * @param data The data for the request.
      * @param data.applicationId
      * @param data.popupId
      * @param data.email
      * @param data.search
+     * @param data.hasTickets
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -1199,6 +1203,7 @@ export class AttendeesService {
                 popup_id: data.popupId,
                 email: data.email,
                 search: data.search,
+                has_tickets: data.hasTickets,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -3819,6 +3819,7 @@ export type AttendeesDeleteMyAttendeeForPopupResponse = ({
 export type AttendeesListAttendeesData = {
     applicationId?: (string | null);
     email?: (string | null);
+    hasTickets?: (boolean | null);
     /**
      * Maximum number of items to return
      */


### PR DESCRIPTION
## Summary
- **feat(attendees):** filter the attendees list to those with at least one ticket
- **fix(events):** render email times in the event's timezone and harden the portal against a timezone flash on load

## Test plan
- [ ] Attendees list correctly filters to attendees holding ≥1 ticket
- [ ] Event emails display times in the event timezone (not server/UTC)
- [ ] Portal no longer flashes the wrong timezone on initial render

🤖 Generated with [Claude Code](https://claude.com/claude-code)