### PR TITLE
feat(events): audit log for event CRUD operations

### DIFF
--- a/backend/app/alembic/versions/b7f3a9c1e4d2_event_audit_logs.py
+++ b/backend/app/alembic/versions/b7f3a9c1e4d2_event_audit_logs.py
@@ -1,0 +1,146 @@
+"""Add event_audit_logs audit table.
+
+Revision ID: b7f3a9c1e4d2
+Revises: 7a3f9c1d8e2b
+Create Date: 2026-06-01
+
+Persistent, append-only history of every event mutation (create/update/delete/
+cancel/approve/reject/recurrence/invitations/hide), recording who acted, from
+which app (Portal vs Backoffice), when, on which event, a snapshot of the
+relevant request data, and a field-level diff for updates.
+
+Unlike check_ins, the actor may be a backoffice User or a portal Human, so the
+actor is stored as flat columns rather than a single FK. ``event_id`` carries
+NO foreign key so the audit row survives a hard delete of its event.
+
+Forward-only migration (no downgrade). Raises RuntimeError if downgrade
+attempted — dropping this table would destroy the audit trail.
+
+Schema:
+  event_audit_logs (
+    id uuid PRIMARY KEY,
+    tenant_id uuid NOT NULL FK → tenants(id),
+    popup_id uuid NULL,
+    event_id uuid NOT NULL,                -- no FK: survives event delete
+    event_title text NULL,
+    action varchar(24) NOT NULL,
+    source varchar(16) NOT NULL,           -- portal | backoffice
+    actor_type varchar(8) NOT NULL,        -- user | human | api_key | system
+    actor_id uuid NULL,
+    actor_email text NULL,
+    actor_name text NULL,
+    request_id varchar(64) NULL,
+    snapshot jsonb NULL,
+    changes jsonb NULL,
+    occurred_at timestamptz NOT NULL DEFAULT now(),
+    created_at timestamptz NOT NULL DEFAULT now()
+  )
+
+Indexes:
+  ix_event_audit_logs_event_occurred ON (event_id, occurred_at DESC)
+  ix_event_audit_logs_tenant_occurred ON (tenant_id, occurred_at DESC)
+  ix_event_audit_logs_popup ON (popup_id)
+  ix_event_audit_logs_action ON (action)
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic
+revision = "b7f3a9c1e4d2"
+down_revision = "7a3f9c1d8e2b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_audit_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tenant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("popup_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_title", sa.Text(), nullable=True),
+        sa.Column("action", sa.String(24), nullable=False),
+        sa.Column("source", sa.String(16), nullable=False),
+        sa.Column("actor_type", sa.String(8), nullable=False),
+        sa.Column("actor_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_email", sa.Text(), nullable=True),
+        sa.Column("actor_name", sa.Text(), nullable=True),
+        sa.Column("request_id", sa.String(64), nullable=True),
+        sa.Column(
+            "snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "changes",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["tenant_id"],
+            ["tenants.id"],
+            name="fk_event_audit_logs_tenant_id",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_event_audit_logs"),
+    )
+
+    op.create_index(
+        "ix_event_audit_logs_event_occurred",
+        "event_audit_logs",
+        ["event_id", sa.text("occurred_at DESC")],
+    )
+    op.create_index(
+        "ix_event_audit_logs_tenant_occurred",
+        "event_audit_logs",
+        ["tenant_id", sa.text("occurred_at DESC")],
+    )
+    op.create_index(
+        "ix_event_audit_logs_popup",
+        "event_audit_logs",
+        ["popup_id"],
+    )
+    op.create_index(
+        "ix_event_audit_logs_action",
+        "event_audit_logs",
+        ["action"],
+    )
+
+    # Grant permissions to tenant roles (mirrors every other tenant table).
+    op.execute(
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE event_audit_logs TO tenant_role"
+    )
+    op.execute("GRANT SELECT ON TABLE event_audit_logs TO tenant_viewer_role")
+
+    # Row Level Security — same tenant_isolation pattern as all tenant tables.
+    op.execute("ALTER TABLE event_audit_logs ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE event_audit_logs FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation_policy_event_audit_logs ON event_audit_logs
+        USING (tenant_id = (SELECT current_setting('app.tenant_id', true)::uuid))
+        WITH CHECK (tenant_id = (SELECT current_setting('app.tenant_id', true)::uuid));
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "b7f3a9c1e4d2 (event_audit_logs) is a forward-only migration. "
+        "Downgrade is not implemented — dropping event_audit_logs would destroy "
+        "the audit trail for event CRUD operations."
+    )

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -37,6 +37,14 @@ from app.api.event.schemas import (
     OccurrenceRef,
     RecurrenceUpdate,
 )
+from app.api.event_audit.crud import (
+    actor_from_human,
+    actor_from_user,
+    build_event_snapshot,
+    compute_changes,
+    record_event_audit,
+)
+from app.api.event_audit.schemas import EventAuditAction
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
@@ -1011,6 +1019,13 @@ async def create_event(
     db.commit()
     db.refresh(event)
 
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.CREATED,
+        actor=actor_from_user(current_user),
+    )
+
     return _to_public(event)
 
 
@@ -1019,13 +1034,15 @@ async def update_event(
     event_id: uuid.UUID,
     event_in: EventUpdate,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+
+    audit_before = build_event_snapshot(db, event)
 
     new_venue_id = (
         event_in.venue_id if event_in.venue_id is not None else event.venue_id
@@ -1076,6 +1093,16 @@ async def update_event(
     if _event_calendar_fields_changed(before, updated):
         await _bump_and_dispatch_itip_update(db, updated, before=before)
 
+    audit_after = build_event_snapshot(db, updated)
+    record_event_audit(
+        db,
+        event=updated,
+        action=EventAuditAction.UPDATED,
+        actor=actor_from_user(current_user),
+        snapshot=audit_after,
+        changes=compute_changes(audit_before, audit_after),
+    )
+
     return _to_public(updated)
 
 
@@ -1083,7 +1110,7 @@ async def update_event(
 async def cancel_event(
     event_id: uuid.UUID,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1098,6 +1125,12 @@ async def cancel_event(
     cancel_update = EventUpdate(status=EventStatus.CANCELLED)
     updated = crud.events_crud.update(db, event, cancel_update)
     await _bump_and_dispatch_itip_cancel(db, updated)
+    record_event_audit(
+        db,
+        event=updated,
+        action=EventAuditAction.CANCELLED,
+        actor=actor_from_user(current_user),
+    )
     return _to_public(updated)
 
 
@@ -1105,7 +1138,7 @@ async def cancel_event(
 async def delete_event(
     event_id: uuid.UUID,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> None:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1118,6 +1151,14 @@ async def delete_event(
         await _bump_and_dispatch_itip_cancel(db, event)
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("iTIP CANCEL on event delete {} failed: {}", event_id, exc)
+    # Record the audit row *before* dropping the row, while the event (and its
+    # tenant/popup/title) is still readable.
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.DELETED,
+        actor=actor_from_user(current_user),
+    )
     crud.events_crud.delete(db, event)
 
 
@@ -1131,7 +1172,7 @@ async def set_recurrence(
     event_id: uuid.UUID,
     payload: RecurrenceUpdate,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     """Set/replace/clear the RRULE on a series master.
 
@@ -1178,6 +1219,15 @@ async def set_recurrence(
     # series.
     if old_rrule != new_rrule:
         await _bump_and_dispatch_itip_update(db, event)
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.RECURRENCE_SET,
+        actor=actor_from_user(current_user),
+        changes={"rrule": {"old": old_rrule, "new": new_rrule}}
+        if old_rrule != new_rrule
+        else None,
+    )
     return _to_public(event)
 
 
@@ -1214,7 +1264,7 @@ async def detach_occurrence(
     event_id: uuid.UUID,
     payload: OccurrenceRef,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     """Materialize a single occurrence of a recurring series as its own row.
 
@@ -1303,6 +1353,16 @@ async def detach_occurrence(
             child.id,
             exc,
         )
+    detach_snapshot = build_event_snapshot(db, master)
+    detach_snapshot["occurrence_start"] = occ_start.isoformat()
+    detach_snapshot["detached_child_id"] = str(child.id)
+    record_event_audit(
+        db,
+        event=master,
+        action=EventAuditAction.OCCURRENCE_DETACHED,
+        actor=actor_from_user(current_user),
+        snapshot=detach_snapshot,
+    )
     return _to_public(child)
 
 
@@ -1311,7 +1371,7 @@ async def delete_occurrence(
     event_id: uuid.UUID,
     payload: OccurrenceRef,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> None:
     """Skip a single occurrence by appending it to the master's EXDATEs.
 
@@ -1347,6 +1407,15 @@ async def delete_occurrence(
             payload.occurrence_start,
             exc,
         )
+    skip_snapshot = build_event_snapshot(db, master)
+    skip_snapshot["occurrence_start"] = payload.occurrence_start.isoformat()
+    record_event_audit(
+        db,
+        event=master,
+        action=EventAuditAction.OCCURRENCE_SKIPPED,
+        actor=actor_from_user(current_user),
+        snapshot=skip_snapshot,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1728,6 +1797,15 @@ async def bulk_invite(
         raise HTTPException(status_code=404, detail="Event not found")
     result = _run_bulk_invite(db, event, payload.emails, current_user.id)
     await _send_event_invitation_emails(db, event, result.invited)
+    invite_snapshot = build_event_snapshot(db, event)
+    invite_snapshot["invited_emails"] = list(payload.emails)
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.INVITATION_ADDED,
+        actor=actor_from_user(current_user),
+        snapshot=invite_snapshot,
+    )
     return result
 
 
@@ -1738,12 +1816,26 @@ async def delete_invitation(
     event_id: uuid.UUID,
     invitation_id: uuid.UUID,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> None:
     inv = crud.invitations_crud.get(db, invitation_id)
     if not inv or inv.event_id != event_id:
         raise HTTPException(status_code=404, detail="Invitation not found")
+    removed_human_id = getattr(inv, "human_id", None)
     crud.invitations_crud.delete(db, inv)
+    event = crud.events_crud.get(db, event_id)
+    if event is not None:
+        inv_snapshot = build_event_snapshot(db, event)
+        inv_snapshot["removed_invitation_id"] = str(invitation_id)
+        if removed_human_id is not None:
+            inv_snapshot["removed_human_id"] = str(removed_human_id)
+        record_event_audit(
+            db,
+            event=event,
+            action=EventAuditAction.INVITATION_REMOVED,
+            actor=actor_from_user(current_user),
+            snapshot=inv_snapshot,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1889,7 +1981,7 @@ async def approve_event(
     event_id: uuid.UUID,
     payload: EventApprovalPayload,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1921,6 +2013,13 @@ async def approve_event(
             exc,
         )
 
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.APPROVED,
+        actor=actor_from_user(current_user),
+    )
+
     return _to_public(event)
 
 
@@ -1929,7 +2028,7 @@ async def reject_event(
     event_id: uuid.UUID,
     payload: EventApprovalPayload,
     db: AdminOrApiKeySession_EventsWrite,
-    _: AdminOrApiKey_EventsWrite,
+    current_user: AdminOrApiKey_EventsWrite,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
@@ -1945,6 +2044,15 @@ async def reject_event(
     db.commit()
     db.refresh(event)
     await _send_event_approval_email(db, event, approved=False, reason=payload.reason)
+    reject_snapshot = build_event_snapshot(db, event)
+    reject_snapshot["rejection_reason"] = payload.reason
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.REJECTED,
+        actor=actor_from_user(current_user),
+        snapshot=reject_snapshot,
+    )
     return _to_public(event)
 
 
@@ -1962,6 +2070,15 @@ async def bulk_invite_portal(
     event = _ensure_portal_event_owner(db, event_id, current_human)
     result = _run_bulk_invite(db, event, payload.emails, current_human.id)
     await _send_event_invitation_emails(db, event, result.invited)
+    invite_snapshot = build_event_snapshot(db, event)
+    invite_snapshot["invited_emails"] = list(payload.emails)
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.INVITATION_ADDED,
+        actor=actor_from_human(current_human),
+        snapshot=invite_snapshot,
+    )
     return result
 
 
@@ -1975,11 +2092,23 @@ async def delete_portal_invitation(
     db: HumanTenantSession,
     current_human: CurrentHuman,
 ) -> None:
-    _ensure_portal_event_owner(db, event_id, current_human)
+    event = _ensure_portal_event_owner(db, event_id, current_human)
     inv = crud.invitations_crud.get(db, invitation_id)
     if not inv or inv.event_id != event_id:
         raise HTTPException(status_code=404, detail="Invitation not found")
+    removed_human_id = getattr(inv, "human_id", None)
     crud.invitations_crud.delete(db, inv)
+    inv_snapshot = build_event_snapshot(db, event)
+    inv_snapshot["removed_invitation_id"] = str(invitation_id)
+    if removed_human_id is not None:
+        inv_snapshot["removed_human_id"] = str(removed_human_id)
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.INVITATION_REMOVED,
+        actor=actor_from_human(current_human),
+        snapshot=inv_snapshot,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -2403,6 +2532,13 @@ async def hide_portal_event(
         human_id=current_human.id,
         event_id=target_id,
     )
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.HIDDEN,
+        actor=actor_from_human(current_human),
+        event_id=target_id,
+    )
 
 
 @router.delete("/portal/events/{event_id}/hide", status_code=status.HTTP_204_NO_CONTENT)
@@ -2419,6 +2555,14 @@ async def unhide_portal_event(
         human_id=current_human.id,
         event_id=target_id,
     )
+    if event is not None:
+        record_event_audit(
+            db,
+            event=event,
+            action=EventAuditAction.UNHIDDEN,
+            actor=actor_from_human(current_human),
+            event_id=target_id,
+        )
 
 
 @router.post(
@@ -2532,6 +2676,13 @@ async def create_portal_event(
             event, popup, settings, reason=approval_reason
         )
 
+    record_event_audit(
+        db,
+        event=event,
+        action=EventAuditAction.CREATED,
+        actor=actor_from_human(current_human),
+    )
+
     return _to_public(event)
 
 
@@ -2552,6 +2703,8 @@ async def update_portal_event(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only the event owner can edit",
         )
+
+    audit_before = build_event_snapshot(db, event)
 
     new_venue_id = (
         event_in.venue_id if event_in.venue_id is not None else event.venue_id
@@ -2603,6 +2756,15 @@ async def update_portal_event(
     updated = crud.events_crud.update(db, event, event_in)
     if _event_calendar_fields_changed(before, updated):
         await _bump_and_dispatch_itip_update(db, updated, before=before)
+    audit_after = build_event_snapshot(db, updated)
+    record_event_audit(
+        db,
+        event=updated,
+        action=EventAuditAction.UPDATED,
+        actor=actor_from_human(current_human),
+        snapshot=audit_after,
+        changes=compute_changes(audit_before, audit_after),
+    )
     return _to_public(updated)
 
 
@@ -2631,6 +2793,12 @@ async def cancel_portal_event(
     cancel_update = EventUpdate(status=EventStatus.CANCELLED)
     updated = crud.events_crud.update(db, event, cancel_update)
     await _bump_and_dispatch_itip_cancel(db, updated)
+    record_event_audit(
+        db,
+        event=updated,
+        action=EventAuditAction.CANCELLED,
+        actor=actor_from_human(current_human),
+    )
     return _to_public(updated)
 
 

--- a/backend/app/api/event_audit/__init__.py
+++ b/backend/app/api/event_audit/__init__.py
@@ -1,0 +1,8 @@
+"""Audit log for event CRUD operations.
+
+One row per mutation of an event (create/update/delete/cancel/approve/etc.),
+capturing who did it, from where (Portal vs Backoffice), when, on which event,
+a snapshot of the relevant request data, and a field-level diff for updates.
+
+See ``app.api.event_audit.crud.record_event_audit`` for the write path.
+"""

--- a/backend/app/api/event_audit/crud.py
+++ b/backend/app/api/event_audit/crud.py
@@ -1,0 +1,192 @@
+"""Write path and helpers for the event audit log.
+
+The router calls :func:`record_event_audit` after each event mutation. The
+actor is resolved from the request principal via :func:`actor_from_user`
+(backoffice) or :func:`actor_from_human` (portal).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+from sqlmodel import Session
+
+from app.api.event_audit.models import EventAuditLog
+from app.api.event_audit.schemas import (
+    AuditActor,
+    EventAuditAction,
+    EventAuditActorType,
+    EventAuditSource,
+)
+
+if TYPE_CHECKING:
+    from app.api.event.models import Events
+    from app.api.human.schemas import HumanPublic
+    from app.api.user.schemas import UserPublic
+
+# Event fields captured in the snapshot and compared for the diff. Kept small
+# and stable on purpose: identity + the "request data" the audit log promises
+# (date/time, venue, visibility) plus the lifecycle status.
+_SNAPSHOT_FIELDS = (
+    "title",
+    "start_time",
+    "end_time",
+    "timezone",
+    "venue_id",
+    "custom_location_name",
+    "visibility",
+    "status",
+)
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a value to something JSON/JSONB-serializable and diff-stable."""
+    if isinstance(value, Enum):
+        # StrEnum / (str, Enum) members → their primitive value ("public")
+        return value.value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    return value
+
+
+def build_event_snapshot(session: Session, event: Events) -> dict[str, Any]:
+    """Snapshot the audited fields of ``event``, resolving the venue name.
+
+    Returns a JSON-serializable dict. ``venue_name`` is looked up from
+    ``event_venues`` when the event references a venue.
+    """
+    snapshot: dict[str, Any] = {
+        field: _jsonable(getattr(event, field, None)) for field in _SNAPSHOT_FIELDS
+    }
+
+    venue_id = getattr(event, "venue_id", None)
+    venue_name: str | None = None
+    if venue_id is not None:
+        from app.api.event_venue.models import EventVenues
+
+        venue = session.get(EventVenues, venue_id)
+        venue_name = venue.name if venue is not None else None
+    snapshot["venue_name"] = venue_name
+
+    return snapshot
+
+
+def compute_changes(
+    before: dict[str, Any], after: dict[str, Any]
+) -> dict[str, dict[str, Any]]:
+    """Diff two snapshots → ``{field: {"old": ..., "new": ...}}``.
+
+    Only fields whose value changed are included. Both inputs are expected to
+    already be JSON-serializable (e.g. from :func:`build_event_snapshot`).
+    """
+    changes: dict[str, dict[str, Any]] = {}
+    for key in before.keys() | after.keys():
+        old = before.get(key)
+        new = after.get(key)
+        if old != new:
+            changes[key] = {"old": old, "new": new}
+    return changes
+
+
+def actor_from_user(current_user: UserPublic) -> AuditActor:
+    """Build an :class:`AuditActor` for a backoffice (staff) user."""
+    return AuditActor(
+        type=EventAuditActorType.USER,
+        source=EventAuditSource.BACKOFFICE,
+        id=current_user.id,
+        email=getattr(current_user, "email", None),
+        name=getattr(current_user, "email", None),
+    )
+
+
+def actor_from_human(current_human: HumanPublic) -> AuditActor:
+    """Build an :class:`AuditActor` for a portal (community) human."""
+    first = getattr(current_human, "first_name", None) or ""
+    last = getattr(current_human, "last_name", None) or ""
+    name = f"{first} {last}".strip() or None
+    return AuditActor(
+        type=EventAuditActorType.HUMAN,
+        source=EventAuditSource.PORTAL,
+        id=current_human.id,
+        email=getattr(current_human, "email", None),
+        name=name,
+    )
+
+
+def record_event_audit(
+    session: Session,
+    *,
+    event: Events,
+    action: EventAuditAction,
+    actor: AuditActor,
+    changes: dict[str, Any] | None = None,
+    snapshot: dict[str, Any] | None = None,
+    event_id: uuid.UUID | None = None,
+    event_title: str | None = None,
+) -> EventAuditLog | None:
+    """Persist one audit row for an event mutation.
+
+    Best-effort: an audit failure must never break the user-facing mutation
+    (which is already committed), so any exception is logged and swallowed.
+
+    Args:
+        session: active session (the mutation has typically already committed).
+        event: the event being audited. May be a stale/expired instance for
+            deletes — pass ``event_id``/``event_title`` explicitly in that case.
+        action: the kind of mutation.
+        actor: resolved identity + source (portal/backoffice).
+        changes: optional precomputed field diff (for updates).
+        snapshot: optional precomputed snapshot; when omitted it is built from
+            ``event`` via :func:`build_event_snapshot`.
+        event_id / event_title: overrides for when ``event`` is unavailable.
+    """
+    try:
+        if snapshot is None:
+            snapshot = build_event_snapshot(session, event)
+
+        row = EventAuditLog(
+            tenant_id=event.tenant_id,
+            popup_id=getattr(event, "popup_id", None),
+            event_id=event_id if event_id is not None else event.id,
+            event_title=event_title
+            if event_title is not None
+            else getattr(event, "title", None),
+            action=action.value,
+            source=actor.source.value,
+            actor_type=actor.type.value,
+            actor_id=actor.id,
+            actor_email=actor.email,
+            actor_name=actor.name,
+            request_id=_current_request_id(),
+            snapshot=snapshot,
+            changes=changes or None,
+        )
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+        return row
+    except Exception as exc:  # noqa: BLE001 — audit must never break the request
+        session.rollback()
+        logger.warning(
+            "event audit write failed (action={} event={}): {}",
+            action.value,
+            event_id if event_id is not None else getattr(event, "id", None),
+            exc,
+        )
+        return None
+
+
+def _current_request_id() -> str | None:
+    """Read the current request id bound by the logging middleware, if any."""
+    try:
+        from app.core.logging import get_request_id
+
+        return get_request_id()
+    except Exception:
+        return None

--- a/backend/app/api/event_audit/models.py
+++ b/backend/app/api/event_audit/models.py
@@ -1,0 +1,91 @@
+"""ORM model for the event_audit_logs table.
+
+One row per event mutation. Appends-only history: never updated or deleted by
+application code. Mirrors the storage style of ``app.api.check_in.models``.
+
+Unlike check_ins, the actor can be either a backoffice ``User`` (token type
+``user``) or a portal ``Human`` (token type ``human``), so the actor is stored
+as flat columns (``actor_type``/``actor_id`` + email/name snapshots) rather than
+a single foreign key. ``event_id`` is stored WITHOUT a foreign key so the audit
+row survives a hard-delete of the event it describes.
+"""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlmodel import Column, DateTime, Field, SQLModel, func
+
+
+class EventAuditLog(SQLModel, table=True):
+    """A single audit entry for an event mutation."""
+
+    __tablename__ = "event_audit_logs"
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(UUID(as_uuid=True), primary_key=True),
+    )
+
+    tenant_id: uuid.UUID = Field(foreign_key="tenants.id", index=True)
+
+    # Popup the event belongs to. Nullable so an audit row can still be written
+    # if the popup is somehow unavailable; indexed for "history of this popup".
+    popup_id: uuid.UUID | None = Field(default=None, index=True)
+
+    # The event this row describes. NOT a foreign key on purpose: the log must
+    # outlive a hard delete of the event row.
+    event_id: uuid.UUID = Field(
+        sa_column=Column(UUID(as_uuid=True), nullable=False, index=True)
+    )
+
+    # Snapshot of the event title at action time (survives rename/delete).
+    event_title: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+
+    # What happened — see app.api.event_audit.schemas.EventAuditAction.
+    action: str = Field(max_length=24)
+
+    # Where the request came from: "portal" or "backoffice".
+    source: str = Field(max_length=16)
+
+    # Actor identity. actor_type ∈ {user, human, api_key, system}.
+    actor_type: str = Field(max_length=8)
+    actor_id: uuid.UUID | None = Field(default=None, nullable=True)
+    actor_email: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    actor_name: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+
+    # X-Request-ID of the originating request, to correlate with stdout logs.
+    request_id: str | None = Field(default=None, max_length=64, nullable=True)
+
+    # Snapshot of the relevant event fields at action time: title, start_time,
+    # end_time, timezone, venue_id, venue_name, visibility, status.
+    snapshot: dict[str, Any] | None = Field(
+        default=None,
+        sa_column=Column(JSONB, nullable=True),
+    )
+
+    # Field-level diff for updates: {field: {"old": ..., "new": ...}}.
+    changes: dict[str, Any] | None = Field(
+        default=None,
+        sa_column=Column(JSONB, nullable=True),
+    )
+
+    occurred_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            nullable=False,
+        ),
+    )
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            nullable=False,
+        ),
+    )

--- a/backend/app/api/event_audit/schemas.py
+++ b/backend/app/api/event_audit/schemas.py
@@ -1,0 +1,52 @@
+"""Schemas for the event audit log."""
+
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+
+
+class EventAuditAction(str, Enum):
+    """Every kind of event mutation we audit."""
+
+    CREATED = "created"
+    UPDATED = "updated"
+    DELETED = "deleted"
+    CANCELLED = "cancelled"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    RECURRENCE_SET = "recurrence_set"
+    OCCURRENCE_DETACHED = "occurrence_detached"
+    OCCURRENCE_SKIPPED = "occurrence_skipped"
+    INVITATION_ADDED = "invitation_added"
+    INVITATION_REMOVED = "invitation_removed"
+    HIDDEN = "hidden"
+    UNHIDDEN = "unhidden"
+
+
+class EventAuditSource(str, Enum):
+    """Originating application."""
+
+    PORTAL = "portal"
+    BACKOFFICE = "backoffice"
+
+
+class EventAuditActorType(str, Enum):
+    USER = "user"
+    HUMAN = "human"
+    API_KEY = "api_key"
+    SYSTEM = "system"
+
+
+@dataclass(frozen=True)
+class AuditActor:
+    """Resolved identity of whoever performed an event mutation.
+
+    Built from the request's auth principal via
+    ``app.api.event_audit.crud.actor_from_user`` / ``actor_from_human``.
+    """
+
+    type: EventAuditActorType
+    source: EventAuditSource
+    id: uuid.UUID | None = None
+    email: str | None = None
+    name: str | None = None

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -25,11 +25,21 @@ because it is our own message rather than user-submitted content.
 import sys
 import time
 import uuid
+from contextvars import ContextVar
 
 from loguru import logger
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.config import settings
+
+# Per-request id, mirrored from the loguru context so non-logging code (e.g. the
+# event audit log) can correlate a persisted row with the stdout request line.
+_request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+def get_request_id() -> str | None:
+    """Return the current request's id, or ``None`` outside a request."""
+    return _request_id_var.get()
 
 _LOG_FORMAT = (
     "{time:YYYY-MM-DD HH:mm:ss.SSS} | "
@@ -128,10 +138,12 @@ class RequestContextMiddleware:
             await send(message)
 
         start = time.perf_counter()
+        token = _request_id_var.set(request_id)
         with logger.contextualize(request_id=request_id, principal=principal):
             try:
                 await self.app(scope, receive, send_wrapper)
             finally:
+                _request_id_var.reset(token)
                 duration_ms = round((time.perf_counter() - start) * 1000, 1)
                 code = status_code["code"]
                 level = "ERROR" if code >= 500 else "WARNING" if code >= 400 else "INFO"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -54,6 +54,7 @@ from app.api.email_template.schemas import (
 # Events module
 from app.api.event.models import EventHiddenByHuman, EventInvitations, Events
 from app.api.event.schemas import EventCreate, EventPublic, EventUpdate
+from app.api.event_audit.models import EventAuditLog
 from app.api.event_participant.models import EventParticipants
 from app.api.event_participant.schemas import (
     EventParticipantCreate,
@@ -244,6 +245,7 @@ __all__ = [
     "ReviewDecision",
     # Events module
     "Events",
+    "EventAuditLog",
     "EventHiddenByHuman",
     "EventInvitations",
     "EventCreate",

--- a/backend/tests/test_event_audit_log.py
+++ b/backend/tests/test_event_audit_log.py
@@ -1,0 +1,129 @@
+"""Integration tests for the event audit log.
+
+Every event mutation through the API should append exactly one row to
+``event_audit_logs`` capturing who acted, from which app (Portal vs
+Backoffice), on which event, a snapshot of the relevant fields, and — for
+updates — a field-level diff.
+
+These tests query ``event_audit_logs`` directly via the session-scoped ``db``
+fixture (the testcontainer superuser bypasses RLS) to assert what was persisted.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.event_audit.models import EventAuditLog
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        name=f"Audit Test {uuid.uuid4().hex[:6]}",
+        slug=f"audit-events-{uuid.uuid4().hex[:10]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _audit_rows(db: Session, event_id: uuid.UUID) -> list[EventAuditLog]:
+    db.expire_all()
+    return list(
+        db.exec(
+            select(EventAuditLog)
+            .where(EventAuditLog.event_id == event_id)
+            .order_by(EventAuditLog.occurred_at)  # type: ignore[arg-type]
+        ).all()
+    )
+
+
+class TestBackofficeAuditTrail:
+    """A create→update→delete lifecycle from the backoffice records 3 rows."""
+
+    def test_crud_lifecycle_is_audited(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_user_tenant_a,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        start = datetime.now(UTC) + timedelta(days=21)
+
+        # --- create ---
+        create = client.post(
+            "/api/v1/events",
+            headers=_auth(admin_token_tenant_a),
+            json={
+                "popup_id": str(popup.id),
+                "title": "Audited Launch",
+                "start_time": start.isoformat(),
+                "end_time": (start + timedelta(hours=1)).isoformat(),
+                "visibility": "public",
+            },
+        )
+        assert create.status_code == 201, create.text
+        event_id = uuid.UUID(create.json()["id"])
+
+        rows = _audit_rows(db, event_id)
+        assert len(rows) == 1
+        created = rows[0]
+        assert created.action == "created"
+        assert created.source == "backoffice"
+        assert created.actor_type == "user"
+        assert created.actor_id == admin_user_tenant_a.id
+        assert created.actor_email == admin_user_tenant_a.email
+        assert created.event_title == "Audited Launch"
+        assert created.tenant_id == tenant_a.id
+        assert created.snapshot["visibility"] == "public"
+        assert created.snapshot["title"] == "Audited Launch"
+
+        # --- update (title + visibility change) ---
+        update = client.patch(
+            f"/api/v1/events/{event_id}",
+            headers=_auth(admin_token_tenant_a),
+            json={"title": "Audited Launch v2", "visibility": "private"},
+        )
+        assert update.status_code == 200, update.text
+
+        rows = _audit_rows(db, event_id)
+        assert len(rows) == 2
+        updated = rows[1]
+        assert updated.action == "updated"
+        assert updated.source == "backoffice"
+        assert updated.changes is not None
+        assert updated.changes["title"] == {
+            "old": "Audited Launch",
+            "new": "Audited Launch v2",
+        }
+        assert updated.changes["visibility"] == {"old": "public", "new": "private"}
+        assert updated.snapshot["title"] == "Audited Launch v2"
+
+        # --- delete ---
+        delete = client.delete(
+            f"/api/v1/events/{event_id}",
+            headers=_auth(admin_token_tenant_a),
+        )
+        assert delete.status_code == 204, delete.text
+
+        rows = _audit_rows(db, event_id)
+        assert len(rows) == 3
+        deleted = rows[2]
+        assert deleted.action == "deleted"
+        assert deleted.source == "backoffice"
+        # The audit row carries the title snapshot even though the event is gone.
+        assert deleted.event_title == "Audited Launch v2"
+        assert deleted.event_id == event_id


### PR DESCRIPTION
## Qué

Historial persistente y consultable de **cada mutación de evento** (CRUD + estado + recurrencia + invitaciones + hide/unhide), en Backoffice y Portal.

Nueva tabla `event_audit_logs` (append-only, RLS por tenant) que registra por cada acción:

- **Origen**: `source` = `portal` | `backoffice`
- **Usuario**: `actor_type` (user/human), `actor_id`, `actor_email`, `actor_name`
- **Fecha**: `occurred_at`
- **Evento**: `event_id` (sin FK → sobrevive al hard-delete) + `event_title` (snapshot)
- **Datos del request**: `snapshot` jsonb (title, start/end, timezone, venue + venue_name, visibility, status)
- **Diff en updates**: `changes` jsonb `{campo: {old, new}}`
- **Correlación**: `request_id` espejado del middleware de logging

## Cobertura

Las 18 mutaciones del router de eventos quedaron instrumentadas (backoffice `/events` + portal `/portal/events`). Las notas de staff (`admin_notes`) se dejaron **fuera** a propósito (no son datos de calendar).

## Diseño

- Módulo nuevo `app/api/event_audit/` (model + schemas + crud), calcando el patrón de `check_ins`.
- Migración forward-only con RLS `tenant_isolation_policy` + grants a `tenant_role`/`tenant_viewer_role`.
- `record_event_audit` es **best-effort**: un fallo de auditoría nunca rompe la operación del usuario.
- Se expone un `request_id` ContextVar en `core.logging` para callers fuera del logging.

## Pruebas

- Test de integración `test_event_audit_log.py` (ciclo create→update→delete) ✅
- Suite de eventos existente sin regresiones (79 passed) ✅
- End-to-end manual contra la DB local: las 3 acciones generaron sus filas, diff old→new correcto, `request_id` correlaciona con los logs, y la fila del delete sobrevivió al borrado del evento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)