### PR TITLE
fix(events): always render calendar in popup timezone + portal locale cleanup

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -599,11 +599,23 @@ def _check_recurrence_conflicts(
         )
 
 
+def _ics_utc_stamp(dt: datetime) -> str:
+    """Format a datetime as an RFC-5545 UTC stamp ('...Z').
+
+    Treats naive values as already-UTC for defense-in-depth, but the schema
+    validator now rejects naive inputs so this branch should only trigger for
+    legacy rows.
+    """
+    if dt.tzinfo is None:
+        return dt.strftime("%Y%m%dT%H%M%SZ")
+    return dt.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
 def _render_ics(event) -> str:
     """Render a minimal, RFC-5545-compliant VCALENDAR string for one event."""
     dtstamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    dtstart = event.start_time.strftime("%Y%m%dT%H%M%SZ")
-    dtend = event.end_time.strftime("%Y%m%dT%H%M%SZ")
+    dtstart = _ics_utc_stamp(event.start_time)
+    dtend = _ics_utc_stamp(event.end_time)
     summary = (event.title or "").replace("\n", " ").replace(",", r"\,")
     description = (event.content or "").replace("\n", r"\n").replace(",", r"\,")
     location = event.meeting_url or ""

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from sqlalchemy import Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Column, DateTime, Field, SQLModel
@@ -126,6 +126,24 @@ class EventBase(SQLModel):
         default_factory=lambda: datetime.now(UTC),
         sa_type=DateTime(timezone=True),
     )
+
+
+def _require_utc_aware(value: datetime | None) -> datetime | None:
+    """Reject naive datetimes and normalize to UTC.
+
+    The ``events.start_time`` / ``events.end_time`` columns are TIMESTAMPTZ, so
+    a naive value would be interpreted as the database server's local time and
+    silently corrupted on the way in. Pydantic accepts ISO strings without an
+    offset as naive, so the schema must enforce this explicitly.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        raise ValueError(
+            "Date must include a timezone offset (e.g. '2026-06-04T13:00:00Z' "
+            "or '2026-06-04T13:00:00-07:00')."
+        )
+    return value.astimezone(UTC)
 
 
 def _enforce_custom_location_xor(
@@ -293,6 +311,8 @@ class EventCreate(BaseModel):
 
     model_config = ConfigDict(str_strip_whitespace=True)
 
+    _normalize_datetimes = field_validator("start_time", "end_time")(_require_utc_aware)
+
     @model_validator(mode="after")
     def _validate_custom_location(self) -> "EventCreate":
         _enforce_custom_location_xor(
@@ -325,6 +345,8 @@ class EventUpdate(BaseModel):
     host_display_name: str | None = None
     status: EventStatus | None = None
     highlighted: bool | None = None
+
+    _normalize_datetimes = field_validator("start_time", "end_time")(_require_utc_aware)
 
     @model_validator(mode="after")
     def _validate_custom_location(self) -> "EventUpdate":

--- a/backend/tests/test_event_timezone.py
+++ b/backend/tests/test_event_timezone.py
@@ -480,3 +480,109 @@ class TestPortalCreateEvent:
         assert row is not None
         assert row.timezone == "America/Los_Angeles"
         assert row.start_time.astimezone(UTC) == start
+
+
+# ---------------------------------------------------------------------------
+# 5. Naive datetime inputs are rejected (fix E)
+#
+# Pydantic accepts ISO strings without an offset and parses them as naive,
+# which Postgres' TIMESTAMPTZ column would then interpret as server-local
+# and silently corrupt. The EventCreate/EventUpdate schemas now reject
+# naive inputs with a 422.
+# ---------------------------------------------------------------------------
+
+
+class TestNaiveDatetimeRejected:
+    def test_create_event_rejects_naive_start_time(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a, tz="America/Los_Angeles")
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "popup_id": str(popup.id),
+                "title": "Naive Test",
+                # No 'Z' and no offset — Pydantic parses this as naive.
+                "start_time": "2026-06-04T20:00:00",
+                "end_time": "2026-06-04T23:00:00Z",
+                "timezone": "America/Los_Angeles",
+                "visibility": "public",
+                "status": "published",
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        detail = resp.json()["detail"]
+        # The validator's message should mention "timezone offset".
+        assert any(
+            "timezone offset" in str(err.get("msg", "")) for err in detail
+        ), detail
+
+    def test_update_event_rejects_naive_end_time(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        from zoneinfo import ZoneInfo
+
+        la = ZoneInfo("America/Los_Angeles")
+        popup = _make_popup(db, tenant_a, tz="America/Los_Angeles")
+        start = datetime(2026, 6, 4, 13, 0, tzinfo=la).astimezone(UTC)
+        end = datetime(2026, 6, 4, 14, 0, tzinfo=la).astimezone(UTC)
+
+        create_resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "popup_id": str(popup.id),
+                "title": "Update Naive Test",
+                "start_time": start.isoformat(),
+                "end_time": end.isoformat(),
+                "timezone": "America/Los_Angeles",
+                "visibility": "public",
+                "status": "published",
+            },
+        )
+        assert create_resp.status_code == 201, create_resp.text
+        event_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/api/v1/events/{event_id}",
+            headers=_auth(admin_token_tenant_a),
+            json={"end_time": "2026-06-04T15:00:00"},
+        )
+        assert patch_resp.status_code == 422, patch_resp.text
+
+    def test_offset_input_normalized_to_utc(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Non-UTC offset is accepted and normalized — round-trips as UTC."""
+        popup = _make_popup(db, tenant_a, tz="America/Los_Angeles")
+        # 13:00-07:00 == 20:00Z. Sent with explicit LA offset, not 'Z'.
+        resp = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "popup_id": str(popup.id),
+                "title": "Offset Test",
+                "start_time": "2026-06-04T13:00:00-07:00",
+                "end_time": "2026-06-04T14:00:00-07:00",
+                "timezone": "America/Los_Angeles",
+                "visibility": "public",
+                "status": "published",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        # Backend serializes UTC instants with '+00:00' or 'Z'.
+        assert body["start_time"].startswith("2026-06-04T20:00:00")

--- a/backoffice/src/components/events/EventsCalendarView.tsx
+++ b/backoffice/src/components/events/EventsCalendarView.tsx
@@ -1,3 +1,4 @@
+import { monthBoundsInTz } from "@edgeos/shared-events"
 import { useQuery } from "@tanstack/react-query"
 import {
   addDays,
@@ -121,7 +122,17 @@ export function EventsCalendarView({
     currentMonth.getFullYear() === maxDate.getFullYear() &&
     currentMonth.getMonth() === maxDate.getMonth()
 
-  const { formatTime, formatDayKey } = useEventTimezone(popupId)
+  const {
+    formatTime,
+    formatDayKey,
+    timezone,
+    isLoading: tzLoading,
+  } = useEventTimezone(popupId)
+
+  // Month bounds anchored to the popup's timezone — otherwise events near
+  // the first/last day of the month (in popup TZ) get clipped from the
+  // query window when the browser TZ differs.
+  const monthBounds = monthBoundsInTz(currentMonth, timezone)
 
   const { data } = useQuery({
     queryKey: [
@@ -129,6 +140,7 @@ export function EventsCalendarView({
       "calendar",
       popupId,
       format(currentMonth, "yyyy-MM"),
+      timezone,
       status,
       venueId,
       search,
@@ -144,11 +156,11 @@ export function EventsCalendarView({
         locationKind:
           venueId === "custom" || venueId === "meeting" ? venueId : undefined,
         search: search || undefined,
-        startAfter: startOfMonth(currentMonth).toISOString(),
-        startBefore: endOfMonth(currentMonth).toISOString(),
+        startAfter: monthBounds.start.toISOString(),
+        startBefore: monthBounds.end.toISOString(),
         limit: 200,
       }),
-    enabled: !!popupId,
+    enabled: !!popupId && !tzLoading,
   })
 
   const events = data?.results ?? []

--- a/backoffice/src/lib/events/useEventTimezone.ts
+++ b/backoffice/src/lib/events/useEventTimezone.ts
@@ -3,14 +3,16 @@ import { useMemo } from "react"
 
 import { EventSettingsService } from "@/client"
 
-const DEFAULT_TZ =
-  (typeof Intl !== "undefined" &&
-    Intl.DateTimeFormat().resolvedOptions().timeZone) ||
-  "UTC"
+// Calendar surfaces must always render in the popup's timezone. When event
+// settings haven't been created yet, fall back to UTC (the backend default)
+// instead of the browser timezone so the displayed wall-clock matches what
+// the backend stores.
+const FALLBACK_TZ = "UTC"
 
 /**
  * Returns a popup's configured timezone along with reusable formatters.
- * Falls back to the browser timezone when settings are missing.
+ * Falls back to UTC when settings are missing or still loading (browser TZ
+ * is never used — every consumer expects popup-tz wall-clock).
  */
 export function useEventTimezone(popupId: string | undefined) {
   const { data: settings, isLoading: settingsLoading } = useQuery({
@@ -27,7 +29,7 @@ export function useEventTimezone(popupId: string | undefined) {
     staleTime: 5 * 60 * 1000,
   })
 
-  const timezone = settings?.timezone || DEFAULT_TZ
+  const timezone = settings?.timezone || FALLBACK_TZ
   const isLoading = settingsLoading
 
   return useMemo(() => {

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -1,3 +1,4 @@
+import { dayBoundsInTz } from "@edgeos/shared-events"
 import {
   keepPreviousData,
   useMutation,
@@ -929,6 +930,42 @@ function EventsTableContent({
 
   const hasFilters = !!(status || venueId || creatorId || startDate || endDate)
 
+  // Popup timezone drives display of every start_time in the table so the
+  // "Events" list matches the calendar views. We render a skeleton until
+  // settings resolve to avoid a browser-tz flash on first paint, and we use
+  // popup-tz day boundaries for the date filter so events near midnight in
+  // popup TZ aren't clipped.
+  const { data: popupSettings, isLoading: popupSettingsLoading } = useQuery({
+    queryKey: ["event-settings", selectedPopupId],
+    queryFn: async () => {
+      if (!selectedPopupId) return null
+      try {
+        return await EventSettingsService.getEventSettings({
+          popupId: selectedPopupId,
+        })
+      } catch {
+        return null
+      }
+    },
+    enabled: !!selectedPopupId,
+  })
+  // Fall back to UTC (the backend default for EventSettings.timezone) when
+  // settings haven't been created yet. Never fall back to browser tz — that
+  // would make the list display drift from the calendar/day views and emails.
+  const popupTz = popupSettings?.timezone ?? "UTC"
+
+  const filterStartAfter = useMemo(() => {
+    if (!startDate) return undefined
+    if (popupTz) return dayBoundsInTz(startDate, popupTz).start.toISOString()
+    return `${startDate}T00:00:00Z`
+  }, [startDate, popupTz])
+
+  const filterStartBefore = useMemo(() => {
+    if (!endDate) return undefined
+    if (popupTz) return dayBoundsInTz(endDate, popupTz).end.toISOString()
+    return `${endDate}T23:59:59Z`
+  }, [endDate, popupTz])
+
   const { data: events } = useQuery({
     queryKey: [
       "events",
@@ -942,6 +979,7 @@ function EventsTableContent({
         creatorId,
         startDate,
         endDate,
+        popupTz,
       },
     ],
     queryFn: () =>
@@ -958,10 +996,10 @@ function EventsTableContent({
         locationKind:
           venueId === "custom" || venueId === "meeting" ? venueId : undefined,
         ownerId: creatorId || undefined,
-        startAfter: startDate ? `${startDate}T00:00:00Z` : undefined,
-        startBefore: endDate ? `${endDate}T23:59:59Z` : undefined,
+        startAfter: filterStartAfter,
+        startBefore: filterStartBefore,
       }),
-    enabled: !!selectedPopupId,
+    enabled: !!selectedPopupId && !popupSettingsLoading,
     placeholderData: keepPreviousData,
   })
 
@@ -993,31 +1031,13 @@ function EventsTableContent({
     return map
   }, [venues])
 
-  // Popup timezone drives display of every start_time in the table so the
-  // "Events" list matches the calendar views. Falls back to browser tz if
-  // settings haven't loaded or aren't configured for this popup.
-  const { data: popupSettings } = useQuery({
-    queryKey: ["event-settings", selectedPopupId],
-    queryFn: async () => {
-      if (!selectedPopupId) return null
-      try {
-        return await EventSettingsService.getEventSettings({
-          popupId: selectedPopupId,
-        })
-      } catch {
-        return null
-      }
-    },
-    enabled: !!selectedPopupId,
-  })
-  const popupTz = popupSettings?.timezone ?? undefined
-
   const columns = useMemo(
     () => buildEventColumns(venueNameById, popupTz),
     [venueNameById, popupTz],
   )
 
-  if (!events) return <Skeleton className="h-64 w-full" />
+  if (!events || popupSettingsLoading)
+    return <Skeleton className="h-64 w-full" />
 
   return (
     <div className="space-y-3">

--- a/packages/shared-events/src/index.ts
+++ b/packages/shared-events/src/index.ts
@@ -5,6 +5,7 @@ export {
   durationFits,
   freeIntervalsForDay,
   localTzNaiveToUtc,
+  monthBoundsInTz,
   tzOffsetMinutes,
   utcToLocalTzNaive,
 } from "./venue-slots"

--- a/packages/shared-events/src/venue-slots.test.ts
+++ b/packages/shared-events/src/venue-slots.test.ts
@@ -5,6 +5,7 @@ import {
   durationFits,
   freeIntervalsForDay,
   localTzNaiveToUtc,
+  monthBoundsInTz,
   tzOffsetMinutes,
   utcToLocalTzNaive,
 } from "./venue-slots"
@@ -38,6 +39,38 @@ describe("dayBoundsInTz", () => {
   it("range is exactly 24h for a non-DST day", () => {
     const { start, end } = dayBoundsInTz("2026-06-04", "America/Los_Angeles")
     expect(end.getTime() - start.getTime()).toBe(24 * 60 * 60 * 1000)
+  })
+})
+
+describe("monthBoundsInTz", () => {
+  it("LA June 2026 → 06-01 07:00Z to 07-01 07:00Z", () => {
+    const anchor = new Date("2026-06-15T12:00:00Z")
+    const { start, end } = monthBoundsInTz(anchor, "America/Los_Angeles")
+    expect(start.toISOString()).toBe("2026-06-01T07:00:00.000Z")
+    expect(end.toISOString()).toBe("2026-07-01T07:00:00.000Z")
+  })
+
+  it("Tokyo June 2026 → 05-31 15:00Z to 06-30 15:00Z", () => {
+    const anchor = new Date("2026-06-15T12:00:00Z")
+    const { start, end } = monthBoundsInTz(anchor, "Asia/Tokyo")
+    expect(start.toISOString()).toBe("2026-05-31T15:00:00.000Z")
+    expect(end.toISOString()).toBe("2026-06-30T15:00:00.000Z")
+  })
+
+  it("wraps year on December anchor", () => {
+    const anchor = new Date("2026-12-20T12:00:00Z")
+    const { start, end } = monthBoundsInTz(anchor, "America/Los_Angeles")
+    expect(start.toISOString()).toBe("2026-12-01T08:00:00.000Z")
+    expect(end.toISOString()).toBe("2027-01-01T08:00:00.000Z")
+  })
+
+  it("uses the popup-tz month even when the anchor instant is in a different month in browser-local time", () => {
+    // 2026-07-01 00:30Z is "2026-06-30 17:30" in LA — the anchor's LA
+    // month is June, so bounds must wrap the June interval (not July).
+    const anchor = new Date("2026-07-01T00:30:00Z")
+    const { start, end } = monthBoundsInTz(anchor, "America/Los_Angeles")
+    expect(start.toISOString()).toBe("2026-06-01T07:00:00.000Z")
+    expect(end.toISOString()).toBe("2026-07-01T07:00:00.000Z")
   })
 })
 

--- a/packages/shared-events/src/venue-slots.ts
+++ b/packages/shared-events/src/venue-slots.ts
@@ -198,6 +198,37 @@ export function dayBoundsInTz(
 }
 
 /**
+ * Build the [monthStart, monthEnd) interval that contains `anchor` in the
+ * supplied timezone. The interval starts at 00:00 on the first day of the
+ * month and ends at 00:00 on the first day of the next month, both expressed
+ * as UTC instants.
+ *
+ * Use this for API query bounds when fetching events for a calendar month:
+ * `startOfMonth(anchor).toISOString()` operates in the browser's TZ and
+ * clips events near month boundaries when the popup TZ differs.
+ */
+export function monthBoundsInTz(
+  anchor: Date,
+  timeZone: string,
+): { start: Date; end: Date } {
+  // YYYY-MM of the anchor in the target timezone (not browser local).
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(anchor)
+  const year = Number(parts.find((p) => p.type === "year")?.value)
+  const month = Number(parts.find((p) => p.type === "month")?.value)
+  const firstDay = `${year}-${String(month).padStart(2, "0")}-01`
+  const nextMonth = month === 12 ? 1 : month + 1
+  const nextYear = month === 12 ? year + 1 : year
+  const firstDayNext = `${nextYear}-${String(nextMonth).padStart(2, "0")}-01`
+  const { start } = dayBoundsInTz(firstDay, timeZone)
+  const { start: end } = dayBoundsInTz(firstDayNext, timeZone)
+  return { start, end }
+}
+
+/**
  * Convert a naive wall-clock datetime ("YYYY-MM-DDTHH:MM[:SS]") interpreted
  * as local time in `timeZone` into the UTC instant it denotes. Round-trip
  * inverse of `utcToLocalTzNaive`.

--- a/portal/src/app/portal/[popupSlug]/application/components/form-header.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/components/form-header.tsx
@@ -2,7 +2,14 @@
 
 import { CalendarDays, MapPin } from "lucide-react"
 import Image from "next/image"
+import { formatDate } from "@/helpers/dates"
 import { useCityProvider } from "@/providers/cityProvider"
+
+const POPUP_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+}
 
 export function FormHeader() {
   const { getCity } = useCityProvider()
@@ -10,20 +17,8 @@ export function FormHeader() {
 
   if (!city) return null
 
-  const startDate = city.start_date
-    ? new Date(city.start_date).toLocaleDateString("en-EN", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      })
-    : null
-  const endDate = city.end_date
-    ? new Date(city.end_date).toLocaleDateString("en-EN", {
-        day: "numeric",
-        month: "long",
-        year: "numeric",
-      })
-    : null
+  const startDate = formatDate(city.start_date ?? undefined, POPUP_DATE_FORMAT)
+  const endDate = formatDate(city.end_date ?? undefined, POPUP_DATE_FORMAT)
 
   return (
     <div className="flex flex-col md:flex-row gap-6">

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { monthBoundsInTz } from "@edgeos/shared-events"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   addDays,
@@ -134,8 +135,19 @@ export function CalendarBody({
     formatTime,
     formatDayKey,
     formatGridDayKey,
+    formatMonthHeader,
+    weekdayShortLabels,
+    locale,
+    timezone,
     isLoading: tzLoading,
   } = useEventTimezone(popupId, timezoneOverride)
+
+  const formatSelectedDateHeader = (d: Date) =>
+    new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    }).format(d)
 
   const { data: currentHuman } = useQuery({
     queryKey: ["current-human"],
@@ -144,11 +156,17 @@ export function CalendarBody({
     enabled: isAuthed,
   })
 
+  // Month bounds anchored to the popup's timezone — otherwise events near
+  // the first/last day of the month (in popup TZ) get clipped from the
+  // query window when the viewer's browser TZ differs.
+  const monthBounds = monthBoundsInTz(currentMonth, timezone)
+
   const { data } = useQuery({
     queryKey: [
       "portal-events-calendar",
       popupId,
       format(currentMonth, "yyyy-MM"),
+      timezone,
       rsvpedOnly,
       search,
       tags,
@@ -158,15 +176,15 @@ export function CalendarBody({
       EventsService.listPortalEvents({
         popupId: popupId!,
         eventStatus: "published",
-        startAfter: startOfMonth(currentMonth).toISOString(),
-        startBefore: endOfMonth(currentMonth).toISOString(),
+        startAfter: monthBounds.start.toISOString(),
+        startBefore: monthBounds.end.toISOString(),
         rsvpedOnly: rsvpedOnly || undefined,
         search: search || undefined,
         tags: tags?.length ? tags : undefined,
         trackIds: trackIds?.length ? trackIds : undefined,
         limit: 200,
       }),
-    enabled: isAuthed && !useOverride && !!popupId,
+    enabled: isAuthed && !useOverride && !!popupId && !tzLoading,
   })
 
   // Recurring events require occurrence_start so the RSVP targets a single
@@ -236,7 +254,6 @@ export function CalendarBody({
   }
 
   const selectedEvents = selectedDate ? getEventsForDate(selectedDate) : []
-  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
   // `from` rebuilds the events-page URL state (view + selected day) so
   // the detail page's "Back to events" link returns the user here.
@@ -305,7 +322,7 @@ export function CalendarBody({
             <ChevronLeft className="h-4 w-4" />
           </Button>
           <h2 className="text-sm font-semibold capitalize">
-            {format(currentMonth, "MMMM yyyy")}
+            {formatMonthHeader(currentMonth)}
           </h2>
           <Button
             variant="ghost"
@@ -318,10 +335,10 @@ export function CalendarBody({
         </div>
 
         <div className="grid grid-cols-7 mb-1">
-          {dayLabels.map((d) => (
+          {weekdayShortLabels.map((d) => (
             <div
               key={d}
-              className="text-center text-[10px] font-medium text-muted-foreground py-1"
+              className="text-center text-[10px] font-medium text-muted-foreground py-1 capitalize"
             >
               {d}
             </div>
@@ -369,8 +386,8 @@ export function CalendarBody({
         {selectedDate ? (
           <>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold">
-                {format(selectedDate, "EEEE, MMMM d")}
+              <h3 className="text-sm font-semibold capitalize">
+                {formatSelectedDateHeader(selectedDate)}
               </h3>
               <span className="text-xs text-muted-foreground">
                 {t("events.calendar.selected_events", {

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { addDays, format, startOfDay, subDays } from "date-fns"
+import { addDays, startOfDay, subDays } from "date-fns"
 import {
   CalendarClock,
   CalendarIcon,
@@ -168,10 +168,22 @@ export function DayBody({
   }
   const {
     timezone,
+    locale,
     formatTime,
     formatDayKey,
     isLoading: tzLoading,
   } = useEventTimezone(popupId, timezoneOverride)
+
+  // Localized "Monday, June 4, 2026" for the date picker trigger. Uses the
+  // selected day's nominal local date (no TZ conversion needed — selectedDate
+  // is already the user-picked wall-clock day).
+  const formatDatePickerLabel = (d: Date) =>
+    new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }).format(d)
   const scrollRef = useRef<HTMLDivElement>(null)
   const mobileScrollRef = useRef<HTMLDivElement>(null)
 
@@ -544,7 +556,7 @@ export function DayBody({
                   title={t("events.day.pick_date")}
                 >
                   <span className="truncate">
-                    {format(selectedDate, "EEEE, MMMM d, yyyy")}
+                    {formatDatePickerLabel(selectedDate)}
                   </span>
                   <CalendarIcon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                 </button>

--- a/portal/src/app/portal/[popupSlug]/events/lib/useEventTimezone.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/useEventTimezone.ts
@@ -2,13 +2,30 @@
 
 import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
 
 import { type EventSettingsPublic, EventSettingsService } from "@/client"
 
-const DEFAULT_TZ =
-  (typeof Intl !== "undefined" &&
-    Intl.DateTimeFormat().resolvedOptions().timeZone) ||
-  "UTC"
+// Calendar surfaces must always render in the popup's timezone. When event
+// settings haven't been created yet, fall back to UTC (the backend default)
+// instead of the browser timezone so the displayed wall-clock matches what
+// the backend stores and what emails carry.
+const FALLBACK_TZ = "UTC"
+
+// Maps i18next language codes to BCP-47 tags used by Intl.DateTimeFormat
+// for month/weekday names. Time and day-key formats are locale-independent
+// (numeric only) so they stay anchored to en-GB / en-CA.
+const LOCALE_MAP: Record<string, string> = {
+  en: "en-US",
+  es: "es-ES",
+  zh: "zh-CN",
+  is: "is-IS",
+}
+
+function resolveLocale(lang: string | undefined): string {
+  if (!lang) return "en-US"
+  return LOCALE_MAP[lang] ?? LOCALE_MAP[lang.split("-")[0] ?? ""] ?? "en-US"
+}
 
 /**
  * Single source of truth for the portal-event-settings query. Other hooks
@@ -39,12 +56,14 @@ export function useEventTimezone(
   popupId: string | undefined,
   timezoneOverride?: string,
 ) {
+  const { i18n } = useTranslation()
   const { data: settings, isLoading: settingsLoading } = usePortalEventSettings(
     timezoneOverride ? undefined : popupId,
   )
 
-  const timezone = timezoneOverride || settings?.timezone || DEFAULT_TZ
+  const timezone = timezoneOverride || settings?.timezone || FALLBACK_TZ
   const isLoading = timezoneOverride ? false : settingsLoading
+  const locale = resolveLocale(i18n.language)
 
   return useMemo(() => {
     const formatTime = (dateStr: string) =>
@@ -56,7 +75,7 @@ export function useEventTimezone(
       }).format(new Date(dateStr))
 
     const formatDateShort = (dateStr: string) =>
-      new Intl.DateTimeFormat("en-US", {
+      new Intl.DateTimeFormat(locale, {
         timeZone: timezone,
         weekday: "short",
         month: "short",
@@ -64,7 +83,7 @@ export function useEventTimezone(
       }).format(new Date(dateStr))
 
     const formatDateFull = (dateStr: string) =>
-      new Intl.DateTimeFormat("en-US", {
+      new Intl.DateTimeFormat(locale, {
         timeZone: timezone,
         weekday: "long",
         month: "long",
@@ -73,6 +92,7 @@ export function useEventTimezone(
       }).format(new Date(dateStr))
 
     // YYYY-MM-DD in the popup's timezone (for grouping/keying by day).
+    // Locale-independent: this is a sort key, not displayed text.
     const formatDayKey = (dateStr: string) => {
       return new Intl.DateTimeFormat("en-CA", {
         timeZone: timezone,
@@ -91,14 +111,36 @@ export function useEventTimezone(
       return `${y}-${m}-${day}`
     }
 
+    // Localized "MMMM yyyy" for the calendar header (e.g. "junio de 2026").
+    const formatMonthHeader = (d: Date) =>
+      new Intl.DateTimeFormat(locale, {
+        month: "long",
+        year: "numeric",
+      }).format(d)
+
+    // Localized weekday short labels starting Monday, in the user's locale
+    // (e.g. ["lun", "mar", "mié", ...] for Spanish).
+    const weekdayShortLabels = (() => {
+      // Pick a known Monday (2026-06-01) and walk 7 days in nominal local
+      // time so the labels are independent of timezone.
+      const monday = new Date(2026, 5, 1)
+      const fmt = new Intl.DateTimeFormat(locale, { weekday: "short" })
+      return Array.from({ length: 7 }, (_, i) =>
+        fmt.format(new Date(monday.getTime() + i * 24 * 60 * 60 * 1000)),
+      )
+    })()
+
     return {
       timezone,
+      locale,
       isLoading,
       formatTime,
       formatDateShort,
       formatDateFull,
       formatDayKey,
       formatGridDayKey,
+      formatMonthHeader,
+      weekdayShortLabels,
     }
-  }, [timezone, isLoading])
+  }, [timezone, isLoading, locale])
 }

--- a/portal/src/components/Card/EventCard.tsx
+++ b/portal/src/components/Card/EventCard.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import type { PopupPublic } from "@/client"
 import { ButtonAnimated } from "@/components/ui/button"
 import { CardAnimation, CardContent } from "@/components/ui/card"
+import { formatDate } from "@/helpers/dates"
 import { EventProgressBar, type EventStatus } from "./EventProgressBar"
 
 const CTA_KEYS: Record<EventStatus, string> = {
@@ -32,13 +33,10 @@ function useEventCard() {
   return ctx
 }
 
-function formatDate(date: string | null | undefined): string {
-  if (!date) return ""
-  return new Date(date).toLocaleDateString("en-EN", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  })
+const POPUP_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
 }
 
 interface RootProps {
@@ -113,8 +111,8 @@ function Location() {
 
 function DateRange() {
   const { popup } = useEventCard()
-  const start = formatDate(popup.start_date)
-  const end = formatDate(popup.end_date)
+  const start = formatDate(popup.start_date ?? undefined, POPUP_DATE_FORMAT)
+  const end = formatDate(popup.end_date ?? undefined, POPUP_DATE_FORMAT)
   if (!start && !end) return null
 
   return (

--- a/portal/src/helpers/dates.ts
+++ b/portal/src/helpers/dates.ts
@@ -2,6 +2,7 @@ const LOCALE_MAP: Record<string, string> = {
   en: "en-US",
   es: "es-ES",
   zh: "zh-CN",
+  is: "is-IS",
 }
 
 function getLocale(): string {


### PR DESCRIPTION
## Summary

Production bug report — "the biggest issue are the dates and times changing after an event is added" — together with broken i18n on popup cards. Two commits, both surface the same root cause: calendar code was leaking the user's browser timezone into rendering paths that should be 100% anchored to the popup's configured timezone.

### What was broken
- **Backoffice list view** showed event start times in browser-TZ while popup settings were loading, then re-painted in popup-TZ — admins read the first paint and reported "the time changed after I saved".
- **Backoffice calendar / day view** built query bounds from `startOfMonth(currentMonth).toISOString()` (browser-TZ); events near month/day boundaries silently fell out of the window.
- **Backoffice list date filter** used literal `T00:00:00Z` / `T23:59:59Z`, so a "show June 4" filter clipped early-morning popup-TZ events.
- **Portal CalendarBody** had the same month-bound bug as the backoffice.
- **`useEventTimezone` (both apps)** fell back to browser-TZ when a popup had no `event_settings` row — the `popupSettingsLoading` skeleton I added only covered the in-flight window, not the resolved-but-null case.
- **Backend** silently accepted naive datetime input (Pydantic v2 default); TIMESTAMPTZ then interpreted it as server-local on insert. Legacy ICS export stamped `Z` without `astimezone(UTC)`.
- **Portal i18n** had hardcoded `en-US` / `en-GB` in `useEventTimezone` formatters, hardcoded English `dayLabels`, `date-fns format()` without locale option for month/day headers; `EventCard.DateRange` and `application/components/form-header.tsx` used `"en-EN"` (not a valid BCP-47 tag).

### What's fixed
**Backend** (`backend/app/api/event/`)
- `_require_utc_aware` field validator on `EventCreate` / `EventUpdate` → naive input returns 422 with a user-facing message pointing at the offset format.
- `_ics_utc_stamp` helper hardens legacy ICS export.
- 3 new regression tests in `TestNaiveDatetimeRejected`.

**Shared** (`@edgeos/shared-events`)
- New `monthBoundsInTz(anchor, tz)` helper plus 4 unit tests (LA, Tokyo, year-wrap, cross-month anchor).

**Backoffice**
- `EventsCalendarView` query bounds via `monthBoundsInTz`, gated on `tzLoading`.
- `events/index.tsx` date filter via `dayBoundsInTz`, skeleton until `popupSettings` resolves.
- `useEventTimezone` falls back to UTC instead of browser-TZ.

**Portal**
- `CalendarBody` mirrors the backoffice month-bound fix.
- `useEventTimezone` resolves locale from i18next, exposes `formatMonthHeader` and `weekdayShortLabels`, falls back to UTC.
- `CalendarBody` / `DayBody` consume the new formatters for month header, day labels, and selected-day heading.
- `EventCard` + `form-header.tsx` use `helpers/dates.formatDate`; `dates.ts` adds `is-IS` to the locale map.

## Test plan

- [x] Backend: `pytest tests/test_event_timezone.py tests/test_event_crud.py tests/test_event_itip.py tests/test_event_when_format.py tests/test_event_participants.py tests/test_recurrence_conflicts.py tests/test_recurring_availability_endpoint.py tests/test_events_approval.py tests/test_event_overrides_endpoint.py tests/test_event_custom_location.py tests/test_event_distinct_tags.py tests/test_event_popup_window.py` — 119 passed, 1 skipped, including 3 new naive-rejection cases.
- [x] Shared: `vitest run` — 24/24 passing, including 4 new `monthBoundsInTz` cases.
- [x] Backoffice: `pnpm --filter backoffice run build` — clean.
- [x] Portal: `pnpm --filter portal run lint && build && test --run` — clean, 223 tests passing.
- [x] Browser test (popup `Asia/Tokyo`, browser `America/Argentina/Buenos_Aires`):
  - Backoffice list shows event entered at 09:00 popup-TZ as **18:00** (Tokyo), not 06:00 (browser).
  - Calendar view places event in the correct popup-TZ cell.
  - Portal renders event in Tokyo time regardless of browser.
  - Portal in Spanish: "Junio De 2026", "Lun Mar Mié Jue Vie Sáb Dom", "Lunes, 15 De Junio".
  - API POST `start_time: "2026-06-20T09:00:00"` (no offset) → 422; with `Z` → 201.
- [x] FALLBACK_TZ verified by deleting `event_settings` row and re-rendering: list shows wall-clock UTC (09:00), not browser-TZ (06:00).