### PR TITLE
fix(events): correct portal pagination totals; restrict admin-notes writes

### DIFF
--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -40,6 +40,7 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
         tags: list[str] | None = None,
         search: str | None = None,
         visibility: EventVisibility | None = None,
+        exclude_visibility: list[EventVisibility] | None = None,
         exclude_statuses: list[EventStatus] | None = None,
         expand_occurrences: bool | None = None,
     ) -> tuple[list[Events], int]:
@@ -58,6 +59,10 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
             statement = statement.where(col(Events.status).not_in(exclude_statuses))
         if visibility is not None:
             statement = statement.where(Events.visibility == visibility)
+        if exclude_visibility:
+            statement = statement.where(
+                col(Events.visibility).not_in(exclude_visibility)
+            )
         if kind is not None:
             statement = statement.where(Events.kind == kind)
         if venue_id is not None:

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -935,10 +935,10 @@ async def get_event_admin_notes(
 async def update_event_admin_notes(
     event_id: uuid.UUID,
     payload: EventAdminNotes,
-    db: TenantSession,
-    _: CurrentUser,
+    db: AdminOrApiKeySession_EventsWrite,
+    _: AdminOrApiKey_EventsWrite,
 ) -> EventAdminNotes:
-    """Set an event's staff-only notes (any backoffice user)."""
+    """Set an event's staff-only notes (requires events write access)."""
     event = crud.events_crud.get(db, event_id)
     if not event:
         raise HTTPException(

--- a/backend/app/api/event_venue/crud.py
+++ b/backend/app/api/event_venue/crud.py
@@ -5,7 +5,11 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, func, or_, select
 
 from app.api.event_venue.models import EventVenues
-from app.api.event_venue.schemas import EventVenueCreate, EventVenueUpdate
+from app.api.event_venue.schemas import (
+    EventVenueCreate,
+    EventVenueUpdate,
+    VenueStatus,
+)
 from app.api.shared.crud import BaseCRUD
 
 
@@ -31,8 +35,12 @@ class EventVenuesCRUD(BaseCRUD[EventVenues, EventVenueCreate, EventVenueUpdate])
         skip: int = 0,
         limit: int = 100,
         search: str | None = None,
+        active_only: bool = False,
     ) -> tuple[list[EventVenues], int]:
         statement = select(EventVenues).where(EventVenues.popup_id == popup_id)
+
+        if active_only:
+            statement = statement.where(EventVenues.status == VenueStatus.ACTIVE.value)
 
         if search:
             term = f"%{search}%"

--- a/backend/app/api/event_venue/router.py
+++ b/backend/app/api/event_venue/router.py
@@ -744,18 +744,19 @@ async def list_portal_venues(
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[EventVenuePublic]:
+    # Hide pending venues from portal listings. Filtering in the query (not in
+    # Python) keeps the paging total correct.
     venues, total = crud.event_venues_crud.find_by_popup(
         db,
         popup_id=popup_id,
         skip=skip,
         limit=limit,
         search=search,
+        active_only=True,
     )
-    # Hide pending venues from portal listings.
-    venues = [v for v in venues if v.status == VenueStatus.ACTIVE]
     return ListModel[EventVenuePublic](
         results=[EventVenuePublic.model_validate(v) for v in venues],
-        paging=Paging(offset=skip, limit=limit, total=len(venues)),
+        paging=Paging(offset=skip, limit=limit, total=total),
     )
 
 

--- a/backend/app/api/track/router.py
+++ b/backend/app/api/track/router.py
@@ -222,18 +222,19 @@ async def list_portal_track_events(
             status_code=status.HTTP_404_NOT_FOUND, detail="Track not found"
         )
 
+    # Track views are public — hide private events only. Unlisted events are
+    # visible in the track view because the track itself acts as a soft share.
+    # Filtering in the query (not in Python) keeps the paging total correct.
     events, total = events_crud.find_by_popup(
         db,
         popup_id=track.popup_id,
         track_ids=[track_id],
         event_status=EventStatus.PUBLISHED,
+        exclude_visibility=[EventVisibility.PRIVATE],
         skip=skip,
         limit=limit,
     )
-    # Track views are public — hide private events only. Unlisted events are
-    # visible in the track view because the track itself acts as a soft share.
-    events = [e for e in events if e.visibility != EventVisibility.PRIVATE]
     return ListModel[EventPublic](
         results=[EventPublic.model_validate(e) for e in events],
-        paging=Paging(offset=skip, limit=limit, total=len(events)),
+        paging=Paging(offset=skip, limit=limit, total=total),
     )

--- a/backend/tests/test_event_admin_notes.py
+++ b/backend/tests/test_event_admin_notes.py
@@ -116,6 +116,31 @@ def test_backoffice_operator_can_read_and_write_notes(
     assert again.json()["notes"] == "internal note"
 
 
+def test_viewer_can_read_but_not_write_admin_notes(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+    viewer_token_tenant_a: str,
+) -> None:
+    # A VIEWER may read staff notes but must NOT be able to write them: the
+    # PUT requires events-write access (operator/admin), not any logged-in user.
+    popup = _make_popup(db, tenant_a)
+    ev = _make_event(db, tenant_a, popup)
+
+    read = client.get(
+        f"/api/v1/events/{ev.id}/admin-notes",
+        headers=_auth(viewer_token_tenant_a),
+    )
+    assert read.status_code == 200, read.text
+
+    blocked = client.put(
+        f"/api/v1/events/{ev.id}/admin-notes",
+        headers=_auth(viewer_token_tenant_a),
+        json={"notes": "should be blocked"},
+    )
+    assert blocked.status_code == 403, blocked.text
+
+
 def test_admin_notes_never_appear_in_event_payload(
     client: TestClient,
     db: Session,


### PR DESCRIPTION
## Correctness fixes (calendar audit)
- **admin-notes auth**: `PUT /events/{id}/admin-notes` accepted any authenticated backoffice user, so a **VIEWER could write** staff notes. Now requires events-write access (operator/admin), matching create/update/approve. Regression test added (VIEWER reads ok, write → 403).
- **pagination totals**: `list_portal_venues` and `list_portal_track_events` filtered in Python after the DB page, so the paging `total` was the post-filter page length. Filters pushed into the query (`find_by_popup(active_only=...)` / `exclude_visibility=[PRIVATE]`) → correct totals.

Note: `list_portal_events` has the same issue but its filtering is entangled with recurrence expansion + per-user hidden events — deferred to the calendar refactor.