### PR TITLE
feat(tasks): inline delete button (drop danger zone)

### DIFF
--- a/backend/tests/api/task/test_task_access.py
+++ b/backend/tests/api/task/test_task_access.py
@@ -134,6 +134,28 @@ def test_priority_defaults_to_medium_and_roundtrips(client, superadmin_token) ->
     assert high.json()["priority"] == "high"
 
 
+def test_priority_update_persists(client, superadmin_token) -> None:
+    created = client.post(
+        "/api/v1/tasks",
+        headers=_auth(superadmin_token),
+        json={"title": "prio-update"},
+    )
+    assert created.status_code == 201
+    tid = created.json()["id"]
+    assert created.json()["priority"] == "medium"
+
+    put = client.put(
+        f"/api/v1/tasks/{tid}",
+        headers=_auth(superadmin_token),
+        json={"priority": "high"},
+    )
+    assert put.status_code == 200
+    assert put.json()["priority"] == "high"
+
+    got = client.get(f"/api/v1/tasks/{tid}", headers=_auth(superadmin_token))
+    assert got.json()["priority"] == "high"
+
+
 def test_report_bug_is_scoped_to_reporter_tenant(
     client, admin_token_tenant_a, tenant_a: Tenants
 ) -> None:

--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Copy } from "lucide-react"
+import { Copy, Trash2 } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import {
@@ -11,7 +11,6 @@ import {
   TenantsService,
   UsersService,
 } from "@/client"
-import { DangerZone } from "@/components/Common/DangerZone"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -437,31 +436,32 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
             )}
             <Separator />
             <TaskCommentThread taskId={task.id} />
-            {!readOnly && (
-              <>
-                <Separator />
-                <DangerZone
-                  description="Permanently delete this task, its comments and attachments. To retire a task instead, set its status to Cancelled."
-                  onDelete={() => deleteMutation.mutate()}
-                  isDeleting={deleteMutation.isPending}
-                  confirmText="Delete Task"
-                  resourceName={task.title}
-                  variant="inline"
-                />
-              </>
-            )}
           </>
         )}
 
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            {readOnly ? "Close" : "Cancel"}
-          </Button>
-          {!readOnly && (
-            <LoadingButton loading={isPending} onClick={handleSave}>
-              {isEdit ? "Save changes" : "Create task"}
+        <DialogFooter className="sm:justify-between">
+          {isEdit && !readOnly ? (
+            <LoadingButton
+              variant="destructive"
+              loading={deleteMutation.isPending}
+              onClick={() => deleteMutation.mutate()}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
             </LoadingButton>
+          ) : (
+            <span />
           )}
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              {readOnly ? "Close" : "Cancel"}
+            </Button>
+            {!readOnly && (
+              <LoadingButton loading={isPending} onClick={handleSave}>
+                {isEdit ? "Save changes" : "Create task"}
+              </LoadingButton>
+            )}
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Follow-up to #258.

- **Delete UX:** removed the "Danger Zone" treatment in the task dialog — deleting a task is low-risk. The Delete button now sits in the footer on the same row as Cancel / Save (left-aligned, destructive style), with no typed confirmation.
- **Test:** added a regression test asserting a priority **update** persists (PUT then GET) — complements the existing create/default coverage.

Backend tests: `tests/api/task` → 8 passing. biome + tsc clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)