### PR TITLE
feat(portal): exclude unnamed humans from participant search

### DIFF
--- a/backend/app/api/human/crud.py
+++ b/backend/app/api/human/crud.py
@@ -214,6 +214,41 @@ class HumansCRUD(BaseCRUD[Humans, HumanCreate, HumanUpdate]):
         results = list(session.exec(statement.offset(skip).limit(limit)).all())
         return results, total
 
+    def search_named(
+        self,
+        session: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        search: str | None = None,
+    ) -> tuple[list[Humans], int]:
+        """Search humans that have a usable display name.
+
+        Powers the portal participant picker. Humans with neither a first nor
+        a last name are excluded so the picker never falls back to rendering a
+        raw UUID prefix.
+        """
+        has_name = or_(
+            func.trim(func.coalesce(col(Humans.first_name), "")) != "",
+            func.trim(func.coalesce(col(Humans.last_name), "")) != "",
+        )
+        statement = select(Humans).where(has_name)
+
+        if search:
+            search_term = f"%{search}%"
+            statement = statement.where(
+                or_(
+                    col(Humans.first_name).ilike(search_term),
+                    col(Humans.last_name).ilike(search_term),
+                )
+            )
+
+        count_statement = select(func.count()).select_from(statement.subquery())
+        total = session.exec(count_statement).one()
+
+        results = list(session.exec(statement.offset(skip).limit(limit)).all())
+        return results, total
+
     def get_profile_stats(
         self, session: Session, human_id: uuid.UUID
     ) -> HumanProfileStats:

--- a/backend/app/api/human/router.py
+++ b/backend/app/api/human/router.py
@@ -184,12 +184,11 @@ async def search_humans_portal(
     HumanTenantSession; the slim response schema omits email so this isn't
     a wider exposure than the participant lists portal users can already see.
     """
-    humans, total = crud.find(
+    humans, total = crud.search_named(
         db,
         skip=skip,
         limit=limit,
         search=search,
-        search_fields=["first_name", "last_name"],
     )
     return ListModel[HumanPortalPublic](
         results=[HumanPortalPublic.model_validate(h) for h in humans],


### PR DESCRIPTION
## What
The portal participant picker (`GET /humans/portal/search`) returned humans with no first/last name, which the UI fell back to rendering as a raw UUID prefix (e.g. `d03bed7f`).

## Change
- Add `HumansCRUD.search_named` — returns only humans with a usable display name (`first_name` or `last_name` non-empty), with the same optional name search.
- `search_humans_portal` now uses it.

Behavior-only change; no schema/client changes. RLS scoping unchanged (HumanTenantSession).