### PR TITLE
style(backoffice): make thin scrollbars global

### DIFF
--- a/backoffice/src/index.css
+++ b/backoffice/src/index.css
@@ -122,29 +122,37 @@
     cursor: pointer;
   }
 
+  /* Thin scrollbars everywhere — consistent across the whole app. The
+     [data-sidebar="content"] / .thin-scrollbar selectors are kept for explicit
+     opt-in, but the universal selector makes every scroll container match. */
+  *,
   [data-sidebar="content"],
   .thin-scrollbar {
     scrollbar-width: thin;
     scrollbar-color: var(--sidebar-border) transparent;
   }
 
+  *::-webkit-scrollbar,
   [data-sidebar="content"]::-webkit-scrollbar,
   .thin-scrollbar::-webkit-scrollbar {
     width: 6px;
     height: 6px;
   }
 
+  *::-webkit-scrollbar-track,
   [data-sidebar="content"]::-webkit-scrollbar-track,
   .thin-scrollbar::-webkit-scrollbar-track {
     background: transparent;
   }
 
+  *::-webkit-scrollbar-thumb,
   [data-sidebar="content"]::-webkit-scrollbar-thumb,
   .thin-scrollbar::-webkit-scrollbar-thumb {
     background-color: var(--sidebar-border);
     border-radius: 9999px;
   }
 
+  *::-webkit-scrollbar-thumb:hover,
   [data-sidebar="content"]::-webkit-scrollbar-thumb:hover,
   .thin-scrollbar::-webkit-scrollbar-thumb:hover {
     background-color: var(--sidebar-ring);


### PR DESCRIPTION
## What

Apply the thin-scrollbar style (6px, rounded, `--sidebar-border` color) to every scroll container via the universal selector, not just `.thin-scrollbar` / `[data-sidebar=content]`.

## Why

Tables and other overflow containers (e.g. bulk-grant at narrow widths) showed the default thick scrollbar. Now every scrollbar in the app matches the sidebar's thin style. The `.thin-scrollbar` / `[data-sidebar=content]` selectors are kept for explicit opt-in.

CSS-only change in `backoffice/src/index.css`.