### PR TITLE
fix(portal): anchor events/calendar window to popup timezone

### DIFF
--- a/portal/src/app/[popupSlug]/calendar/PublicCalendarClient.tsx
+++ b/portal/src/app/[popupSlug]/calendar/PublicCalendarClient.tsx
@@ -55,11 +55,17 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
 
   // Default window: 180 days from today. The endpoint expands recurring
   // events server-side when ``start_after`` is set, so we always pass it.
+  //
+  // We pad one day on each side of the UTC window so events near the popup's
+  // local-day boundary are never missed regardless of the popup's UTC offset
+  // (the backend filters in UTC). The list is then trimmed to "today onward"
+  // in popup time once the timezone is known — see ``events`` below.
   const window = useMemo(() => {
     const start = new Date()
     start.setUTCHours(0, 0, 0, 0)
+    start.setUTCDate(start.getUTCDate() - 1)
     const end = new Date(start)
-    end.setUTCDate(end.getUTCDate() + 180)
+    end.setUTCDate(end.getUTCDate() + 182)
     return {
       startAfter: start.toISOString(),
       startBefore: end.toISOString(),
@@ -85,6 +91,11 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
   const meta = query.data?.meta
   const timezone = meta?.timezone
 
+  const { formatTime, formatDateShort, formatDayKey } = useEventTimezone(
+    meta?.popup_id,
+    timezone,
+  )
+
   // Override the static "Calendar" title set by generateMetadata once
   // we know the popup name. The server-side metadata can't reach an
   // anonymous "get popup by slug" endpoint, so we patch it here.
@@ -100,7 +111,16 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
   // (which our calls pass), so undefined fields never get rendered.
   const events = useMemo<EventPublic[]>(() => {
     const rows = query.data?.results ?? []
-    return rows.map(
+    // The fetch window is padded a day on each side and the backend filters
+    // in UTC, so an event that starts after 00:00Z can still be "yesterday"
+    // in the popup's timezone. Trim to events whose start day is today or
+    // later *in popup time* (day-keys are YYYY-MM-DD, so a string compare is
+    // chronological).
+    const todayKey = timezone ? formatDayKey(new Date().toISOString()) : null
+    const visibleRows = todayKey
+      ? rows.filter((r) => formatDayKey(r.start_time) >= todayKey)
+      : rows
+    return visibleRows.map(
       (r) =>
         ({
           id: r.id,
@@ -143,7 +163,7 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
           my_rsvp_status: null,
         }) as unknown as EventPublic,
     )
-  }, [query.data, meta?.popup_id])
+  }, [query.data, meta?.popup_id, timezone, formatDayKey])
 
   const handleEventClick = useCallback(
     (event: EventPublic) => {
@@ -166,11 +186,6 @@ export function PublicCalendarClient({ popupSlug }: PublicCalendarClientProps) {
       return true
     },
     [isAuthenticated, popupSlug, router],
-  )
-
-  const { formatTime, formatDateShort, formatDayKey } = useEventTimezone(
-    meta?.popup_id,
-    timezone,
   )
 
   const allowedTracks = useMemo(

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { dayBoundsInTz } from "@edgeos/shared-events"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { CalendarDays, Plus } from "lucide-react"
 import Link from "next/link"
@@ -15,7 +16,6 @@ import {
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
-
 import {
   ApiError,
   EventParticipantsService,
@@ -315,29 +315,27 @@ export default function EventsPage() {
   // empty. Falls back to a 180-day window from today before the popup
   // record loads.
   //
-  // Bounds use UTC midnight of the popup's first day and UTC midnight of
-  // the day *after* end_date — independent of the browser's timezone — so
-  // the filter always covers the whole calendar day starting at 00:00Z and
-  // doesn't drift if the user opens the portal from a different region.
+  // Bounds are anchored to the popup's timezone, not the browser's and not
+  // UTC: the booking dates name calendar days *in the popup's timezone*, so
+  // a UTC-midnight bound would leak the prior local evening and clip the
+  // last local evening (e.g. for a UTC-7 popup, the night of the last day
+  // falls after 00:00Z of the next day and would be dropped).
   const listWindow = useMemo(() => {
-    const parseUtcMidnight = (s: string | null | undefined) => {
-      if (!s) return null
-      const m = s.slice(0, 10).match(/^(\d{4})-(\d{2})-(\d{2})$/)
-      if (!m) return null
-      return new Date(
-        Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0),
-      )
+    const dayStr = (s: string | null | undefined) => {
+      const m = s?.slice(0, 10).match(/^\d{4}-\d{2}-\d{2}$/)
+      return m ? m[0] : null
     }
-    const startUtc = parseUtcMidnight(city?.start_date)
-    const endUtc = parseUtcMidnight(city?.end_date)
-    // For end, advance by one UTC day so events on the last day are included.
-    const endExclusive = endUtc
-      ? new Date(endUtc.getTime() + 24 * 60 * 60 * 1000)
-      : null
-    if (startUtc && endExclusive) {
+    const startDay = dayStr(city?.start_date)
+    const endDay = dayStr(city?.end_date)
+    if (startDay && endDay) {
+      // dayBoundsInTz returns [dayStart, dayEnd): the end of ``endDay`` is
+      // midnight of the following local day — exactly the exclusive upper
+      // bound that keeps the last day's events in.
+      const { start } = dayBoundsInTz(startDay, timezone)
+      const { end } = dayBoundsInTz(endDay, timezone)
       return {
-        startAfter: startUtc.toISOString(),
-        startBefore: endExclusive.toISOString(),
+        startAfter: start.toISOString(),
+        startBefore: end.toISOString(),
       }
     }
     const start = new Date()
@@ -345,10 +343,10 @@ export default function EventsPage() {
     const end = new Date(start)
     end.setUTCDate(end.getUTCDate() + 180)
     return {
-      startAfter: (startUtc ?? start).toISOString(),
-      startBefore: (endExclusive ?? end).toISOString(),
+      startAfter: start.toISOString(),
+      startBefore: end.toISOString(),
     }
-  }, [city?.start_date, city?.end_date])
+  }, [city?.start_date, city?.end_date, timezone])
 
   // The list is built from up to three independent "channels" — picking
   // events with OR semantics across the active filters so that toggling


### PR DESCRIPTION
## Summary

The `/events` list and the public `/calendar` built their fetch window from **UTC midnight** instead of the **popup's local midnight**. For a popup in `America/Los_Angeles` (UTC-7), an event stored at `2026-05-31T00:00:00Z` is `2026-05-30 17:00` locally (yesterday), yet it passed the `start_time >= start_after` filter and showed up in the calendar. Confirmed against production data.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- **Public calendar** (`PublicCalendarClient.tsx`): pad the UTC fetch window by one day on each side so events near the popup's local-day boundary are never missed in any UTC offset, then trim the result to events whose start day is today or later **in popup time** (`formatDayKey` `YYYY-MM-DD` compare). No double fetch, no flash.
- **Authenticated list** (`events/page.tsx`): derive the window from the popup's booking dates via `dayBoundsInTz(date, timezone)` instead of UTC midnight, so each whole local day (00:00 to 24:00 popup-time) is covered. Fixes a symmetric bug: the prior local evening leaked in and the last day's evening was clipped.
- Both reuse `dayBoundsInTz` from `@edgeos/shared-events`, the same helper `CalendarBody` already uses via `monthBoundsInTz`. No backend change: the UTC filter is correct given correct bounds.

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`)
- [ ] Backend linting passes (`bash scripts/lint.sh`)
- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [x] Portal linting passes (`pnpm --filter portal run lint`)
- [x] Manual testing performed (verified bounds against production data: leaking event now excluded, control events unaffected)

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed
- [ ] I have added tests for new functionality
- [x] All new and existing tests pass
- [x] No backend API change (OpenAPI client regeneration not needed)
- [x] No database migrations needed
