### PR TITLE
Release: request logging, group-invite checkout fix, profile photo upload

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24 * 8
     BACKOFFICE_URL: str = "http://localhost:5173"
     ENVIRONMENT: Environment = Environment.DEV
+    # Minimum level emitted by the loguru stdout sink. Set to DEBUG for verbose
+    # local debugging; INFO keeps production logs to signal + request lines.
+    LOG_LEVEL: str = "INFO"
 
     PROJECT_NAME: str = Field(...)
     SENTRY_DSN: HttpUrl | None = None

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,146 @@
+"""Centralized logging configuration and per-request context.
+
+Goal: make a single real request followable end to end in the logs, and make a
+customer report locatable without asking the user for any id.
+
+- ``configure_logging`` reconfigures loguru so every line carries a
+  ``request_id`` and the authenticated ``principal``.
+- ``RequestContextMiddleware`` assigns or propagates an ``X-Request-ID`` per
+  request, derives the principal from the bearer token, binds both into the
+  loguru context (so every log emitted while handling that request shares them),
+  and emits one structured line per request with method, path, status, and
+  duration. Health checks are skipped to keep the signal high.
+
+The ``principal`` (``<token_type>:<sub>``, e.g. ``human:<uuid>``) is what makes a
+cold report findable: map the customer's email to their human_id, then grep that
+id. The ``request_id`` is for correlating all lines of one request once found
+(and for support flows where it can be surfaced to the user).
+
+Request and response bodies are intentionally NOT logged: these routes carry
+PII, payment data, and auth tokens. The error *detail* returned to the client
+is logged by the HTTPException handler in ``app.main`` instead, which is safe
+because it is our own message rather than user-submitted content.
+"""
+
+import sys
+import time
+import uuid
+
+from loguru import logger
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.config import settings
+
+_LOG_FORMAT = (
+    "{time:YYYY-MM-DD HH:mm:ss.SSS} | "
+    "{level: <8} | "
+    "{extra[request_id]} | "
+    "{extra[principal]} | "
+    "{name}:{function}:{line} - "
+    "{message}"
+)
+
+
+def _principal_from_headers(headers: dict[bytes, bytes]) -> str:
+    """Best-effort identity for log correlation, read from the bearer token.
+
+    Returns ``"<token_type>:<sub>"`` (e.g. ``human:<uuid>``) so a customer
+    report can be located by mapping their email to a human_id and grepping that
+    id. Returns ``-`` for anonymous requests, api-key auth, or tokens that fail
+    to decode. This NEVER enforces auth; real auth still runs in the route
+    dependencies. Decoding is verified (signature + exp) and cheap.
+    """
+    auth = headers.get(b"authorization", b"").decode(errors="ignore")
+    if not auth.lower().startswith("bearer "):
+        return "-"
+    token = auth[7:].strip()
+    if not token:
+        return "-"
+    try:
+        from app.core.security import decode_access_token
+
+        payload = decode_access_token(token)
+    except Exception:
+        # Expired/invalid/non-JWT (e.g. api key): nothing to bind for logging.
+        return "-"
+    if not payload.sub:
+        return "-"
+    return f"{payload.token_type or 'token'}:{payload.sub}"
+
+
+def configure_logging() -> None:
+    """Reconfigure loguru: single stdout sink with a request_id on every line.
+
+    Idempotent — safe to call once at import time. ``extra["request_id"]``
+    defaults to ``-`` so lines emitted outside a request (startup, background
+    jobs) still render with the same format.
+    """
+    logger.remove()
+    logger.configure(extra={"request_id": "-", "principal": "-"})
+    logger.add(
+        sys.stdout,
+        format=_LOG_FORMAT,
+        level=settings.LOG_LEVEL,
+        colorize=False,
+        backtrace=False,
+        diagnose=False,
+    )
+
+
+class RequestContextMiddleware:
+    """Pure-ASGI middleware: per-request id plus one structured access line.
+
+    Implemented as pure ASGI (not ``BaseHTTPMiddleware``) so the contextvar set
+    by ``logger.contextualize`` propagates into the route handler and every log
+    it emits, letting one ``request_id`` tie the whole request together.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path == "/health-check":
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers") or [])
+        inbound = headers.get(b"x-request-id")
+        request_id = inbound.decode() if inbound else uuid.uuid4().hex[:12]
+
+        method = scope.get("method", "-")
+        client = scope.get("client")
+        client_ip = client[0] if client else "-"
+        principal = _principal_from_headers(headers)
+
+        status_code = {"code": 0}
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                status_code["code"] = message["status"]
+                # Echo the id back so support can correlate a user report.
+                message.setdefault("headers", [])
+                message["headers"].append((b"x-request-id", request_id.encode()))
+            await send(message)
+
+        start = time.perf_counter()
+        with logger.contextualize(request_id=request_id, principal=principal):
+            try:
+                await self.app(scope, receive, send_wrapper)
+            finally:
+                duration_ms = round((time.perf_counter() - start) * 1000, 1)
+                code = status_code["code"]
+                level = "ERROR" if code >= 500 else "WARNING" if code >= 400 else "INFO"
+                logger.log(
+                    level,
+                    "{} {} -> {} ({}ms) ip={}",
+                    method,
+                    path,
+                    code,
+                    duration_ms,
+                    client_ip,
+                )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,12 +7,16 @@ from fastapi.routing import APIRoute
 from loguru import logger
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError, ProgrammingError
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
 
 import app.models  # noqa: F401 - Register all models with SQLAlchemy
 from app.api.router import api_router
 from app.core.config import Environment, settings
+from app.core.logging import RequestContextMiddleware, configure_logging
 from app.core.rate_limit import RateLimitExceeded
+
+configure_logging()
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -101,6 +105,33 @@ def handle_integrity_error(_: Request, exc: IntegrityError) -> JSONResponse:
     )
 
 
+@application.exception_handler(StarletteHTTPException)
+def handle_http_exception(
+    request: Request, exc: StarletteHTTPException
+) -> JSONResponse:
+    """Log the detail returned to the client for every raised HTTPException.
+
+    Without this, a raised ``HTTPException`` (e.g. 403 "Application must be
+    accepted before purchasing products") leaves only a bare status code in the
+    access log, so a real user report cannot be traced. 4xx are logged at
+    WARNING, 5xx at ERROR. The response shape matches Starlette's default
+    handler so clients see no change.
+    """
+    log = logger.warning if exc.status_code < 500 else logger.error
+    log(
+        "{} {} -> {}: {}",
+        request.method,
+        request.url.path,
+        exc.status_code,
+        exc.detail,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail},
+        headers=getattr(exc, "headers", None),
+    )
+
+
 application.add_middleware(
     CORSMiddleware,  # type: ignore[arg-type]
     allow_origins=["*"],
@@ -108,6 +139,10 @@ application.add_middleware(
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "X-Tenant-Id", "Accept-Language"],
 )
+
+# Outermost middleware: assigns a request_id, binds it to all logs in the
+# request, and emits one structured access line per request.
+application.add_middleware(RequestContextMiddleware)  # type: ignore[arg-type]
 
 
 @application.get("/health-check", tags=["utils"], include_in_schema=False)

--- a/portal/src/app/checkout/components/PopupCheckoutContent.tsx
+++ b/portal/src/app/checkout/components/PopupCheckoutContent.tsx
@@ -64,6 +64,7 @@ export const PopupCheckoutContent = ({
     errorMessage,
     handleSubmit,
     setCheckoutState,
+    joinGroupAsApplicant,
   } = useCheckoutState({
     popupId: popup.id,
     saleType: resolvePopupCheckoutPolicy(popup).saleType,
@@ -190,6 +191,12 @@ export const PopupCheckoutContent = ({
     // so this redirect to /portal is structurally unreachable in checkout mode.
     if (policy.saleType !== "application") return
     if (!existingApplication || checkoutState !== "form") return
+    // In a group flow, wait for participation to resolve and never auto-skip a
+    // companion — the CompanionSwitchPrompt drives that case.
+    if (isGroupFlow) {
+      if (participation === undefined) return
+      if (isCompanion) return
+    }
 
     hasSkippedForm.current = true
 
@@ -202,6 +209,18 @@ export const PopupCheckoutContent = ({
       return
     }
 
+    // Existing applicant clicking a group invite link whose application isn't
+    // accepted yet: persist the group membership so the backend auto-accepts it
+    // before checkout, otherwise the payment step 403s ("Application must be
+    // accepted before purchasing products"). Only attempt it for statuses the
+    // backend allows updating (draft/pending_fee/in review); rejected/withdrawn
+    // fall through unchanged and stay gated at payment.
+    const joinableStatuses = ["draft", "pending_fee", "in review"]
+    if (groupId && joinableStatuses.includes(existingApplication.status)) {
+      joinGroupAsApplicant()
+      return
+    }
+
     setCheckoutState("passes")
   }, [
     policy.saleType,
@@ -210,6 +229,11 @@ export const PopupCheckoutContent = ({
     setCheckoutState,
     getCity,
     router,
+    groupId,
+    isGroupFlow,
+    participation,
+    isCompanion,
+    joinGroupAsApplicant,
   ])
 
   const handleFormSubmit = async (

--- a/portal/src/app/checkout/hooks/useCheckoutState.ts
+++ b/portal/src/app/checkout/hooks/useCheckoutState.ts
@@ -229,6 +229,39 @@ const useCheckoutState = ({
     },
   })
 
+  // Existing applicant arriving through a group invite link. Persists the
+  // group membership on their current application so the backend auto-accepts
+  // it (mirrors the form-submit path, which also sends group_id). Without this
+  // the payment step 403s with "Application must be accepted before purchasing
+  // products" because the reused draft/in-review application is never accepted.
+  const joinGroupMutation = useMutation({
+    mutationFn: async () => {
+      if (!popupId) throw new Error("No popup selected")
+      if (!groupId) throw new Error("No group selected")
+      return ApplicationsService.updateMyApplication({
+        popupId,
+        requestBody: { group_id: groupId },
+      })
+    },
+    onMutate: () => {
+      setCheckoutState("processing")
+      setErrorMessage(null)
+    },
+    onSuccess: (application) => {
+      queryClient.setQueryData(queryKeys.applications.mine(), [application])
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.attendees.byHumanPopup(popupId),
+      })
+      setCheckoutState("passes")
+      setErrorMessage(null)
+    },
+    onError: (error: unknown) => {
+      const detail = error instanceof ApiError ? getApiErrorDetail(error) : null
+      setErrorMessage(detail ?? "Something went wrong. Please try again.")
+      setCheckoutState("form")
+    },
+  })
+
   const handleSubmit = async (
     formData: DefaultCheckoutFormData | CheckoutApplicationValues,
   ): Promise<void> => {
@@ -241,6 +274,8 @@ const useCheckoutState = ({
     errorMessage,
     handleSubmit,
     setCheckoutState,
+    joinGroupAsApplicant: joinGroupMutation.mutate,
+    isJoiningGroup: joinGroupMutation.isPending,
   }
 }
 

--- a/portal/src/helpers/upload.ts
+++ b/portal/src/helpers/upload.ts
@@ -1,29 +1,31 @@
+import { UploadsService } from "@/client"
+
 /**
- * Upload a file to S3 via the server-side API route.
- * This keeps AWS credentials secure on the server.
+ * Upload a file to S3 using the backend presigned URL flow.
+ * Step 1: request a presigned PUT URL from the backend.
+ * Step 2: upload the file directly to S3.
+ * Returns the public URL of the uploaded file.
  */
 const uploadFileToS3 = async (file: File): Promise<string> => {
-  const formData = new FormData()
-  formData.append("file", file)
-
-  try {
-    const response = await fetch("/api/upload", {
-      method: "POST",
-      body: formData,
+  const { upload_url, public_url } =
+    await UploadsService.getPresignedUploadUrlPortal({
+      requestBody: {
+        filename: file.name,
+        content_type: file.type,
+      },
     })
 
-    if (!response.ok) {
-      const errorData = await response.json()
-      throw new Error(errorData.error || "Failed to upload file")
-    }
+  const response = await fetch(upload_url, {
+    method: "PUT",
+    headers: { "Content-Type": file.type },
+    body: file,
+  })
 
-    const data = await response.json()
-    console.log("File uploaded successfully:", data.url)
-    return data.url
-  } catch (error) {
-    console.error("Error uploading file to S3:", error)
-    throw error
+  if (!response.ok) {
+    throw new Error(`Failed to upload file (status ${response.status})`)
   }
+
+  return public_url
 }
 
 export default uploadFileToS3


### PR DESCRIPTION
Release of `dev` into `main`. Includes three changes.

## fix(portal): group-invite checkout 403 (#228)
Existing applicants (`draft` / `pending_fee` / `in review`) opening a group invite link had their application reused and the form skipped straight to checkout without sending `group_id`, so the application stayed unaccepted and the payment step returned `403 "Application must be accepted before purchasing products"`. The form-skip path now persists the group membership via `updateMyApplication({ group_id })`, which the backend validates (group belongs to popup, email whitelisted or group open) and then force-accepts (mirroring the create flow), so checkout proceeds. The group-flow skip waits for participation to resolve and never auto-skips a companion.

## feat(backend): request-scoped logging with request_id and principal (#227)
Adds an `HTTPException` handler that logs `method path -> status: detail` for every raised 4xx/5xx (previously only a bare status code reached the access log), plus a pure-ASGI `RequestContextMiddleware` that assigns an `X-Request-ID` and binds the authenticated `principal` (`human:<uuid>`) onto every log line of the request. A reported case can now be located by mapping the customer email to a `human_id` and grepping, without asking the user for an id. Adds a `LOG_LEVEL` setting (default `INFO`). Bodies are intentionally not logged.

## fix(portal): profile photo upload (#226)
Uses the backend presigned URL flow for profile photo upload.

## Notes
- The logging and group-invite fixes are complementary: the 403 that triggered this investigation is now both fixed (group invitees get accepted) and traceable (the detail and principal are logged) for any future case.