### PR TITLE
fix(events): recognize superadmins as staff for portal admin notes

### DIFF
--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -384,21 +384,30 @@ def get_current_portal_staff(
 
     Some features (e.g. event admin notes) are staff-only but must be reachable
     from the portal, which authenticates Humans (no roles). We bridge the two
-    identity systems by email within the tenant: a logged-in human whose email
-    matches a non-deleted backoffice User in the same tenant is treated as
-    staff. The human already proved control of that email via OTP login, so the
-    match is as trustworthy as the human session itself. Raises 403 otherwise.
+    identity systems by email: a logged-in human whose email matches a
+    non-deleted backoffice User is treated as staff. The human already proved
+    control of that email via OTP login, so the match is as trustworthy as the
+    human session itself.
+
+    A SUPERADMIN spans all tenants (their ``tenant_id`` is typically NULL), so a
+    matching superadmin grants staff access in any tenant. Other roles are
+    tenant-scoped: the User must belong to the human's tenant. Raises 403 when
+    no matching User qualifies.
     """
     from app.api.user.models import Users
 
-    staff = db.exec(
+    candidates = db.exec(
         select(Users).where(
             func.lower(Users.email) == current_human.email.lower(),
-            Users.tenant_id == current_human.tenant_id,
             Users.deleted == False,  # noqa: E712
         )
-    ).first()
-    if staff is None:
+    ).all()
+    is_staff = any(
+        user.role == UserRole.SUPERADMIN
+        or user.tenant_id == current_human.tenant_id
+        for user in candidates
+    )
+    if not is_staff:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="This action is restricted to backoffice staff.",

--- a/backend/tests/test_event_admin_notes.py
+++ b/backend/tests/test_event_admin_notes.py
@@ -156,6 +156,27 @@ def test_portal_staff_human_can_read_and_write_notes(
     assert read.json()["notes"] == "note from portal"
 
 
+def test_portal_superadmin_human_can_edit_notes_cross_tenant(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+    superadmin_user: Users,
+) -> None:
+    # A superadmin's User has no tenant_id, so the email match must grant staff
+    # access in any tenant (the original same-tenant-only check 403'd them).
+    popup = _make_popup(db, tenant_a)
+    ev = _make_event(db, tenant_a, popup)
+    staff = _make_human(db, tenant_a, email=superadmin_user.email)
+
+    wrote = client.put(
+        f"/api/v1/events/portal/events/{ev.id}/admin-notes",
+        headers=_human_auth(staff),
+        json={"notes": "superadmin via portal"},
+    )
+    assert wrote.status_code == 200, wrote.text
+    assert wrote.json()["notes"] == "superadmin via portal"
+
+
 def test_portal_regular_human_is_forbidden(
     client: TestClient,
     db: Session,


### PR DESCRIPTION
## Problem
On develop, a superadmin (e.g. the product lead) created an admin note on an event from the backoffice, but the **Admin notes** section never appeared on the portal event page for the same account.

## Cause
`CurrentPortalStaff` (the portal staff bridge) required a matching backoffice `User` in the **same tenant** as the logged-in human:
```python
Users.tenant_id == current_human.tenant_id
```
Superadmins have no `tenant_id` (they span all tenants), so the match failed → 403 → the portal section (which self-hides on non-200) stayed hidden.

## Fix
A matching non-deleted `User` now grants staff access when it is a **SUPERADMIN** (any tenant) **or** belongs to the human's tenant. Regular roles stay tenant-scoped. Added a regression test reproducing the superadmin cross-tenant case; the existing tenant-isolation test (non-superadmin from another tenant → 403) still holds.

Backoffice notes were unaffected (different code path) and already worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)