### PR TITLE
fix(events): edit form clobbers saved start time with venue's open hour

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/lib/useVenueAvailability.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/useVenueAvailability.ts
@@ -225,8 +225,10 @@ export function useVenueAvailability(
   )
 
   // Snap timeStr to the first available slot once availability has loaded
-  // for a newly-selected venue.
-  const lastVenueSnapRef = useRef("")
+  // for a newly-selected venue. Seed the ref with the initial venueId so
+  // the edit form (which mounts with the saved venue already populated)
+  // doesn't get its loaded start time clobbered by the venue's open hour.
+  const lastVenueSnapRef = useRef(venueId)
   useEffect(() => {
     if (!setTimeStr) return
     if (!venueId) {


### PR DESCRIPTION
## Summary

The portal event edit form was silently overwriting the saved start time with the venue's first open hour on mount. Reported by Timour (Edge Esmeralda 2026): event created for 10:00 LA → edit view shows 06:00 LA, save would shift the event 4+ hours.

## Root cause

`portal/src/app/portal/[popupSlug]/events/lib/useVenueAvailability.ts:229` — the "snap timeStr to the first available slot" effect uses `useRef("")` for its "last snapped venue" memory. The effect is meant to fire when a user *picks* a venue in the create flow. But on the edit form, `venueId` is already populated from the loaded event on first render. Since `"" !== venueId`, the inequality check passes and the snap fires, overwriting the loaded time with `startOptions[0].label` (the venue's open hour). If the user clicks Save, the event silently shifts to that hour.

## Fix

Seed the ref with the initial `venueId`. On edit, the ref matches `venueId` on first render and the effect early-returns — loaded time preserved. On create, the initial `venueId` is `""` so the existing snap-on-venue-pick behavior is unchanged.

## Repro (before this PR)

1. Tenant with a popup configured with `event_settings.timezone = America/Los_Angeles`.
2. Create an event at a venue (e.g. Healdsburg Plaza, open 06:00 LA), pick a time in the middle of the day (e.g. 15:00 LA).
3. Save, then open the event's `/edit` page.
4. Edit form shows **06:00** (the venue's open hour), not the saved **15:00**. Clicking Save shifts the event by the delta.

## Verification

- Repro'd locally with the analogous setup: popup tz=LA, venue open 06:00–23:00 LA, event saved at 15:00 LA, browser tz=Asia/Shanghai.
- Pre-fix: edit form showed `time=06:00, date=Jun 15`.
- Post-fix: edit form shows `time=15:00, date=Jun 15` ✓
- Create flow re-verified: open create form (no venue), pick Test Plaza → time correctly snaps to 06:00. ✓
- `pnpm test` in `portal/` — 223/223 pass.

## Test plan

- [ ] On `dev`, open an event whose start time isn't its venue's first open slot; confirm `/edit` loads at the saved time.
- [ ] Change the venue mid-edit; confirm the time still snaps to the new venue's first slot.
- [ ] On the create form, pick a venue; confirm the time snaps to the venue's first open slot.
- [ ] Save an edited event without touching the time; confirm the stored UTC is unchanged.