### PR TITLE
fix(cart): avoid post-commit reload race on portal cart update

### DIFF
--- a/backend/app/api/cart/crud.py
+++ b/backend/app/api/cart/crud.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import UTC, datetime
 
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, func, select
@@ -82,11 +83,17 @@ class CartsCRUD:
         cart: Carts,
         items: CartState,
     ) -> Carts:
-        """Replace cart items."""
+        """Replace cart items.
+
+        Sets updated_at client-side instead of reloading from the DB after
+        commit: the committed row is authoritative and a post-commit reload
+        races with concurrent deletes (DELETE /my/{popup_id}, checkout cleanup),
+        which under RLS surfaces as "Could not refresh instance".
+        """
         cart.items = items.model_dump()
+        cart.updated_at = datetime.now(UTC)
         session.add(cart)
         session.commit()
-        session.refresh(cart)
         return cart
 
     def delete_by_human_popup(

--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -369,7 +369,11 @@ def get_human_tenant_session(
         cached_cred.password,
     )
 
-    with Session(tenant_engine) as tenant_session:
+    # expire_on_commit=False: portal write routes build their response from the
+    # in-memory object after commit. Re-reading expired attributes would issue a
+    # post-commit SELECT that races with concurrent deletes and, under RLS, fails
+    # with "Could not refresh instance".
+    with Session(tenant_engine, expire_on_commit=False) as tenant_session:
         yield tenant_session
 
 


### PR DESCRIPTION
## Summary

Fixes an intermittent `InvalidRequestError: Could not refresh instance '<Carts>'` on the portal cart update endpoint (`PUT /carts/my/{popup_id}`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cart/crud.py`: `update_items` no longer calls `session.refresh(cart)` after commit; sets `updated_at` client-side instead. The committed in-memory object is authoritative.
- `dependencies/users.py`: `get_human_tenant_session` now uses `expire_on_commit=False`, so portal write routes build their response from the in-memory object instead of a post-commit reload SELECT.

## Root cause

The post-commit reload (`session.refresh`, and implicitly any attribute access under `expire_on_commit=True`) issues a `SELECT WHERE id=:pk`. When a concurrent request (e.g. `DELETE /my/{popup_id}` or checkout cleanup) deletes the row between commit and reload, the SELECT returns 0 rows (under RLS, filtered by `app_effective_tenant_id()`), and SQLAlchemy raises. Intermittent by nature — a concurrency race, not a deterministic RLS misconfig.

## Testing

- [x] Backend linting passes on changed files (`ruff check` + `ruff format`)
- [ ] Full `bash scripts/test.sh` not run (testcontainers); change is a 14-line, logic-isolated fix

## Note

Touches `backend/app/core/dependencies/users.py`, which is also reformatted by the `style/ruff-format-backend` PR. Merge that one first, then rebase this small fix on top.