### PR TITLE
fix(portal): evaluate product sale window by instant, not calendar day

### DIFF
--- a/portal/src/lib/product-availability.test.ts
+++ b/portal/src/lib/product-availability.test.ts
@@ -39,7 +39,7 @@ describe("getProductAvailability", () => {
         total_stock_cap: 10,
         total_stock_remaining: 10,
       },
-      "2026-02-01",
+      new Date("2026-02-01"),
     )
     expect(av.state).toBe("ended")
     expect(av.canSelect).toBe(false)
@@ -52,7 +52,7 @@ describe("getProductAvailability", () => {
         ...baseProduct,
         sale_starts_at: "2027-01-01",
       },
-      "2026-01-01",
+      new Date("2026-01-01"),
     )
     expect(av.state).toBe("upcoming")
     expect(av.canSelect).toBe(false)

--- a/portal/src/lib/product-availability.ts
+++ b/portal/src/lib/product-availability.ts
@@ -29,9 +29,9 @@ export interface ProductAvailability {
  */
 export function getProductAvailability(
   product: AvailabilityProduct,
-  today?: string,
+  now?: Date,
 ): ProductAvailability {
-  const state = deriveProductState(product, today)
+  const state = deriveProductState(product, now)
   const canSelect = state === "on_sale"
   const maxAllowedQuantity = canSelect ? resolveMaxQuantity(product) : 0
   return { state, canSelect, maxAllowedQuantity }

--- a/portal/src/lib/product-state.ts
+++ b/portal/src/lib/product-state.ts
@@ -2,19 +2,17 @@ import type { ProductPublic } from "@/client"
 
 export type ProductSaleState = "upcoming" | "on_sale" | "ended" | "sold_out"
 
-/** YYYY-MM-DD for "today" in UTC, built from native Date UTC accessors. */
-const todayUtcYmd = (): string => {
-  const now = new Date()
-  const pad = (n: number) => String(n).padStart(2, "0")
-  return `${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}`
-}
-
 /**
  * Mirror of backend `derive_product_state` (see backend/app/api/product/product_state.py).
  *
- * Both ends of the sale window are inclusive: `sale_ends_at = "2026-01-10"`
- * keeps the product on sale through all of Jan 10 UTC. Comparisons are
- * lexicographic on YYYY-MM-DD strings (calendar order matches string order).
+ * The sale window is evaluated as precise datetime instants (not whole days),
+ * so `sale_ends_at` can express a cutoff like "Friday 11:59 PM". Both bounds
+ * are inclusive: the product stays on sale while
+ * `sale_starts_at <= now <= sale_ends_at`.
+ *
+ * Comparing absolute instants is timezone-safe — the stored values are UTC and
+ * `Date.parse` yields an absolute epoch, so the browser timezone never leaks
+ * into the result.
  */
 export function deriveProductState(
   product: Pick<
@@ -24,7 +22,7 @@ export function deriveProductState(
     | "total_stock_remaining"
     | "total_stock_cap"
   >,
-  today: string = todayUtcYmd(),
+  now: Date = new Date(),
 ): ProductSaleState {
   const cap = product.total_stock_cap ?? null
   const remaining = product.total_stock_remaining ?? null
@@ -32,8 +30,13 @@ export function deriveProductState(
     return "sold_out"
   }
 
-  const { sale_starts_at, sale_ends_at } = product
-  if (sale_ends_at && today > sale_ends_at) return "ended"
-  if (sale_starts_at && today < sale_starts_at) return "upcoming"
+  const nowMs = now.getTime()
+  const endsMs = product.sale_ends_at ? Date.parse(product.sale_ends_at) : null
+  const startsMs = product.sale_starts_at
+    ? Date.parse(product.sale_starts_at)
+    : null
+
+  if (endsMs !== null && nowMs > endsMs) return "ended"
+  if (startsMs !== null && nowMs < startsMs) return "upcoming"
   return "on_sale"
 }


### PR DESCRIPTION
## What
`deriveProductState` (portal) compared `sale_starts_at`/`sale_ends_at` as `YYYY-MM-DD` calendar days, so a precise cutoff like "Friday 11:59 PM" was treated as end-of-day — a product (e.g. a meal plan) showed on sale through all of Friday and only flipped to `ended` on Saturday, out of sync with the backend.

## Why
`b5d4a32` made the sale window precise `datetime` instants end-to-end on the backend (and enforced the cutoff on the portal purchase path), but did not touch any `portal/` files — leaving this client-side mirror on day granularity.

## Change
- `deriveProductState` now compares absolute epoch instants (`Date.parse` of the UTC ISO value vs `now.getTime()`), matching backend `derive_product_state`. Timezone-safe — no browser-TZ leak.
- `getProductAvailability` signature: `today?: string` → `now?: Date` (all real callers pass only `product`; only the test passed the second arg).

## Tests
- `product-availability.test.ts` updated (string args → `Date`).
- Full portal suite: 235 passing. `pnpm --filter portal run build` green.