### PR TITLE
fix(portal): scope host picker to popup attendees, stop leaking opted-out names

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 from sqlalchemy import desc, exists, or_
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, func, select
 
@@ -271,6 +272,101 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         results = list(session.exec(statement).all())
 
         return results, total
+
+    def find_directory_humans(
+        self,
+        session: Session,
+        popup_id: uuid.UUID,
+        q: str | None = None,
+        skip: int = 0,
+        limit: int = 20,
+    ) -> tuple[list["Humans"], int]:
+        """Find humans in the Portal attendee directory who share their name.
+
+        Same population as ``find_directory`` (accepted application, the attendee
+        holds at least one product, directory-visible main/spouse category) but
+        returns the distinct underlying Humans instead of Attendee rows. Powers
+        the event host picker: a creator may only pick a host who actually
+        attends this popup AND has not hidden their name for it.
+
+        Applications that listed "first_name" or "last_name" in
+        ``info_not_shared`` are excluded — picking them would surface a name the
+        attendee chose to hide. Humans with no usable name are also excluded so
+        the picker never renders a blank entry. Optional ``q`` does an ilike
+        match on the human's first/last name.
+        """
+        has_products = exists().where(AttendeeProducts.attendee_id == Attendees.id)
+        # info_not_shared is a Postgres text[] column, so name-hiding is detected
+        # with the array-overlap operator (&&): true when the list shares any
+        # element with {first_name, last_name}. (?| is a JSONB operator and does
+        # NOT apply to a real array column.) Negated to EXCLUDE those rows.
+        hides_name = col(Applications.info_not_shared).op("&&")(
+            postgresql.array(("first_name", "last_name"))
+        )
+        has_name = or_(
+            func.trim(func.coalesce(col(Humans.first_name), "")) != "",
+            func.trim(func.coalesce(col(Humans.last_name), "")) != "",
+        )
+
+        base_statement = (
+            select(Humans)
+            .join(Attendees, Attendees.human_id == Humans.id)  # type: ignore[arg-type]
+            .join(Applications, Attendees.application_id == Applications.id)  # type: ignore[arg-type]
+            .join(
+                AttendeeCategories,
+                Attendees.category_id == AttendeeCategories.id,  # type: ignore[arg-type]
+            )
+            .where(Attendees.popup_id == popup_id)
+            .where(Applications.status == ApplicationStatus.ACCEPTED.value)
+            .where(has_products)
+            .where(col(AttendeeCategories.key).in_(DIRECTORY_VISIBLE_CATEGORY_KEYS))
+            .where(~hides_name)
+            .where(has_name)
+        )
+
+        if q:
+            search_term = f"%{q}%"
+            base_statement = base_statement.where(
+                or_(
+                    col(Humans.first_name).ilike(search_term),
+                    col(Humans.last_name).ilike(search_term),
+                )
+            )
+
+        distinct_statement = base_statement.distinct()
+        count_statement = select(func.count()).select_from(
+            distinct_statement.subquery()
+        )
+        total = session.exec(count_statement).one()
+
+        results = list(session.exec(distinct_statement.offset(skip).limit(limit)).all())
+        return results, total
+
+    def human_ids_hiding_name(
+        self,
+        session: Session,
+        popup_id: uuid.UUID,
+        human_ids: list[uuid.UUID],
+    ) -> set[uuid.UUID]:
+        """Return the subset of ``human_ids`` who hid their name for ``popup_id``.
+
+        A human hides their name when their Application for the popup lists
+        "first_name" or "last_name" in ``info_not_shared``. Used to drop those
+        people from portal-facing participant/RSVP lists.
+        """
+        if not human_ids:
+            return set()
+
+        hides_name = col(Applications.info_not_shared).op("&&")(
+            postgresql.array(("first_name", "last_name"))
+        )
+        statement = (
+            select(Applications.human_id)
+            .where(Applications.popup_id == popup_id)
+            .where(col(Applications.human_id).in_(human_ids))
+            .where(hides_name)
+        )
+        return set(session.exec(statement).all())
 
     def create_internal(
         self,

--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -212,6 +212,9 @@ async def list_portal_participants(
     occurrence; otherwise return every participant row of the event (used
     by the admin/owner participants section that wants the full picture).
     """
+    from app.api.application.crud import applications_crud
+    from app.api.event.crud import events_crud
+
     participants, total = crud.event_participants_crud.find_by_event(
         db,
         event_id=event_id,
@@ -220,6 +223,22 @@ async def list_portal_participants(
         occurrence_start=occurrence_start,
         scope_to_occurrence=occurrence_start is not None,
     )
+
+    # Privacy: drop participants who hid their name (info_not_shared) on their
+    # application for this event's popup. Excluding (not masking) keeps the RSVP
+    # list from leaking a name the attendee chose to hide.
+    event = events_crud.get(db, event_id)
+    if event is not None and participants:
+        hidden = applications_crud.human_ids_hiding_name(
+            db,
+            event.popup_id,
+            [p.profile_id for p in participants],
+        )
+        if hidden:
+            dropped = sum(1 for p in participants if p.profile_id in hidden)
+            participants = [p for p in participants if p.profile_id not in hidden]
+            total = max(total - dropped, len(participants))
+
     return ListModel[EventParticipantPublic](
         results=_participants_with_names(db, participants),
         paging=Paging(offset=skip, limit=limit, total=total),

--- a/backend/app/api/human/crud.py
+++ b/backend/app/api/human/crud.py
@@ -214,41 +214,6 @@ class HumansCRUD(BaseCRUD[Humans, HumanCreate, HumanUpdate]):
         results = list(session.exec(statement.offset(skip).limit(limit)).all())
         return results, total
 
-    def search_named(
-        self,
-        session: Session,
-        *,
-        skip: int = 0,
-        limit: int = 100,
-        search: str | None = None,
-    ) -> tuple[list[Humans], int]:
-        """Search humans that have a usable display name.
-
-        Powers the portal participant picker. Humans with neither a first nor
-        a last name are excluded so the picker never falls back to rendering a
-        raw UUID prefix.
-        """
-        has_name = or_(
-            func.trim(func.coalesce(col(Humans.first_name), "")) != "",
-            func.trim(func.coalesce(col(Humans.last_name), "")) != "",
-        )
-        statement = select(Humans).where(has_name)
-
-        if search:
-            search_term = f"%{search}%"
-            statement = statement.where(
-                or_(
-                    col(Humans.first_name).ilike(search_term),
-                    col(Humans.last_name).ilike(search_term),
-                )
-            )
-
-        count_statement = select(func.count()).select_from(statement.subquery())
-        total = session.exec(count_statement).one()
-
-        results = list(session.exec(statement.offset(skip).limit(limit)).all())
-        return results, total
-
     def get_profile_stats(
         self, session: Session, human_id: uuid.UUID
     ) -> HumanProfileStats:

--- a/backend/app/api/human/router.py
+++ b/backend/app/api/human/router.py
@@ -175,22 +175,27 @@ async def update_current_human(
 async def search_humans_portal(
     db: HumanTenantSession,
     _: CurrentHuman,
+    popup_id: uuid.UUID,
     search: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 20,
 ) -> ListModel[HumanPortalPublic]:
-    """Search humans in the current tenant for portal pickers.
+    """Search a popup's attendees who share their name, for portal pickers.
 
     Used by the event-creation Displayed-host field to let a creator pick a
-    participant by name. RLS already scopes to the caller's tenant via
-    HumanTenantSession; the slim response schema omits email so this isn't
-    a wider exposure than the participant lists portal users can already see.
+    host. Scoped to humans who actually attend ``popup_id`` (accepted
+    application with a ticket-holding main/spouse attendee) AND who have not
+    hidden their name via ``info_not_shared`` for that popup. RLS scopes to the
+    caller's tenant; the slim response schema omits email.
     """
-    humans, total = crud.search_named(
+    from app.api.application.crud import applications_crud
+
+    humans, total = applications_crud.find_directory_humans(
         db,
+        popup_id=popup_id,
+        q=search,
         skip=skip,
         limit=limit,
-        search=search,
     )
     return ListModel[HumanPortalPublic](
         results=[HumanPortalPublic.model_validate(h) for h in humans],

--- a/backend/tests/api/application/test_directory_humans_privacy.py
+++ b/backend/tests/api/application/test_directory_humans_privacy.py
@@ -1,0 +1,334 @@
+"""Privacy tests for popup-scoped host picker + RSVP name hiding.
+
+Covers the privacy fix that:
+
+- Scopes the portal host picker (``find_directory_humans``) to a popup's
+  accepted attendees who share their name, EXCLUDING anyone who put
+  "first_name"/"last_name" in ``info_not_shared`` and anyone who is not an
+  accepted ticket-holding attendee of that popup.
+- Excludes (does not mask) RSVP participants who hid their name for the event's
+  popup, via ``human_ids_hiding_name``.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlmodel import Session
+
+from app.api.application.crud import applications_crud
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import AttendeeProducts, Attendees
+from app.api.attendee_category.models import AttendeeCategories
+from app.api.event.models import Events
+from app.api.event.schemas import EventStatus
+from app.api.event_participant.models import EventParticipants
+from app.api.event_participant.schemas import ParticipantStatus
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.tenant.models import Tenants
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror tests/api/application/test_attendee_directory.py)
+# ---------------------------------------------------------------------------
+
+
+def _popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        name="Host Picker Popup",
+        slug=f"host-popup-{uuid.uuid4().hex[:8]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _category(
+    db: Session, popup: Popups, key: str, *, is_primary: bool
+) -> AttendeeCategories:
+    cat = AttendeeCategories(
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        key=key,
+        label=key.capitalize(),
+        is_primary=is_primary,
+        enabled_in_passes_flow=True,
+    )
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+def _human(db: Session, tenant: Tenants, first: str, last: str, **extra) -> Humans:
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        email=f"{first.lower()}-{uuid.uuid4().hex[:6]}@test.com",
+        first_name=first,
+        last_name=last,
+        **extra,
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _product(db: Session, popup: Popups, name: str = "GA") -> Products:
+    product = Products(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        name=name,
+        slug=f"prod-{uuid.uuid4().hex[:6]}",
+        price=Decimal("100.00"),
+        category="ticket",
+        is_active=True,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _application(
+    db: Session,
+    popup: Popups,
+    human: Humans,
+    *,
+    status: str = ApplicationStatus.ACCEPTED.value,
+    info_not_shared: list[str] | None = None,
+) -> Applications:
+    app = Applications(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=status,
+        info_not_shared=info_not_shared or [],
+    )
+    db.add(app)
+    db.commit()
+    db.refresh(app)
+    return app
+
+
+def _attendee(
+    db: Session,
+    popup: Popups,
+    app: Applications,
+    human: Humans,
+    category: AttendeeCategories,
+    *,
+    tickets: int = 1,
+    product: Products | None = None,
+) -> Attendees:
+    attendee = Attendees(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        application_id=app.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        name=f"{human.first_name} {human.last_name}",
+        category_id=category.id,
+        email=human.email,
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+    if tickets:
+        prod = product or _product(db, popup)
+        for _ in range(tickets):
+            db.add(
+                AttendeeProducts(
+                    id=uuid.uuid4(),
+                    tenant_id=popup.tenant_id,
+                    attendee_id=attendee.id,
+                    product_id=prod.id,
+                    check_in_code=uuid.uuid4().hex[:10].upper(),
+                )
+            )
+        db.commit()
+        db.refresh(attendee)
+    return attendee
+
+
+# ---------------------------------------------------------------------------
+# find_directory_humans — host picker
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def picker_world(db: Session, tenant_a: Tenants):
+    """A popup with: a name-sharing attendee, a name-hiding attendee, and a
+    non-attendee human in the same tenant."""
+    popup = _popup(db, tenant_a)
+    main = _category(db, popup, "main", is_primary=True)
+
+    sharer = _human(db, tenant_a, "Shara", "Sharer")
+    sharer_app = _application(db, popup, sharer)
+    _attendee(db, popup, sharer_app, sharer, main, tickets=1)
+
+    hider = _human(db, tenant_a, "Hilda", "Hider")
+    hider_app = _application(db, popup, hider, info_not_shared=["first_name"])
+    _attendee(db, popup, hider_app, hider, main, tickets=1)
+
+    # Same tenant, but never applied to this popup → not an attendee.
+    outsider = _human(db, tenant_a, "Otto", "Outsider")
+
+    return {
+        "popup": popup,
+        "sharer": sharer,
+        "hider": hider,
+        "outsider": outsider,
+    }
+
+
+def test_picker_returns_name_sharing_attendee(db: Session, picker_world) -> None:
+    results, total = applications_crud.find_directory_humans(
+        db, popup_id=picker_world["popup"].id
+    )
+    ids = {h.id for h in results}
+    assert picker_world["sharer"].id in ids
+    assert total >= 1
+
+
+def test_picker_excludes_name_hiding_attendee(db: Session, picker_world) -> None:
+    results, _ = applications_crud.find_directory_humans(
+        db, popup_id=picker_world["popup"].id
+    )
+    ids = {h.id for h in results}
+    assert picker_world["hider"].id not in ids
+
+
+def test_picker_excludes_non_attendee(db: Session, picker_world) -> None:
+    results, _ = applications_crud.find_directory_humans(
+        db, popup_id=picker_world["popup"].id
+    )
+    ids = {h.id for h in results}
+    assert picker_world["outsider"].id not in ids
+
+
+def test_picker_excludes_last_name_hider(db: Session, tenant_a: Tenants) -> None:
+    """Hiding only last_name also excludes the human from the picker."""
+    popup = _popup(db, tenant_a)
+    main = _category(db, popup, "main", is_primary=True)
+    human = _human(db, tenant_a, "Lara", "Lastless")
+    app = _application(db, popup, human, info_not_shared=["last_name"])
+    _attendee(db, popup, app, human, main, tickets=1)
+
+    results, total = applications_crud.find_directory_humans(db, popup_id=popup.id)
+    assert total == 0
+    assert results == []
+
+
+def test_picker_search_filters_by_name(db: Session, picker_world) -> None:
+    results, total = applications_crud.find_directory_humans(
+        db, popup_id=picker_world["popup"].id, q="Sharer"
+    )
+    assert total == 1
+    assert results[0].id == picker_world["sharer"].id
+
+
+# ---------------------------------------------------------------------------
+# human_ids_hiding_name — RSVP exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_human_ids_hiding_name_returns_only_hiders(
+    db: Session, tenant_a: Tenants
+) -> None:
+    popup = _popup(db, tenant_a)
+    sharer = _human(db, tenant_a, "Sam", "Shares")
+    hider = _human(db, tenant_a, "Hank", "Hides")
+    _application(db, popup, sharer)
+    _application(db, popup, hider, info_not_shared=["last_name", "telegram"])
+
+    result = applications_crud.human_ids_hiding_name(
+        db, popup.id, [sharer.id, hider.id]
+    )
+    assert result == {hider.id}
+
+
+def test_human_ids_hiding_name_empty_input(db: Session, tenant_a: Tenants) -> None:
+    popup = _popup(db, tenant_a)
+    assert applications_crud.human_ids_hiding_name(db, popup.id, []) == set()
+
+
+# ---------------------------------------------------------------------------
+# list_portal_participants — RSVP list excludes name hiders
+# ---------------------------------------------------------------------------
+
+
+def _event(db: Session, popup: Popups, owner: Humans) -> Events:
+    now = datetime.now(UTC)
+    event = Events(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        owner_id=owner.id,
+        title="Test Event",
+        start_time=now + timedelta(days=1),
+        end_time=now + timedelta(days=1, hours=1),
+        status=EventStatus.PUBLISHED,
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def _participant(db: Session, event: Events, human: Humans) -> EventParticipants:
+    p = EventParticipants(
+        id=uuid.uuid4(),
+        tenant_id=event.tenant_id,
+        event_id=event.id,
+        profile_id=human.id,
+        status=ParticipantStatus.REGISTERED,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def test_portal_participants_excludes_name_hiders(
+    db: Session, tenant_a: Tenants
+) -> None:
+    """The portal RSVP list drops a participant who hid their name for the popup
+    and keeps one who did not. Mirrors the router's filtering logic.
+    """
+    from app.api.event.crud import events_crud
+    from app.api.event_participant.crud import event_participants_crud
+    from app.api.event_participant.router import _participants_with_names
+
+    popup = _popup(db, tenant_a)
+    sharer = _human(db, tenant_a, "Vera", "Visible")
+    hider = _human(db, tenant_a, "Ivy", "Invisible")
+    owner = _human(db, tenant_a, "Olga", "Owner")
+
+    _application(db, popup, sharer)
+    _application(db, popup, hider, info_not_shared=["first_name"])
+
+    event = _event(db, popup, owner)
+    _participant(db, event, sharer)
+    _participant(db, event, hider)
+
+    participants, _ = event_participants_crud.find_by_event(db, event_id=event.id)
+
+    resolved_event = events_crud.get(db, event.id)
+    hidden = applications_crud.human_ids_hiding_name(
+        db, resolved_event.popup_id, [p.profile_id for p in participants]
+    )
+    participants = [p for p in participants if p.profile_id not in hidden]
+
+    out = _participants_with_names(db, participants)
+    profile_ids = {p.profile_id for p in out}
+    assert sharer.id in profile_ids
+    assert hider.id not in profile_ids

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -5151,24 +5151,27 @@ export class HumansService {
     
     /**
      * Search participants directory
-     * Search humans in the current tenant for portal pickers.
+     * Search a popup's attendees who share their name, for portal pickers.
      *
      * Used by the event-creation Displayed-host field to let a creator pick a
-     * participant by name. RLS already scopes to the caller's tenant via
-     * HumanTenantSession; the slim response schema omits email so this isn't
-     * a wider exposure than the participant lists portal users can already see.
+     * host. Scoped to humans who actually attend ``popup_id`` (accepted
+     * application with a ticket-holding main/spouse attendee) AND who have not
+     * hidden their name via ``info_not_shared`` for that popup. RLS scopes to the
+     * caller's tenant; the slim response schema omits email.
      * @param data The data for the request.
+     * @param data.popupId
      * @param data.search
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_HumanPortalPublic_ Successful Response
      * @throws ApiError
      */
-    public static searchHumansPortal(data: HumansSearchHumansPortalData = {}): CancelablePromise<HumansSearchHumansPortalResponse> {
+    public static searchHumansPortal(data: HumansSearchHumansPortalData): CancelablePromise<HumansSearchHumansPortalResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/humans/portal/search',
             query: {
+                popup_id: data.popupId,
                 search: data.search,
                 skip: data.skip,
                 limit: data.limit

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -5326,6 +5326,7 @@ export type HumansSearchHumansPortalData = {
      * Maximum number of items to return
      */
     limit?: number;
+    popupId: string;
     search?: (string | null);
     /**
      * Number of items to skip

--- a/portal/src/app/portal/[popupSlug]/events/components/HostDisplayField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/HostDisplayField.tsx
@@ -57,13 +57,14 @@ export function HostDisplayField({
   const trimmedSearch = debouncedSearch.trim()
 
   const { data: results, isFetching } = useQuery({
-    queryKey: ["host-picker-humans", trimmedSearch],
+    queryKey: ["host-picker-humans", popupId, trimmedSearch],
     queryFn: () =>
       HumansService.searchHumansPortal({
+        popupId: popupId as string,
         search: trimmedSearch || null,
         limit: 10,
       }),
-    enabled: pickerOpen,
+    enabled: pickerOpen && !!popupId,
   })
 
   return (

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -3042,6 +3042,17 @@ export const AttendeesDirectoryEntrySchema = {
             ],
             title: 'Picture Url'
         },
+        category: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Category'
+        },
         participation: {
             items: {
                 '$ref': '#/components/schemas/DirectoryProduct'
@@ -3062,7 +3073,10 @@ export const AttendeesDirectoryEntrySchema = {
     type: 'object',
     required: ['id'],
     title: 'AttendeesDirectoryEntry',
-    description: 'Single entry in the attendees directory.'
+    description: `Single entry in the attendees directory.
+
+The directory is attendee-centric: one entry per ticket-holding attendee
+(any category), sourced from that attendee's own human record.`
 } as const;
 
 export const AuditLogPublicSchema = {
@@ -15464,6 +15478,10 @@ export const TaskCreateSchema = {
             '$ref': '#/components/schemas/TaskType',
             default: 'feature'
         },
+        priority: {
+            '$ref': '#/components/schemas/TaskPriority',
+            default: 'medium'
+        },
         responsible_user_id: {
             anyOf: [
                 {
@@ -15537,6 +15555,10 @@ export const TaskDetailPublicSchema = {
         },
         type: {
             '$ref': '#/components/schemas/TaskType'
+        },
+        priority: {
+            '$ref': '#/components/schemas/TaskPriority',
+            default: 'medium'
         },
         responsible_user_id: {
             anyOf: [
@@ -15662,6 +15684,12 @@ export const TaskMediaTypeSchema = {
     title: 'TaskMediaType'
 } as const;
 
+export const TaskPrioritySchema = {
+    type: 'string',
+    enum: ['low', 'medium', 'high'],
+    title: 'TaskPriority'
+} as const;
+
 export const TaskPublicSchema = {
     properties: {
         id: {
@@ -15689,6 +15717,10 @@ export const TaskPublicSchema = {
         },
         type: {
             '$ref': '#/components/schemas/TaskType'
+        },
+        priority: {
+            '$ref': '#/components/schemas/TaskPriority',
+            default: 'medium'
         },
         responsible_user_id: {
             anyOf: [
@@ -15865,6 +15897,16 @@ export const TaskUpdateSchema = {
             anyOf: [
                 {
                     '$ref': '#/components/schemas/TaskType'
+                },
+                {
+                    type: 'null'
+                }
+            ]
+        },
+        priority: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/TaskPriority'
                 },
                 {
                     type: 'null'

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -5151,24 +5151,27 @@ export class HumansService {
     
     /**
      * Search participants directory
-     * Search humans in the current tenant for portal pickers.
+     * Search a popup's attendees who share their name, for portal pickers.
      *
      * Used by the event-creation Displayed-host field to let a creator pick a
-     * participant by name. RLS already scopes to the caller's tenant via
-     * HumanTenantSession; the slim response schema omits email so this isn't
-     * a wider exposure than the participant lists portal users can already see.
+     * host. Scoped to humans who actually attend ``popup_id`` (accepted
+     * application with a ticket-holding main/spouse attendee) AND who have not
+     * hidden their name via ``info_not_shared`` for that popup. RLS scopes to the
+     * caller's tenant; the slim response schema omits email.
      * @param data The data for the request.
+     * @param data.popupId
      * @param data.search
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_HumanPortalPublic_ Successful Response
      * @throws ApiError
      */
-    public static searchHumansPortal(data: HumansSearchHumansPortalData = {}): CancelablePromise<HumansSearchHumansPortalResponse> {
+    public static searchHumansPortal(data: HumansSearchHumansPortalData): CancelablePromise<HumansSearchHumansPortalResponse> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/humans/portal/search',
             query: {
+                popup_id: data.popupId,
                 search: data.search,
                 skip: data.skip,
                 limit: data.limit
@@ -6367,9 +6370,11 @@ export class TasksService {
      * Report Bug
      * File a bug report (any authenticated backoffice user).
      *
-     * Always creates an internal bug in the to-do column, attributed to the
-     * reporter. Optional attachments are screenshots / screen-recordings already
-     * uploaded to S3 via POST /uploads/presigned-url.
+     * Creates a to-do bug attributed to the reporter, scoped to the reporter's
+     * tenant (``visibility='tenant'``) so that tenant's users can see it. A
+     * superadmin reporter (no tenant) falls back to an ``internal`` bug. Optional
+     * attachments are screenshots / screen-recordings already uploaded to S3 via
+     * POST /uploads/presigned-url.
      * @param data The data for the request.
      * @param data.requestBody
      * @returns TaskPublic Successful Response
@@ -6389,7 +6394,7 @@ export class TasksService {
     
     /**
      * List Tasks
-     * List tasks with optional filters (superadmin only).
+     * List tasks the current user may see (filtered by visibility).
      * @param data The data for the request.
      * @param data.status
      * @param data.type
@@ -6444,7 +6449,7 @@ export class TasksService {
     
     /**
      * Get Task
-     * Get a single task with its attachments (superadmin only).
+     * Get a single task with its attachments (visible to the user).
      * @param data The data for the request.
      * @param data.taskId
      * @returns TaskDetailPublic Successful Response
@@ -6583,7 +6588,7 @@ export class TasksService {
     
     /**
      * List Task Comments
-     * List a task's comments, oldest first (superadmin only).
+     * List a task's comments, oldest first (any user who can view the task).
      * @param data The data for the request.
      * @param data.taskId
      * @returns ListModel_TaskCommentPublic_ Successful Response
@@ -6604,7 +6609,7 @@ export class TasksService {
     
     /**
      * Create Task Comment
-     * Add a comment to a task (superadmin only).
+     * Add a comment to a task (any user who can view the task).
      * @param data The data for the request.
      * @param data.taskId
      * @param data.requestBody
@@ -6628,7 +6633,7 @@ export class TasksService {
     
     /**
      * Update Task Comment
-     * Edit your own comment (superadmin only).
+     * Edit your own comment (any user who can view the task).
      * @param data The data for the request.
      * @param data.taskId
      * @param data.commentId
@@ -6654,7 +6659,7 @@ export class TasksService {
     
     /**
      * Delete Task Comment
-     * Soft-delete a comment (superadmin only). The row is preserved.
+     * Soft-delete a comment: the author, or any superadmin. Row is preserved.
      * @param data The data for the request.
      * @param data.taskId
      * @param data.commentId

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -554,6 +554,9 @@ export type AttendeePurchases = {
 
 /**
  * Single entry in the attendees directory.
+ *
+ * The directory is attendee-centric: one entry per ticket-holding attendee
+ * (any category), sourced from that attendee's own human record.
  */
 export type AttendeesDirectoryEntry = {
     id: string;
@@ -567,6 +570,7 @@ export type AttendeesDirectoryEntry = {
     age?: (string | null);
     gender?: (string | null);
     picture_url?: (string | null);
+    category?: (string | null);
     participation?: Array<DirectoryProduct>;
     associated_attendees?: Array<AssociatedAttendee>;
 };
@@ -3119,6 +3123,7 @@ export type TaskCreate = {
     detail?: (string | null);
     status?: TaskStatus;
     type?: TaskType;
+    priority?: TaskPriority;
     responsible_user_id?: (string | null);
     release?: (string | null);
     visibility?: TaskVisibility;
@@ -3131,6 +3136,7 @@ export type TaskDetailPublic = {
     detail?: (string | null);
     status: TaskStatus;
     type: TaskType;
+    priority?: TaskPriority;
     responsible_user_id?: (string | null);
     responsible_name?: (string | null);
     responsible_email?: (string | null);
@@ -3147,12 +3153,15 @@ export type TaskDetailPublic = {
 
 export type TaskMediaType = 'image' | 'video';
 
+export type TaskPriority = 'low' | 'medium' | 'high';
+
 export type TaskPublic = {
     id: string;
     title: string;
     detail?: (string | null);
     status: TaskStatus;
     type: TaskType;
+    priority?: TaskPriority;
     responsible_user_id?: (string | null);
     responsible_name?: (string | null);
     responsible_email?: (string | null);
@@ -3182,6 +3191,7 @@ export type TaskUpdate = {
     detail?: (string | null);
     status?: (TaskStatus | null);
     type?: (TaskType | null);
+    priority?: (TaskPriority | null);
     responsible_user_id?: (string | null);
     release?: (string | null);
     visibility?: (TaskVisibility | null);
@@ -5316,6 +5326,7 @@ export type HumansSearchHumansPortalData = {
      * Maximum number of items to return
      */
     limit?: number;
+    popupId: string;
     search?: (string | null);
     /**
      * Number of items to skip


### PR DESCRIPTION
## Privacy fix (calendar)
The participant search and the event RSVP list returned attendee names ignoring `application.info_not_shared` — the same preference the attendee directory respects. The host picker also searched ALL tenant humans, not just people attending the popup.

- `GET /humans/portal/search` now **requires `popup_id`** and returns only the popup's directory population (accepted application + ticket-holding main/spouse attendee) who have **not hidden their name**. Backed by `ApplicationsCRUD.find_directory_humans` (reuses the directory definition; via CRUD, no inline router queries).
- `list_portal_participants` **excludes** RSVPers who hid their name for the popup (not masked).
- Portal `HostDisplayField` passes `popup_id`; OpenAPI clients regenerated. Dropped now-unused `HumansCRUD.search_named`.

Tests: 8 new privacy tests + suite green. Found in a calendar audit.