### PR TITLE
fix(humans): invalidate list query after delete

### DIFF
--- a/backoffice/src/routes/_layout/humans/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/humans/$id.edit.tsx
@@ -47,7 +47,7 @@ function EditHumanContent({ humanId }: { humanId: string }) {
       // Drop cached detail + api-keys subqueries first so the list invalidation
       // below doesn't refetch the now-deleted human and 404.
       queryClient.removeQueries({ queryKey: ["humans", humanId] })
-      queryClient.invalidateQueries({ queryKey: ["humans"], exact: true })
+      queryClient.invalidateQueries({ queryKey: ["humans"] })
       navigate(getHumansNavigationTarget())
     },
     onError: createErrorHandler(showErrorToast),


### PR DESCRIPTION
## Summary

PR #213 added `exact: true` to the list invalidation after a human delete to avoid refetching the deleted human's detail query. But the list query uses a composite key:

```ts
queryKey: ["humans", { popupId, page, pageSize, search, applicationFilter }]
```

With `exact: true`, the invalidation only matches a literal `["humans"]` key — which doesn't exist. So the list query is never invalidated, stays "fresh" for the global `staleTime` (30s), and serves cached data on navigation. Result: the deleted human keeps showing in the list for several seconds.

This drops `exact: true`. The prior `removeQueries({ queryKey: ["humans", humanId] })` already evicts the deleted human's detail + api-keys subqueries, so the broader invalidate won't re-trigger a 404 refetch.

## Test plan

- [ ] As superadmin, delete a human from the edit page
- [ ] Verify the list updates within a network round-trip (no ~30s stale display)
- [ ] Verify no 404 toast/console error from a re-fetched detail query