### PR TITLE
fix(portal): use backend presigned URL flow for profile photo upload

### DIFF
--- a/portal/src/helpers/upload.ts
+++ b/portal/src/helpers/upload.ts
@@ -1,29 +1,31 @@
+import { UploadsService } from "@/client"
+
 /**
- * Upload a file to S3 via the server-side API route.
- * This keeps AWS credentials secure on the server.
+ * Upload a file to S3 using the backend presigned URL flow.
+ * Step 1: request a presigned PUT URL from the backend.
+ * Step 2: upload the file directly to S3.
+ * Returns the public URL of the uploaded file.
  */
 const uploadFileToS3 = async (file: File): Promise<string> => {
-  const formData = new FormData()
-  formData.append("file", file)
-
-  try {
-    const response = await fetch("/api/upload", {
-      method: "POST",
-      body: formData,
+  const { upload_url, public_url } =
+    await UploadsService.getPresignedUploadUrlPortal({
+      requestBody: {
+        filename: file.name,
+        content_type: file.type,
+      },
     })
 
-    if (!response.ok) {
-      const errorData = await response.json()
-      throw new Error(errorData.error || "Failed to upload file")
-    }
+  const response = await fetch(upload_url, {
+    method: "PUT",
+    headers: { "Content-Type": file.type },
+    body: file,
+  })
 
-    const data = await response.json()
-    console.log("File uploaded successfully:", data.url)
-    return data.url
-  } catch (error) {
-    console.error("Error uploading file to S3:", error)
-    throw error
+  if (!response.ok) {
+    throw new Error(`Failed to upload file (status ${response.status})`)
   }
+
+  return public_url
 }
 
 export default uploadFileToS3


### PR DESCRIPTION
## Problema

El upload de foto de perfil en `portal/profile` falla con `POST /api/upload 404 (Not Found)` y "Error uploading file to S3".

El helper `portal/src/helpers/upload.ts` posteaba a `/api/upload`, una Next.js API route que **no existe** en el portal (no hay `src/app/api/`). El backend nunca expuso ese endpoint.

## Solución

Reescribí el helper para usar el flujo de presigned URL en 2 pasos del backend (`POST /api/v1/uploads/portal/presigned-url`), el mismo patrón que el backoffice ya usa:

1. Pide la presigned URL al backend (`filename` + `content_type`).
2. Hace `PUT` del archivo directo a S3 con el `Content-Type` correcto.
3. Devuelve `public_url`.

El cliente generado (`UploadsService.getPresignedUploadUrlPortal`) ya tenía el endpoint, no hizo falta regenerar. La firma del helper se mantiene, no se tocó `HumanForm.tsx`.

## Verificación

- `pnpm --filter portal run build` pasa sin errores de tipos.