### PR TITLE
fix(portal): auto-accept reused application on group invite checkout

### DIFF
--- a/portal/src/app/checkout/components/PopupCheckoutContent.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.tsx
@@ -64,6 +64,7 @@ export const PopupCheckoutContent = ({
     errorMessage,
     handleSubmit,
     setCheckoutState,
+    joinGroupAsApplicant,
   } = useCheckoutState({
     popupId: popup.id,
     saleType: resolvePopupCheckoutPolicy(popup).saleType,
@@ -190,6 +191,12 @@ export const PopupCheckoutContent = ({
     // so this redirect to /portal is structurally unreachable in checkout mode.
     if (policy.saleType !== "application") return
     if (!existingApplication || checkoutState !== "form") return
+    // In a group flow, wait for participation to resolve and never auto-skip a
+    // companion — the CompanionSwitchPrompt drives that case.
+    if (isGroupFlow) {
+      if (participation === undefined) return
+      if (isCompanion) return
+    }
 
     hasSkippedForm.current = true
 
@@ -202,6 +209,18 @@ export const PopupCheckoutContent = ({
       return
     }
 
+    // Existing applicant clicking a group invite link whose application isn't
+    // accepted yet: persist the group membership so the backend auto-accepts it
+    // before checkout, otherwise the payment step 403s ("Application must be
+    // accepted before purchasing products"). Only attempt it for statuses the
+    // backend allows updating (draft/pending_fee/in review); rejected/withdrawn
+    // fall through unchanged and stay gated at payment.
+    const joinableStatuses = ["draft", "pending_fee", "in review"]
+    if (groupId && joinableStatuses.includes(existingApplication.status)) {
+      joinGroupAsApplicant()
+      return
+    }
+
     setCheckoutState("passes")
   }, [
     policy.saleType,
@@ -210,6 +229,11 @@ export const PopupCheckoutContent = ({
     setCheckoutState,
     getCity,
     router,
+    groupId,
+    isGroupFlow,
+    participation,
+    isCompanion,
+    joinGroupAsApplicant,
   ])
 
   const handleFormSubmit = async (

--- a/portal/src/app/checkout/hooks/useCheckoutState.ts
+++ b/portal/src/app/checkout/hooks/useCheckoutState.ts
@@ -229,6 +229,39 @@ const useCheckoutState = ({
     },
   })
 
+  // Existing applicant arriving through a group invite link. Persists the
+  // group membership on their current application so the backend auto-accepts
+  // it (mirrors the form-submit path, which also sends group_id). Without this
+  // the payment step 403s with "Application must be accepted before purchasing
+  // products" because the reused draft/in-review application is never accepted.
+  const joinGroupMutation = useMutation({
+    mutationFn: async () => {
+      if (!popupId) throw new Error("No popup selected")
+      if (!groupId) throw new Error("No group selected")
+      return ApplicationsService.updateMyApplication({
+        popupId,
+        requestBody: { group_id: groupId },
+      })
+    },
+    onMutate: () => {
+      setCheckoutState("processing")
+      setErrorMessage(null)
+    },
+    onSuccess: (application) => {
+      queryClient.setQueryData(queryKeys.applications.mine(), [application])
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.attendees.byHumanPopup(popupId),
+      })
+      setCheckoutState("passes")
+      setErrorMessage(null)
+    },
+    onError: (error: unknown) => {
+      const detail = error instanceof ApiError ? getApiErrorDetail(error) : null
+      setErrorMessage(detail ?? "Something went wrong. Please try again.")
+      setCheckoutState("form")
+    },
+  })
+
   const handleSubmit = async (
     formData: DefaultCheckoutFormData | CheckoutApplicationValues,
   ): Promise<void> => {
@@ -241,6 +274,8 @@ const useCheckoutState = ({
     errorMessage,
     handleSubmit,
     setCheckoutState,
+    joinGroupAsApplicant: joinGroupMutation.mutate,
+    isJoiningGroup: joinGroupMutation.isPending,
   }
 }
 


### PR DESCRIPTION
## Problema

Cuando un applicant existente (status `draft` o `in review`) abre un link de invitación a grupo (`/groups/{group-slug}`), el portal reutilizaba su application y saltaba el formulario directo al checkout, pero **nunca enviaba el `group_id` al backend**. La application quedaba sin aceptar y, al intentar pagar, el backend devolvía **403** (`Application must be accepted before purchasing products`).

El backend ya soporta el flujo: `PATCH /applications/my/{popup_id}` auto-acepta cuando llega `group_id` (rama `is_group_join`). El bug era puramente del portal, que solo mandaba `group_id` por el camino de submit del formulario, no por el de skip.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `portal/src/app/checkout/hooks/useCheckoutState.ts` | Nueva `joinGroupMutation` (PATCH con `group_id`) expuesta como `joinGroupAsApplicant`; actualiza el cache de `applications.mine()` y `attendees`, y avanza a `passes`. |
| `portal/src/app/checkout/components/PopupCheckoutContent.tsx` | En el `useEffect` de skip: si hay `groupId` y la application está en un status joineable (`draft`/`pending_fee`/`in review`), dispara `joinGroupAsApplicant()` para forzar el auto-accept antes del checkout. El skip en flujo de grupo además espera a que `participation` resuelva y nunca auto-saltea a un companion (eso lo maneja `CompanionSwitchPrompt`). |

## Notas

- `rejected`/`withdrawn` no se intentan unir (el backend no permite update) y caen al comportamiento previo, quedando gateados en el pago.
- Sin doble envío de `group_id`: los caminos de skip y de submit son mutuamente excluyentes.

## Test plan

- [x] `pnpm --filter portal run lint`
- [x] `pnpm --filter portal run build`
- [ ] Manual: applicant en `draft`/`in review` entra a `/groups/{slug}` y completa el pago sin 403.