### PR TITLE
feat(backoffice): events list view and venues grid with edit-first flow

### DIFF
--- a/backoffice/src/components/Common/FormPageLayout.tsx
+++ b/backoffice/src/components/Common/FormPageLayout.tsx
@@ -8,6 +8,8 @@ interface FormPageLayoutProps {
   description: string
   backTo: string
   onBack?: () => void
+  /** Optional header actions rendered on the right of the title row. */
+  actions?: React.ReactNode
   children: React.ReactNode
 }
 
@@ -16,6 +18,7 @@ export function FormPageLayout({
   description,
   backTo,
   onBack,
+  actions,
   children,
 }: FormPageLayoutProps) {
   const goBack = useGoBack({ to: backTo })
@@ -35,6 +38,9 @@ export function FormPageLayout({
           <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
           <p className="text-muted-foreground">{description}</p>
         </div>
+        {actions && (
+          <div className="ml-auto flex items-center gap-2">{actions}</div>
+        )}
       </div>
       {children}
     </div>

--- a/backoffice/src/components/LucideIcon.tsx
+++ b/backoffice/src/components/LucideIcon.tsx
@@ -1,0 +1,57 @@
+import { DynamicIcon, type IconName, iconNames } from "lucide-react/dynamic"
+
+const AVAILABLE = new Set<string>(iconNames)
+
+function normalizeToSlug(raw: string): string {
+  return raw
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[_\s]+/g, "-")
+    .toLowerCase()
+}
+
+const LEGACY_ALIASES: Record<string, string> = {
+  chairs: "armchair",
+  chair: "armchair",
+  microphone: "mic",
+  couch: "sofa",
+  outlet: "plug",
+  light: "lightbulb",
+  power: "zap",
+  pool: "waves",
+  food: "utensils",
+  water: "droplet",
+  ac: "snowflake",
+  box: "package",
+  lock: "shield",
+  internet: "wifi",
+  "wi-fi": "wifi",
+  gamepad: "gamepad-2",
+}
+
+function resolveSlug(name: string | null | undefined): IconName | null {
+  if (!name) return null
+  const slug = normalizeToSlug(name)
+  if (!slug) return null
+  if (AVAILABLE.has(slug)) return slug as IconName
+  const aliased = LEGACY_ALIASES[slug]
+  if (aliased && AVAILABLE.has(aliased)) return aliased as IconName
+  return null
+}
+
+interface Props {
+  name: string | null | undefined
+  className?: string
+  size?: number
+}
+
+/**
+ * Render any Lucide icon by its kebab-case slug, lazy-loaded via the
+ * dynamic registry so we only fetch chunks for icons used at runtime.
+ * Returns null when the name doesn't resolve to a known icon.
+ */
+export function LucideIcon({ name, className, size }: Props) {
+  const slug = resolveSlug(name)
+  if (!slug) return null
+  return <DynamicIcon name={slug} className={className} size={size} />
+}

--- a/backoffice/src/components/events/EventsListView.tsx
+++ b/backoffice/src/components/events/EventsListView.tsx
@@ -1,0 +1,229 @@
+import { useQuery } from "@tanstack/react-query"
+import {
+  CalendarDays,
+  Clock,
+  Filter,
+  Layers,
+  MapPin,
+  Repeat,
+  Tag,
+} from "lucide-react"
+import { type EventPublic, type EventStatus, EventsService } from "@/client"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { summarizeRrule } from "@/lib/events/summarizeRrule"
+import { useEventTimezone } from "@/lib/events/useEventTimezone"
+import { cn } from "@/lib/utils"
+import { CoverImage } from "./CoverImage"
+
+interface EventsListViewProps {
+  popupId: string
+  status: EventStatus | undefined
+  venueId: string | undefined
+  search: string
+  onEventClick: (event: EventPublic) => void
+}
+
+const statusColors: Record<string, string> = {
+  published: "bg-primary/10 text-primary",
+  draft: "bg-muted text-muted-foreground",
+  cancelled: "bg-destructive/10 text-destructive",
+  pending_approval:
+    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+  rejected: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200",
+}
+
+const statusLabels: Record<string, string> = {
+  published: "Public",
+  draft: "Draft",
+  cancelled: "Cancelled",
+  pending_approval: "Pending approval",
+  rejected: "Rejected",
+}
+
+function groupByDate(
+  events: EventPublic[],
+  formatDayKey: (d: string) => string,
+): [string, EventPublic[]][] {
+  const groups: Record<string, EventPublic[]> = {}
+  for (const event of events) {
+    const key = formatDayKey(event.start_time)
+    if (!groups[key]) groups[key] = []
+    groups[key].push(event)
+  }
+  return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b))
+}
+
+/**
+ * Grouped-by-day event card list for the backoffice events page. Mirrors
+ * the portal list view but in admin mode: shows ALL events (past and
+ * future, every status), each with its status badge, and clicks route into
+ * the event edit flow via `onEventClick` (no attendee RSVP / hide controls).
+ * Times are rendered in the popup's timezone.
+ */
+export function EventsListView({
+  popupId,
+  status,
+  venueId,
+  search,
+  onEventClick,
+}: EventsListViewProps) {
+  const {
+    formatTime,
+    formatDateFull,
+    formatDayKey,
+    isLoading: tzLoading,
+  } = useEventTimezone(popupId)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["events", "list", popupId, status, venueId, search],
+    queryFn: () =>
+      EventsService.listEvents({
+        popupId,
+        eventStatus: status,
+        venueId:
+          venueId && venueId !== "custom" && venueId !== "meeting"
+            ? venueId
+            : undefined,
+        locationKind:
+          venueId === "custom" || venueId === "meeting" ? venueId : undefined,
+        search: search || undefined,
+        limit: 500,
+      }),
+    enabled: !!popupId && !tzLoading,
+  })
+
+  if (isLoading || tzLoading) {
+    return <Skeleton className="h-64 w-full" />
+  }
+
+  const events = data?.results ?? []
+
+  if (events.length === 0) {
+    return (
+      <div className="text-center py-20">
+        <Filter className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
+        <p className="text-muted-foreground">No events match these filters</p>
+      </div>
+    )
+  }
+
+  const grouped = groupByDate(events, formatDayKey)
+
+  return (
+    <div className="space-y-6">
+      {grouped.map(([date, dayEvents]) => (
+        <div key={date}>
+          <div className="flex items-center gap-3 mb-3">
+            <div className="h-2 w-2 rounded-full bg-primary" />
+            <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {formatDateFull(dayEvents[0].start_time)}
+            </h2>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+          <div className="space-y-2 pl-5 border-l-2 border-border">
+            {dayEvents.map((event) => {
+              const isHighlighted = event.highlighted === true
+              const recurrenceLabel =
+                summarizeRrule(event.rrule) ??
+                (event.recurrence_master_id
+                  ? "Part of a recurring series"
+                  : null)
+              const thumbUrl = event.cover_url || event.venue_image_url || null
+              return (
+                <div
+                  key={event.id}
+                  className={cn(
+                    "relative rounded-xl border bg-card hover:shadow-md transition-shadow",
+                    isHighlighted &&
+                      "border-2 border-amber-400 bg-amber-50 dark:bg-amber-950/30",
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onEventClick(event)}
+                    className="block w-full text-left p-3 sm:p-4"
+                  >
+                    <div className="flex items-start gap-3">
+                      <div className="h-14 w-14 sm:h-16 sm:w-16 shrink-0 rounded-lg overflow-hidden">
+                        <CoverImage
+                          src={thumbUrl}
+                          alt={event.title}
+                          className="w-full h-full object-cover"
+                          fallback={
+                            <CalendarDays className="h-5 w-5 text-muted-foreground/40" />
+                          }
+                        />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-2 mb-1">
+                          <h3 className="font-medium text-sm sm:text-base">
+                            {event.title}
+                          </h3>
+                          <Badge
+                            variant="secondary"
+                            className={
+                              statusColors[event.status as string] ?? ""
+                            }
+                          >
+                            {statusLabels[event.status as string] ??
+                              event.status}
+                          </Badge>
+                        </div>
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          <Clock className="h-3 w-3" />
+                          <span>
+                            {formatTime(event.start_time)} –{" "}
+                            {formatTime(event.end_time)}
+                          </span>
+                        </div>
+                        {event.venue_title && (
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                            <MapPin className="h-3 w-3" />
+                            <span className="truncate">
+                              {event.venue_title}
+                              {event.venue_location
+                                ? ` · ${event.venue_location}`
+                                : ""}
+                            </span>
+                          </div>
+                        )}
+                        {recurrenceLabel && (
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                            <Repeat className="h-3 w-3" />
+                            <span className="truncate">{recurrenceLabel}</span>
+                          </div>
+                        )}
+                        {event.track_title && (
+                          <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mt-0.5">
+                            <Layers className="h-3 w-3" />
+                            <span className="truncate">
+                              {event.track_title}
+                            </span>
+                          </div>
+                        )}
+                        {event.tags && event.tags.length > 0 && (
+                          <div className="flex items-center gap-1 mt-1.5 flex-wrap">
+                            {event.tags.slice(0, 3).map((tag: string) => (
+                              <span
+                                key={tag}
+                                className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded border border-border bg-muted/60 text-muted-foreground"
+                              >
+                                <Tag className="h-2.5 w-2.5" />
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/backoffice/src/components/events/EventsViewSwitcher.tsx
+++ b/backoffice/src/components/events/EventsViewSwitcher.tsx
@@ -1,9 +1,9 @@
-import { CalendarClock, CalendarDays, Table } from "lucide-react"
+import { CalendarClock, CalendarDays, List, Table } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
-export type EventsView = "table" | "calendar" | "day"
+export type EventsView = "table" | "list" | "calendar" | "day"
 
 interface EventsViewSwitcherProps {
   view: EventsView
@@ -34,6 +34,21 @@ export function EventsViewSwitcher({
         )}
       >
         <Table className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant={view === "list" ? "default" : "ghost"}
+        size="sm"
+        aria-label="List"
+        title="List"
+        aria-pressed={view === "list"}
+        onClick={() => onViewChange("list")}
+        className={cn(
+          "h-7 w-7 rounded-sm p-0",
+          view === "list" && "shadow-none",
+        )}
+      >
+        <List className="h-4 w-4" />
       </Button>
       <Button
         type="button"

--- a/backoffice/src/components/events/VenuesGridView.tsx
+++ b/backoffice/src/components/events/VenuesGridView.tsx
@@ -1,0 +1,117 @@
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "@tanstack/react-router"
+import { MapPin, Users } from "lucide-react"
+import { type EventVenuePublic, EventVenuesService } from "@/client"
+import { EmptyState } from "@/components/Common/EmptyState"
+import { LucideIcon } from "@/components/LucideIcon"
+import { Skeleton } from "@/components/ui/skeleton"
+import { CoverImage } from "./CoverImage"
+
+interface VenuesGridViewProps {
+  popupId: string
+  search: string
+}
+
+/**
+ * Card grid of venues for the backoffice, mirroring the portal layout
+ * (16/9 cover, capacity, property chips). Cards open the read-only venue
+ * detail page; admin actions stay on the table view.
+ */
+export function VenuesGridView({ popupId, search }: VenuesGridViewProps) {
+  const navigate = useNavigate()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["event-venues", "grid", { popupId, search }],
+    queryFn: () =>
+      EventVenuesService.listVenues({
+        popupId,
+        search: search || undefined,
+        skip: 0,
+        limit: 500,
+      }),
+    enabled: !!popupId,
+  })
+
+  if (isLoading) return <Skeleton className="h-64 w-full" />
+
+  const venues: EventVenuePublic[] = data?.results ?? []
+
+  if (venues.length === 0) {
+    return search ? (
+      <div className="rounded-lg border p-8 text-center text-sm text-muted-foreground">
+        No venues match your search.
+      </div>
+    ) : (
+      <EmptyState
+        icon={MapPin}
+        title="No venues yet"
+        description="Venues will appear here when created."
+      />
+    )
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {venues.map((venue) => (
+        <button
+          key={venue.id}
+          type="button"
+          onClick={() =>
+            navigate({
+              to: "/events/venues/$venueId/edit",
+              params: { venueId: venue.id },
+            })
+          }
+          className="group flex flex-col overflow-hidden rounded-xl border bg-card text-left transition-shadow hover:shadow-md"
+        >
+          <CoverImage
+            src={venue.image_url}
+            alt={venue.title}
+            className="aspect-[16/9] w-full object-cover"
+            fallback={<MapPin className="h-8 w-8 text-muted-foreground/40" />}
+          />
+          <div className="flex-1 p-4">
+            <h3 className="mb-1 font-semibold text-base transition-colors group-hover:text-primary">
+              {venue.title || "Untitled venue"}
+            </h3>
+            {venue.location && (
+              <p className="line-clamp-1 text-sm text-muted-foreground">
+                {venue.location}
+              </p>
+            )}
+            <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+              {venue.capacity != null && (
+                <span className="inline-flex items-center gap-1">
+                  <Users className="h-3.5 w-3.5" />
+                  {venue.capacity}
+                </span>
+              )}
+            </div>
+            {venue.properties && venue.properties.length > 0 && (
+              <ul
+                aria-label="Venue properties"
+                className="mt-2 flex flex-wrap gap-1.5"
+              >
+                {venue.properties.slice(0, 6).map((p) => (
+                  <li
+                    key={p.id}
+                    title={p.name}
+                    className="inline-flex items-center gap-1 rounded-md border bg-muted/40 px-1.5 py-0.5 text-[11px] text-muted-foreground"
+                  >
+                    <LucideIcon name={p.icon} className="h-3 w-3" />
+                    <span className="max-w-[8rem] truncate">{p.name}</span>
+                  </li>
+                ))}
+                {venue.properties.length > 6 && (
+                  <li className="inline-flex items-center rounded-md border bg-muted/40 px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                    +{venue.properties.length - 6}
+                  </li>
+                )}
+              </ul>
+            )}
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Textarea } from "@/components/ui/textarea"
+import { VenueHoursSummary } from "@/components/VenueHoursSummary"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
@@ -797,6 +798,23 @@ export function EventForm({
 
   const startFits = fitnessIssue === null
 
+  // When the typed slot doesn't fit, suggest the closest open slots so the
+  // user can fix it in one click instead of hunting for a valid time. Ranked
+  // by proximity to the typed start; capped at three.
+  const nearbyStartOptions = useMemo(() => {
+    if (startFits || startSlotOptions.length === 0) return []
+    const anchor = startUtc?.getTime() ?? null
+    const ranked =
+      anchor == null
+        ? startSlotOptions
+        : [...startSlotOptions].sort(
+            (a, b) =>
+              Math.abs(Date.parse(a.isoUtc) - anchor) -
+              Math.abs(Date.parse(b.isoUtc) - anchor),
+          )
+    return ranked.slice(0, 3)
+  }, [startFits, startSlotOptions, startUtc])
+
   // Combined availability: when the slot doesn't fit locally, surface the
   // precise reason — we'd otherwise show a stale "Slot available" from the
   // server check, which only validates conflicts (not open hours).
@@ -1143,19 +1161,40 @@ export function EventForm({
         )}
 
         {selectedVenue && (
-          <InlineRow
-            label="Venue details"
-            description="Capacity, booking mode and weekly hours"
-          >
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setVenueDialogOpen(true)}
-            >
-              View details
-            </Button>
-          </InlineRow>
+          <div className="space-y-3 px-1 py-2">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <p className="mb-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Open hours
+                </p>
+                <VenueHoursSummary hours={selectedVenue.weekly_hours} />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setVenueDialogOpen(true)}
+              >
+                View details
+              </Button>
+            </div>
+
+            {selectedVenue.photos && selectedVenue.photos.length > 0 && (
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                {[...selectedVenue.photos]
+                  .sort((a, b) => a.position - b.position)
+                  .slice(0, 6)
+                  .map((photo) => (
+                    <img
+                      key={photo.id}
+                      src={photo.image_url}
+                      alt=""
+                      className="h-16 w-16 shrink-0 rounded-md border object-cover"
+                    />
+                  ))}
+              </div>
+            )}
+          </div>
         )}
 
         {selectedVenue && isVenueUnbookable && (
@@ -1341,6 +1380,29 @@ export function EventForm({
               }
             />
             <AvailabilityIndicator availability={effectiveAvailability} />
+            {!readOnly && nearbyStartOptions.length > 0 && (
+              <div className="flex flex-col items-end gap-1">
+                <span className="text-xs text-muted-foreground">
+                  Nearby open times
+                </span>
+                <div className="flex flex-wrap justify-end gap-1.5">
+                  {nearbyStartOptions.map((opt) => (
+                    <button
+                      key={opt.isoUtc}
+                      type="button"
+                      onClick={() => {
+                        const date =
+                          dateStr || new Date().toISOString().slice(0, 10)
+                        form.setFieldValue("start_time", `${date}T${opt.label}`)
+                      }}
+                      className="inline-flex h-7 items-center rounded-md border bg-background px-2.5 text-xs font-medium shadow-sm transition-colors hover:bg-muted"
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </InlineRow>
 

--- a/backoffice/src/components/forms/VenueForm.tsx
+++ b/backoffice/src/components/forms/VenueForm.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { ArrowUpRight, MapPin } from "lucide-react"
 
 import { useMemo, useState } from "react"
 
@@ -301,6 +302,25 @@ export function VenueForm({ defaultValues, onSuccess }: VenueFormProps) {
   const [resolving, setResolving] = useState(false)
   const parsedCoords = parseGoogleMapsUrl(mapsLink)
 
+  // Convenience "open in Maps" target: prefer the venue's coordinates,
+  // falling back to a name + address search query.
+  const mapsUrl = useMemo(() => {
+    const lat = parsedCoords?.lat ?? defaultValues?.geo_lat
+    const lng = parsedCoords?.lng ?? defaultValues?.geo_lng
+    if (lat != null && lng != null) {
+      return `https://www.google.com/maps/@${lat},${lng},17z`
+    }
+    const query = [
+      defaultValues?.title,
+      defaultValues?.formatted_address || defaultValues?.location,
+    ]
+      .filter(Boolean)
+      .join(", ")
+    return query
+      ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+      : null
+  }, [parsedCoords, defaultValues])
+
   const handleMapsLinkChange = async (
     url: string,
     fieldChange: (v: string) => void,
@@ -418,6 +438,18 @@ export function VenueForm({ defaultValues, onSuccess }: VenueFormProps) {
                       : "Could not extract coordinates from this link"}
                 </p>
               )}
+              {mapsUrl && (
+                <a
+                  href={mapsUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+                >
+                  <MapPin className="h-3.5 w-3.5" />
+                  Open in Google Maps
+                  <ArrowUpRight className="h-3 w-3" />
+                </a>
+              )}
             </div>
           </InlineRow>
 
@@ -446,6 +478,7 @@ export function VenueForm({ defaultValues, onSuccess }: VenueFormProps) {
                   onChange={(url) => field.handleChange(url ?? "")}
                   disabled={readOnly}
                   cropAspect={16 / 9}
+                  displayAspect={16 / 9}
                 />
               )}
             </form.Field>

--- a/backoffice/src/components/ui/image-upload.tsx
+++ b/backoffice/src/components/ui/image-upload.tsx
@@ -19,6 +19,13 @@ interface ImageUploadProps {
   cropAspect?: number
   /** When "image+video", also accepts .mp4. Preview switches to <video>. */
   accept?: "image" | "image+video"
+  /**
+   * When set, the filled-state preview renders full-width at this aspect
+   * ratio with overlaid Replace / Remove buttons (the portal cover style)
+   * instead of the compact inline thumbnail. Opt-in — existing callers keep
+   * the thumbnail preview.
+   */
+  displayAspect?: number
 }
 
 const IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"]
@@ -36,6 +43,7 @@ export function ImageUpload({
   disabled,
   cropAspect,
   accept = "image",
+  displayAspect,
 }: ImageUploadProps) {
   const allowVideo = accept === "image+video"
   const acceptedTypes = allowVideo
@@ -137,6 +145,64 @@ export function ImageUpload({
       saving={isUploading}
     />
   ) : null
+
+  if (value && displayAspect) {
+    const isVid = isVideoUrl(value)
+    return (
+      <>
+        <div
+          className={cn(
+            "relative mx-auto w-full max-h-72 max-w-xl overflow-hidden rounded-lg border bg-muted",
+            className,
+          )}
+          style={{ aspectRatio: String(displayAspect) }}
+        >
+          {isVid ? (
+            <video
+              src={value}
+              className="h-full w-full object-cover"
+              muted
+              autoPlay
+              loop
+              playsInline
+            />
+          ) : (
+            <img
+              src={value}
+              alt="Uploaded"
+              className="h-full w-full object-cover"
+            />
+          )}
+          {!disabled && (
+            <div className="absolute right-2 top-2 flex items-center gap-1.5">
+              <label className="inline-flex h-8 cursor-pointer items-center gap-1 rounded-md border bg-background/90 px-2.5 text-xs font-medium shadow-sm backdrop-blur transition-colors hover:bg-background">
+                <Upload className="h-3.5 w-3.5" />
+                Replace
+                <input
+                  type="file"
+                  className="hidden"
+                  accept={inputAccept}
+                  onChange={handleChange}
+                  disabled={disabled}
+                />
+              </label>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="h-8 px-2.5 text-xs"
+                onClick={handleRemove}
+              >
+                <X className="mr-1 h-3.5 w-3.5" />
+                Remove
+              </Button>
+            </div>
+          )}
+        </div>
+        {cropper}
+      </>
+    )
+  }
 
   if (value) {
     return (

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -41,6 +41,7 @@ import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
 import { EventsCalendarView } from "@/components/events/EventsCalendarView"
 import { EventsDayView } from "@/components/events/EventsDayView"
+import { EventsListView } from "@/components/events/EventsListView"
 import {
   type EventsView,
   EventsViewSwitcher,
@@ -106,7 +107,23 @@ const EVENT_STATUS_OPTIONS: { value: EventStatus; label: string }[] = [
   { value: "rejected", label: "Rejected" },
 ]
 
-const VALID_EVENT_VIEWS: Set<string> = new Set(["table", "calendar", "day"])
+const VALID_EVENT_VIEWS: Set<string> = new Set([
+  "table",
+  "list",
+  "calendar",
+  "day",
+])
+
+// Remember the last view the user picked so returning to /events (or a fresh
+// session) lands on it. Defaults to the card "list" view when nothing is
+// stored yet.
+const EVENTS_VIEW_STORAGE_KEY = "edgeos:events-view"
+
+function readStoredEventsView(): EventsView | null {
+  if (typeof window === "undefined") return null
+  const v = window.localStorage.getItem(EVENTS_VIEW_STORAGE_KEY)
+  return v && VALID_EVENT_VIEWS.has(v) ? (v as EventsView) : null
+}
 
 type EventsSearchParams = TableSearchParams & {
   status?: EventStatus
@@ -1191,7 +1208,7 @@ function EventsPage() {
   const { selectedPopupId } = useWorkspace()
   const navigate = useNavigate()
   const searchParams = Route.useSearch()
-  const view: EventsView = searchParams.view ?? "table"
+  const view: EventsView = searchParams.view ?? readStoredEventsView() ?? "list"
   const selectedDate = parseSelectedDate(searchParams.date)
   // Picking an occurrence row pops a "series or this only" prompt; non-recurring
   // rows skip the dialog and navigate straight to /events/:id/edit.
@@ -1259,13 +1276,16 @@ function EventsPage() {
 
   const setView = useCallback(
     (next: EventsView) => {
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(EVENTS_VIEW_STORAGE_KEY, next)
+      }
       navigate({
         to: "/events",
         search: (prev: Record<string, unknown>) => {
           const prevDate = typeof prev.date === "string" ? prev.date : undefined
           return {
             ...prev,
-            view: next === "table" ? undefined : next,
+            view: next,
             date: next === "day" ? prevDate : undefined,
           }
         },
@@ -1363,6 +1383,26 @@ function EventsPage() {
           <Suspense fallback={<Skeleton className="h-64 w-full" />}>
             {view === "table" && (
               <EventsTableContent onRowClick={handleRowClick} />
+            )}
+            {view === "list" && (
+              <div className="space-y-3">
+                <CalendarDayToolbar
+                  popupId={selectedPopupId}
+                  status={searchParams.status}
+                  venueId={searchParams.venueId}
+                  search={searchParams.search ?? ""}
+                  setStatus={setStatusGlobal}
+                  setVenueId={setVenueIdGlobal}
+                  setSearch={setSearchGlobal}
+                />
+                <EventsListView
+                  popupId={selectedPopupId}
+                  status={searchParams.status}
+                  venueId={searchParams.venueId}
+                  search={searchParams.search ?? ""}
+                  onEventClick={handleRowClick}
+                />
+              </div>
             )}
             {view === "calendar" && (
               <div className="space-y-3">

--- a/backoffice/src/routes/_layout/events/venues/$venueId.edit.tsx
+++ b/backoffice/src/routes/_layout/events/venues/$venueId.edit.tsx
@@ -1,11 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { CalendarRange } from "lucide-react"
 import { Suspense } from "react"
 
 import { EventVenuesService } from "@/client"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { VenueForm } from "@/components/forms/VenueForm"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useGoBack } from "@/hooks/useGoBack"
 
@@ -34,6 +36,14 @@ function EditVenuePage() {
       title="Edit Venue"
       description="Update venue details"
       backTo="/events/venues"
+      actions={
+        <Button asChild variant="outline" size="sm">
+          <Link to="/events/venues/$venueId/schedule" params={{ venueId }}>
+            <CalendarRange className="mr-2 h-4 w-4" />
+            Schedule
+          </Link>
+        </Button>
+      }
     >
       <QueryErrorBoundary>
         <Suspense fallback={<Skeleton className="h-96 w-full" />}>

--- a/backoffice/src/routes/_layout/events/venues/index.tsx
+++ b/backoffice/src/routes/_layout/events/venues/index.tsx
@@ -20,9 +20,11 @@ import {
   Check,
   CheckCircle2,
   GripVertical,
+  LayoutGrid,
   MapPin,
   Plus,
   Search,
+  Table as TableIcon,
   X,
 } from "lucide-react"
 import { Suspense, useEffect, useMemo, useState } from "react"
@@ -37,6 +39,7 @@ import { EmptyState } from "@/components/Common/EmptyState"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { StatusBadge } from "@/components/Common/StatusBadge"
 import { WorkspaceAlert } from "@/components/Common/WorkspaceAlert"
+import { VenuesGridView } from "@/components/events/VenuesGridView"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -65,13 +68,121 @@ const BOOKING_MODE_LABELS: Record<VenueBookingMode, string> = {
   unbookable: "Unbookable",
 }
 
+type VenuesView = "table" | "grid"
+
+const VALID_VENUES_VIEWS: Set<string> = new Set(["table", "grid"])
+
+// Remember the last venues view; defaults to the card "grid" when unset.
+const VENUES_VIEW_STORAGE_KEY = "edgeos:venues-view"
+
+function readStoredVenuesView(): VenuesView | null {
+  if (typeof window === "undefined") return null
+  const v = window.localStorage.getItem(VENUES_VIEW_STORAGE_KEY)
+  return v && VALID_VENUES_VIEWS.has(v) ? (v as VenuesView) : null
+}
+
+type VenuesSearchParams = ReturnType<typeof validateTableSearch> & {
+  view?: VenuesView
+}
+
 export const Route = createFileRoute("/_layout/events/venues/")({
   component: VenuesPage,
-  validateSearch: validateTableSearch,
+  validateSearch: (raw: Record<string, unknown>): VenuesSearchParams => ({
+    ...validateTableSearch(raw),
+    ...(typeof raw.view === "string" && VALID_VENUES_VIEWS.has(raw.view)
+      ? { view: raw.view as VenuesView }
+      : {}),
+  }),
   head: () => ({
     meta: [{ title: "Venues - EdgeOS" }],
   }),
 })
+
+function VenuesViewSwitcher({
+  view,
+  onViewChange,
+}: {
+  view: VenuesView
+  onViewChange: (view: VenuesView) => void
+}) {
+  return (
+    <div className="inline-flex rounded-md border bg-card p-0.5">
+      <Button
+        type="button"
+        variant={view === "table" ? "default" : "ghost"}
+        size="sm"
+        aria-label="Table"
+        title="Table"
+        aria-pressed={view === "table"}
+        onClick={() => onViewChange("table")}
+        className={cn(
+          "h-7 w-7 rounded-sm p-0",
+          view === "table" && "shadow-none",
+        )}
+      >
+        <TableIcon className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        variant={view === "grid" ? "default" : "ghost"}
+        size="sm"
+        aria-label="Grid"
+        title="Grid"
+        aria-pressed={view === "grid"}
+        onClick={() => onViewChange("grid")}
+        className={cn(
+          "h-7 w-7 rounded-sm p-0",
+          view === "grid" && "shadow-none",
+        )}
+      >
+        <LayoutGrid className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}
+
+function VenuesGridContent() {
+  const searchParams = Route.useSearch()
+  const { selectedPopupId } = useWorkspace()
+  const { search, setSearch } = useTableSearchParams(
+    searchParams,
+    "/events/venues/",
+  )
+  const [localSearch, setLocalSearch] = useState(search)
+  useEffect(() => setLocalSearch(search), [search])
+  useEffect(() => {
+    if (localSearch === search) return
+    const t = setTimeout(() => setSearch(localSearch), 300)
+    return () => clearTimeout(t)
+  }, [localSearch, search, setSearch])
+
+  if (!selectedPopupId) return null
+
+  return (
+    <div className="space-y-3">
+      <div className="relative w-full min-w-0 sm:max-w-xs">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search venues..."
+          value={localSearch}
+          onChange={(e) => setLocalSearch(e.target.value)}
+          className="pl-9 pr-8"
+        />
+        {localSearch && (
+          <button
+            type="button"
+            onClick={() => setLocalSearch("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-muted-foreground transition-colors hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <VenuesGridView popupId={selectedPopupId} search={search} />
+    </div>
+  )
+}
 
 function VenueRowActions({ venue }: { venue: EventVenuePublic }) {
   const navigate = useNavigate()
@@ -409,6 +520,23 @@ function VenuesTableContent() {
 
 function VenuesPage() {
   const { selectedPopupId } = useWorkspace()
+  const navigate = useNavigate()
+  const searchParams = Route.useSearch()
+  const view: VenuesView = searchParams.view ?? readStoredVenuesView() ?? "grid"
+
+  const setView = (next: VenuesView) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VENUES_VIEW_STORAGE_KEY, next)
+    }
+    navigate({
+      to: "/events/venues",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        view: next,
+      }),
+      replace: true,
+    })
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -420,18 +548,21 @@ function VenuesPage() {
           </p>
         </div>
         {selectedPopupId && (
-          <Button asChild>
-            <Link to="/events/venues/new">
-              <Plus className="mr-2 h-4 w-4" />
-              Add Venue
-            </Link>
-          </Button>
+          <div className="flex items-center gap-2">
+            <VenuesViewSwitcher view={view} onViewChange={setView} />
+            <Button asChild>
+              <Link to="/events/venues/new">
+                <Plus className="mr-2 h-4 w-4" />
+                Add Venue
+              </Link>
+            </Button>
+          </div>
         )}
       </div>
       {selectedPopupId ? (
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-            <VenuesTableContent />
+            {view === "grid" ? <VenuesGridContent /> : <VenuesTableContent />}
           </Suspense>
         </QueryErrorBoundary>
       ) : (


### PR DESCRIPTION
## Events
- New grouped-by-day card **list** view alongside the existing table / calendar / day views (shows all events — past and future, every status).
- Richer event form UX ported from portal: **nearby open-slot suggestions** when the chosen time doesn't fit, and an inline venue picker showing **hours + photos**.

## Venues
- New card **grid** view; the separate read-only detail page was dropped — grid cards open the **edit** page directly (consistent with events).
- Rescued the **Open in Google Maps** link onto the edit form, and surfaced **Schedule** from the edit header.
- Selected view persists per user (events default = list, venues default = grid).

## Shared
- Reusable `LucideIcon` (dynamic) and an opt-in full-width `displayAspect` mode on `ImageUpload`.
- `FormPageLayout` gained an optional `actions` header slot.

Backoffice-only; no backend or generated-client changes. Build / tsc / biome green.