### PR TITLE
feat(tasks): creator display, responsible filter, superadmin-only assignment, scrollbars

### DIFF
--- a/backend/app/api/task/router.py
+++ b/backend/app/api/task/router.py
@@ -54,6 +54,23 @@ def _validate_visibility(visibility: str, target_tenant_id: uuid.UUID | None) ->
         )
 
 
+def _validate_responsible(
+    db: SessionDep, responsible_user_id: uuid.UUID | None
+) -> None:
+    """Tasks may only be assigned to a superadmin (phase 1 policy)."""
+    if responsible_user_id is None:
+        return
+    from app.api.shared.enums import UserRole
+    from app.api.user.models import Users
+
+    user = db.get(Users, responsible_user_id)
+    if not user or user.deleted or user.role != UserRole.SUPERADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tasks can only be assigned to a superadmin",
+        )
+
+
 def _get_task_or_404(db: SessionDep, task_id: uuid.UUID) -> Task:
     task = crud.tasks_crud.get(db, task_id)
     if not task:
@@ -150,6 +167,7 @@ async def create_task(
 ) -> TaskDetailPublic:
     """Create a task (superadmin only)."""
     _validate_visibility(task_in.visibility, task_in.target_tenant_id)
+    _validate_responsible(db, task_in.responsible_user_id)
 
     data = task_in.model_dump()
     if data["visibility"] != TaskVisibility.TENANT.value:
@@ -193,6 +211,9 @@ async def update_task(
     _validate_visibility(new_visibility, new_target)
     if new_visibility != TaskVisibility.TENANT.value:
         update_data["target_tenant_id"] = None
+
+    if "responsible_user_id" in update_data:
+        _validate_responsible(db, update_data["responsible_user_id"])
 
     if (
         update_data.get("status") == TaskStatus.PUBLISHED.value

--- a/backoffice/src/components/Tasks/ReportBugButton.tsx
+++ b/backoffice/src/components/Tasks/ReportBugButton.tsx
@@ -92,7 +92,7 @@ export function ReportBugButton() {
           </span>
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
+      <DialogContent className="thin-scrollbar max-h-[90vh] max-w-lg overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Report a bug</DialogTitle>
           <DialogDescription>

--- a/backoffice/src/components/Tasks/TaskBoard.tsx
+++ b/backoffice/src/components/Tasks/TaskBoard.tsx
@@ -85,7 +85,7 @@ export function TaskBoard({ tasks, onOpen }: TaskBoardProps) {
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-      <div className="flex gap-4 overflow-x-auto pb-4">
+      <div className="thin-scrollbar flex gap-4 overflow-x-auto pb-4">
         {TASK_STATUSES.map((status) => (
           <Column
             key={status}

--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -188,7 +188,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+      <DialogContent className="thin-scrollbar max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit task" : "New task"}</DialogTitle>
           <DialogDescription>

--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -197,6 +197,16 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
           </DialogDescription>
         </DialogHeader>
 
+        {isEdit && task && (
+          <p className="-mt-2 text-xs text-muted-foreground">
+            Created by{" "}
+            <span className="font-medium text-foreground/80">
+              {task.created_by_name ?? "Unknown"}
+            </span>{" "}
+            · {new Date(task.created_at).toLocaleString()}
+          </p>
+        )}
+
         <div className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="task-title">Title</Label>

--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -87,9 +87,10 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
     enabled: open && isEdit,
   })
 
+  // Tasks may only be assigned to superadmins (phase 1 policy).
   const { data: usersData } = useQuery({
-    queryKey: ["tasks-users"],
-    queryFn: () => UsersService.listUsers({ limit: 1000 }),
+    queryKey: ["tasks-superadmins"],
+    queryFn: () => UsersService.listUsers({ limit: 1000, role: "superadmin" }),
     enabled: open,
   })
 

--- a/backoffice/src/components/Tasks/columns.tsx
+++ b/backoffice/src/components/Tasks/columns.tsx
@@ -53,6 +53,15 @@ export const taskColumns: ColumnDef<TaskPublic>[] = [
     ),
   },
   {
+    accessorKey: "created_by_name",
+    header: "Created by",
+    cell: ({ row }) => (
+      <span className="text-sm text-muted-foreground">
+        {row.original.created_by_name ?? "—"}
+      </span>
+    ),
+  },
+  {
     accessorKey: "release",
     header: "Release",
     cell: ({ row }) => (

--- a/backoffice/src/routes/_layout/tasks/index.tsx
+++ b/backoffice/src/routes/_layout/tasks/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { ListChecks, Plus } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 
-import { TasksService, type TaskType } from "@/client"
+import { TasksService, type TaskType, UsersService } from "@/client"
 import { DataTable } from "@/components/Common/DataTable"
 import { EmptyState } from "@/components/Common/EmptyState"
 import { taskColumns } from "@/components/Tasks/columns"
@@ -35,6 +35,7 @@ function Tasks() {
   const { isSuperadmin, isUserLoading } = useAuth()
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState<TaskType | "all">("all")
+  const [responsibleFilter, setResponsibleFilter] = useState<string>("all")
   const [dialogOpen, setDialogOpen] = useState(false)
   const [activeTaskId, setActiveTaskId] = useState<string | null>(null)
 
@@ -51,18 +52,33 @@ function Tasks() {
     enabled: isSuperadmin,
   })
 
+  const { data: usersData } = useQuery({
+    queryKey: ["tasks-users"],
+    queryFn: () => UsersService.listUsers({ limit: 1000 }),
+    enabled: isSuperadmin,
+  })
+  const users = usersData?.results ?? []
+
   const filtered = useMemo(() => {
     const all = data?.results ?? []
     const q = search.trim().toLowerCase()
     return all.filter((task) => {
       if (typeFilter !== "all" && task.type !== typeFilter) return false
+      if (responsibleFilter === "unassigned") {
+        if (task.responsible_user_id) return false
+      } else if (
+        responsibleFilter !== "all" &&
+        task.responsible_user_id !== responsibleFilter
+      ) {
+        return false
+      }
       if (!q) return true
       return (
         task.title.toLowerCase().includes(q) ||
         (task.detail ?? "").toLowerCase().includes(q)
       )
     })
-  }, [data, typeFilter, search])
+  }, [data, typeFilter, responsibleFilter, search])
 
   if (isUserLoading || !isSuperadmin) return null
 
@@ -109,6 +125,20 @@ function Tasks() {
             {TASK_TYPES.map((t) => (
               <SelectItem key={t} value={t}>
                 {TYPE_LABELS[t]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={responsibleFilter} onValueChange={setResponsibleFilter}>
+          <SelectTrigger className="w-52">
+            <SelectValue placeholder="Responsible" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All responsibles</SelectItem>
+            <SelectItem value="unassigned">Unassigned</SelectItem>
+            {users.map((u) => (
+              <SelectItem key={u.id} value={u.id}>
+                {u.full_name || u.email}
               </SelectItem>
             ))}
           </SelectContent>

--- a/backoffice/src/routes/_layout/tasks/index.tsx
+++ b/backoffice/src/routes/_layout/tasks/index.tsx
@@ -52,9 +52,10 @@ function Tasks() {
     enabled: isSuperadmin,
   })
 
+  // Only superadmins can be assigned, so the filter lists superadmins only.
   const { data: usersData } = useQuery({
-    queryKey: ["tasks-users"],
-    queryFn: () => UsersService.listUsers({ limit: 1000 }),
+    queryKey: ["tasks-superadmins"],
+    queryFn: () => UsersService.listUsers({ limit: 1000, role: "superadmin" }),
     enabled: isSuperadmin,
   })
   const users = usersData?.results ?? []


### PR DESCRIPTION
Follow-ups on top of the task tracker (#236), as 4 atomic commits:

- **surface task creator** — show `created_by` in the edit dialog and as a "Created by" column (data was already captured, just not shown).
- **Responsible filter** — filter the board (List + Kanban) by responsible / Unassigned / All.
- **superadmin-only assignment** — backend rejects assigning a non-superadmin; pickers list superadmins only.
- **thin-scrollbar** — task/report dialogs and the Kanban scroll use the shared `.thin-scrollbar` (matches sidebar + DataTable).

Verified: ruff + backend import OK; biome + tsc clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)