### PR TITLE
feat(tasks): open board by visibility, add priority, shareable links

### DIFF
--- a/backend/app/alembic/versions/b3d8f1a25c47_task_priority.py
+++ b/backend/app/alembic/versions/b3d8f1a25c47_task_priority.py
@@ -1,0 +1,37 @@
+"""add priority to tasks
+
+Adds a `priority` column (low | medium | high) to the tasks table. Existing
+rows backfill to 'medium' via the server_default.
+
+Revision ID: b3d8f1a25c47
+Revises: e7d2b9f4a6c1
+Create Date: 2026-06-03
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3d8f1a25c47"
+down_revision = "e7d2b9f4a6c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tasks",
+        sa.Column(
+            "priority",
+            sa.String(length=16),
+            nullable=False,
+            server_default="medium",
+        ),
+    )
+    op.create_index("ix_tasks_priority", "tasks", ["priority"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tasks_priority", table_name="tasks")
+    op.drop_column("tasks", "priority")

--- a/backend/app/api/task/crud.py
+++ b/backend/app/api/task/crud.py
@@ -6,10 +6,12 @@ single batched lookup to keep list responses free of N+1 queries.
 """
 
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlmodel import Session, col, func, select
 
 from app.api.shared.crud import BaseCRUD
+from app.api.shared.enums import UserRole
 from app.api.task.models import Task, TaskComment
 from app.api.task.schemas import (
     TaskAttachmentPublic,
@@ -17,7 +19,28 @@ from app.api.task.schemas import (
     TaskDetailPublic,
     TaskPublic,
     TaskUpdate,
+    TaskVisibility,
 )
+
+if TYPE_CHECKING:
+    from app.api.user.schemas import UserPublic
+
+
+def can_view_task(user: "UserPublic", task: Task) -> bool:
+    """Whether ``user`` may view ``task`` under its visibility.
+
+    superadmin → everything; ``universal`` → everyone; ``tenant`` → users of the
+    target tenant; ``internal`` → superadmins only.
+    """
+    if user.role == UserRole.SUPERADMIN:
+        return True
+    if task.visibility == TaskVisibility.UNIVERSAL.value:
+        return True
+    return (
+        task.visibility == TaskVisibility.TENANT.value
+        and task.target_tenant_id is not None
+        and task.target_tenant_id == user.tenant_id
+    )
 
 
 class TasksCRUD(BaseCRUD[Task, TaskCreate, TaskUpdate]):
@@ -38,8 +61,21 @@ class TasksCRUD(BaseCRUD[Task, TaskCreate, TaskUpdate]):
         responsible_user_id: uuid.UUID | None = None,
         release: str | None = None,
         search: str | None = None,
+        viewer: "UserPublic | None" = None,
     ) -> tuple[list[Task], int]:
         statement = select(Task)
+
+        # Visibility gate for non-superadmin viewers: only universal tasks and
+        # tenant tasks targeting their own tenant. Superadmins (or no viewer)
+        # see everything. internal tasks never reach non-superadmins.
+        if viewer is not None and viewer.role != UserRole.SUPERADMIN:
+            statement = statement.where(
+                (col(Task.visibility) == TaskVisibility.UNIVERSAL.value)
+                | (
+                    (col(Task.visibility) == TaskVisibility.TENANT.value)
+                    & (col(Task.target_tenant_id) == viewer.tenant_id)
+                )
+            )
 
         if status is not None:
             statement = statement.where(Task.status == status)

--- a/backend/app/api/task/models.py
+++ b/backend/app/api/task/models.py
@@ -42,9 +42,11 @@ class Task(SQLModel, table=True):
     title: str = Field(max_length=200)
     detail: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
 
-    # See app.api.task.schemas: TaskStatus / TaskType / TaskVisibility.
+    # See app.api.task.schemas: TaskStatus / TaskType / TaskPriority / TaskVisibility.
     status: str = Field(max_length=16, index=True)
     type: str = Field(max_length=16, index=True)
+    # low | medium | high. Defaults to medium for existing/new rows.
+    priority: str = Field(default="medium", max_length=16, index=True)
 
     # Assignee — any backoffice user. Nullable (e.g. fresh bug reports).
     responsible_user_id: uuid.UUID | None = Field(

--- a/backend/app/api/task/router.py
+++ b/backend/app/api/task/router.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Query, status
 
+from app.api.shared.enums import UserRole
 from app.api.shared.response import (
     ListModel,
     PaginationLimit,
@@ -60,7 +61,6 @@ def _validate_responsible(
     """Tasks may only be assigned to a superadmin (phase 1 policy)."""
     if responsible_user_id is None:
         return
-    from app.api.shared.enums import UserRole
     from app.api.user.models import Users
 
     user = db.get(Users, responsible_user_id)
@@ -74,6 +74,16 @@ def _validate_responsible(
 def _get_task_or_404(db: SessionDep, task_id: uuid.UUID) -> Task:
     task = crud.tasks_crud.get(db, task_id)
     if not task:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
+    return task
+
+
+def _get_viewable_task_or_404(db: SessionDep, task_id: uuid.UUID, user) -> Task:
+    """Like _get_task_or_404 but 404s when the user can't view it (no info leak)."""
+    task = _get_task_or_404(db, task_id)
+    if not crud.can_view_task(user, task):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
         )
@@ -95,16 +105,26 @@ async def report_bug(
 ) -> TaskPublic:
     """File a bug report (any authenticated backoffice user).
 
-    Always creates an internal bug in the to-do column, attributed to the
-    reporter. Optional attachments are screenshots / screen-recordings already
-    uploaded to S3 via POST /uploads/presigned-url.
+    Creates a to-do bug attributed to the reporter, scoped to the reporter's
+    tenant (``visibility='tenant'``) so that tenant's users can see it. A
+    superadmin reporter (no tenant) falls back to an ``internal`` bug. Optional
+    attachments are screenshots / screen-recordings already uploaded to S3 via
+    POST /uploads/presigned-url.
     """
+    if current_user.tenant_id is not None:
+        visibility = TaskVisibility.TENANT.value
+        target_tenant_id = current_user.tenant_id
+    else:
+        visibility = TaskVisibility.INTERNAL.value
+        target_tenant_id = None
+
     task = Task(
         title=report_in.title,
         detail=report_in.detail,
         status=TaskStatus.TO_DO.value,
         type=TaskType.BUG.value,
-        visibility=TaskVisibility.INTERNAL.value,
+        visibility=visibility,
+        target_tenant_id=target_tenant_id,
         created_by=current_user.id,
     )
     db.add(task)
@@ -131,7 +151,7 @@ async def report_bug(
 @router.get("", response_model=ListModel[TaskPublic])
 async def list_tasks(
     db: SessionDep,
-    _: CurrentSuperadmin,
+    current_user: CurrentUser,
     task_status: TaskStatus | None = Query(default=None, alias="status"),
     task_type: TaskType | None = Query(default=None, alias="type"),
     visibility: TaskVisibility | None = None,
@@ -141,7 +161,7 @@ async def list_tasks(
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[TaskPublic]:
-    """List tasks with optional filters (superadmin only)."""
+    """List tasks the current user may see (filtered by visibility)."""
     tasks, total = crud.tasks_crud.find_tasks(
         db,
         skip=skip,
@@ -152,6 +172,7 @@ async def list_tasks(
         responsible_user_id=responsible_user_id,
         release=release,
         search=search,
+        viewer=current_user,
     )
     return ListModel[TaskPublic](
         results=crud.to_public_list(db, tasks),
@@ -187,10 +208,10 @@ async def create_task(
 async def get_task(
     task_id: uuid.UUID,
     db: SessionDep,
-    _: CurrentSuperadmin,
+    current_user: CurrentUser,
 ) -> TaskDetailPublic:
-    """Get a single task with its attachments (superadmin only)."""
-    task = _get_task_or_404(db, task_id)
+    """Get a single task with its attachments (visible to the user)."""
+    task = _get_viewable_task_or_404(db, task_id, current_user)
     return crud.to_detail(db, task)
 
 
@@ -318,10 +339,10 @@ async def delete_attachment(
 async def list_task_comments(
     task_id: uuid.UUID,
     db: SessionDep,
-    _: CurrentSuperadmin,
+    current_user: CurrentUser,
 ) -> ListModel[TaskCommentPublic]:
-    """List a task's comments, oldest first (superadmin only)."""
-    _get_task_or_404(db, task_id)
+    """List a task's comments, oldest first (any user who can view the task)."""
+    _get_viewable_task_or_404(db, task_id, current_user)
     comments = crud.list_comments(db, task_id)
     return ListModel[TaskCommentPublic](
         results=[TaskCommentPublic.model_validate(c) for c in comments],
@@ -338,10 +359,10 @@ async def create_task_comment(
     task_id: uuid.UUID,
     comment_in: TaskCommentCreate,
     db: SessionDep,
-    current_user: CurrentSuperadmin,
+    current_user: CurrentUser,
 ) -> TaskCommentPublic:
-    """Add a comment to a task (superadmin only)."""
-    _get_task_or_404(db, task_id)
+    """Add a comment to a task (any user who can view the task)."""
+    _get_viewable_task_or_404(db, task_id, current_user)
     comment = TaskComment(
         task_id=task_id,
         author_user_id=current_user.id,
@@ -361,9 +382,10 @@ async def update_task_comment(
     comment_id: uuid.UUID,
     comment_in: TaskCommentUpdate,
     db: SessionDep,
-    current_user: CurrentSuperadmin,
+    current_user: CurrentUser,
 ) -> TaskCommentPublic:
-    """Edit your own comment (superadmin only)."""
+    """Edit your own comment (any user who can view the task)."""
+    _get_viewable_task_or_404(db, task_id, current_user)
     comment = db.get(TaskComment, comment_id)
     if not comment or comment.task_id != task_id or comment.deleted_at is not None:
         raise HTTPException(
@@ -390,13 +412,22 @@ async def delete_task_comment(
     task_id: uuid.UUID,
     comment_id: uuid.UUID,
     db: SessionDep,
-    _: CurrentSuperadmin,
+    current_user: CurrentUser,
 ) -> None:
-    """Soft-delete a comment (superadmin only). The row is preserved."""
+    """Soft-delete a comment: the author, or any superadmin. Row is preserved."""
+    _get_viewable_task_or_404(db, task_id, current_user)
     comment = db.get(TaskComment, comment_id)
     if not comment or comment.task_id != task_id or comment.deleted_at is not None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Comment not found"
+        )
+    if (
+        current_user.role != UserRole.SUPERADMIN
+        and comment.author_user_id != current_user.id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only delete your own comments",
         )
     comment.deleted_at = datetime.now(UTC)
     db.add(comment)

--- a/backend/app/api/task/schemas.py
+++ b/backend/app/api/task/schemas.py
@@ -21,6 +21,12 @@ class TaskType(str, Enum):
     FEATURE = "feature"
 
 
+class TaskPriority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
 class TaskVisibility(str, Enum):
     UNIVERSAL = "universal"  # all tenants (phase 2)
     TENANT = "tenant"  # a single target tenant (phase 2)
@@ -95,6 +101,7 @@ class TaskCreate(BaseModel):
     detail: str | None = None
     status: TaskStatus = TaskStatus.TO_DO
     type: TaskType = TaskType.FEATURE
+    priority: TaskPriority = TaskPriority.MEDIUM
     responsible_user_id: uuid.UUID | None = None
     release: str | None = Field(default=None, max_length=50)
     visibility: TaskVisibility = TaskVisibility.INTERNAL
@@ -108,6 +115,7 @@ class TaskUpdate(BaseModel):
     detail: str | None = None
     status: TaskStatus | None = None
     type: TaskType | None = None
+    priority: TaskPriority | None = None
     responsible_user_id: uuid.UUID | None = None
     release: str | None = Field(default=None, max_length=50)
     visibility: TaskVisibility | None = None
@@ -144,6 +152,7 @@ class TaskPublic(BaseModel):
     detail: str | None = None
     status: TaskStatus
     type: TaskType
+    priority: TaskPriority = TaskPriority.MEDIUM
     responsible_user_id: uuid.UUID | None = None
     responsible_name: str | None = None
     responsible_email: str | None = None

--- a/backend/tests/api/task/test_task_access.py
+++ b/backend/tests/api/task/test_task_access.py
@@ -1,0 +1,149 @@
+"""Tasks: visibility-aware viewing, comment access, priority, report-bug scoping.
+
+Covers the change that opens the task board to all backoffice users (read +
+comment) while respecting each task's visibility, adds a `priority` field, and
+scopes reported bugs to the reporter's tenant.
+
+The session-scoped `db` has no per-test rollback, so each test tags its rows with
+a unique token and asserts membership rather than absolute counts.
+"""
+
+import uuid
+
+import pytest
+from sqlmodel import Session
+
+from app.api.task.models import Task
+from app.api.task.schemas import TaskStatus, TaskType
+from app.api.tenant.models import Tenants
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_task(
+    db: Session,
+    *,
+    title: str,
+    visibility: str,
+    target_tenant_id: uuid.UUID | None = None,
+) -> Task:
+    task = Task(
+        title=title,
+        status=TaskStatus.TO_DO.value,
+        type=TaskType.FEATURE.value,
+        visibility=visibility,
+        target_tenant_id=target_tenant_id,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@pytest.fixture()
+def visibility_tasks(db: Session, tenant_a: Tenants, tenant_b: Tenants) -> dict:
+    tag = uuid.uuid4().hex[:8]
+    return {
+        "universal": _make_task(db, title=f"u-{tag}", visibility="universal"),
+        "tenant_a": _make_task(
+            db, title=f"ta-{tag}", visibility="tenant", target_tenant_id=tenant_a.id
+        ),
+        "tenant_b": _make_task(
+            db, title=f"tb-{tag}", visibility="tenant", target_tenant_id=tenant_b.id
+        ),
+        "internal": _make_task(db, title=f"i-{tag}", visibility="internal"),
+    }
+
+
+def test_non_superadmin_list_respects_visibility(
+    client, admin_token_tenant_a, visibility_tasks
+) -> None:
+    """A tenant_a admin sees universal + own-tenant tasks; not other-tenant nor internal."""
+    r = client.get("/api/v1/tasks?limit=1000", headers=_auth(admin_token_tenant_a))
+    assert r.status_code == 200
+    ids = {t["id"] for t in r.json()["results"]}
+    assert str(visibility_tasks["universal"].id) in ids
+    assert str(visibility_tasks["tenant_a"].id) in ids
+    assert str(visibility_tasks["tenant_b"].id) not in ids
+    assert str(visibility_tasks["internal"].id) not in ids
+
+
+def test_superadmin_sees_all_visibilities(
+    client, superadmin_token, visibility_tasks
+) -> None:
+    r = client.get("/api/v1/tasks?limit=1000", headers=_auth(superadmin_token))
+    ids = {t["id"] for t in r.json()["results"]}
+    for key in ("universal", "tenant_a", "tenant_b", "internal"):
+        assert str(visibility_tasks[key].id) in ids
+
+
+def test_get_task_404_when_not_viewable(
+    client, admin_token_tenant_a, visibility_tasks
+) -> None:
+    internal = client.get(
+        f"/api/v1/tasks/{visibility_tasks['internal'].id}",
+        headers=_auth(admin_token_tenant_a),
+    )
+    assert internal.status_code == 404
+    universal = client.get(
+        f"/api/v1/tasks/{visibility_tasks['universal'].id}",
+        headers=_auth(admin_token_tenant_a),
+    )
+    assert universal.status_code == 200
+
+
+def test_non_superadmin_cannot_mutate_tasks(client, admin_token_tenant_a) -> None:
+    r = client.post(
+        "/api/v1/tasks", headers=_auth(admin_token_tenant_a), json={"title": "nope"}
+    )
+    assert r.status_code == 403
+
+
+def test_non_superadmin_can_comment_on_viewable_only(
+    client, admin_token_tenant_a, visibility_tasks
+) -> None:
+    ok = client.post(
+        f"/api/v1/tasks/{visibility_tasks['universal'].id}/comments",
+        headers=_auth(admin_token_tenant_a),
+        json={"body": "looking into it"},
+    )
+    assert ok.status_code == 201
+    blocked = client.post(
+        f"/api/v1/tasks/{visibility_tasks['internal'].id}/comments",
+        headers=_auth(admin_token_tenant_a),
+        json={"body": "should not work"},
+    )
+    assert blocked.status_code == 404
+
+
+def test_priority_defaults_to_medium_and_roundtrips(client, superadmin_token) -> None:
+    default = client.post(
+        "/api/v1/tasks", headers=_auth(superadmin_token), json={"title": "prio-default"}
+    )
+    assert default.status_code == 201
+    assert default.json()["priority"] == "medium"
+
+    high = client.post(
+        "/api/v1/tasks",
+        headers=_auth(superadmin_token),
+        json={"title": "prio-high", "priority": "high"},
+    )
+    assert high.status_code == 201
+    assert high.json()["priority"] == "high"
+
+
+def test_report_bug_is_scoped_to_reporter_tenant(
+    client, admin_token_tenant_a, tenant_a: Tenants
+) -> None:
+    r = client.post(
+        "/api/v1/tasks/report-bug",
+        headers=_auth(admin_token_tenant_a),
+        json={"title": "checkout button broken"},
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["type"] == "bug"
+    assert body["visibility"] == "tenant"
+    assert body["target_tenant_id"] == str(tenant_a.id)

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -3042,6 +3042,17 @@ export const AttendeesDirectoryEntrySchema = {
             ],
             title: 'Picture Url'
         },
+        category: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Category'
+        },
         participation: {
             items: {
                 '$ref': '#/components/schemas/DirectoryProduct'
@@ -3062,7 +3073,10 @@ export const AttendeesDirectoryEntrySchema = {
     type: 'object',
     required: ['id'],
     title: 'AttendeesDirectoryEntry',
-    description: 'Single entry in the attendees directory.'
+    description: `Single entry in the attendees directory.
+
+The directory is attendee-centric: one entry per ticket-holding attendee
+(any category), sourced from that attendee's own human record.`
 } as const;
 
 export const AuditLogPublicSchema = {
@@ -15464,6 +15478,10 @@ export const TaskCreateSchema = {
             '$ref': '#/components/schemas/TaskType',
             default: 'feature'
         },
+        priority: {
+            '$ref': '#/components/schemas/TaskPriority',
+            default: 'medium'
+        },
         responsible_user_id: {
             anyOf: [
                 {
@@ -15537,6 +15555,10 @@ export const TaskDetailPublicSchema = {
         },
         type: {
             '$ref': '#/components/schemas/TaskType'
+        },
+        priority: {
+            '$ref': '#/components/schemas/TaskPriority',
+            default: 'medium'
         },
         responsible_user_id: {
             anyOf: [
@@ -15662,6 +15684,12 @@ export const TaskMediaTypeSchema = {
     title: 'TaskMediaType'
 } as const;
 
+export const TaskPrioritySchema = {
+    type: 'string',
+    enum: ['low', 'medium', 'high'],
+    title: 'TaskPriority'
+} as const;
+
 export const TaskPublicSchema = {
     properties: {
         id: {
@@ -15689,6 +15717,10 @@ export const TaskPublicSchema = {
         },
         type: {
             '$ref': '#/components/schemas/TaskType'
+        },
+        priority: {
+            '$ref': '#/components/schemas/TaskPriority',
+            default: 'medium'
         },
         responsible_user_id: {
             anyOf: [
@@ -15865,6 +15897,16 @@ export const TaskUpdateSchema = {
             anyOf: [
                 {
                     '$ref': '#/components/schemas/TaskType'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        priority: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/TaskPriority'
                 },
                 {
                     type: 'null'

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -6367,9 +6367,11 @@ export class TasksService {
      * Report Bug
      * File a bug report (any authenticated backoffice user).
      *
-     * Always creates an internal bug in the to-do column, attributed to the
-     * reporter. Optional attachments are screenshots / screen-recordings already
-     * uploaded to S3 via POST /uploads/presigned-url.
+     * Creates a to-do bug attributed to the reporter, scoped to the reporter's
+     * tenant (``visibility='tenant'``) so that tenant's users can see it. A
+     * superadmin reporter (no tenant) falls back to an ``internal`` bug. Optional
+     * attachments are screenshots / screen-recordings already uploaded to S3 via
+     * POST /uploads/presigned-url.
      * @param data The data for the request.
      * @param data.requestBody
      * @returns TaskPublic Successful Response
@@ -6389,7 +6391,7 @@ export class TasksService {
     
     /**
      * List Tasks
-     * List tasks with optional filters (superadmin only).
+     * List tasks the current user may see (filtered by visibility).
      * @param data The data for the request.
      * @param data.status
      * @param data.type
@@ -6444,7 +6446,7 @@ export class TasksService {
     
     /**
      * Get Task
-     * Get a single task with its attachments (superadmin only).
+     * Get a single task with its attachments (visible to the user).
      * @param data The data for the request.
      * @param data.taskId
      * @returns TaskDetailPublic Successful Response
@@ -6583,7 +6585,7 @@ export class TasksService {
     
     /**
      * List Task Comments
-     * List a task's comments, oldest first (superadmin only).
+     * List a task's comments, oldest first (any user who can view the task).
      * @param data The data for the request.
      * @param data.taskId
      * @returns ListModel_TaskCommentPublic_ Successful Response
@@ -6604,7 +6606,7 @@ export class TasksService {
     
     /**
      * Create Task Comment
-     * Add a comment to a task (superadmin only).
+     * Add a comment to a task (any user who can view the task).
      * @param data The data for the request.
      * @param data.taskId
      * @param data.requestBody
@@ -6628,7 +6630,7 @@ export class TasksService {
     
     /**
      * Update Task Comment
-     * Edit your own comment (superadmin only).
+     * Edit your own comment (any user who can view the task).
      * @param data The data for the request.
      * @param data.taskId
      * @param data.commentId
@@ -6654,7 +6656,7 @@ export class TasksService {
     
     /**
      * Delete Task Comment
-     * Soft-delete a comment (superadmin only). The row is preserved.
+     * Soft-delete a comment: the author, or any superadmin. Row is preserved.
      * @param data The data for the request.
      * @param data.taskId
      * @param data.commentId

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -554,6 +554,9 @@ export type AttendeePurchases = {
 
 /**
  * Single entry in the attendees directory.
+ *
+ * The directory is attendee-centric: one entry per ticket-holding attendee
+ * (any category), sourced from that attendee's own human record.
  */
 export type AttendeesDirectoryEntry = {
     id: string;
@@ -567,6 +570,7 @@ export type AttendeesDirectoryEntry = {
     age?: (string | null);
     gender?: (string | null);
     picture_url?: (string | null);
+    category?: (string | null);
     participation?: Array<DirectoryProduct>;
     associated_attendees?: Array<AssociatedAttendee>;
 };
@@ -3119,6 +3123,7 @@ export type TaskCreate = {
     detail?: (string | null);
     status?: TaskStatus;
     type?: TaskType;
+    priority?: TaskPriority;
     responsible_user_id?: (string | null);
     release?: (string | null);
     visibility?: TaskVisibility;
@@ -3131,6 +3136,7 @@ export type TaskDetailPublic = {
     detail?: (string | null);
     status: TaskStatus;
     type: TaskType;
+    priority?: TaskPriority;
     responsible_user_id?: (string | null);
     responsible_name?: (string | null);
     responsible_email?: (string | null);
@@ -3147,12 +3153,15 @@ export type TaskDetailPublic = {
 
 export type TaskMediaType = 'image' | 'video';
 
+export type TaskPriority = 'low' | 'medium' | 'high';
+
 export type TaskPublic = {
     id: string;
     title: string;
     detail?: (string | null);
     status: TaskStatus;
     type: TaskType;
+    priority?: TaskPriority;
     responsible_user_id?: (string | null);
     responsible_name?: (string | null);
     responsible_email?: (string | null);
@@ -3182,6 +3191,7 @@ export type TaskUpdate = {
     detail?: (string | null);
     status?: (TaskStatus | null);
     type?: (TaskType | null);
+    priority?: (TaskPriority | null);
     responsible_user_id?: (string | null);
     release?: (string | null);
     visibility?: (TaskVisibility | null);

--- a/backoffice/src/components/Tasks/TaskBoard.tsx
+++ b/backoffice/src/components/Tasks/TaskBoard.tsx
@@ -18,16 +18,20 @@ import { STATUS_CLASSES, STATUS_LABELS, TASK_STATUSES } from "./taskMeta"
 interface TaskBoardProps {
   tasks: TaskPublic[]
   onOpen: (taskId: string) => void
+  /** Whether the viewer can move cards (change status). Superadmin only. */
+  canManage?: boolean
 }
 
 function Column({
   status,
   tasks,
   onOpen,
+  canManage,
 }: {
   status: TaskStatus
   tasks: TaskPublic[]
   onOpen: (taskId: string) => void
+  canManage?: boolean
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: status })
   return (
@@ -51,14 +55,19 @@ function Column({
       </div>
       <div className="flex min-h-[40px] flex-col gap-2">
         {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} onOpen={onOpen} />
+          <TaskCard
+            key={task.id}
+            task={task}
+            onOpen={onOpen}
+            draggable={canManage}
+          />
         ))}
       </div>
     </div>
   )
 }
 
-export function TaskBoard({ tasks, onOpen }: TaskBoardProps) {
+export function TaskBoard({ tasks, onOpen, canManage }: TaskBoardProps) {
   const queryClient = useQueryClient()
   const { showErrorToast } = useCustomToast()
   const sensors = useSensors(
@@ -77,6 +86,7 @@ export function TaskBoard({ tasks, onOpen }: TaskBoardProps) {
   ) as Record<TaskStatus, TaskPublic[]>
 
   const handleDragEnd = (event: DragEndEvent) => {
+    if (!canManage) return
     const overId = event.over?.id as TaskStatus | undefined
     const current = event.active.data.current?.status as TaskStatus | undefined
     if (!overId || overId === current) return
@@ -92,6 +102,7 @@ export function TaskBoard({ tasks, onOpen }: TaskBoardProps) {
             status={status}
             tasks={byStatus[status]}
             onOpen={onOpen}
+            canManage={canManage}
           />
         ))}
       </div>

--- a/backoffice/src/components/Tasks/TaskCard.tsx
+++ b/backoffice/src/components/Tasks/TaskCard.tsx
@@ -9,11 +9,17 @@ import { TYPE_CLASSES, TYPE_LABELS } from "./taskMeta"
 interface TaskCardProps {
   task: TaskPublic
   onOpen: (taskId: string) => void
+  /** When false the card can be opened but not dragged between columns. */
+  draggable?: boolean
 }
 
-export function TaskCard({ task, onOpen }: TaskCardProps) {
+export function TaskCard({ task, onOpen, draggable = true }: TaskCardProps) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({ id: task.id, data: { status: task.status } })
+    useDraggable({
+      id: task.id,
+      data: { status: task.status },
+      disabled: !draggable,
+    })
 
   return (
     <button
@@ -24,7 +30,8 @@ export function TaskCard({ task, onOpen }: TaskCardProps) {
       {...attributes}
       onClick={() => onOpen(task.id)}
       className={cn(
-        "w-full cursor-grab rounded-lg border bg-card p-3 text-left shadow-sm transition-shadow hover:shadow-md active:cursor-grabbing",
+        "w-full rounded-lg border bg-card p-3 text-left shadow-sm transition-shadow hover:shadow-md",
+        draggable && "cursor-grab active:cursor-grabbing",
         isDragging && "opacity-50",
       )}
     >

--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { Copy } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import {
+  type TaskPriority,
   type TaskStatus,
   TasksService,
   type TaskType,
@@ -31,12 +33,16 @@ import {
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Textarea } from "@/components/ui/textarea"
+import { useWorkspace } from "@/contexts/WorkspaceContext"
+import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
 import { createErrorHandler } from "@/utils"
 import { TaskAttachments } from "./TaskAttachments"
 import { TaskCommentThread } from "./TaskCommentThread"
 import {
+  PRIORITY_LABELS,
   STATUS_LABELS,
+  TASK_PRIORITIES,
   TASK_STATUSES,
   TASK_TYPES,
   TASK_VISIBILITIES,
@@ -57,6 +63,7 @@ interface FormState {
   title: string
   detail: string
   type: TaskType
+  priority: TaskPriority
   status: TaskStatus
   visibility: TaskVisibility
   target_tenant_id: string
@@ -68,6 +75,7 @@ const DEFAULTS: FormState = {
   title: "",
   detail: "",
   type: "feature",
+  priority: "medium",
   status: "to_do",
   visibility: "internal",
   target_tenant_id: "",
@@ -79,6 +87,10 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
   const isEdit = !!taskId
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
+  const { isSuperadmin } = useAuth()
+  const { selectedTenantId } = useWorkspace()
+  // Non-superadmins can view + comment, but not edit the task fields.
+  const readOnly = !isSuperadmin
   const [form, setForm] = useState<FormState>(DEFAULTS)
 
   const { data: task } = useQuery({
@@ -87,17 +99,18 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
     enabled: open && isEdit,
   })
 
-  // Tasks may only be assigned to superadmins (phase 1 policy).
+  // Editing affordances (assignee picker, tenant picker) are superadmin-only;
+  // skip these lookups for read-only viewers (who also lack the permission).
   const { data: usersData } = useQuery({
     queryKey: ["tasks-superadmins"],
     queryFn: () => UsersService.listUsers({ limit: 1000, role: "superadmin" }),
-    enabled: open,
+    enabled: open && isSuperadmin,
   })
 
   const { data: tenantsData } = useQuery({
     queryKey: ["tasks-tenants"],
     queryFn: () => TenantsService.listTenants({ limit: 1000 }),
-    enabled: open && form.visibility === "tenant",
+    enabled: open && isSuperadmin && form.visibility === "tenant",
   })
 
   // Reset the form whenever the dialog opens or the loaded task changes.
@@ -108,6 +121,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
         title: task.title,
         detail: task.detail ?? "",
         type: task.type,
+        priority: task.priority ?? "medium",
         status: task.status,
         visibility: task.visibility,
         target_tenant_id: task.target_tenant_id ?? "",
@@ -126,6 +140,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
     title: form.title.trim(),
     detail: form.detail.trim() || null,
     type: form.type,
+    priority: form.priority,
     status: form.status,
     visibility: form.visibility,
     target_tenant_id:
@@ -169,6 +184,13 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
     onError: createErrorHandler(showErrorToast),
   })
 
+  const copyLink = () => {
+    navigator.clipboard.writeText(
+      `${window.location.origin}/tasks?task=${taskId}`,
+    )
+    showSuccessToast("Link copied to clipboard")
+  }
+
   const handleSave = () => {
     if (!form.title.trim()) {
       showErrorToast("Title is required")
@@ -190,10 +212,26 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="thin-scrollbar max-h-[90vh] max-w-2xl overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{isEdit ? "Edit task" : "New task"}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            {isEdit ? (readOnly ? "Task" : "Edit task") : "New task"}
+            {isEdit && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 text-muted-foreground"
+                title="Copy link to this task"
+                onClick={copyLink}
+              >
+                <Copy className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </DialogTitle>
           <DialogDescription>
             {isEdit
-              ? "Update the task, manage attachments and discuss it below."
+              ? readOnly
+                ? "View this task and discuss it below."
+                : "Update the task, manage attachments and discuss it below."
               : "Track a bug or feature for the EdgeOS product."}
           </DialogDescription>
         </DialogHeader>
@@ -216,6 +254,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
               value={form.title}
               onChange={(e) => set("title", e.target.value)}
               placeholder="Short, specific summary"
+              disabled={readOnly}
             />
           </div>
 
@@ -227,6 +266,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
               value={form.detail}
               onChange={(e) => set("detail", e.target.value)}
               placeholder="What's the change / problem? Add context, steps, links."
+              disabled={readOnly}
             />
           </div>
 
@@ -236,6 +276,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
               <Select
                 value={form.type}
                 onValueChange={(v) => set("type", v as TaskType)}
+                disabled={readOnly}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -251,10 +292,31 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
             </div>
 
             <div className="space-y-2">
+              <Label>Priority</Label>
+              <Select
+                value={form.priority}
+                onValueChange={(v) => set("priority", v as TaskPriority)}
+                disabled={readOnly}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TASK_PRIORITIES.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {PRIORITY_LABELS[p]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
               <Label>Status</Label>
               <Select
                 value={form.status}
                 onValueChange={(v) => set("status", v as TaskStatus)}
+                disabled={readOnly}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -276,6 +338,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
                 onValueChange={(v) =>
                   set("responsible_user_id", v === NONE ? "" : v)
                 }
+                disabled={readOnly}
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Unassigned" />
@@ -298,6 +361,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
                 value={form.release}
                 onChange={(e) => set("release", e.target.value)}
                 placeholder="e.g. v1.2.0"
+                disabled={readOnly}
               />
             </div>
 
@@ -305,7 +369,21 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
               <Label>Visibility</Label>
               <Select
                 value={form.visibility}
-                onValueChange={(v) => set("visibility", v as TaskVisibility)}
+                onValueChange={(v) => {
+                  const vis = v as TaskVisibility
+                  // Default the target tenant to the one being worked in.
+                  setForm((prev) => ({
+                    ...prev,
+                    visibility: vis,
+                    target_tenant_id:
+                      vis === "tenant" &&
+                      !prev.target_tenant_id &&
+                      selectedTenantId
+                        ? selectedTenantId
+                        : prev.target_tenant_id,
+                  }))
+                }}
+                disabled={readOnly}
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -328,6 +406,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
                   onValueChange={(v) =>
                     set("target_tenant_id", v === NONE ? "" : v)
                   }
+                  disabled={readOnly}
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select a tenant" />
@@ -347,32 +426,42 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
 
         {isEdit && task && (
           <>
-            <Separator />
-            <TaskAttachments
-              taskId={task.id}
-              attachments={task.attachments ?? []}
-            />
+            {!readOnly && (
+              <>
+                <Separator />
+                <TaskAttachments
+                  taskId={task.id}
+                  attachments={task.attachments ?? []}
+                />
+              </>
+            )}
             <Separator />
             <TaskCommentThread taskId={task.id} />
-            <Separator />
-            <DangerZone
-              description="Permanently delete this task, its comments and attachments. To retire a task instead, set its status to Cancelled."
-              onDelete={() => deleteMutation.mutate()}
-              isDeleting={deleteMutation.isPending}
-              confirmText="Delete Task"
-              resourceName={task.title}
-              variant="inline"
-            />
+            {!readOnly && (
+              <>
+                <Separator />
+                <DangerZone
+                  description="Permanently delete this task, its comments and attachments. To retire a task instead, set its status to Cancelled."
+                  onDelete={() => deleteMutation.mutate()}
+                  isDeleting={deleteMutation.isPending}
+                  confirmText="Delete Task"
+                  resourceName={task.title}
+                  variant="inline"
+                />
+              </>
+            )}
           </>
         )}
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
+            {readOnly ? "Close" : "Cancel"}
           </Button>
-          <LoadingButton loading={isPending} onClick={handleSave}>
-            {isEdit ? "Save changes" : "Create task"}
-          </LoadingButton>
+          {!readOnly && (
+            <LoadingButton loading={isPending} onClick={handleSave}>
+              {isEdit ? "Save changes" : "Create task"}
+            </LoadingButton>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/backoffice/src/components/Tasks/columns.tsx
+++ b/backoffice/src/components/Tasks/columns.tsx
@@ -5,6 +5,8 @@ import { SortableHeader } from "@/components/Common/DataTable"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
 import {
+  PRIORITY_CLASSES,
+  PRIORITY_LABELS,
   STATUS_CLASSES,
   STATUS_LABELS,
   TYPE_CLASSES,
@@ -30,6 +32,21 @@ export const taskColumns: ColumnDef<TaskPublic>[] = [
         {TYPE_LABELS[row.original.type]}
       </Badge>
     ),
+  },
+  {
+    accessorKey: "priority",
+    header: "Priority",
+    cell: ({ row }) => {
+      const priority = row.original.priority ?? "medium"
+      return (
+        <Badge
+          variant="outline"
+          className={cn("font-normal", PRIORITY_CLASSES[priority])}
+        >
+          {PRIORITY_LABELS[priority]}
+        </Badge>
+      )
+    },
   },
   {
     accessorKey: "status",

--- a/backoffice/src/components/Tasks/taskMeta.ts
+++ b/backoffice/src/components/Tasks/taskMeta.ts
@@ -1,4 +1,9 @@
-import type { TaskStatus, TaskType, TaskVisibility } from "@/client"
+import type {
+  TaskPriority,
+  TaskStatus,
+  TaskType,
+  TaskVisibility,
+} from "@/client"
 
 /** Kanban column order, left → right. */
 export const TASK_STATUSES: TaskStatus[] = [
@@ -39,6 +44,21 @@ export const TYPE_LABELS: Record<TaskType, string> = {
 export const TYPE_CLASSES: Record<TaskType, string> = {
   bug: "bg-rose-100 text-rose-700 border-rose-200",
   feature: "bg-violet-100 text-violet-700 border-violet-200",
+}
+
+/** Priority order, low → high. */
+export const TASK_PRIORITIES: TaskPriority[] = ["low", "medium", "high"]
+
+export const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+}
+
+export const PRIORITY_CLASSES: Record<TaskPriority, string> = {
+  low: "bg-slate-100 text-slate-600 border-slate-200",
+  medium: "bg-sky-100 text-sky-700 border-sky-200",
+  high: "bg-orange-100 text-orange-800 border-orange-200",
 }
 
 export const TASK_VISIBILITIES: TaskVisibility[] = [

--- a/backoffice/src/routes/_layout/tasks/index.tsx
+++ b/backoffice/src/routes/_layout/tasks/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { ListChecks, Plus } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { TasksService, type TaskType, UsersService } from "@/client"
 import { DataTable } from "@/components/Common/DataTable"
@@ -25,6 +25,10 @@ import useAuth from "@/hooks/useAuth"
 
 export const Route = createFileRoute("/_layout/tasks/")({
   component: Tasks,
+  // `?task=<id>` deep-links straight into a task's modal (shareable link).
+  validateSearch: (search: Record<string, unknown>): { task?: string } => ({
+    task: typeof search.task === "string" ? search.task : undefined,
+  }),
   head: () => ({
     meta: [{ title: "Tasks - EdgeOS" }],
   }),
@@ -32,27 +36,21 @@ export const Route = createFileRoute("/_layout/tasks/")({
 
 function Tasks() {
   const navigate = useNavigate()
+  const { task: taskParam } = Route.useSearch()
   const { isSuperadmin, isUserLoading } = useAuth()
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState<TaskType | "all">("all")
   const [responsibleFilter, setResponsibleFilter] = useState<string>("all")
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const [activeTaskId, setActiveTaskId] = useState<string | null>(null)
+  const [newOpen, setNewOpen] = useState(false)
 
-  // Superadmin-only board (phase 1). Redirect everyone else.
-  useEffect(() => {
-    if (!isUserLoading && !isSuperadmin) {
-      navigate({ to: "/" })
-    }
-  }, [isUserLoading, isSuperadmin, navigate])
-
+  // Open to every backoffice user; the backend filters by task visibility.
   const { data, isLoading } = useQuery({
     queryKey: ["tasks", "board"],
     queryFn: () => TasksService.listTasks({ limit: 1000 }),
-    enabled: isSuperadmin,
   })
 
-  // Only superadmins can be assigned, so the filter lists superadmins only.
+  // Only superadmins can be assigned, so the filter lists superadmins only
+  // (and only superadmins may list users).
   const { data: usersData } = useQuery({
     queryKey: ["tasks-superadmins"],
     queryFn: () => UsersService.listUsers({ limit: 1000, role: "superadmin" }),
@@ -81,16 +79,12 @@ function Tasks() {
     })
   }, [data, typeFilter, responsibleFilter, search])
 
-  if (isUserLoading || !isSuperadmin) return null
+  if (isUserLoading) return null
 
-  const openNewTask = () => {
-    setActiveTaskId(null)
-    setDialogOpen(true)
-  }
-  const openTask = (taskId: string) => {
-    setActiveTaskId(taskId)
-    setDialogOpen(true)
-  }
+  const openNewTask = () => setNewOpen(true)
+  const openTask = (taskId: string) =>
+    navigate({ to: "/tasks", search: { task: taskId } })
+  const closeTask = () => navigate({ to: "/tasks", search: {} })
 
   return (
     <div className="flex flex-col gap-6">
@@ -101,10 +95,12 @@ function Tasks() {
             Track bugs and features for the EdgeOS product
           </p>
         </div>
-        <Button onClick={openNewTask}>
-          <Plus className="mr-2 h-4 w-4" />
-          New task
-        </Button>
+        {isSuperadmin && (
+          <Button onClick={openNewTask}>
+            <Plus className="mr-2 h-4 w-4" />
+            New task
+          </Button>
+        )}
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
@@ -130,20 +126,25 @@ function Tasks() {
             ))}
           </SelectContent>
         </Select>
-        <Select value={responsibleFilter} onValueChange={setResponsibleFilter}>
-          <SelectTrigger className="w-52">
-            <SelectValue placeholder="Responsible" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">All responsibles</SelectItem>
-            <SelectItem value="unassigned">Unassigned</SelectItem>
-            {users.map((u) => (
-              <SelectItem key={u.id} value={u.id}>
-                {u.full_name || u.email}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        {isSuperadmin && (
+          <Select
+            value={responsibleFilter}
+            onValueChange={setResponsibleFilter}
+          >
+            <SelectTrigger className="w-52">
+              <SelectValue placeholder="Responsible" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All responsibles</SelectItem>
+              <SelectItem value="unassigned">Unassigned</SelectItem>
+              {users.map((u) => (
+                <SelectItem key={u.id} value={u.id}>
+                  {u.full_name || u.email}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </div>
 
       <Tabs defaultValue="kanban">
@@ -161,14 +162,20 @@ function Tasks() {
               title="No tasks yet"
               description="Create a task to start tracking bugs and features."
               action={
-                <Button onClick={openNewTask}>
-                  <Plus className="mr-2 h-4 w-4" />
-                  New task
-                </Button>
+                isSuperadmin ? (
+                  <Button onClick={openNewTask}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    New task
+                  </Button>
+                ) : undefined
               }
             />
           ) : (
-            <TaskBoard tasks={filtered} onOpen={openTask} />
+            <TaskBoard
+              tasks={filtered}
+              onOpen={openTask}
+              canManage={isSuperadmin}
+            />
           )}
         </TabsContent>
 
@@ -192,10 +199,14 @@ function Tasks() {
         </TabsContent>
       </Tabs>
 
+      {/* Create dialog (superadmin) and the deep-linkable view/edit dialog. */}
+      <TaskDialog open={newOpen} onOpenChange={setNewOpen} taskId={null} />
       <TaskDialog
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
-        taskId={activeTaskId}
+        open={!!taskParam}
+        onOpenChange={(o) => {
+          if (!o) closeTask()
+        }}
+        taskId={taskParam ?? null}
       />
     </div>
   )


### PR DESCRIPTION
Bundles four task-tracker changes for the next release (branch off `dev`).

## (b) View + comment for all backoffice users, by visibility
- List/get tasks and list/create/edit/delete comments move from superadmin-only to **any authenticated user**, filtered by each task's `visibility`:
  - `internal` → superadmins only · `tenant` → superadmin + users of `target_tenant_id` · `universal` → everyone.
- New `can_view_task` helper; non-viewable tasks return **404** (no info leak).
- Create/update/delete task, status PATCH and attachments stay **superadmin-only**. Comment edit/delete are author-or-superadmin.
- Frontend: `/tasks` loads for everyone; mutations + kanban drag gated to superadmins; non-superadmins get a **read-only dialog with an interactive comment thread**.

## (c) Priority field
- `low | medium | high`, default **medium**. Enum + model column/index + schemas + migration (`server_default 'medium'` backfills existing rows). Shown as a column and an editable select.

## (d) Shareable per-task link
- Copy icon in the task modal copies `…/tasks?task=<id>`; the route's `?task=<id>` search param deep-links straight into that task's modal.

## (e) Tenant default
- Choosing `tenant` visibility defaults the target tenant to the one currently being worked in (`useWorkspace().selectedTenantId`).

## (f) report-bug scoping
- Reported bugs are now `visibility=tenant` scoped to the reporter's tenant (superadmin reporters fall back to `internal`).

## Tests
- `backend/tests/api/task/test_task_access.py`: visibility filtering, comment/mutation permissions, priority defaults/roundtrip, report-bug scoping — **7 passing**. `ruff` clean; backoffice `tsc` clean for touched files.

## Note
The regenerated OpenAPI client also catches up `AttendeesDirectoryEntry` (a `category` field already on `dev` from the directory change) — unrelated but correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)