### PR TITLE
feat(ui): reusable thin-scrollbar utility on DataTable

### DIFF
--- a/backoffice/src/components/Common/DataTable.tsx
+++ b/backoffice/src/components/Common/DataTable.tsx
@@ -426,7 +426,7 @@ export function DataTable<TData, TValue>({
         </div>
       )}
 
-      <div className="overflow-x-auto">
+      <div className="thin-scrollbar overflow-x-auto">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/backoffice/src/index.css
+++ b/backoffice/src/index.css
@@ -122,25 +122,31 @@
     cursor: pointer;
   }
 
-  [data-sidebar="content"] {
+  [data-sidebar="content"],
+  .thin-scrollbar {
     scrollbar-width: thin;
     scrollbar-color: var(--sidebar-border) transparent;
   }
 
-  [data-sidebar="content"]::-webkit-scrollbar {
+  [data-sidebar="content"]::-webkit-scrollbar,
+  .thin-scrollbar::-webkit-scrollbar {
     width: 6px;
+    height: 6px;
   }
 
-  [data-sidebar="content"]::-webkit-scrollbar-track {
+  [data-sidebar="content"]::-webkit-scrollbar-track,
+  .thin-scrollbar::-webkit-scrollbar-track {
     background: transparent;
   }
 
-  [data-sidebar="content"]::-webkit-scrollbar-thumb {
+  [data-sidebar="content"]::-webkit-scrollbar-thumb,
+  .thin-scrollbar::-webkit-scrollbar-thumb {
     background-color: var(--sidebar-border);
     border-radius: 9999px;
   }
 
-  [data-sidebar="content"]::-webkit-scrollbar-thumb:hover {
+  [data-sidebar="content"]::-webkit-scrollbar-thumb:hover,
+  .thin-scrollbar::-webkit-scrollbar-thumb:hover {
     background-color: var(--sidebar-ring);
   }
 }


### PR DESCRIPTION
## Summary

- Extract the sidebar's thin scrollbar styles into a reusable `.thin-scrollbar` utility class in `index.css`.
- Apply it to the DataTable's horizontal overflow container so wide tables get the same slim scrollbar as the sidebar.
- Add `height: 6px` so the horizontal scrollbar matches the existing vertical width.

## Test plan

- [ ] Open a wide table (e.g. `/humans` with many columns at a narrow viewport) and confirm the horizontal scrollbar is thin and themed
- [ ] Confirm sidebar scrollbar still renders identically (selector still matches)