### PR TITLE
feat(tenant): show read-only credentials to admins, keep CRUD superadmin-only

### DIFF
--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -307,11 +307,25 @@ async def delete_tenant(
 async def get_credentials(
     tenant_id: uuid.UUID,
     db: SessionDep,
-    _: CurrentSuperadmin,
+    current_user: CurrentAdmin,
 ) -> TenantCredentialResponse:
+    # Admins are scoped to their own tenant; superadmins can read any tenant.
+    if current_user.role == UserRole.ADMIN and current_user.tenant_id != tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only view credentials for your own organization",
+        )
+
+    # Superadmins see CRUD and read-only credentials; admins only read-only.
+    allowed_types = (
+        list(CredentialType)
+        if current_user.role == UserRole.SUPERADMIN
+        else [CredentialType.READONLY]
+    )
+
     credential_infos: list[CredentialInfo] = []
 
-    for cred_type in CredentialType:
+    for cred_type in allowed_types:
         result = get_tenant_credential(db, tenant_id, cred_type)
         if result:
             username, password = result
@@ -353,5 +367,3 @@ async def delete_credentials(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tenant has no credentials to revoke",
         )
-
-

--- a/backend/tests/test_rls.py
+++ b/backend/tests/test_rls.py
@@ -366,19 +366,53 @@ class TestTenantEndpointsAccess:
 
         assert response.status_code == 403
 
-    def test_tenant_admin_cannot_get_tenant_credentials(
+    def test_tenant_admin_gets_only_readonly_credentials(
         self,
         client: TestClient,
         admin_token_tenant_a: str,
         tenant_a: Tenants,
     ) -> None:
-        """Tenant admin should NOT be able to get tenant credentials."""
+        """Tenant admin can read its own tenant credentials, read-only only."""
         response = client.get(
             f"/api/v1/tenants/{tenant_a.id}/credentials",
             headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
         )
 
+        assert response.status_code == 200
+        data = response.json()
+        types = {c["credential_type"] for c in data["credentials"]}
+        assert types == {CredentialType.READONLY.value}
+
+    def test_tenant_admin_cannot_get_other_tenant_credentials(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        tenant_b: Tenants,
+    ) -> None:
+        """Tenant admin should NOT read another tenant's credentials."""
+        response = client.get(
+            f"/api/v1/tenants/{tenant_b.id}/credentials",
+            headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
+        )
+
         assert response.status_code == 403
+
+    def test_superadmin_gets_crud_and_readonly_credentials(
+        self,
+        client: TestClient,
+        superadmin_token: str,
+        tenant_a: Tenants,
+    ) -> None:
+        """Superadmin reads both CRUD and read-only credentials."""
+        response = client.get(
+            f"/api/v1/tenants/{tenant_a.id}/credentials",
+            headers={"Authorization": f"Bearer {superadmin_token}"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        types = {c["credential_type"] for c in data["credentials"]}
+        assert types == {CredentialType.CRUD.value, CredentialType.READONLY.value}
 
     def test_superadmin_can_list_tenants(
         self,
@@ -675,8 +709,7 @@ class TestSessionUserRLS:
         # Tenant B popup must not leak in
         with psycopg.connect(dsn, autocommit=True) as conn:
             ids = [
-                row[0]
-                for row in conn.execute("SELECT id::text FROM popups").fetchall()
+                row[0] for row in conn.execute("SELECT id::text FROM popups").fetchall()
             ]
         assert str(popup_tenant_b.id) not in ids
         assert str(popup_tenant_a.id) in ids
@@ -735,9 +768,7 @@ class TestSessionUserRLS:
 
         Covers SCENARIO-5 and REQ-2.
         """
-        dsn = _get_tenant_dsn(
-            db, postgres_container, tenant_a.id, CredentialType.CRUD
-        )
+        dsn = _get_tenant_dsn(db, postgres_container, tenant_a.id, CredentialType.CRUD)
         with psycopg.connect(dsn) as conn:
             with pytest.raises(psycopg.errors.InsufficientPrivilege):
                 conn.execute(

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -63,7 +63,7 @@ const PORTAL_DOMAIN = import.meta.env.VITE_PORTAL_DOMAIN ?? ""
 export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const { isSuperadmin } = useAuth()
+  const { isSuperadmin, isAdmin } = useAuth()
   const [copied, setCopied] = useState(false)
 
   const cnameTarget =
@@ -523,7 +523,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
         </div>
       </form>
 
-      {isEdit && isSuperadmin && (
+      {isEdit && isAdmin && (
         <div className="mx-auto max-w-2xl">
           <TenantCredentialsSection tenantId={defaultValues.id} />
         </div>


### PR DESCRIPTION
## Summary

The organization edit form's database-credentials section is now visible to ADMIN as well as SUPERADMIN. Admins only see read-only credentials (and only for their own organization); CRUD credentials remain superadmin-only.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `get_credentials` endpoint guard changed from `CurrentSuperadmin` to `CurrentAdmin`.
- Added tenant-ownership scoping: an admin gets 403 when requesting another tenant's credentials (mirrors the existing `update_tenant` pattern).
- Role-based filtering: SUPERADMIN receives CRUD + read-only; ADMIN receives read-only only. Enforced in the backend, so admins never receive CRUD credentials in the response.
- Backoffice credentials section visibility changed from `isSuperadmin` to `isAdmin`; the section is not rendered (and no request is made) for non-admins.
- Updated RLS tests: admin gets read-only only, admin 403 cross-tenant, superadmin gets both.

## Testing

- [x] Backend tests pass (`tests/test_rls.py -k credentials`, 3 passed)
- [x] Backend linting passes (ruff + ty)
- [x] Backoffice builds successfully (`pnpm --filter backoffice run build`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [ ] OpenAPI client regeneration not needed (response model unchanged)
- [ ] No database migrations (none required)