### PR TITLE
fix(dashboard): correct metric semantics and popup-local trend bucketing

### DIFF
--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -63,12 +63,26 @@ async def get_enriched_dashboard(
     attendee_stats = _get_attendee_stats(db, popup_id)
     payment_stats = _get_payment_stats(db, popup_id)
 
+    # Popup fetched once and shared (currency + application-fee flag)
+    popup = popups_crud.get(db, popup_id)
+    currency = popup.currency if popup else "USD"
+    fee_enabled = bool(popup and popup.requires_application_fee)
+
+    # Daily buckets follow the popup's local calendar, not UTC (matches the
+    # rest of the app's timezone handling).
+    from app.api.event_venue.router import _resolve_popup_timezone
+
+    popup_tz = _resolve_popup_timezone(db, popup_id)
+
     # Enriched data
-    key_metrics = _get_key_metrics(db, popup_id, attendee_stats, payment_stats)
-    cumulative_trends = _get_cumulative_trends(db, popup_id)
+    key_metrics = _get_key_metrics(
+        db, popup_id, app_stats, attendee_stats, payment_stats, currency
+    )
+    cumulative_trends = _get_cumulative_trends(db, popup_id, popup_tz)
     revenue_breakdown = _get_revenue_breakdown(db, popup_id)
     distribution = _get_distribution(db, popup_id)
-    application_funnel = _get_application_funnel(app_stats, payment_stats)
+    fee_paid = _get_fee_paid_count(db, popup_id) if fee_enabled else 0
+    application_funnel = _get_application_funnel(app_stats, fee_paid, fee_enabled)
 
     return EnrichedDashboardStats(
         key_metrics=key_metrics,
@@ -117,14 +131,16 @@ def _get_application_stats(db: TenantSession, popup_id: uuid.UUID) -> Applicatio
 def _get_attendee_stats(db: TenantSession, popup_id: uuid.UUID) -> AttendeeStats:
     """Get attendee statistics for a popup.
 
-    Groups by AttendeeCategories.key (via category_id FK) since the legacy
+    Scoped by the denormalized Attendees.popup_id so direct-sale attendees
+    (application_id IS NULL) are included in the headcount. Groups by
+    AttendeeCategories.key (via category_id FK) since the legacy
     attendees.category string column was dropped in PR 2.
     """
     category_counts = db.exec(
         select(AttendeeCategories.key, func.count(Attendees.id))
-        .join(Applications, Attendees.application_id == Applications.id)
+        .select_from(Attendees)
         .outerjoin(AttendeeCategories, Attendees.category_id == AttendeeCategories.id)
-        .where(Applications.popup_id == popup_id)
+        .where(Attendees.popup_id == popup_id)
         .group_by(AttendeeCategories.key)
     ).all()
 
@@ -150,9 +166,8 @@ def _get_payment_stats(db: TenantSession, popup_id: uuid.UUID) -> PaymentStats:
             func.coalesce(func.sum(Payments.amount), Decimal("0")),
             func.coalesce(func.sum(Payments.discount_value), Decimal("0")),
         )
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
         )
         .group_by(Payments.status)
@@ -191,11 +206,16 @@ ONE_DECIMAL = Decimal("0.1")
 def _get_key_metrics(
     db: TenantSession,
     popup_id: uuid.UUID,
+    app_stats: ApplicationStats,
     attendee_stats: AttendeeStats,
     payment_stats: PaymentStats,
+    currency: str,
 ) -> KeyMetrics:
     """Compute high-level KPI cards."""
-    people = attendee_stats.main
+    # People = total headcount (all attendees, paid or not). Revenue-per-person
+    # uses only paying attendees so sponsors/guests/comps don't dilute it.
+    people = attendee_stats.total
+    paying_people = _get_paying_attendees_count(db, popup_id)
     revenue = payment_stats.approved_revenue
     approved_count = payment_stats.approved
 
@@ -205,31 +225,30 @@ def _get_key_metrics(
         else Decimal("0")
     )
     avg_per_person = (
-        (revenue / people).quantize(TWO_DECIMAL, ROUND_HALF_UP)
-        if people > 0
+        (revenue / paying_people).quantize(TWO_DECIMAL, ROUND_HALF_UP)
+        if paying_people > 0
         else Decimal("0")
     )
 
-    # Conversion: accepted applications / total non-draft applications
-    total_non_draft = (
-        payment_stats.approved + payment_stats.pending + payment_stats.rejected
-    )
+    # Conversion (acceptance rate): accepted / decided applications
+    # (accepted + rejected). In-review/pending-fee (undecided) and withdrawn
+    # (self-removed) are excluded so the rate reflects real accept/reject
+    # decisions, not in-flight queue depth.
+    decided = app_stats.accepted + app_stats.rejected
     conversion = (
-        (Decimal(payment_stats.approved) / Decimal(total_non_draft) * 100).quantize(
+        (Decimal(app_stats.accepted) / Decimal(decided) * 100).quantize(
             ONE_DECIMAL, ROUND_HALF_UP
         )
-        if total_non_draft > 0
+        if decided > 0
         else Decimal("0")
     )
 
-    # Accommodation percentage: attendees with housing product / total main attendees
+    # Accommodation percentage: attendees with housing product / total headcount
     accommodation_pct = _get_accommodation_percentage(db, popup_id, people)
-
-    popup = popups_crud.get(db, popup_id)
-    currency = popup.currency if popup else "USD"
 
     return KeyMetrics(
         people=people,
+        paying_people=paying_people,
         total_revenue=revenue,
         currency=currency,
         avg_ticket_price=avg_ticket,
@@ -250,9 +269,8 @@ def _get_accommodation_percentage(
     housing_attendees = db.exec(
         select(func.count(func.distinct(PaymentProducts.attendee_id)))
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             PaymentProducts.product_category == CATEGORY_HOUSING,
@@ -265,21 +283,47 @@ def _get_accommodation_percentage(
     )
 
 
-def _get_cumulative_trends(db: TenantSession, popup_id: uuid.UUID) -> CumulativeTrends:
-    """Daily cumulative trends for tickets (accepted apps) and revenue."""
-    # Tickets: applications that reached accepted, grouped by accepted_at date
-    ticket_rows = db.exec(
-        select(
-            func.date(Applications.accepted_at),
-            func.count(Applications.id),
-        )
+def _get_paying_attendees_count(db: TenantSession, popup_id: uuid.UUID) -> int:
+    """Count distinct attendees with at least one approved pass_purchase product.
+
+    Denominator for revenue-per-person: only people who actually paid, so
+    non-paying attendees (sponsors, guests, comps) don't dilute the average.
+    """
+    count = db.exec(
+        select(func.count(func.distinct(PaymentProducts.attendee_id)))
+        .join(Payments, PaymentProducts.payment_id == Payments.id)
         .where(
-            Applications.popup_id == popup_id,
-            Applications.status == ApplicationStatus.ACCEPTED.value,
-            Applications.accepted_at.is_not(None),  # type: ignore[union-attr]
+            Payments.popup_id == popup_id,
+            Payments.status == PaymentStatus.APPROVED.value,
+            Payments.payment_type == PaymentType.PASS_PURCHASE.value,
         )
-        .group_by(func.date(Applications.accepted_at))
-        .order_by(func.date(Applications.accepted_at))
+    ).one()
+    return count or 0
+
+
+def _get_cumulative_trends(
+    db: TenantSession, popup_id: uuid.UUID, tz_name: str
+) -> CumulativeTrends:
+    """Daily cumulative trends for tickets sold and revenue.
+
+    Both series are bucketed by payment date in the popup's timezone, so day
+    boundaries follow the event's local calendar (not UTC) and the two curves
+    share the same time axis.
+    """
+    bucket = func.date(func.timezone(tz_name, Payments.created_at))
+
+    # Tickets sold: ticket-category product quantity on approved purchases
+    ticket_rows = db.exec(
+        select(bucket, func.coalesce(func.sum(PaymentProducts.quantity), 0))
+        .join(Payments, PaymentProducts.payment_id == Payments.id)
+        .where(
+            Payments.popup_id == popup_id,
+            Payments.status == PaymentStatus.APPROVED.value,
+            Payments.payment_type == PaymentType.PASS_PURCHASE.value,
+            PaymentProducts.product_category == CATEGORY_TICKET,
+        )
+        .group_by(bucket)
+        .order_by(bucket)
     ).all()
 
     tickets: list[TimelinePoint] = []
@@ -294,20 +338,16 @@ def _get_cumulative_trends(db: TenantSession, popup_id: uuid.UUID) -> Cumulative
             )
         )
 
-    # Revenue: approved payments grouped by created_at date
+    # Revenue: approved pass_purchase amount on the same payment-date axis
     revenue_rows = db.exec(
-        select(
-            func.date(Payments.created_at),
-            func.coalesce(func.sum(Payments.amount), Decimal("0")),
-        )
-        .join(Applications, Payments.application_id == Applications.id)
+        select(bucket, func.coalesce(func.sum(Payments.amount), Decimal("0")))
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
         )
-        .group_by(func.date(Payments.created_at))
-        .order_by(func.date(Payments.created_at))
+        .group_by(bucket)
+        .order_by(bucket)
     ).all()
 
     revenue: list[RevenueTimelinePoint] = []
@@ -336,9 +376,8 @@ def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBre
             func.sum(PaymentProducts.product_price * PaymentProducts.quantity),
         )
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
         )
@@ -395,9 +434,8 @@ def _get_distribution(db: TenantSession, popup_id: uuid.UUID) -> Distribution:
         )
         .join(PaymentProducts, Products.id == PaymentProducts.product_id)
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             Products.category == CATEGORY_TICKET,
@@ -439,13 +477,12 @@ def _get_distribution(db: TenantSession, popup_id: uuid.UUID) -> Distribution:
         .select_from(Products)
         .join(PaymentProducts, Products.id == PaymentProducts.product_id)
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .outerjoin(
             AttendeeCategories,
             Products.attendee_category_id == AttendeeCategories.id,
         )
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             Products.category == CATEGORY_TICKET,
@@ -483,9 +520,8 @@ def _get_distribution(db: TenantSession, popup_id: uuid.UUID) -> Distribution:
             func.sum(PaymentProducts.quantity),
         )
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             PaymentProducts.product_category == CATEGORY_HOUSING,
@@ -530,9 +566,8 @@ def _get_attach_rate(db: TenantSession, popup_id: uuid.UUID) -> list[AttachRateI
         )
         .join(PaymentProducts, Products.id == PaymentProducts.product_id)
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             Products.category == CATEGORY_TICKET,
@@ -548,9 +583,8 @@ def _get_attach_rate(db: TenantSession, popup_id: uuid.UUID) -> list[AttachRateI
     housing_attendee_ids = (
         select(PaymentProducts.attendee_id)
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             PaymentProducts.product_category == CATEGORY_HOUSING,
@@ -564,9 +598,8 @@ def _get_attach_rate(db: TenantSession, popup_id: uuid.UUID) -> list[AttachRateI
         )
         .join(PaymentProducts, Products.id == PaymentProducts.product_id)
         .join(Payments, PaymentProducts.payment_id == Payments.id)
-        .join(Applications, Payments.application_id == Applications.id)
         .where(
-            Applications.popup_id == popup_id,
+            Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
             Products.category == CATEGORY_TICKET,
@@ -606,14 +639,34 @@ def _get_attach_rate(db: TenantSession, popup_id: uuid.UUID) -> list[AttachRateI
     return result
 
 
+def _get_fee_paid_count(db: TenantSession, popup_id: uuid.UUID) -> int:
+    """Count applications with an approved application_fee payment.
+
+    'Paid' in the funnel means the application fee was paid, an intermediate
+    stage between pending_fee and review. Counts distinct applications (not
+    payment rows) so multiple fee payments on one application don't inflate it.
+    """
+    count = db.exec(
+        select(func.count(func.distinct(Payments.application_id)))
+        .join(Applications, Payments.application_id == Applications.id)
+        .where(
+            Applications.popup_id == popup_id,
+            Payments.payment_type == PaymentType.APPLICATION_FEE.value,
+            Payments.status == PaymentStatus.APPROVED.value,
+        )
+    ).one()
+    return count or 0
+
+
 def _get_application_funnel(
-    app_stats: ApplicationStats, payment_stats: PaymentStats
+    app_stats: ApplicationStats, fee_paid: int, fee_enabled: bool
 ) -> ApplicationFunnel:
     """Build application funnel from existing stats."""
     return ApplicationFunnel(
         draft=app_stats.draft,
         pending_fee=app_stats.pending_fee,
+        paid=fee_paid,
         in_review=app_stats.in_review,
         accepted=app_stats.accepted,
-        paid=payment_stats.approved,
+        fee_enabled=fee_enabled,
     )

--- a/backend/app/api/dashboard/schemas.py
+++ b/backend/app/api/dashboard/schemas.py
@@ -55,6 +55,7 @@ class KeyMetrics(BaseModel):
     """Top-level KPI cards with derived metrics."""
 
     people: int = 0
+    paying_people: int = 0
     total_revenue: Decimal = Decimal("0")
     currency: str = "USD"
     avg_ticket_price: Decimal = Decimal("0")
@@ -143,9 +144,10 @@ class ApplicationFunnel(BaseModel):
 
     draft: int = 0
     pending_fee: int = 0
+    paid: int = 0
     in_review: int = 0
     accepted: int = 0
-    paid: int = 0
+    fee_enabled: bool = False
 
 
 class DashboardStats(BaseModel):

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,28 @@
+"""Smoke tests for the dashboard endpoints.
+
+These exercise the full query path of the enriched dashboard (KPIs, trends,
+revenue breakdown, distribution, attach rate, funnel) so a broken aggregation
+query surfaces as a 500 instead of silently shipping.
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+
+class TestDashboardEnrichedSmoke:
+    def test_enriched_executes_for_unknown_popup(
+        self,
+        client: TestClient,
+        operator_token_tenant_a: str,
+    ) -> None:
+        # A random popup_id yields empty result sets but still runs every
+        # aggregation query, validating the SQL compiles and executes.
+        response = client.get(
+            "/api/v1/dashboard/enriched?popup_id=" + str(uuid.uuid4()),
+            headers={"Authorization": f"Bearer {operator_token_tenant_a}"},
+        )
+        assert response.status_code == 200, (
+            f"GET /dashboard/enriched must execute, "
+            f"got {response.status_code}: {response.text}"
+        )

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -848,6 +848,11 @@ export const ApplicationFunnelSchema = {
             title: 'Pending Fee',
             default: 0
         },
+        paid: {
+            type: 'integer',
+            title: 'Paid',
+            default: 0
+        },
         in_review: {
             type: 'integer',
             title: 'In Review',
@@ -858,10 +863,10 @@ export const ApplicationFunnelSchema = {
             title: 'Accepted',
             default: 0
         },
-        paid: {
-            type: 'integer',
-            title: 'Paid',
-            default: 0
+        fee_enabled: {
+            type: 'boolean',
+            title: 'Fee Enabled',
+            default: false
         }
     },
     type: 'object',
@@ -4389,7 +4394,7 @@ export const CheckoutRuntimeProductSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -4401,7 +4406,7 @@ export const CheckoutRuntimeProductSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -9864,6 +9869,11 @@ export const KeyMetricsSchema = {
             title: 'People',
             default: 0
         },
+        paying_people: {
+            type: 'integer',
+            title: 'Paying People',
+            default: 0
+        },
         total_revenue: {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
@@ -13555,7 +13565,7 @@ export const ProductBatchItemSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13567,7 +13577,7 @@ export const ProductBatchItemSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13740,7 +13750,7 @@ export const ProductBatchResultSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13752,7 +13762,7 @@ export const ProductBatchResultSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13980,7 +13990,7 @@ export const ProductCreateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13992,7 +14002,7 @@ export const ProductCreateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14185,7 +14195,7 @@ export const ProductPublicSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14197,7 +14207,7 @@ export const ProductPublicSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14274,10 +14284,9 @@ export const ProductPublicSchema = {
     title: 'ProductPublic',
     description: `Product schema for API responses.
 
-Sale window fields are exposed as \`date\` (inclusive day) even though they
-are persisted as \`datetime\` UTC (exclusive instant). \`sale_ends_at\` is
-de-bumped by 1 day so the response shows the last day the product is on
-sale — the canonical "operator-friendly" representation.`
+Sale window fields are exposed as full \`\`datetime\`\` instants (UTC), so the
+sale window can express a precise cutoff like "Friday 11:59 PM" rather than
+a whole calendar day. Clients render them in the popup's timezone.`
 } as const;
 
 export const ProductUpdateSchema = {
@@ -14397,7 +14406,7 @@ export const ProductUpdateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14409,7 +14418,7 @@ export const ProductUpdateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14611,7 +14620,7 @@ export const ProductWithQuantitySchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14623,7 +14632,7 @@ export const ProductWithQuantitySchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -5231,12 +5231,16 @@ export class HumansService {
     }
     
     /**
-     * Hard-delete a human and all related rows (superadmin only)
+     * Hard-delete a human and all related rows (admin or superadmin)
      * Permanently delete a Human with full cascade.
      *
      * Removes applications, attendees, payments, products, carts, group
      * memberships, and ambassador-owned groups in a single transaction. Designed
      * for cleaning up test users — destructive and irreversible.
+     *
+     * Superadmins may delete any human; a tenant admin may only delete humans
+     * within their own tenant. Both run on the control-plane session (which
+     * bypasses RLS), so the tenant ownership check is enforced explicitly here.
      * @param data The data for the request.
      * @param data.humanId
      * @returns HardDeleteSummary Successful Response

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -188,9 +188,10 @@ export type ApplicationFeeCreate = {
 export type ApplicationFunnel = {
     draft?: number;
     pending_fee?: number;
+    paid?: number;
     in_review?: number;
     accepted?: number;
-    paid?: number;
+    fee_enabled?: boolean;
 };
 
 /**
@@ -2028,6 +2029,7 @@ export type HumanVerify = {
  */
 export type KeyMetrics = {
     people?: number;
+    paying_people?: number;
     total_revenue?: string;
     currency?: string;
     avg_ticket_price?: string;
@@ -2841,10 +2843,9 @@ export type ProductLine = {
 /**
  * Product schema for API responses.
  *
- * Sale window fields are exposed as `date` (inclusive day) even though they
- * are persisted as `datetime` UTC (exclusive instant). `sale_ends_at` is
- * de-bumped by 1 day so the response shows the last day the product is on
- * sale — the canonical "operator-friendly" representation.
+ * Sale window fields are exposed as full ``datetime`` instants (UTC), so the
+ * sale window can express a precise cutoff like "Friday 11:59 PM" rather than
+ * a whole calendar day. Clients render them in the popup's timezone.
  */
 export type ProductPublic = {
     tenant_id: string;

--- a/backoffice/src/components/Dashboard/ApplicationFunnelChart.tsx
+++ b/backoffice/src/components/Dashboard/ApplicationFunnelChart.tsx
@@ -18,17 +18,17 @@ import { Skeleton } from "@/components/ui/skeleton"
 const FUNNEL_COLORS = [
   "oklch(0.65 0.15 260)", // draft — blue-ish
   "oklch(0.75 0.18 80)", // pending_fee — amber
+  "oklch(0.55 0.22 160)", // paid — dark green
   "oklch(0.7 0.15 200)", // in_review — teal
   "oklch(0.65 0.2 145)", // accepted — green
-  "oklch(0.55 0.22 160)", // paid — dark green
 ]
 
 const funnelConfig = {
   draft: { label: "Draft", color: FUNNEL_COLORS[0] },
   pending_fee: { label: "Pending Fee", color: FUNNEL_COLORS[1] },
-  in_review: { label: "In Review", color: FUNNEL_COLORS[2] },
-  accepted: { label: "Accepted", color: FUNNEL_COLORS[3] },
-  paid: { label: "Paid", color: FUNNEL_COLORS[4] },
+  paid: { label: "Paid", color: FUNNEL_COLORS[2] },
+  in_review: { label: "In Review", color: FUNNEL_COLORS[3] },
+  accepted: { label: "Accepted", color: FUNNEL_COLORS[4] },
 } satisfies ChartConfig
 
 type ApplicationFunnelChartProps = {
@@ -59,16 +59,19 @@ export function ApplicationFunnelChart({
   const inReview = data.in_review ?? 0
   const accepted = data.accepted ?? 0
   const paid = data.paid ?? 0
+  const feeEnabled = data.fee_enabled ?? false
   const total = draft + pendingFee + inReview + accepted
   const barData = [
-    { stage: "Draft", value: draft },
-    { stage: "Pending Fee", value: pendingFee },
-    { stage: "In Review", value: inReview },
-    { stage: "Accepted", value: accepted },
-    { stage: "Paid", value: paid },
+    { stage: "Draft", value: draft, color: FUNNEL_COLORS[0] },
+    { stage: "Pending Fee", value: pendingFee, color: FUNNEL_COLORS[1] },
+    ...(feeEnabled
+      ? [{ stage: "Paid", value: paid, color: FUNNEL_COLORS[2] }]
+      : []),
+    { stage: "In Review", value: inReview, color: FUNNEL_COLORS[3] },
+    { stage: "Accepted", value: accepted, color: FUNNEL_COLORS[4] },
   ]
 
-  const hasData = total > 0 || paid > 0
+  const hasData = total > 0
 
   return (
     <Card>
@@ -76,7 +79,9 @@ export function ApplicationFunnelChart({
         <CardTitle className="text-base">Application Pipeline</CardTitle>
         <CardDescription>
           {hasData
-            ? `${total} applications, ${paid} paid`
+            ? feeEnabled
+              ? `${total} applications, ${paid} fee paid`
+              : `${total} applications`
             : "No applications yet"}
         </CardDescription>
       </CardHeader>
@@ -98,11 +103,8 @@ export function ApplicationFunnelChart({
               <YAxis tickLine={false} axisLine={false} width={40} />
               <ChartTooltip content={<ChartTooltipContent />} />
               <Bar dataKey="value" radius={[4, 4, 0, 0]}>
-                {barData.map((entry, i) => (
-                  <Cell
-                    key={entry.stage}
-                    fill={FUNNEL_COLORS[i % FUNNEL_COLORS.length]}
-                  />
+                {barData.map((entry) => (
+                  <Cell key={entry.stage} fill={entry.color} />
                 ))}
               </Bar>
             </BarChart>

--- a/backoffice/src/components/Dashboard/CumulativeTrendsCharts.tsx
+++ b/backoffice/src/components/Dashboard/CumulativeTrendsCharts.tsx
@@ -97,8 +97,8 @@ export function CumulativeTrendsCharts({
           <CardTitle className="text-base">Cumulative Tickets</CardTitle>
           <CardDescription>
             {hasTickets
-              ? `${tickets[tickets.length - 1].cumulative} accepted total`
-              : "No accepted applications yet"}
+              ? `${tickets[tickets.length - 1].cumulative} tickets sold`
+              : "No tickets sold yet"}
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/backoffice/src/components/Dashboard/KeyMetricsCards.tsx
+++ b/backoffice/src/components/Dashboard/KeyMetricsCards.tsx
@@ -144,12 +144,14 @@ export function KeyMetricsCards({ data, isLoading }: KeyMetricsCardsProps) {
         title="Revenue / Person"
         value={formatCurrency(data.avg_revenue_per_person, currency)}
         icon={TrendingUp}
+        description={`${(data.paying_people ?? 0).toLocaleString()} paying`}
         accentClass="text-violet-500"
       />
       <MetricCard
         title="Conversion Rate"
         value={`${data.conversion_rate ?? 0}%`}
         icon={Percent}
+        description="accepted vs rejected"
         accentClass="text-emerald-500"
       />
       <MetricCard

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -848,6 +848,11 @@ export const ApplicationFunnelSchema = {
             title: 'Pending Fee',
             default: 0
         },
+        paid: {
+            type: 'integer',
+            title: 'Paid',
+            default: 0
+        },
         in_review: {
             type: 'integer',
             title: 'In Review',
@@ -858,10 +863,10 @@ export const ApplicationFunnelSchema = {
             title: 'Accepted',
             default: 0
         },
-        paid: {
-            type: 'integer',
-            title: 'Paid',
-            default: 0
+        fee_enabled: {
+            type: 'boolean',
+            title: 'Fee Enabled',
+            default: false
         }
     },
     type: 'object',
@@ -4389,7 +4394,7 @@ export const CheckoutRuntimeProductSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -4401,7 +4406,7 @@ export const CheckoutRuntimeProductSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -9864,6 +9869,11 @@ export const KeyMetricsSchema = {
             title: 'People',
             default: 0
         },
+        paying_people: {
+            type: 'integer',
+            title: 'Paying People',
+            default: 0
+        },
         total_revenue: {
             type: 'string',
             pattern: '^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
@@ -13555,7 +13565,7 @@ export const ProductBatchItemSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13567,7 +13577,7 @@ export const ProductBatchItemSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13740,7 +13750,7 @@ export const ProductBatchResultSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13752,7 +13762,7 @@ export const ProductBatchResultSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13980,7 +13990,7 @@ export const ProductCreateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -13992,7 +14002,7 @@ export const ProductCreateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14185,7 +14195,7 @@ export const ProductPublicSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14197,7 +14207,7 @@ export const ProductPublicSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14274,10 +14284,9 @@ export const ProductPublicSchema = {
     title: 'ProductPublic',
     description: `Product schema for API responses.
 
-Sale window fields are exposed as \`date\` (inclusive day) even though they
-are persisted as \`datetime\` UTC (exclusive instant). \`sale_ends_at\` is
-de-bumped by 1 day so the response shows the last day the product is on
-sale — the canonical "operator-friendly" representation.`
+Sale window fields are exposed as full \`\`datetime\`\` instants (UTC), so the
+sale window can express a precise cutoff like "Friday 11:59 PM" rather than
+a whole calendar day. Clients render them in the popup's timezone.`
 } as const;
 
 export const ProductUpdateSchema = {
@@ -14397,7 +14406,7 @@ export const ProductUpdateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14409,7 +14418,7 @@ export const ProductUpdateSchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14611,7 +14620,7 @@ export const ProductWithQuantitySchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'
@@ -14623,7 +14632,7 @@ export const ProductWithQuantitySchema = {
             anyOf: [
                 {
                     type: 'string',
-                    format: 'date'
+                    format: 'date-time'
                 },
                 {
                     type: 'null'

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -5231,12 +5231,16 @@ export class HumansService {
     }
     
     /**
-     * Hard-delete a human and all related rows (superadmin only)
+     * Hard-delete a human and all related rows (admin or superadmin)
      * Permanently delete a Human with full cascade.
      *
      * Removes applications, attendees, payments, products, carts, group
      * memberships, and ambassador-owned groups in a single transaction. Designed
      * for cleaning up test users — destructive and irreversible.
+     *
+     * Superadmins may delete any human; a tenant admin may only delete humans
+     * within their own tenant. Both run on the control-plane session (which
+     * bypasses RLS), so the tenant ownership check is enforced explicitly here.
      * @param data The data for the request.
      * @param data.humanId
      * @returns HardDeleteSummary Successful Response

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -188,9 +188,10 @@ export type ApplicationFeeCreate = {
 export type ApplicationFunnel = {
     draft?: number;
     pending_fee?: number;
+    paid?: number;
     in_review?: number;
     accepted?: number;
-    paid?: number;
+    fee_enabled?: boolean;
 };
 
 /**
@@ -2028,6 +2029,7 @@ export type HumanVerify = {
  */
 export type KeyMetrics = {
     people?: number;
+    paying_people?: number;
     total_revenue?: string;
     currency?: string;
     avg_ticket_price?: string;
@@ -2841,10 +2843,9 @@ export type ProductLine = {
 /**
  * Product schema for API responses.
  *
- * Sale window fields are exposed as `date` (inclusive day) even though they
- * are persisted as `datetime` UTC (exclusive instant). `sale_ends_at` is
- * de-bumped by 1 day so the response shows the last day the product is on
- * sale — the canonical "operator-friendly" representation.
+ * Sale window fields are exposed as full ``datetime`` instants (UTC), so the
+ * sale window can express a precise cutoff like "Friday 11:59 PM" rather than
+ * a whole calendar day. Clients render them in the popup's timezone.
  */
 export type ProductPublic = {
     tenant_id: string;


### PR DESCRIPTION
## What

Fixes to dashboard metrics identified during a backoffice + backend review. Each change was reviewed and approved issue by issue with the team.

## Changes

**Popup-level scoping (includes direct sales)**

* Payment and attendee aggregations are now scoped directly by `popup_id` instead of joining through applications. This prevents direct-sale records (sponsors, guests, and sales without an application) from being excluded.

**Decoupling payments from attendees**

* `revenue / person` now divides by paying attendees (`paying_people`) rather than the total number of people. Sponsors and guests do not generate payments and were skewing the average.

**Conversion rate**

* Updated to `accepted / (accepted + rejected)`, reflecting actual acceptance/rejection decisions.
* Applications in `in-review` and `pending-fee` states (not yet decided) are excluded, as are `withdrawn` applications (automatically withdrawn).

**Funnel: Paid stage**

* New fee-paid stage: counts applications with an approved `application_fee` payment.
* Displayed **only** when the popup has `requires_application_fee` enabled (`fee_enabled`), avoiding noise for popups without an application fee.

**Cumulative trends in the popup's timezone**

* Both series are now bucketed by payment date using the popup's timezone rather than UTC, ensuring that days are aligned with the event's local midnight.
* The ticket series has been redefined as tickets sold (number of approved pass purchases), so both curves share the same payment-based timeline.

## Additional Changes

* Regenerated OpenAPI client (backoffice + portal).
* Added a smoke test covering all aggregation queries used by the `/dashboard/enriched` endpoint.

## Validation

* `ruff check` + `ruff format --check` passed
* Backoffice build passed (generated client compiles consistently)
* `/enriched` smoke test → 200
* No new migrations
