### PR TITLE
fix(ticketing-step): run template_config validators on ticket-select (#132)

### DIFF
--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -85,7 +85,7 @@ def _validate_template_config_fk(
     Pattern B (locked decision #1268): Pydantic validates UUID structure,
     router validates FK existence. This keeps schemas pure.
     """
-    if template != "ticket_select" or not template_config:
+    if template != "ticket-select" or not template_config:
         return
     sections = template_config.get("sections") or []
     from app.api.attendee_category.crud import attendee_categories_crud

--- a/backend/app/api/ticketing_step/schemas.py
+++ b/backend/app/api/ticketing_step/schemas.py
@@ -9,7 +9,7 @@ from sqlmodel import Field, SQLModel
 
 
 class TicketSelectSection(BaseModel):
-    """Typed representation of a single section inside ticket_select template_config.sections."""
+    """Typed representation of a single section inside ticket-select template_config.sections."""
 
     key: str
     label: str
@@ -107,12 +107,12 @@ def _validate_sections_in_template_config(
     template: str | None,
     template_config: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Validate sections inside template_config when template == 'ticket_select'.
+    """Validate sections inside template_config when template == 'ticket-select'.
 
     No-ops for other templates or when template_config is absent/has no sections.
     Raises ValueError on invalid section data (FastAPI converts to HTTP 422).
     """
-    if template != "ticket_select" or not template_config:
+    if template != "ticket-select" or not template_config:
         return template_config
     sections = template_config.get("sections")
     if sections is None:
@@ -143,9 +143,7 @@ def _validate_meal_plan_select_template_config(
     sections = template_config.get("sections")
     if sections is not None:
         if not isinstance(sections, list):
-            raise ValueError(
-                "meal_plan_select template_config.sections must be a list"
-            )
+            raise ValueError("meal_plan_select template_config.sections must be a list")
         validated_sections = [MealPlanSection.model_validate(s) for s in sections]
         out["sections"] = [s.model_dump(mode="json") for s in validated_sections]
 

--- a/backend/tests/api/attendee_category/test_attendee_validation.py
+++ b/backend/tests/api/attendee_category/test_attendee_validation.py
@@ -90,7 +90,7 @@ def test_ticketing_step_create_with_unknown_uuid_rejected(
             "popup_id": str(popup_tenant_a.id),
             "step_type": "product_selection",
             "title": "Test Step",
-            "template": "ticket_select",
+            "template": "ticket-select",
             "template_config": {
                 "sections": [
                     {
@@ -123,7 +123,7 @@ def test_ticketing_step_create_with_valid_uuid_accepted(
             "popup_id": popup_id,
             "step_type": "product_selection",
             "title": "Test Step Valid",
-            "template": "ticket_select",
+            "template": "ticket-select",
             "template_config": {
                 "sections": [
                     {
@@ -157,7 +157,7 @@ def test_ticketing_step_update_with_unknown_uuid_rejected(
             "popup_id": popup_id,
             "step_type": "product_selection",
             "title": "Update Test Step",
-            "template": "ticket_select",
+            "template": "ticket-select",
             "template_config": {
                 "sections": [
                     {
@@ -180,7 +180,7 @@ def test_ticketing_step_update_with_unknown_uuid_rejected(
         f"/api/v1/ticketing-steps/{step_id}",
         headers=_admin_headers(admin_token_tenant_a),
         json={
-            "template": "ticket_select",
+            "template": "ticket-select",
             "template_config": {
                 "sections": [
                     {

--- a/backend/tests/api/ticketing_step/test_template_config_validation.py
+++ b/backend/tests/api/ticketing_step/test_template_config_validation.py
@@ -25,7 +25,7 @@ def _make_ticket_select_step(popup_id: uuid.UUID, sections: list[dict]) -> dict:
         "popup_id": str(popup_id),
         "step_type": "tickets",
         "title": f"Ticket Step {uuid.uuid4().hex[:8]}",
-        "template": "ticket_select",
+        "template": "ticket-select",
         "template_config": {"sections": sections},
     }
 
@@ -175,7 +175,7 @@ class TestTemplateConfigAttendeeCategories:
             f"/api/v1/ticketing-steps/{step_id}",
             headers=_admin_headers(admin_token_tenant_a),
             json={
-                "template": "ticket_select",
+                "template": "ticket-select",
                 "template_config": {"sections": [invalid_section]},
             },
         )


### PR DESCRIPTION
## What

The backend validators for a ticketing step's `template_config` never ran because they compared against `"ticket_select"` (underscore) while the canonical template value is `"ticket-select"` (hyphen, seeded in `constants.py` and used by the DB/frontend).

Two validators were dead as a result:
- `_validate_sections_in_template_config` (section schema) — malformed `sections` payloads (wrong types, invalid UUIDs) were persisted silently.
- the router FK-existence check — `attendee_categories` referencing non-existent categories were accepted.

## Fix

Match `"ticket-select"` in both `schemas.py` and `router.py` so create/update now return 422 on bad payloads (Option 1 from the issue).

## Tests

The existing validation tests used the wrong `"ticket_select"` value and passed against the wrong-but-matching validator (false confidence). Aligned them to the real value so they now actually exercise the validators.

Closes #132