### PR TITLE
feat(portal): collapsible day groups in events list + share button on event detail

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -8,6 +8,7 @@ import {
   CalendarCheck,
   CalendarDays,
   CalendarPlus,
+  Check,
   CheckCircle,
   Clock,
   Home,
@@ -19,6 +20,7 @@ import {
   Pencil,
   Repeat,
   Send,
+  Share2,
   Tag,
   Trash2,
   User,
@@ -261,6 +263,7 @@ export default function EventDetailPage() {
   })
 
   const [cancelEventOpen, setCancelEventOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
   const cancelEventMutation = useMutation({
     mutationFn: () =>
       EventsService.cancelPortalEvent({ eventId: params.eventId }),
@@ -427,6 +430,33 @@ export default function EventDetailPage() {
   const coverCredit =
     !event.cover_url && event.venue_image_url ? event.venue_title : null
 
+  const sharePath = `/portal/${city?.slug}/events/${params.eventId}${
+    occParam ? `?occ=${encodeURIComponent(occParam)}` : ""
+  }`
+  const shareUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}${sharePath}`
+      : sharePath
+
+  const handleShare = async () => {
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({ title: event.title, url: shareUrl })
+        return
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") return
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+      toast.success(t("events.detail.share_link_copied"))
+    } catch {
+      toast.error(t("events.detail.share_link_error"))
+    }
+  }
+
   return (
     <div className="max-w-2xl mx-auto p-4 sm:p-6 space-y-4">
       <div className="flex items-center justify-between gap-2">
@@ -587,7 +617,24 @@ export default function EventDetailPage() {
             </Badge>
           )}
         </div>
-        <h1 className="text-xl sm:text-2xl font-bold">{event.title}</h1>
+        <div className="flex items-start justify-between gap-3">
+          <h1 className="text-xl sm:text-2xl font-bold">{event.title}</h1>
+          {event.status === "published" && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleShare}
+              aria-label={t("events.detail.share_button")}
+              className="shrink-0"
+            >
+              {copied ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Share2 className="h-4 w-4" />
+              )}
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Details card */}

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -3,6 +3,7 @@
 import {
   CalendarDays,
   CheckCircle,
+  ChevronDown,
   Clock,
   Crown,
   Eye,
@@ -16,10 +17,17 @@ import {
   Tag,
 } from "lucide-react"
 import Link from "next/link"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import type { EventPublic } from "@/client"
 import { Badge } from "@/components/ui/badge"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { cn } from "@/lib/utils"
 import { CoverImage } from "./CoverImage"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
@@ -110,6 +118,15 @@ export function ListBody({
 }: ListBodyProps) {
   const { t } = useTranslation()
   const isAuthed = mode === "authed"
+  const [collapsedDays, setCollapsedDays] = useState<Set<string>>(new Set())
+  const toggleDay = (date: string) => {
+    setCollapsedDays((prev) => {
+      const next = new Set(prev)
+      if (next.has(date)) next.delete(date)
+      else next.add(date)
+      return next
+    })
+  }
 
   if (isLoading) {
     return (
@@ -132,250 +149,281 @@ export function ListBody({
 
   return (
     <div className="space-y-6">
-      {grouped.map(([date, dayEvents]) => (
-        <div key={date}>
-          <div className="flex items-center gap-3 mb-3">
-            <div className="h-2 w-2 rounded-full bg-primary" />
-            <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              {formatDateShort(dayEvents[0].start_time)}
-            </h2>
-            <div className="flex-1 h-px bg-border" />
-          </div>
-          <div className="space-y-2 pl-5 border-l-2 border-border">
-            {dayEvents.map((event) => {
-              const isOwner =
-                isAuthed &&
-                currentHumanId != null &&
-                event.owner_id === currentHumanId
-              const isHidden = isAuthed && event.hidden === true
-              const isHighlighted = event.highlighted === true
-              const cardClass = isHidden
-                ? "relative rounded-xl border bg-card opacity-60 hover:opacity-100 transition-opacity"
-                : isHighlighted
-                  ? "relative rounded-xl border-2 border-amber-400 bg-amber-50 dark:bg-amber-950/30 hover:shadow-md transition-shadow"
-                  : "relative rounded-xl border bg-card hover:shadow-md transition-shadow"
-              const href = event.occurrence_id
-                ? `/portal/${slug}/events/${event.id}?occ=${encodeURIComponent(event.start_time)}`
-                : `/portal/${slug}/events/${event.id}`
-              const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-                if (onEventClick) {
-                  const handled = onEventClick(event)
-                  if (handled === true) {
-                    e.preventDefault()
-                    return
-                  }
-                }
-                if (onEventLinkClick) {
-                  const main =
-                    typeof document !== "undefined"
-                      ? document.querySelector("main")
-                      : null
-                  onEventLinkClick("list", null, {
-                    outer: main?.scrollTop ?? 0,
-                  })
-                }
-              }
-              const thumbUrl =
-                event.cover_url ||
-                event.venue_image_url ||
-                placeholderUrl ||
-                null
-              return (
-                <div
-                  key={event.id}
-                  id={
-                    event.occurrence_id
-                      ? `event-card-${event.id}__${event.start_time}`
-                      : `event-card-${event.id}`
-                  }
-                  className={cardClass}
-                >
-                  <Link
-                    href={href}
-                    onClick={handleClick}
-                    className={
-                      isAuthed ? "block p-3 sm:p-4 pb-11" : "block p-3 sm:p-4"
+      {grouped.map(([date, dayEvents]) => {
+        const isOpen = !collapsedDays.has(date)
+        const dayLabel = formatDateShort(dayEvents[0].start_time)
+        return (
+          <Collapsible
+            key={date}
+            open={isOpen}
+            onOpenChange={() => toggleDay(date)}
+          >
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                aria-label={t(
+                  isOpen
+                    ? "events.list.collapse_day_aria"
+                    : "events.list.expand_day_aria",
+                  { date: dayLabel },
+                )}
+                className="w-full flex items-center gap-3 mb-3 group cursor-pointer"
+              >
+                <div className="h-2 w-2 rounded-full bg-primary" />
+                <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {dayLabel}
+                </h2>
+                <div className="flex-1 h-px bg-border" />
+                <ChevronDown
+                  className={cn(
+                    "w-4 h-4 text-muted-foreground shrink-0 transition-transform duration-200 group-hover:text-foreground",
+                    isOpen && "rotate-180",
+                  )}
+                />
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="space-y-2 pl-5 border-l-2 border-border">
+                {dayEvents.map((event) => {
+                  const isOwner =
+                    isAuthed &&
+                    currentHumanId != null &&
+                    event.owner_id === currentHumanId
+                  const isHidden = isAuthed && event.hidden === true
+                  const isHighlighted = event.highlighted === true
+                  const cardClass = isHidden
+                    ? "relative rounded-xl border bg-card opacity-60 hover:opacity-100 transition-opacity"
+                    : isHighlighted
+                      ? "relative rounded-xl border-2 border-amber-400 bg-amber-50 dark:bg-amber-950/30 hover:shadow-md transition-shadow"
+                      : "relative rounded-xl border bg-card hover:shadow-md transition-shadow"
+                  const href = event.occurrence_id
+                    ? `/portal/${slug}/events/${event.id}?occ=${encodeURIComponent(event.start_time)}`
+                    : `/portal/${slug}/events/${event.id}`
+                  const handleClick = (
+                    e: React.MouseEvent<HTMLAnchorElement>,
+                  ) => {
+                    if (onEventClick) {
+                      const handled = onEventClick(event)
+                      if (handled === true) {
+                        e.preventDefault()
+                        return
+                      }
                     }
-                  >
-                    <div className="flex items-start gap-3">
-                      <div className="h-14 w-14 sm:h-16 sm:w-16 shrink-0 rounded-lg overflow-hidden">
-                        <CoverImage
-                          src={thumbUrl}
-                          alt={event.title}
-                          className="w-full h-full object-cover"
-                          fallback={
-                            <CalendarDays className="h-5 w-5 text-muted-foreground/40" />
-                          }
-                        />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-start justify-between gap-2 mb-1">
-                          <h3 className="font-medium text-sm sm:text-base flex items-center gap-1.5">
-                            {isOwner && (
-                              <Crown
-                                className="h-3.5 w-3.5 shrink-0 text-amber-500"
-                                aria-label={t("events.list.owned_title")}
-                              />
-                            )}
-                            <span>{event.title}</span>
-                          </h3>
-                          {isAuthed && (
-                            <Badge
-                              variant="secondary"
-                              className={
-                                statusColors[event.status as string] ?? ""
+                    if (onEventLinkClick) {
+                      const main =
+                        typeof document !== "undefined"
+                          ? document.querySelector("main")
+                          : null
+                      onEventLinkClick("list", null, {
+                        outer: main?.scrollTop ?? 0,
+                      })
+                    }
+                  }
+                  const thumbUrl =
+                    event.cover_url ||
+                    event.venue_image_url ||
+                    placeholderUrl ||
+                    null
+                  return (
+                    <div
+                      key={event.id}
+                      id={
+                        event.occurrence_id
+                          ? `event-card-${event.id}__${event.start_time}`
+                          : `event-card-${event.id}`
+                      }
+                      className={cardClass}
+                    >
+                      <Link
+                        href={href}
+                        onClick={handleClick}
+                        className={
+                          isAuthed
+                            ? "block p-3 sm:p-4 pb-11"
+                            : "block p-3 sm:p-4"
+                        }
+                      >
+                        <div className="flex items-start gap-3">
+                          <div className="h-14 w-14 sm:h-16 sm:w-16 shrink-0 rounded-lg overflow-hidden">
+                            <CoverImage
+                              src={thumbUrl}
+                              alt={event.title}
+                              className="w-full h-full object-cover"
+                              fallback={
+                                <CalendarDays className="h-5 w-5 text-muted-foreground/40" />
                               }
+                            />
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-start justify-between gap-2 mb-1">
+                              <h3 className="font-medium text-sm sm:text-base flex items-center gap-1.5">
+                                {isOwner && (
+                                  <Crown
+                                    className="h-3.5 w-3.5 shrink-0 text-amber-500"
+                                    aria-label={t("events.list.owned_title")}
+                                  />
+                                )}
+                                <span>{event.title}</span>
+                              </h3>
+                              {isAuthed && (
+                                <Badge
+                                  variant="secondary"
+                                  className={
+                                    statusColors[event.status as string] ?? ""
+                                  }
+                                >
+                                  {t(`events.status.${event.status}`)}
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                              <Clock className="h-3 w-3" />
+                              <span>
+                                {formatTime(event.start_time)} –{" "}
+                                {formatTime(event.end_time)}
+                              </span>
+                            </div>
+                            {event.venue_title && (
+                              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                                <MapPin className="h-3 w-3" />
+                                <span className="truncate">
+                                  {event.venue_title}
+                                  {event.venue_location
+                                    ? ` · ${event.venue_location}`
+                                    : ""}
+                                </span>
+                              </div>
+                            )}
+                            {(event.rrule || event.recurrence_master_id) && (
+                              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
+                                <Repeat className="h-3 w-3" />
+                                <span className="truncate">
+                                  {summarizeRrule(event.rrule) ??
+                                    t("events.list.part_of_recurring_series")}
+                                </span>
+                              </div>
+                            )}
+                            {event.track_title && (
+                              <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mt-0.5">
+                                <Layers className="h-3 w-3" />
+                                <span className="truncate">
+                                  {event.track_title}
+                                </span>
+                              </div>
+                            )}
+                            {event.tags && event.tags.length > 0 && (
+                              <div className="flex items-center gap-1 mt-1.5 flex-wrap">
+                                {event.tags.slice(0, 3).map((tag: string) => (
+                                  <span
+                                    key={tag}
+                                    className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded border border-border bg-muted/60 text-muted-foreground"
+                                  >
+                                    <Tag className="h-2.5 w-2.5" />
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      </Link>
+                      {isAuthed && (
+                        <div className="absolute bottom-2 right-2 flex items-center gap-1.5">
+                          {event.status === "published" &&
+                            (() => {
+                              const rsvpKey = `${event.id}:${event.start_time}`
+                              const isRsvpPending = pendingRsvpKey === rsvpKey
+                              const isRsvped =
+                                event.my_rsvp_status &&
+                                event.my_rsvp_status !== "cancelled"
+                              return isRsvped ? (
+                                <button
+                                  type="button"
+                                  disabled={isRsvpPending}
+                                  onClick={(e) => {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    onCancelRsvp?.(event)
+                                  }}
+                                  className="inline-flex h-7 items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
+                                >
+                                  {isRsvpPending ? (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                  ) : (
+                                    <CheckCircle className="h-3 w-3" />
+                                  )}
+                                  {t("events.rsvp.going")}
+                                </button>
+                              ) : (
+                                <button
+                                  type="button"
+                                  disabled={isRsvpPending}
+                                  onClick={(e) => {
+                                    e.preventDefault()
+                                    e.stopPropagation()
+                                    onRsvp?.(event)
+                                  }}
+                                  className="inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2 text-xs font-medium shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                  {isRsvpPending && (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                  )}
+                                  {t("events.rsvp.rsvp")}
+                                </button>
+                              )
+                            })()}
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              if (isHidden) onUnhide?.(event.id)
+                              else onHide?.(event.id)
+                            }}
+                            aria-label={
+                              isHidden
+                                ? t("events.list.unhide_event_aria", {
+                                    title: event.title,
+                                  })
+                                : t("events.list.hide_event_aria", {
+                                    title: event.title,
+                                  })
+                            }
+                            title={
+                              isHidden
+                                ? t("events.list.unhide_title")
+                                : t("events.list.hide_title")
+                            }
+                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground"
+                          >
+                            {isHidden ? (
+                              <EyeOff className="h-3.5 w-3.5" />
+                            ) : (
+                              <Eye className="h-3.5 w-3.5" />
+                            )}
+                          </button>
+                          {isOwner && (
+                            <Link
+                              href={`/portal/${slug}/events/${event.id}/edit`}
+                              onClick={(e) => e.stopPropagation()}
+                              aria-label={t("events.list.edit_event_aria", {
+                                title: event.title,
+                              })}
+                              className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground"
                             >
-                              {t(`events.status.${event.status}`)}
-                            </Badge>
+                              <Pencil className="h-3.5 w-3.5" />
+                            </Link>
                           )}
                         </div>
-                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                          <Clock className="h-3 w-3" />
-                          <span>
-                            {formatTime(event.start_time)} –{" "}
-                            {formatTime(event.end_time)}
-                          </span>
-                        </div>
-                        {event.venue_title && (
-                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
-                            <MapPin className="h-3 w-3" />
-                            <span className="truncate">
-                              {event.venue_title}
-                              {event.venue_location
-                                ? ` · ${event.venue_location}`
-                                : ""}
-                            </span>
-                          </div>
-                        )}
-                        {(event.rrule || event.recurrence_master_id) && (
-                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
-                            <Repeat className="h-3 w-3" />
-                            <span className="truncate">
-                              {summarizeRrule(event.rrule) ??
-                                t("events.list.part_of_recurring_series")}
-                            </span>
-                          </div>
-                        )}
-                        {event.track_title && (
-                          <div className="flex items-center gap-1.5 text-xs font-medium text-violet-700 dark:text-violet-300 mt-0.5">
-                            <Layers className="h-3 w-3" />
-                            <span className="truncate">
-                              {event.track_title}
-                            </span>
-                          </div>
-                        )}
-                        {event.tags && event.tags.length > 0 && (
-                          <div className="flex items-center gap-1 mt-1.5 flex-wrap">
-                            {event.tags.slice(0, 3).map((tag: string) => (
-                              <span
-                                key={tag}
-                                className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded border border-border bg-muted/60 text-muted-foreground"
-                              >
-                                <Tag className="h-2.5 w-2.5" />
-                                {tag}
-                              </span>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </Link>
-                  {isAuthed && (
-                    <div className="absolute bottom-2 right-2 flex items-center gap-1.5">
-                      {event.status === "published" &&
-                        (() => {
-                          const rsvpKey = `${event.id}:${event.start_time}`
-                          const isRsvpPending = pendingRsvpKey === rsvpKey
-                          const isRsvped =
-                            event.my_rsvp_status &&
-                            event.my_rsvp_status !== "cancelled"
-                          return isRsvped ? (
-                            <button
-                              type="button"
-                              disabled={isRsvpPending}
-                              onClick={(e) => {
-                                e.preventDefault()
-                                e.stopPropagation()
-                                onCancelRsvp?.(event)
-                              }}
-                              className="inline-flex h-7 items-center gap-1 rounded-md border border-emerald-300 bg-emerald-50 px-2 text-xs font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-60 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60"
-                            >
-                              {isRsvpPending ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              ) : (
-                                <CheckCircle className="h-3 w-3" />
-                              )}
-                              {t("events.rsvp.going")}
-                            </button>
-                          ) : (
-                            <button
-                              type="button"
-                              disabled={isRsvpPending}
-                              onClick={(e) => {
-                                e.preventDefault()
-                                e.stopPropagation()
-                                onRsvp?.(event)
-                              }}
-                              className="inline-flex h-7 items-center gap-1 rounded-md border bg-background px-2 text-xs font-medium shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-                            >
-                              {isRsvpPending && (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                              )}
-                              {t("events.rsvp.rsvp")}
-                            </button>
-                          )
-                        })()}
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.preventDefault()
-                          e.stopPropagation()
-                          if (isHidden) onUnhide?.(event.id)
-                          else onHide?.(event.id)
-                        }}
-                        aria-label={
-                          isHidden
-                            ? t("events.list.unhide_event_aria", {
-                                title: event.title,
-                              })
-                            : t("events.list.hide_event_aria", {
-                                title: event.title,
-                              })
-                        }
-                        title={
-                          isHidden
-                            ? t("events.list.unhide_title")
-                            : t("events.list.hide_title")
-                        }
-                        className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground"
-                      >
-                        {isHidden ? (
-                          <EyeOff className="h-3.5 w-3.5" />
-                        ) : (
-                          <Eye className="h-3.5 w-3.5" />
-                        )}
-                      </button>
-                      {isOwner && (
-                        <Link
-                          href={`/portal/${slug}/events/${event.id}/edit`}
-                          onClick={(e) => e.stopPropagation()}
-                          aria-label={t("events.list.edit_event_aria", {
-                            title: event.title,
-                          })}
-                          className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-background text-muted-foreground shadow-sm transition-colors hover:text-foreground"
-                        >
-                          <Pencil className="h-3.5 w-3.5" />
-                        </Link>
                       )}
                     </div>
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      ))}
+                  )
+                })}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        )
+      })}
     </div>
   )
 }

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -514,7 +514,9 @@
       "unhide_title": "Unhide",
       "highlighted_badge": "Featured",
       "highlighted_title": "Featured event",
-      "owned_title": "Created by you"
+      "owned_title": "Created by you",
+      "collapse_day_aria": "Collapse events for {{date}}",
+      "expand_day_aria": "Expand events for {{date}}"
     },
     "status": {
       "draft": "Draft",
@@ -640,7 +642,10 @@
       "cancel_event_error": "Couldn't cancel event",
       "pending_approval_banner_title": "Pending approval",
       "pending_approval_banner_message": "Your event is pending approval and not yet visible to others.",
-      "open_in_maps": "Open in Google Maps"
+      "open_in_maps": "Open in Google Maps",
+      "share_button": "Share event",
+      "share_link_copied": "Link copied",
+      "share_link_error": "Couldn't copy link"
     },
     "form": {
       "create_heading": "Create event",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -513,7 +513,9 @@
       "unhide_title": "Mostrar",
       "highlighted_badge": "Destacado",
       "highlighted_title": "Evento destacado",
-      "owned_title": "Creado por ti"
+      "owned_title": "Creado por ti",
+      "collapse_day_aria": "Colapsar eventos del {{date}}",
+      "expand_day_aria": "Expandir eventos del {{date}}"
     },
     "status": {
       "draft": "Borrador",
@@ -639,7 +641,10 @@
       "cancel_event_error": "No se pudo cancelar el evento",
       "pending_approval_banner_title": "Pendiente de aprobación",
       "pending_approval_banner_message": "Tu evento está pendiente de aprobación y aún no es visible para otros.",
-      "open_in_maps": "Abrir en Google Maps"
+      "open_in_maps": "Abrir en Google Maps",
+      "share_button": "Compartir evento",
+      "share_link_copied": "Link copiado",
+      "share_link_error": "No se pudo copiar el link"
     },
     "form": {
       "create_heading": "Crear evento",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -489,7 +489,9 @@
       "unhide_title": "Sýna aftur",
       "highlighted_badge": "Áberandi",
       "highlighted_title": "Áberandi viðburður",
-      "owned_title": "Búið til af þér"
+      "owned_title": "Búið til af þér",
+      "collapse_day_aria": "Fella saman viðburði fyrir {{date}}",
+      "expand_day_aria": "Stækka viðburði fyrir {{date}}"
     },
     "status": {
       "draft": "Drög",
@@ -615,7 +617,10 @@
       "cancel_event_error": "Mistókst að aflýsa viðburði",
       "pending_approval_banner_title": "Bíður samþykkis",
       "pending_approval_banner_message": "Viðburðurinn þinn bíður samþykkis og er ekki enn sýnilegur öðrum.",
-      "open_in_maps": "Opna í Google kortum"
+      "open_in_maps": "Opna í Google kortum",
+      "share_button": "Deila viðburði",
+      "share_link_copied": "Hlekkur afritaður",
+      "share_link_error": "Mistókst að afrita hlekk"
     },
     "form": {
       "create_heading": "Búa til viðburð",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -499,7 +499,9 @@
       "unhide_title": "取消隐藏",
       "highlighted_badge": "精选",
       "highlighted_title": "精选活动",
-      "owned_title": "由你创建"
+      "owned_title": "由你创建",
+      "collapse_day_aria": "折叠 {{date}} 的活动",
+      "expand_day_aria": "展开 {{date}} 的活动"
     },
     "status": {
       "draft": "草稿",
@@ -625,7 +627,10 @@
       "cancel_event_error": "无法取消活动",
       "pending_approval_banner_title": "等待审批",
       "pending_approval_banner_message": "你的活动正在等待审批,其他人暂时无法查看。",
-      "open_in_maps": "在 Google 地图中打开"
+      "open_in_maps": "在 Google 地图中打开",
+      "share_button": "分享活动",
+      "share_link_copied": "链接已复制",
+      "share_link_error": "无法复制链接"
     },
     "form": {
       "create_heading": "创建活动",


### PR DESCRIPTION
## Summary
- **Events list — collapsible day groups**: Each day section in `ListBody` is now wrapped in a `Collapsible`, so users can hide a day's events with a chevron toggle. Per-day collapsed state is local to the component. Adds `collapse_day_aria` / `expand_day_aria` strings to en/es/is/zh locales.
- **Event detail — share button**: Published events now show a `Share2` icon button next to the title. Uses `navigator.share` when available (mobile) and falls back to copying the canonical URL via `navigator.clipboard.writeText` (desktop), with a `Check` icon + toast for confirmation and a localized error toast. Adds `share_button`, `share_link_copied`, `share_link_error` strings to all locales.

## Test plan
- [ ] Open the events list on portal — confirm each day shows a chevron and clicking it collapses/expands only that day.
- [ ] Verify the collapse toggle does not interfere with clicking individual event cards.
- [ ] Open a published event detail page — confirm a Share icon appears next to the title.
- [ ] On mobile (Web Share supported): tap Share and verify the native share sheet appears with the event title + correct URL (including `?occ=` when viewing an occurrence).
- [ ] On desktop: click Share and verify the URL is copied to clipboard, the icon flips to a checkmark for ~2s, and the "Link copied" toast appears.
- [ ] Verify the Share button is hidden for non-published events (draft/pending/cancelled).
- [ ] Spot-check translations in es/is/zh for both features.