### PR TITLE
Default events list to current popup day

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/lib/listWindow.test.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/listWindow.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { eventListWindowForPopup } from "./listWindow"
+
+describe("eventListWindowForPopup", () => {
+  it("starts at popup-timezone today when the popup is in progress", () => {
+    const window = eventListWindowForPopup(
+      "2026-05-30",
+      "2026-06-02",
+      "America/Los_Angeles",
+      new Date("2026-06-01T01:00:00.000Z"),
+    )
+
+    // 2026-06-01T01:00Z is still May 31 in Los Angeles. Same-day morning
+    // events stay visible, but May 30 events are no longer in the default list.
+    expect(window.startAfter).toBe("2026-05-31T07:00:00.000Z")
+    expect(window.startBefore).toBe("2026-06-03T07:00:00.000Z")
+  })
+
+  it("keeps the full popup window before the popup starts", () => {
+    const window = eventListWindowForPopup(
+      "2026-05-30",
+      "2026-06-02",
+      "America/Los_Angeles",
+      new Date("2026-05-29T18:00:00.000Z"),
+    )
+
+    expect(window.startAfter).toBe("2026-05-30T07:00:00.000Z")
+    expect(window.startBefore).toBe("2026-06-03T07:00:00.000Z")
+  })
+
+  it("keeps the full popup window after the popup ends", () => {
+    const window = eventListWindowForPopup(
+      "2026-05-30",
+      "2026-06-02",
+      "America/Los_Angeles",
+      new Date("2026-06-04T18:00:00.000Z"),
+    )
+
+    expect(window.startAfter).toBe("2026-05-30T07:00:00.000Z")
+    expect(window.startBefore).toBe("2026-06-03T07:00:00.000Z")
+  })
+
+  it("falls back to a 180-day UTC window without popup dates", () => {
+    const window = eventListWindowForPopup(
+      null,
+      null,
+      "America/Los_Angeles",
+      new Date("2026-06-01T15:30:00.000Z"),
+    )
+
+    expect(window.startAfter).toBe("2026-06-01T00:00:00.000Z")
+    expect(window.startBefore).toBe("2026-11-28T00:00:00.000Z")
+  })
+})

--- a/portal/src/app/portal/[popupSlug]/events/lib/listWindow.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/listWindow.ts
@@ -1,0 +1,50 @@
+import { dayBoundsInTz } from "@edgeos/shared-events"
+
+function dayStr(s: string | null | undefined) {
+  const m = s?.slice(0, 10).match(/^\d{4}-\d{2}-\d{2}$/)
+  return m ? m[0] : null
+}
+
+function dayKeyInTz(date: Date, timezone: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date)
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ""
+  return `${get("year")}-${get("month")}-${get("day")}`
+}
+
+export function eventListWindowForPopup(
+  popupStartDate: string | null | undefined,
+  popupEndDate: string | null | undefined,
+  timezone: string,
+  now = new Date(),
+) {
+  const startDay = dayStr(popupStartDate)
+  const endDay = dayStr(popupEndDate)
+  if (startDay && endDay) {
+    const today = dayKeyInTz(now, timezone)
+    const queryStartDay =
+      startDay <= today && today <= endDay ? today : startDay
+
+    // dayBoundsInTz returns [dayStart, dayEnd): the end of ``endDay`` is
+    // midnight of the following local day, which keeps the last day's events in.
+    const { start } = dayBoundsInTz(queryStartDay, timezone)
+    const { end } = dayBoundsInTz(endDay, timezone)
+    return {
+      startAfter: start.toISOString(),
+      startBefore: end.toISOString(),
+    }
+  }
+
+  const start = new Date(now)
+  start.setUTCHours(0, 0, 0, 0)
+  const end = new Date(start)
+  end.setUTCDate(end.getUTCDate() + 180)
+  return {
+    startAfter: start.toISOString(),
+    startBefore: end.toISOString(),
+  }
+}

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { dayBoundsInTz } from "@edgeos/shared-events"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { CalendarDays, Plus } from "lucide-react"
 import Link from "next/link"
@@ -36,6 +35,7 @@ import {
   saveEventsViewState,
 } from "./lib/eventsViewState"
 import { ListBody } from "./lib/ListBody"
+import { eventListWindowForPopup } from "./lib/listWindow"
 import {
   useEventTimezone,
   usePortalEventSettings,
@@ -309,44 +309,22 @@ export default function EventsPage() {
   // events render only at their master's start (hiding the other instances
   // from the list while the calendar still showed them).
   //
-  // Anchored to the popup's booking window so the list view starts on the
-  // popup's first day rather than "today" — if the popup hasn't started or
-  // has already ended, the list still shows its events instead of being
-  // empty. Falls back to a 180-day window from today before the popup
-  // record loads.
+  // Anchored to the popup's booking window, but once the popup is in progress
+  // the list starts at the popup-timezone start of today. That hides prior
+  // days while still keeping same-day events that happened earlier today.
+  // If the popup hasn't started or has already ended, the list still shows
+  // its events instead of being empty. Falls back to a 180-day window from
+  // today before the popup record loads.
   //
   // Bounds are anchored to the popup's timezone, not the browser's and not
   // UTC: the booking dates name calendar days *in the popup's timezone*, so
   // a UTC-midnight bound would leak the prior local evening and clip the
   // last local evening (e.g. for a UTC-7 popup, the night of the last day
   // falls after 00:00Z of the next day and would be dropped).
-  const listWindow = useMemo(() => {
-    const dayStr = (s: string | null | undefined) => {
-      const m = s?.slice(0, 10).match(/^\d{4}-\d{2}-\d{2}$/)
-      return m ? m[0] : null
-    }
-    const startDay = dayStr(city?.start_date)
-    const endDay = dayStr(city?.end_date)
-    if (startDay && endDay) {
-      // dayBoundsInTz returns [dayStart, dayEnd): the end of ``endDay`` is
-      // midnight of the following local day — exactly the exclusive upper
-      // bound that keeps the last day's events in.
-      const { start } = dayBoundsInTz(startDay, timezone)
-      const { end } = dayBoundsInTz(endDay, timezone)
-      return {
-        startAfter: start.toISOString(),
-        startBefore: end.toISOString(),
-      }
-    }
-    const start = new Date()
-    start.setUTCHours(0, 0, 0, 0)
-    const end = new Date(start)
-    end.setUTCDate(end.getUTCDate() + 180)
-    return {
-      startAfter: start.toISOString(),
-      startBefore: end.toISOString(),
-    }
-  }, [city?.start_date, city?.end_date, timezone])
+  const listWindow = useMemo(
+    () => eventListWindowForPopup(city?.start_date, city?.end_date, timezone),
+    [city?.start_date, city?.end_date, timezone],
+  )
 
   // The list is built from up to three independent "channels" — picking
   // events with OR semantics across the active filters so that toggling


### PR DESCRIPTION
## Summary
- Start the portal events list at the popup-timezone start of today while a popup is in progress
- Keep same-day earlier events visible and hide prior popup days by default
- Add focused tests for pre-start, in-progress, post-end, and fallback windows

## Testing
- pnpm --filter portal exec biome ci "src/app/portal/[popupSlug]/events/page.tsx" "src/app/portal/[popupSlug]/events/lib/listWindow.ts" "src/app/portal/[popupSlug]/events/lib/listWindow.test.ts"
- pnpm --filter portal exec vitest run "src/app/portal/[popupSlug]/events/lib/listWindow.test.ts" "src/app/portal/[popupSlug]/events/page.test.tsx"
- pnpm --filter portal exec tsc --noEmit
- Agent-browser QA: /tmp/opencode/edgeos-calendar-upcoming-qa/events-upcoming-today-portal-rerun.png