### PR TITLE
feat(events): popup-scoped placeholder image for events

### DIFF
--- a/backend/app/alembic/versions/7a3f9c1d8e2b_event_settings_placeholder_url.py
+++ b/backend/app/alembic/versions/7a3f9c1d8e2b_event_settings_placeholder_url.py
@@ -1,0 +1,29 @@
+"""event_settings placeholder_url
+
+Adds nullable event_settings.placeholder_url (TEXT) — popup-scoped fallback
+image used by the portal when an individual event has no cover image.
+
+Revision ID: 7a3f9c1d8e2b
+Revises: d4b1e7a9c2f5
+Create Date: 2026-05-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7a3f9c1d8e2b"
+down_revision = "d4b1e7a9c2f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "event_settings",
+        sa.Column("placeholder_url", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("event_settings", "placeholder_url")

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -774,6 +774,7 @@ async def list_public_calendar(
 
     settings = event_settings_crud.get_by_popup_id(db, popup.id)
     timezone = settings.timezone if settings else "UTC"
+    placeholder_url = settings.placeholder_url if settings else None
     # Distinct tags actually present on the popup's published+public events,
     # not the curated ``event_settings.allowed_tags`` list — creators can use
     # tags outside that list, and the filter must surface them.
@@ -793,6 +794,7 @@ async def list_public_calendar(
             popup_id=popup.id,
             popup_slug=popup.slug,
             popup_name=popup.name,
+            placeholder_url=placeholder_url,
         ),
     )
 

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -257,6 +257,10 @@ class EventCalendarMeta(BaseModel):
     popup_id: uuid.UUID
     popup_slug: str
     popup_name: str
+    # Popup-scoped fallback image used by the portal when an event has no
+    # cover/venue image. Surfaced here so the anonymous calendar can apply
+    # the same fallback without calling the authenticated settings endpoint.
+    placeholder_url: str | None = None
 
 
 class EventPublicCalendarResponse(BaseModel):

--- a/backend/app/api/event_settings/schemas.py
+++ b/backend/app/api/event_settings/schemas.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import Column
+from sqlalchemy import Column, Text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import DateTime, Field, SQLModel
 
@@ -47,6 +47,10 @@ class EventSettingsBase(SQLModel):
         default_factory=list,
         sa_column=Column(JSONB, nullable=False, server_default="[]"),
     )
+    # Popup-scoped fallback image used by the portal when an individual event
+    # has no cover image. When this is also empty, the portal falls back to a
+    # generic icon placeholder.
+    placeholder_url: str | None = Field(default=None, sa_type=Text())
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC), sa_type=DateTime(timezone=True)
     )
@@ -76,6 +80,7 @@ class EventSettingsCreate(BaseModel):
     allowed_tags: list[str] = []
     allowed_kinds: list[str] = []
     approval_notification_emails: list[str] = []
+    placeholder_url: str | None = None
 
 
 class EventSettingsUpdate(BaseModel):
@@ -90,3 +95,4 @@ class EventSettingsUpdate(BaseModel):
     allowed_tags: list[str] | None = None
     allowed_kinds: list[str] | None = None
     approval_notification_emails: list[str] | None = None
+    placeholder_url: str | None = None

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -5149,6 +5149,17 @@ export const EventCalendarMetaSchema = {
         popup_name: {
             type: 'string',
             title: 'Popup Name'
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         }
     },
     type: 'object',
@@ -6382,6 +6393,17 @@ export const EventSettingsCreateSchema = {
             type: 'array',
             title: 'Approval Notification Emails',
             default: []
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         }
     },
     type: 'object',
@@ -6452,6 +6474,17 @@ export const EventSettingsPublicSchema = {
             },
             type: 'array',
             title: 'Approval Notification Emails'
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         },
         created_at: {
             type: 'string',
@@ -6583,6 +6616,17 @@ export const EventSettingsUpdateSchema = {
                 }
             ],
             title: 'Approval Notification Emails'
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         }
     },
     type: 'object',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1184,6 +1184,7 @@ export type EventCalendarMeta = {
     popup_id: string;
     popup_slug: string;
     popup_name: string;
+    placeholder_url?: (string | null);
 };
 
 /**
@@ -1418,6 +1419,7 @@ export type EventSettingsCreate = {
     allowed_tags?: Array<(string)>;
     allowed_kinds?: Array<(string)>;
     approval_notification_emails?: Array<(string)>;
+    placeholder_url?: (string | null);
 };
 
 /**
@@ -1435,6 +1437,7 @@ export type EventSettingsPublic = {
     allowed_tags?: Array<(string)>;
     allowed_kinds?: Array<(string)>;
     approval_notification_emails?: Array<(string)>;
+    placeholder_url?: (string | null);
     created_at?: string;
     updated_at?: string;
     id: string;
@@ -1453,6 +1456,7 @@ export type EventSettingsUpdate = {
     allowed_tags?: (Array<(string)> | null);
     allowed_kinds?: (Array<(string)> | null);
     approval_notification_emails?: (Array<(string)> | null);
+    placeholder_url?: (string | null);
 };
 
 export type EventStatus = 'draft' | 'published' | 'cancelled' | 'pending_approval' | 'rejected';

--- a/backoffice/src/routes/_layout/events/settings.tsx
+++ b/backoffice/src/routes/_layout/events/settings.tsx
@@ -8,6 +8,7 @@ import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { ChipInput } from "@/components/forms/EventForm/ChipInput"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ImageUpload } from "@/components/ui/image-upload"
 import { Label } from "@/components/ui/label"
 import {
   Select,
@@ -107,6 +108,7 @@ function EventSettingsForm() {
     allowed_tags: [] as string[],
     allowed_kinds: [] as string[],
     approval_notification_emails: [] as string[],
+    placeholder_url: null as string | null,
   }
 
   return (
@@ -227,6 +229,25 @@ function EventSettingsForm() {
             })}
           </SelectContent>
         </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Image placeholder</Label>
+        <ImageUpload
+          value={currentSettings.placeholder_url ?? null}
+          disabled={readOnly}
+          onChange={(url) =>
+            upsertMutation.mutate({
+              ...currentSettings,
+              popup_id: selectedPopupId!,
+              placeholder_url: url,
+            })
+          }
+        />
+        <p className="text-sm text-muted-foreground">
+          Shown in the portal as the event cover when an individual event has no
+          image. If left empty, the portal falls back to a generic icon.
+        </p>
       </div>
 
       <div className="space-y-2">

--- a/portal/src/app/[popupSlug]/calendar/PublicCalendarClient.tsx
+++ b/portal/src/app/[popupSlug]/calendar/PublicCalendarClient.tsx
@@ -255,6 +255,7 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
             eventsOverride={events}
             onEventClick={handleEventClick}
             timezoneOverride={timezone}
+            placeholderUrl={meta?.placeholder_url}
           />
         ) : view === "day" ? (
           <DayBody
@@ -288,6 +289,7 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
             formatDayKey={formatDayKey}
             mode="public"
             onEventClick={handleEventClick}
+            placeholderUrl={meta?.placeholder_url}
           />
         )}
       </div>

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -61,7 +61,10 @@ import { AddToCalendarModal } from "../lib/AddToCalendarModal"
 import { CoverImage } from "../lib/CoverImage"
 import { summarizeRrule } from "../lib/summarizeRrule"
 import { useCalendarAddedFlag } from "../lib/useCalendarAddedFlag"
-import { useEventTimezone } from "../lib/useEventTimezone"
+import {
+  useEventTimezone,
+  usePortalEventSettings,
+} from "../lib/useEventTimezone"
 
 function AdminNotesSection({ eventId }: { eventId: string }) {
   const queryClient = useQueryClient()
@@ -163,6 +166,7 @@ export default function EventDetailPage() {
     formatDateFull,
     isLoading: tzLoading,
   } = useEventTimezone(city?.id)
+  const { data: eventSettings } = usePortalEventSettings(city?.id)
 
   const {
     data: event,
@@ -415,7 +419,11 @@ export default function EventDetailPage() {
   })()
   const eventStarted = new Date(effectiveStartTime) <= new Date()
 
-  const coverUrl = event.cover_url || event.venue_image_url || null
+  const coverUrl =
+    event.cover_url ||
+    event.venue_image_url ||
+    eventSettings?.placeholder_url ||
+    null
   const coverCredit =
     !event.cover_url && event.venue_image_url ? event.venue_title : null
 

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -88,6 +88,8 @@ interface CalendarBodyProps {
   /** Timezone forwarded to ``useEventTimezone`` when settings aren't
    * available (public mode has no authenticated settings endpoint). */
   timezoneOverride?: string
+  /** Popup-scoped fallback image when an event has no cover/venue image. */
+  placeholderUrl?: string | null
 }
 
 /**
@@ -108,6 +110,7 @@ export function CalendarBody({
   eventsOverride,
   onEventClick,
   timezoneOverride,
+  placeholderUrl,
 }: CalendarBodyProps) {
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
@@ -416,18 +419,26 @@ export function CalendarBody({
                         className="block p-3"
                       >
                         <div className="flex items-start gap-3">
-                          {event.venue_image_url && (
-                            <div className="h-12 w-12 rounded-md overflow-hidden shrink-0">
-                              <CoverImage
-                                src={event.venue_image_url}
-                                alt={event.venue_title ?? ""}
-                                className="h-full w-full object-cover"
-                                fallback={
-                                  <MapPin className="h-5 w-5 text-muted-foreground/40" />
-                                }
-                              />
-                            </div>
-                          )}
+                          {(() => {
+                            const thumbUrl =
+                              event.cover_url ||
+                              event.venue_image_url ||
+                              placeholderUrl ||
+                              null
+                            if (!thumbUrl) return null
+                            return (
+                              <div className="h-12 w-12 rounded-md overflow-hidden shrink-0">
+                                <CoverImage
+                                  src={thumbUrl}
+                                  alt={event.venue_title ?? ""}
+                                  className="h-full w-full object-cover"
+                                  fallback={
+                                    <MapPin className="h-5 w-5 text-muted-foreground/40" />
+                                  }
+                                />
+                              </div>
+                            )
+                          })()}
                           <div className="min-w-0 flex-1">
                             <h4 className="text-sm font-medium truncate flex items-center gap-1.5">
                               {isOwner && (

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -79,6 +79,8 @@ interface ListBodyProps {
   pendingRsvpKey?: string | null
   onHide?: (eventId: string) => void
   onUnhide?: (eventId: string) => void
+  /** Popup-scoped fallback image when an event has no cover/venue image. */
+  placeholderUrl?: string | null
 }
 
 /**
@@ -104,6 +106,7 @@ export function ListBody({
   pendingRsvpKey,
   onHide,
   onUnhide,
+  placeholderUrl,
 }: ListBodyProps) {
   const { t } = useTranslation()
   const isAuthed = mode === "authed"
@@ -172,7 +175,11 @@ export function ListBody({
                   })
                 }
               }
-              const thumbUrl = event.cover_url || event.venue_image_url || null
+              const thumbUrl =
+                event.cover_url ||
+                event.venue_image_url ||
+                placeholderUrl ||
+                null
               return (
                 <div
                   key={event.id}

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -760,6 +760,7 @@ export default function EventsPage() {
             trackIds={selectedTrackIds}
             defaultDate={selectedDate}
             onEventLinkClick={handleEventLinkClick}
+            placeholderUrl={eventSettings?.placeholder_url}
           />
         ) : view === "day" ? (
           isDayFullscreen ? null : (
@@ -794,6 +795,7 @@ export default function EventsPage() {
             pendingRsvpKey={pendingRsvpKey}
             onHide={(id) => hideMutation.mutate(id)}
             onUnhide={(id) => unhideMutation.mutate(id)}
+            placeholderUrl={eventSettings?.placeholder_url}
           />
         )}
       </div>

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -5149,6 +5149,17 @@ export const EventCalendarMetaSchema = {
         popup_name: {
             type: 'string',
             title: 'Popup Name'
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         }
     },
     type: 'object',
@@ -6382,6 +6393,17 @@ export const EventSettingsCreateSchema = {
             type: 'array',
             title: 'Approval Notification Emails',
             default: []
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         }
     },
     type: 'object',
@@ -6452,6 +6474,17 @@ export const EventSettingsPublicSchema = {
             },
             type: 'array',
             title: 'Approval Notification Emails'
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         },
         created_at: {
             type: 'string',
@@ -6583,6 +6616,17 @@ export const EventSettingsUpdateSchema = {
                 }
             ],
             title: 'Approval Notification Emails'
+        },
+        placeholder_url: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Placeholder Url'
         }
     },
     type: 'object',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1184,6 +1184,7 @@ export type EventCalendarMeta = {
     popup_id: string;
     popup_slug: string;
     popup_name: string;
+    placeholder_url?: (string | null);
 };
 
 /**
@@ -1418,6 +1419,7 @@ export type EventSettingsCreate = {
     allowed_tags?: Array<(string)>;
     allowed_kinds?: Array<(string)>;
     approval_notification_emails?: Array<(string)>;
+    placeholder_url?: (string | null);
 };
 
 /**
@@ -1435,6 +1437,7 @@ export type EventSettingsPublic = {
     allowed_tags?: Array<(string)>;
     allowed_kinds?: Array<(string)>;
     approval_notification_emails?: Array<(string)>;
+    placeholder_url?: (string | null);
     created_at?: string;
     updated_at?: string;
     id: string;
@@ -1453,6 +1456,7 @@ export type EventSettingsUpdate = {
     allowed_tags?: (Array<(string)> | null);
     allowed_kinds?: (Array<(string)> | null);
     approval_notification_emails?: (Array<(string)> | null);
+    placeholder_url?: (string | null);
 };
 
 export type EventStatus = 'draft' | 'published' | 'cancelled' | 'pending_approval' | 'rejected';


### PR DESCRIPTION
## Summary
Adds a popup-scoped fallback image for events. Backoffice admins upload it in **Event Settings → Image placeholder**; the portal uses it when an individual event has no cover/venue image, and falls back to the existing generic icon when the placeholder is also missing.

## Changes
| Area | File | Change |
|------|------|--------|
| Backend | `app/alembic/versions/7a3f9c1d8e2b_event_settings_placeholder_url.py` | New migration — `event_settings.placeholder_url TEXT NULL` |
| Backend | `app/api/event_settings/schemas.py` | Adds `placeholder_url` to `EventSettingsBase` / `Create` / `Update` |
| Backend | `app/api/event/schemas.py`, `router.py` | Surfaces `placeholder_url` via `EventCalendarMeta` so the anonymous public calendar can apply the same fallback |
| Backoffice | `routes/_layout/events/settings.tsx` | New `Image placeholder` field reusing `<ImageUpload>` |
| Portal | `events/lib/ListBody.tsx`, `events/lib/CalendarBody.tsx` | New `placeholderUrl` prop, plugged into the cover fallback chain (CalendarBody now also considers `cover_url` alongside `venue_image_url`) |
| Portal | `events/[eventId]/page.tsx` | Pulls `usePortalEventSettings` and uses `placeholder_url` in the cover fallback |
| Portal | `events/page.tsx`, `[popupSlug]/calendar/PublicCalendarClient.tsx` | Pass `placeholder_url` from settings/meta down to the list and calendar views |
| Both | `src/client/*.gen.*` | Regenerated SDKs |

Cover fallback chain becomes: `event.cover_url → event.venue_image_url → event_settings.placeholder_url → generic icon`.

## Migration
Includes Alembic revision `7a3f9c1d8e2b` (head). Run `alembic upgrade head` on the develop DB before deploying the API.

## Test plan
- [x] `bash backend/scripts/lint.sh` — green
- [x] `pnpm --filter backoffice run build` — green
- [x] `pnpm --filter portal run build` — green
- [x] `alembic heads` returns a single head
- [ ] Manual: backoffice — upload a placeholder under Event Settings, confirm it saves and reloads
- [ ] Manual: portal — event without a cover renders the placeholder in list view, calendar view and event detail
- [ ] Manual: portal — event without a cover and no popup placeholder still renders the generic icon
- [ ] Manual: anonymous `/[popupSlug]/calendar` shows the placeholder via the public meta