### PR TITLE
feat(tasks): surface task creator in UI

### DIFF
--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -197,6 +197,16 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
+        {isEdit && task && (
+          <p className="-mt-2 text-xs text-muted-foreground">
+            Created by{" "}
+            <span className="font-medium text-foreground/80">
+              {task.created_by_name ?? "Unknown"}
+            </span>{" "}
+            · {new Date(task.created_at).toLocaleString()}
+          </p>
+        )}
+
         <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="task-title">Title</Label>

--- a/backoffice/src/components/Tasks/columns.tsx
+++ b/backoffice/src/components/Tasks/columns.tsx
@@ -53,6 +53,15 @@ export const taskColumns: ColumnDef<TaskPublic>[] = [
     ),
   },
   {
+    accessorKey: "created_by_name",
+    header: "Created by",
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.created_by_name ?? "—"}
+      </span>
+    ),
+  },
+  {
     accessorKey: "release",
     header: "Release",
     cell: ({ row }) => (


### PR DESCRIPTION
Follow-up to #236.

The creator was already stored (`created_by`) and returned by the API
(`created_by_name`), but it wasn't shown anywhere in the UI. This surfaces it:

- Edit dialog: a "Created by … · {date}" line under the header.
- List view: a new "Created by" column — handy for scanning who reported each bug.

No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)