### PR TITLE
feat(events): let a designated host edit, cancel and manage their event

### DIFF
--- a/backend/app/alembic/versions/f4a9c1e7b6d2_event_host_id.py
+++ b/backend/app/alembic/versions/f4a9c1e7b6d2_event_host_id.py
@@ -1,0 +1,34 @@
+"""event host_id
+
+Adds nullable events.host_id (UUID, indexed) — the human designated as the
+event's host. Grants that host the same manage rights as the owner (edit /
+cancel / invitations). Modeled like owner_id: an indexed uuid with no FK
+constraint. Set only when a directory human is picked as host; NULL otherwise.
+
+Revision ID: f4a9c1e7b6d2
+Revises: b7e2a4c9f013
+Create Date: 2026-06-02
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "f4a9c1e7b6d2"
+down_revision = "b7e2a4c9f013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("host_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index("ix_events_host_id", "events", ["host_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_host_id", table_name="events")
+    op.drop_column("events", "host_id")

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -892,9 +892,7 @@ async def list_event_hosts(
     omitted (they have no host to filter by).
     """
     hosts = crud.events_crud.list_distinct_hosts(db, popup_id=popup_id)
-    return [
-        EventHostOption(id=h.id, name=h.full_name, email=h.email) for h in hosts
-    ]
+    return [EventHostOption(id=h.id, name=h.full_name, email=h.email) for h in hosts]
 
 
 @router.get("/{event_id}", response_model=EventPublic)
@@ -1837,18 +1835,28 @@ async def delete_invitation(
 
 
 # ---------------------------------------------------------------------------
-# Portal invitations — event owner only
+# Portal invitations — event owner or host
 # ---------------------------------------------------------------------------
+
+
+def _human_manages_event(event, current_human) -> bool:
+    """Whether a human may manage an event (edit / cancel / invitations).
+
+    True for the event's owner (creator) or its designated host — the host
+    carries the same responsibility over the event even though they didn't
+    create it. ``host_id`` is NULL when no directory human was assigned.
+    """
+    return current_human.id in (event.owner_id, event.host_id)
 
 
 def _ensure_portal_event_owner(db, event_id: uuid.UUID, current_human):
     event = crud.events_crud.get(db, event_id)
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
-    if event.owner_id != current_human.id:
+    if not _human_manages_event(event, current_human):
         raise HTTPException(
             status_code=403,
-            detail="Only the event owner can manage invitations",
+            detail="Only the event owner or host can manage invitations",
         )
     return event
 
@@ -2422,7 +2430,7 @@ async def get_portal_event(
             .where(EventInvitations.event_id == event_id)
             .where(EventInvitations.human_id == current_human.id)
         ).first()
-        if not invited and event.owner_id != current_human.id:
+        if not invited and not _human_manages_event(event, current_human):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
             )
@@ -2465,9 +2473,7 @@ async def get_portal_event(
 # ---------------------------------------------------------------------------
 
 
-@router.get(
-    "/portal/events/{event_id}/admin-notes", response_model=EventAdminNotes
-)
+@router.get("/portal/events/{event_id}/admin-notes", response_model=EventAdminNotes)
 async def get_portal_event_admin_notes(
     event_id: uuid.UUID,
     db: HumanTenantSession,
@@ -2482,9 +2488,7 @@ async def get_portal_event_admin_notes(
     return EventAdminNotes(notes=event.admin_notes)
 
 
-@router.put(
-    "/portal/events/{event_id}/admin-notes", response_model=EventAdminNotes
-)
+@router.put("/portal/events/{event_id}/admin-notes", response_model=EventAdminNotes)
 async def update_portal_event_admin_notes(
     event_id: uuid.UUID,
     payload: EventAdminNotes,
@@ -2696,10 +2700,10 @@ async def update_portal_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
-    if event.owner_id != current_human.id:
+    if not _human_manages_event(event, current_human):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the event owner can edit",
+            detail="Only the event owner or host can edit",
         )
 
     audit_before = build_event_snapshot(db, event)
@@ -2777,10 +2781,10 @@ async def cancel_portal_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
-    if event.owner_id != current_human.id:
+    if not _human_manages_event(event, current_human):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the event owner can cancel",
+            detail="Only the event owner or host can cancel",
         )
     if event.status == EventStatus.CANCELLED:
         raise HTTPException(

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -93,6 +93,12 @@ class EventBase(SQLModel):
     # event creators choose any of: tenant name, their own name, a participant's
     # name, or a custom value — all stored as plain text.
     host_display_name: str | None = Field(default=None, max_length=255)
+    # Optional human designated as the event's host. Unlike host_display_name
+    # (free text shown on the card), this is a real human id, set only when a
+    # participant is picked from the directory. Grants the host the same manage
+    # rights as the owner (edit / cancel / invitations). NULL when the host is
+    # free text or unset. Modeled like owner_id: indexed uuid, no hard FK.
+    host_id: uuid.UUID | None = Field(default=None, index=True)
     status: EventStatus = Field(default=EventStatus.DRAFT)
     # When true, portal clients render the event with a "special" treatment
     # (badge, accent border) so it stands out in the list/day/calendar views.
@@ -309,6 +315,7 @@ class EventCreate(BaseModel):
     require_approval: bool = False
     kind: str | None = None
     host_display_name: str | None = None
+    host_id: uuid.UUID | None = None
     status: EventStatus = EventStatus.DRAFT
     highlighted: bool = False
     recurrence: RecurrenceRule | None = None
@@ -347,6 +354,7 @@ class EventUpdate(BaseModel):
     require_approval: bool | None = None
     kind: str | None = None
     host_display_name: str | None = None
+    host_id: uuid.UUID | None = None
     status: EventStatus | None = None
     highlighted: bool | None = None
 

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -489,7 +489,7 @@ class TestApiKeyPolicy:
         )
 
         assert resp.status_code == 403, resp.text
-        assert resp.json()["detail"] == "Only the event owner can edit"
+        assert resp.json()["detail"] == "Only the event owner or host can edit"
 
     def test_pat_patch_requires_events_write_scope(
         self,
@@ -758,7 +758,8 @@ class TestApiKeyPolicy:
         )
         assert post_resp.status_code == 403, post_resp.text
         assert (
-            post_resp.json()["detail"] == "Only the event owner can manage invitations"
+            post_resp.json()["detail"]
+            == "Only the event owner or host can manage invitations"
         )
 
         del_resp = client.delete(
@@ -767,7 +768,8 @@ class TestApiKeyPolicy:
         )
         assert del_resp.status_code == 403, del_resp.text
         assert (
-            del_resp.json()["detail"] == "Only the event owner can manage invitations"
+            del_resp.json()["detail"]
+            == "Only the event owner or host can manage invitations"
         )
 
     def test_flagging_human_revokes_existing_api_keys(

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -5557,6 +5557,18 @@ export const EventCreateSchema = {
             ],
             title: 'Host Display Name'
         },
+        host_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Host Id'
+        },
         status: {
             '$ref': '#/components/schemas/EventStatus',
             default: 'draft'
@@ -6079,6 +6091,18 @@ export const EventPublicSchema = {
                 }
             ],
             title: 'Host Display Name'
+        },
+        host_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Host Id'
         },
         status: {
             '$ref': '#/components/schemas/EventStatus',
@@ -7050,6 +7074,18 @@ export const EventUpdateSchema = {
                 }
             ],
             title: 'Host Display Name'
+        },
+        host_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Host Id'
         },
         status: {
             anyOf: [

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1276,6 +1276,7 @@ export type EventCreate = {
     require_approval?: boolean;
     kind?: (string | null);
     host_display_name?: (string | null);
+    host_id?: (string | null);
     status?: EventStatus;
     highlighted?: boolean;
     recurrence?: (RecurrenceRule | null);
@@ -1380,6 +1381,7 @@ export type EventPublic = {
     require_approval?: boolean;
     kind?: (string | null);
     host_display_name?: (string | null);
+    host_id?: (string | null);
     status?: EventStatus;
     highlighted?: boolean;
     rejection_reason?: (string | null);
@@ -1541,6 +1543,7 @@ export type EventUpdate = {
     require_approval?: (boolean | null);
     kind?: (string | null);
     host_display_name?: (string | null);
+    host_id?: (string | null);
     status?: (EventStatus | null);
     highlighted?: (boolean | null);
 };

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -347,6 +347,7 @@ export function EventForm({
       require_approval: false,
       highlighted: defaultValues?.highlighted ?? false,
       host_display_name: defaultValues?.host_display_name ?? "",
+      host_id: defaultValues?.host_id ?? null,
       tags: defaultValues?.tags ?? [],
     },
     onSubmit: ({ value }) => {
@@ -403,6 +404,7 @@ export function EventForm({
           content: value.content || null,
           kind: value.kind || null,
           host_display_name: hostDisplayName,
+          host_id: value.host_id,
           start_time: startDate.toISOString(),
           end_time: endDate.toISOString(),
           timezone: value.timezone,
@@ -429,6 +431,7 @@ export function EventForm({
           content: value.content || null,
           kind: value.kind || null,
           host_display_name: hostDisplayName,
+          host_id: value.host_id,
           start_time: startDate.toISOString(),
           end_time: endDate.toISOString(),
           timezone: value.timezone,
@@ -1490,7 +1493,10 @@ export function EventForm({
               <div className="flex w-full max-w-[380px] flex-col gap-2">
                 <Input
                   value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value)
+                    form.setFieldValue("host_id", null)
+                  }}
                   placeholder={
                     popup?.name ? `${popup.name} (default)` : "Optional"
                   }
@@ -1505,7 +1511,10 @@ export function EventForm({
                         variant="ghost"
                         size="sm"
                         className="h-7 px-2 text-xs"
-                        onClick={() => field.handleChange(popup.name ?? "")}
+                        onClick={() => {
+                          field.handleChange(popup.name ?? "")
+                          form.setFieldValue("host_id", null)
+                        }}
                       >
                         Use {popup.name}
                       </Button>
@@ -1516,9 +1525,10 @@ export function EventForm({
                         variant="ghost"
                         size="sm"
                         className="h-7 px-2 text-xs"
-                        onClick={() =>
+                        onClick={() => {
                           field.handleChange(currentUserDisplayName)
-                        }
+                          form.setFieldValue("host_id", null)
+                        }}
                       >
                         Use my name
                       </Button>
@@ -1563,6 +1573,7 @@ export function EventForm({
                                   className="flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left text-sm hover:bg-muted"
                                   onClick={() => {
                                     field.handleChange(name)
+                                    form.setFieldValue("host_id", h.id)
                                     setHostPickerOpen(false)
                                     setHostSearch("")
                                   }}

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
@@ -285,6 +285,7 @@ export function EditEventForm({
         <HostDisplayField
           value={form.hostDisplayName}
           onChange={form.setHostDisplayName}
+          onHostIdChange={form.setHostId}
           currentUserName={currentHumanName}
           popupName={cityName}
           popupId={popupId}

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/page.tsx
@@ -47,7 +47,10 @@ export default function EditPortalEventPage() {
     )
   }
 
-  if (!currentHuman || event.owner_id !== currentHuman.id) {
+  const canManage =
+    !!currentHuman &&
+    (event.owner_id === currentHuman.id || event.host_id === currentHuman.id)
+  if (!canManage) {
     return (
       <div className="max-w-2xl mx-auto p-4 sm:p-6 text-center py-20">
         <h1 className="text-xl font-semibold">

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/useEditEventForm.ts
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/useEditEventForm.ts
@@ -31,6 +31,8 @@ export interface UseEditEventFormResult {
   setTags: (next: string[]) => void
   hostDisplayName: string
   setHostDisplayName: (next: string) => void
+  hostId: string | null
+  setHostId: (next: string | null) => void
   buildPayload: (
     timezone: string,
     startIso: string,
@@ -65,6 +67,9 @@ export function useEditEventForm(event: EventPublic): UseEditEventFormResult {
   const [hostDisplayName, setHostDisplayName] = useState(
     () => event.host_display_name ?? "",
   )
+  const [hostId, setHostId] = useState<string | null>(
+    () => event.host_id ?? null,
+  )
 
   const buildPayload = (
     timezone: string,
@@ -90,6 +95,7 @@ export function useEditEventForm(event: EventPublic): UseEditEventFormResult {
       cover_url: coverUrl || null,
       tags,
       host_display_name: hostDisplayName.trim() || null,
+      host_id: hostId,
     }
   }
 
@@ -118,6 +124,8 @@ export function useEditEventForm(event: EventPublic): UseEditEventFormResult {
     setTags,
     hostDisplayName,
     setHostDisplayName,
+    hostId,
+    setHostId,
     buildPayload,
   }
 }

--- a/portal/src/app/portal/[popupSlug]/events/components/HostDisplayField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/HostDisplayField.tsx
@@ -17,6 +17,13 @@ import {
 interface HostDisplayFieldProps {
   value: string
   onChange: (next: string) => void
+  /**
+   * Reports the picked human's id, or null when the host is free text. Set
+   * only when a participant is chosen from the directory; typing into the
+   * field or using the quick-fill buttons clears it. The id is what grants
+   * that human edit rights over the event.
+   */
+  onHostIdChange?: (next: string | null) => void
   currentUserName?: string | null
   popupName?: string | null
   /** Required for the participant picker; when missing, the button is disabled. */
@@ -31,6 +38,7 @@ function humanName(h: HumanPortalPublic): string {
 export function HostDisplayField({
   value,
   onChange,
+  onHostIdChange,
   currentUserName,
   popupName,
   popupId,
@@ -65,7 +73,10 @@ export function HostDisplayField({
         id="host"
         value={value}
         maxLength={255}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => {
+          onChange(e.target.value)
+          onHostIdChange?.(null)
+        }}
         placeholder={
           trimmedPopup
             ? t("events.form.host_placeholder_default", { name: trimmedPopup })
@@ -79,7 +90,10 @@ export function HostDisplayField({
             variant="ghost"
             size="sm"
             className="h-7 px-2 text-xs"
-            onClick={() => onChange(trimmedPopup)}
+            onClick={() => {
+              onChange(trimmedPopup)
+              onHostIdChange?.(null)
+            }}
           >
             {t("events.form.host_use_popup", { name: trimmedPopup })}
           </Button>
@@ -90,7 +104,10 @@ export function HostDisplayField({
             variant="ghost"
             size="sm"
             className="h-7 px-2 text-xs"
-            onClick={() => onChange(trimmedUser)}
+            onClick={() => {
+              onChange(trimmedUser)
+              onHostIdChange?.(null)
+            }}
           >
             {t("events.form.host_use_me")}
           </Button>
@@ -135,6 +152,7 @@ export function HostDisplayField({
                       className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted"
                       onClick={() => {
                         onChange(name)
+                        onHostIdChange?.(h.id)
                         setPickerOpen(false)
                         setSearchInput("")
                       }}

--- a/portal/src/app/portal/[popupSlug]/events/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/new/page.tsx
@@ -208,6 +208,7 @@ function NewPortalEventForm({
   const [trackId, setTrackId] = useState<string>("")
   const [coverUrl, setCoverUrl] = useState("")
   const [hostDisplayName, setHostDisplayName] = useState("")
+  const [hostId, setHostId] = useState<string | null>(null)
 
   // ---- venue + availability ------------------------------------------
   const {
@@ -283,6 +284,7 @@ function NewPortalEventForm({
           cover_url: coverUrl || null,
           tags,
           host_display_name: hostDisplayName.trim() || null,
+          host_id: hostId,
           status: "published",
         },
       })
@@ -545,6 +547,7 @@ function NewPortalEventForm({
         <HostDisplayField
           value={hostDisplayName}
           onChange={setHostDisplayName}
+          onHostIdChange={setHostId}
           currentUserName={currentHumanName}
           popupName={city?.name}
           popupId={popupId}

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -5557,6 +5557,18 @@ export const EventCreateSchema = {
             ],
             title: 'Host Display Name'
         },
+        host_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Host Id'
+        },
         status: {
             '$ref': '#/components/schemas/EventStatus',
             default: 'draft'
@@ -6079,6 +6091,18 @@ export const EventPublicSchema = {
                 }
             ],
             title: 'Host Display Name'
+        },
+        host_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Host Id'
         },
         status: {
             '$ref': '#/components/schemas/EventStatus',
@@ -7050,6 +7074,18 @@ export const EventUpdateSchema = {
                 }
             ],
             title: 'Host Display Name'
+        },
+        host_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Host Id'
         },
         status: {
             anyOf: [

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1276,6 +1276,7 @@ export type EventCreate = {
     require_approval?: boolean;
     kind?: (string | null);
     host_display_name?: (string | null);
+    host_id?: (string | null);
     status?: EventStatus;
     highlighted?: boolean;
     recurrence?: (RecurrenceRule | null);
@@ -1380,6 +1381,7 @@ export type EventPublic = {
     require_approval?: boolean;
     kind?: (string | null);
     host_display_name?: (string | null);
+    host_id?: (string | null);
     status?: EventStatus;
     highlighted?: boolean;
     rejection_reason?: (string | null);
@@ -1541,6 +1543,7 @@ export type EventUpdate = {
     require_approval?: (boolean | null);
     kind?: (string | null);
     host_display_name?: (string | null);
+    host_id?: (string | null);
     status?: (EventStatus | null);
     highlighted?: (boolean | null);
 };


### PR DESCRIPTION
> ⚠️ **Stacked on #245** (`feat/backoffice-events-venues`) because both touch `backoffice/EventForm.tsx`. Review/merge #245 first, then retarget this to `dev`. The diff here is host_id-only on top of #245.

## What
Today only the event creator (owner) can edit. A **host** of an event now gets the same manage rights — it's still their event even though they didn't create it.

## Change
- New nullable `events.host_id` (indexed uuid, no FK — modeled like `owner_id`). Migration `f4a9c1e7b6d2` (single head).
- Backend: `_human_manages_event` = owner **or** host, applied to **edit / cancel / manage invitations** and the **private-event visibility** gate. `host_id` on EventBase/Create/Update.
- Frontend: the host picker now stores the picked human's id (portal + backoffice); set only when a directory participant is picked, cleared on free text / quick-fill. Portal edit gating allows owner or host.
- OpenAPI client regenerated (both frontends).

Verified at runtime: owner ✅, host ✅, other ❌. Builds / tsc / lint green; backend ruff clean.

## Note
Backfilling `host_id` retroactively from legacy `host_display_name` strings is intentionally deferred.