### PR TITLE
fix(portal): clamp pagination range and i18n controls; keep prev page data

### DIFF
--- a/portal/src/app/portal/[popupSlug]/attendees/hooks/useGetData.tsx
+++ b/portal/src/app/portal/[popupSlug]/attendees/hooks/useGetData.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 import { ApplicationsService } from "@/client"
 import { queryKeys } from "@/lib/query-keys"
@@ -47,6 +47,9 @@ const useGetData = () => {
       }
     },
     enabled: !!city?.id && attendeeDirectoryEnabled,
+    // Keep the previous page's data (including total) while the next page
+    // loads, so the page count never collapses to 0 mid-navigation.
+    placeholderData: keepPreviousData,
   })
 
   const handlePageChange = (page: number) => {

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -69,6 +69,7 @@ import {
 } from "../lib/useEventTimezone"
 
 function AdminNotesSection({ eventId }: { eventId: string }) {
+  const { t } = useTranslation()
   const queryClient = useQueryClient()
   const [value, setValue] = useState("")
   const [dirty, setDirty] = useState(false)
@@ -95,9 +96,9 @@ function AdminNotesSection({ eventId }: { eventId: string }) {
     onSuccess: (res) => {
       setDirty(false)
       queryClient.setQueryData(["portal-event-admin-notes", eventId], res)
-      toast.success("Notes saved")
+      toast.success(t("events.detail.admin_notes_saved_toast"))
     },
-    onError: () => toast.error("Could not save notes"),
+    onError: () => toast.error(t("events.detail.admin_notes_error_toast")),
   })
 
   if (!isSuccess) return null
@@ -106,15 +107,17 @@ function AdminNotesSection({ eventId }: { eventId: string }) {
     <div className="rounded-xl border bg-card p-4 space-y-3">
       <div className="flex items-center gap-2">
         <Lock className="h-4 w-4 text-muted-foreground" />
-        <h3 className="text-sm font-semibold">Admin notes</h3>
+        <h3 className="text-sm font-semibold">
+          {t("events.detail.admin_notes_heading")}
+        </h3>
         <span className="text-xs text-muted-foreground">
-          Internal — staff only
+          {t("events.detail.admin_notes_staff_only")}
         </span>
       </div>
       <Textarea
         value={value}
         rows={4}
-        placeholder="Notes about this event, visible only to backoffice staff…"
+        placeholder={t("events.detail.admin_notes_placeholder") as string}
         onChange={(e) => {
           setValue(e.target.value)
           setDirty(true)
@@ -126,7 +129,9 @@ function AdminNotesSection({ eventId }: { eventId: string }) {
           disabled={!dirty || saveMutation.isPending}
           onClick={() => saveMutation.mutate()}
         >
-          {saveMutation.isPending ? "Saving…" : "Save notes"}
+          {saveMutation.isPending
+            ? t("events.detail.admin_notes_saving_button")
+            : t("events.detail.admin_notes_save_button")}
         </Button>
       </div>
     </div>
@@ -684,7 +689,7 @@ export default function EventDetailPage() {
             </p>
             {timezone && (
               <p className="text-[11px] text-muted-foreground/80 mt-0.5">
-                — {t("events.common.in_timezone_time", { timezone })}
+                {t("events.common.in_timezone_time", { timezone })}
               </p>
             )}
           </div>
@@ -716,7 +721,7 @@ export default function EventDetailPage() {
               <Repeat className="h-4 w-4 text-blue-600" />
             </div>
             <p className="text-sm text-muted-foreground">
-              {summarizeRrule(event.rrule)}
+              {summarizeRrule(event.rrule, t)}
             </p>
           </div>
         )}

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { monthBoundsInTz } from "@edgeos/shared-events"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import {
   addDays,
   addMonths,
@@ -31,20 +31,14 @@ import {
 import Link from "next/link"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { toast } from "sonner"
 
-import {
-  ApiError,
-  EventParticipantsService,
-  type EventPublic,
-  EventsService,
-  HumansService,
-} from "@/client"
+import { type EventPublic, EventsService, HumansService } from "@/client"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { CoverImage } from "./CoverImage"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
+import { useEventRsvp } from "./useEventRsvp"
 import { useEventTimezone } from "./useEventTimezone"
 
 interface CalendarBodyProps {
@@ -116,7 +110,6 @@ export function CalendarBody({
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
   const { t } = useTranslation()
-  const queryClient = useQueryClient()
   const [currentMonth, setCurrentMonth] = useState(
     () => defaultDate ?? new Date(),
   )
@@ -190,53 +183,9 @@ export function CalendarBody({
     enabled: isAuthed && !useOverride && !!popupId && !tzLoading,
   })
 
-  // Recurring events require occurrence_start so the RSVP targets a single
-  // instance. That includes both expanded pseudo-rows (have occurrence_id)
-  // AND the series master itself, whose start_time IS the first occurrence.
-  // One-off events must not send it.
-  const rsvpBodyFor = (e: EventPublic) =>
-    e.rrule || e.occurrence_id ? { occurrence_start: e.start_time } : undefined
-  const toastRsvpError = (err: unknown) => {
-    const fallback = t("events.rsvp.action_error") as string
-    let detail = fallback
-    if (err instanceof ApiError && err.body && typeof err.body === "object") {
-      const body = err.body as { detail?: unknown }
-      if (typeof body.detail === "string") detail = body.detail
-    }
-    toast.error(detail)
-  }
-  const rsvpMutation = useMutation({
-    mutationFn: (e: EventPublic) =>
-      EventParticipantsService.registerForEvent({
-        eventId: e.id,
-        requestBody: rsvpBodyFor(e),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portal-events-calendar"] })
-    },
-    onError: toastRsvpError,
-  })
-  const cancelRsvpMutation = useMutation({
-    mutationFn: (e: EventPublic) =>
-      EventParticipantsService.cancelRegistration({
-        eventId: e.id,
-        requestBody: rsvpBodyFor(e),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portal-events-calendar"] })
-    },
-    onError: toastRsvpError,
-  })
-  // Tracks the in-flight RSVP target so we can pin the spinner to the
-  // specific event (and recurring occurrence) the user clicked instead
-  // of flipping every "Going" button on the day.
-  const pendingRsvpKey: string | null = (() => {
-    const pending =
-      (rsvpMutation.isPending && rsvpMutation.variables) ||
-      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
-      null
-    return pending ? `${pending.id}:${pending.start_time}` : null
-  })()
+  const { rsvpMutation, cancelRsvpMutation, pendingRsvpKey } = useEventRsvp([
+    "portal-events-calendar",
+  ])
 
   const events = useOverride ? (eventsOverride ?? []) : (data?.results ?? [])
 
@@ -409,7 +358,7 @@ export function CalendarBody({
               <div className="space-y-2">
                 {selectedEvents.map((event) => {
                   const recurrenceLabel =
-                    summarizeRrule(event.rrule) ??
+                    summarizeRrule(event.rrule, t) ??
                     (event.recurrence_master_id
                       ? t("events.list.part_of_recurring_series")
                       : null)

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { addDays, startOfDay, subDays } from "date-fns"
 import {
   CalendarClock,
@@ -21,11 +21,8 @@ import {
 import Link from "next/link"
 import { Fragment, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { toast } from "sonner"
 
 import {
-  ApiError,
-  EventParticipantsService,
   type EventPublic,
   EventsService,
   EventVenuesService,
@@ -41,6 +38,7 @@ import {
 import { cn } from "@/lib/utils"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
+import { useEventRsvp } from "./useEventRsvp"
 import { useEventTimezone } from "./useEventTimezone"
 
 interface DayBodyProps {
@@ -154,7 +152,6 @@ export function DayBody({
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
   const { t } = useTranslation()
-  const queryClient = useQueryClient()
   // Fall back to the popup's first booking day (or today, before the
   // popup record loads) when the parent hasn't set a date yet — no
   // `?date=` in the URL on first visit.
@@ -255,52 +252,9 @@ export function DayBody({
   // (public calendar) the tz is known synchronously, so this stays false.
   const isLoading = useOverride ? false : eventsLoading || tzLoading
 
-  // Recurring events require occurrence_start so the RSVP targets a single
-  // instance. That includes both expanded pseudo-rows (have occurrence_id)
-  // AND the series master itself, whose start_time IS the first occurrence.
-  // One-off events must not send it.
-  const rsvpBodyFor = (e: EventPublic) =>
-    e.rrule || e.occurrence_id ? { occurrence_start: e.start_time } : undefined
-  const toastRsvpError = (err: unknown) => {
-    const fallback = t("events.rsvp.action_error") as string
-    let detail = fallback
-    if (err instanceof ApiError && err.body && typeof err.body === "object") {
-      const body = err.body as { detail?: unknown }
-      if (typeof body.detail === "string") detail = body.detail
-    }
-    toast.error(detail)
-  }
-  const rsvpMutation = useMutation({
-    mutationFn: (e: EventPublic) =>
-      EventParticipantsService.registerForEvent({
-        eventId: e.id,
-        requestBody: rsvpBodyFor(e),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portal-events-day"] })
-    },
-    onError: toastRsvpError,
-  })
-  const cancelRsvpMutation = useMutation({
-    mutationFn: (e: EventPublic) =>
-      EventParticipantsService.cancelRegistration({
-        eventId: e.id,
-        requestBody: rsvpBodyFor(e),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portal-events-day"] })
-    },
-    onError: toastRsvpError,
-  })
-  // Tracks the in-flight RSVP target so the spinner stays on the
-  // specific event card (and recurring instance) the user clicked.
-  const pendingRsvpKey: string | null = (() => {
-    const pending =
-      (rsvpMutation.isPending && rsvpMutation.variables) ||
-      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
-      null
-    return pending ? `${pending.id}:${pending.start_time}` : null
-  })()
+  const { rsvpMutation, cancelRsvpMutation, pendingRsvpKey } = useEventRsvp([
+    "portal-events-day",
+  ])
 
   // "HH:MM" in the popup timezone (24h) -> minutes since 00:00.
   const minutesInTz = useMemo(() => {
@@ -701,7 +655,7 @@ export function DayBody({
                         const leftPct = laneIndex * widthPct
                         const isShort = endMin - startMin < 60
                         const recurrenceLabel =
-                          summarizeRrule(event.rrule) ??
+                          summarizeRrule(event.rrule, t) ??
                           (event.recurrence_master_id
                             ? t("events.list.part_of_recurring_series")
                             : null)

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -298,7 +298,7 @@ export function ListBody({
                               <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-0.5">
                                 <Repeat className="h-3 w-3" />
                                 <span className="truncate">
-                                  {summarizeRrule(event.rrule) ??
+                                  {summarizeRrule(event.rrule, t) ??
                                     t("events.list.part_of_recurring_series")}
                                 </span>
                               </div>

--- a/portal/src/app/portal/[popupSlug]/events/lib/summarizeRrule.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/summarizeRrule.ts
@@ -1,20 +1,16 @@
 /**
  * Render a human-readable summary of an RFC 5545 recurrence rule. Returns
  * null when the rule is missing or its FREQ is not understood.
+ *
+ * Requires an i18next `t` function so the output is translated according to
+ * the active locale. All strings are keyed under `events.recurrence.*`.
  */
 
-const WEEKDAY_LABELS: Record<string, string> = {
-  MO: "Monday",
-  TU: "Tuesday",
-  WE: "Wednesday",
-  TH: "Thursday",
-  FR: "Friday",
-  SA: "Saturday",
-  SU: "Sunday",
-}
+import type { TFunction } from "i18next"
 
 export function summarizeRrule(
   rrule: string | null | undefined,
+  t: TFunction,
 ): string | null {
   if (!rrule) return null
   const kv: Record<string, string> = {}
@@ -25,32 +21,36 @@ export function summarizeRrule(
   const interval = parseInt(kv.INTERVAL ?? "1", 10) || 1
   let base = ""
   if (kv.FREQ === "DAILY") {
-    base = interval === 1 ? "Repeats daily" : `Repeats every ${interval} days`
+    base = t("events.recurrence.daily", { count: interval })
   } else if (kv.FREQ === "WEEKLY") {
     const byDay = (kv.BYDAY ?? "")
       .split(",")
-      .map((c) => WEEKDAY_LABELS[c.toUpperCase()])
+      .map((c) => t(`events.recurrence.weekday_${c.toUpperCase()}`))
       .filter(Boolean)
-    const every = interval === 1 ? "weekly" : `every ${interval} weeks`
-    base =
-      byDay.length > 0
-        ? `Repeats ${every} on ${byDay.join(", ")}`
-        : `Repeats ${every}`
+    if (byDay.length > 0) {
+      base = t("events.recurrence.weekly_on", {
+        count: interval,
+        days: byDay.join(", "),
+      })
+    } else {
+      base = t("events.recurrence.weekly", { count: interval })
+    }
   } else if (kv.FREQ === "MONTHLY") {
-    base =
-      interval === 1 ? "Repeats monthly" : `Repeats every ${interval} months`
+    base = t("events.recurrence.monthly", { count: interval })
   } else {
     return null
   }
   if (kv.COUNT) {
-    base += `, for ${kv.COUNT} occurrences`
+    base += t("events.recurrence.count_suffix", {
+      count: parseInt(kv.COUNT, 10),
+    })
   } else if (kv.UNTIL) {
     const raw = kv.UNTIL.replace("Z", "")
     if (raw.length >= 8) {
       const y = raw.slice(0, 4)
       const m = raw.slice(4, 6)
       const d = raw.slice(6, 8)
-      base += `, until ${y}-${m}-${d}`
+      base += t("events.recurrence.until_suffix", { date: `${y}-${m}-${d}` })
     }
   }
   return base

--- a/portal/src/app/portal/[popupSlug]/events/lib/useEventRsvp.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/useEventRsvp.ts
@@ -1,0 +1,80 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
+import { toast } from "sonner"
+
+import { ApiError, EventParticipantsService, type EventPublic } from "@/client"
+
+/**
+ * Shared RSVP logic used by the list, calendar, and day-view event bodies.
+ *
+ * @param invalidateQueryKey - The React Query cache key to invalidate after a
+ *   successful register or cancel. Each view has its own key:
+ *   - list:     `["portal-events"]`
+ *   - calendar: `["portal-events-calendar"]`
+ *   - day:      `["portal-events-day"]`
+ */
+export function useEventRsvp(invalidateQueryKey: string[]) {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+
+  // Recurring events require occurrence_start so the RSVP targets a single
+  // instance. That includes both expanded pseudo-rows (have occurrence_id)
+  // AND the series master itself, whose start_time IS the first occurrence.
+  // One-off events must not send it.
+  const rsvpBodyFor = (e: EventPublic) =>
+    e.rrule || e.occurrence_id ? { occurrence_start: e.start_time } : undefined
+
+  const toastRsvpError = (err: unknown) => {
+    const fallback = t("events.rsvp.action_error") as string
+    let detail = fallback
+    if (err instanceof ApiError && err.body && typeof err.body === "object") {
+      const body = err.body as { detail?: unknown }
+      if (typeof body.detail === "string") detail = body.detail
+    }
+    toast.error(detail)
+  }
+
+  const rsvpMutation = useMutation({
+    mutationFn: (e: EventPublic) =>
+      EventParticipantsService.registerForEvent({
+        eventId: e.id,
+        requestBody: rsvpBodyFor(e),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: invalidateQueryKey })
+    },
+    onError: toastRsvpError,
+  })
+
+  const cancelRsvpMutation = useMutation({
+    mutationFn: (e: EventPublic) =>
+      EventParticipantsService.cancelRegistration({
+        eventId: e.id,
+        requestBody: rsvpBodyFor(e),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: invalidateQueryKey })
+    },
+    onError: toastRsvpError,
+  })
+
+  // The in-flight RSVP target in `${id}:${start_time}` format. Including the
+  // occurrence start keeps the spinner pinned to the specific recurring
+  // instance the user clicked rather than every row sharing the same event id.
+  const pendingRsvpKey: string | null = (() => {
+    const pending =
+      (rsvpMutation.isPending && rsvpMutation.variables) ||
+      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
+      null
+    return pending ? `${pending.id}:${pending.start_time}` : null
+  })()
+
+  return {
+    rsvpBodyFor,
+    rsvpMutation,
+    cancelRsvpMutation,
+    pendingRsvpKey,
+  }
+}

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -14,10 +14,7 @@ import {
 } from "react"
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
-import { toast } from "sonner"
 import {
-  ApiError,
-  EventParticipantsService,
   type EventPublic,
   EventsService,
   HumansService,
@@ -36,6 +33,7 @@ import {
 } from "./lib/eventsViewState"
 import { ListBody } from "./lib/ListBody"
 import { eventListWindowForPopup } from "./lib/listWindow"
+import { useEventRsvp } from "./lib/useEventRsvp"
 import {
   useEventTimezone,
   usePortalEventSettings,
@@ -433,55 +431,9 @@ export default function EventsPage() {
     staleTime: 30 * 1000,
   })
 
-  // Recurring events require occurrence_start so the RSVP targets a single
-  // instance. That includes both expanded pseudo-rows (have occurrence_id)
-  // AND the series master itself, whose start_time IS the first occurrence.
-  // One-off events must not send it.
-  const rsvpBodyFor = (e: EventPublic) =>
-    e.rrule || e.occurrence_id ? { occurrence_start: e.start_time } : undefined
-  const toastRsvpError = (err: unknown) => {
-    const fallback = t("events.rsvp.action_error") as string
-    let detail = fallback
-    if (err instanceof ApiError && err.body && typeof err.body === "object") {
-      const body = err.body as { detail?: unknown }
-      if (typeof body.detail === "string") detail = body.detail
-    }
-    toast.error(detail)
-  }
-  const rsvpMutation = useMutation({
-    mutationFn: (e: EventPublic) =>
-      EventParticipantsService.registerForEvent({
-        eventId: e.id,
-        requestBody: rsvpBodyFor(e),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portal-events"] })
-    },
-    onError: toastRsvpError,
-  })
-  const cancelRsvpMutation = useMutation({
-    mutationFn: (e: EventPublic) =>
-      EventParticipantsService.cancelRegistration({
-        eventId: e.id,
-        requestBody: rsvpBodyFor(e),
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["portal-events"] })
-    },
-    onError: toastRsvpError,
-  })
-  // The row whose RSVP request is currently in flight, in the
-  // `${id}:${start_time}` format ListBody matches against. Including the
-  // occurrence start in the key keeps the spinner pinned to the specific
-  // recurring instance the user clicked rather than every row sharing
-  // the same event id.
-  const pendingRsvpKey: string | null = (() => {
-    const pending =
-      (rsvpMutation.isPending && rsvpMutation.variables) ||
-      (cancelRsvpMutation.isPending && cancelRsvpMutation.variables) ||
-      null
-    return pending ? `${pending.id}:${pending.start_time}` : null
-  })()
+  const { rsvpMutation, cancelRsvpMutation, pendingRsvpKey } = useEventRsvp([
+    "portal-events",
+  ])
 
   const hideMutation = useMutation({
     mutationFn: (eventId: string) => EventsService.hidePortalEvent({ eventId }),

--- a/portal/src/components/common/Pagination.tsx
+++ b/portal/src/components/common/Pagination.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
 import { Button } from "../ui/button"
 
 interface PaginationProps {
@@ -12,25 +13,31 @@ const Pagination = ({
   totalPages,
   onPageChange,
 }: PaginationProps) => {
-  // Mostrar la paginación siempre, incluso con una sola página (para fines de demostración)
+  const { t } = useTranslation()
+
+  const goToPage = (page: number) => {
+    // Clamp to the valid range so navigation can never produce a page < 1,
+    // which would send a negative skip to the API and 422.
+    onPageChange(Math.min(Math.max(page, 1), Math.max(totalPages, 1)))
+  }
 
   return (
     <div className="flex justify-center items-center gap-2 mt-8 py-2">
       <Button
-        onClick={() => onPageChange(Math.max(currentPage - 1, 1))}
-        disabled={currentPage === 1}
+        onClick={() => goToPage(currentPage - 1)}
+        disabled={currentPage <= 1}
         variant="outline"
-        aria-label="Previous page"
+        aria-label={t("common.previous_page")}
       >
         <ChevronLeftIcon className="w-4 h-4" />
       </Button>
       <span className="text-sm font-medium px-2">
-        Page {currentPage}/{totalPages}
+        {t("common.page_of", { current: currentPage, total: totalPages })}
       </span>
       <Button
-        onClick={() => onPageChange(Math.min(currentPage + 1, totalPages))}
-        disabled={currentPage === totalPages}
-        aria-label="Next page"
+        onClick={() => goToPage(currentPage + 1)}
+        disabled={currentPage >= totalPages}
+        aria-label={t("common.next_page")}
         variant="outline"
       >
         <ChevronRightIcon className="w-4 h-4" />

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -502,7 +502,7 @@
     "list": {
       "heading": "Events",
       "subheading": "Upcoming events at {{cityName}}",
-      "subheading_with_tz": "Upcoming events at {{cityName}} — times shown in {{timezone}}",
+      "subheading_with_tz": "Upcoming events at {{cityName}}, times shown in {{timezone}}",
       "empty_state": "No events yet",
       "events_disabled_heading": "Events are disabled",
       "events_disabled_message": "The organizer has turned off events for {{cityName}}.",
@@ -591,6 +591,26 @@
       "checked_in": "Checked in",
       "action_error": "Couldn't update your RSVP. Please try again."
     },
+    "recurrence": {
+      "daily_one": "Repeats daily",
+      "daily_other": "Repeats every {{count}} days",
+      "weekly_one": "Repeats weekly",
+      "weekly_other": "Repeats every {{count}} weeks",
+      "weekly_on_one": "Repeats weekly on {{days}}",
+      "weekly_on_other": "Repeats every {{count}} weeks on {{days}}",
+      "monthly_one": "Repeats monthly",
+      "monthly_other": "Repeats every {{count}} months",
+      "count_suffix_one": ", for {{count}} occurrence",
+      "count_suffix_other": ", for {{count}} occurrences",
+      "until_suffix": ", until {{date}}",
+      "weekday_MO": "Monday",
+      "weekday_TU": "Tuesday",
+      "weekday_WE": "Wednesday",
+      "weekday_TH": "Thursday",
+      "weekday_FR": "Friday",
+      "weekday_SA": "Saturday",
+      "weekday_SU": "Sunday"
+    },
     "login_required": {
       "title": "Sign in to view this event",
       "message": "Event details are only visible to signed-in users. A ticket for {{popupName}} is required to participate.",
@@ -602,7 +622,7 @@
       "page_title": "{{popupName}} - Calendar",
       "page_title_fallback": "Calendar",
       "subheading": "Upcoming events at {{popupName}}",
-      "subheading_with_tz": "Upcoming events at {{popupName}} — times shown in {{timezone}}"
+      "subheading_with_tz": "Upcoming events at {{popupName}}, times shown in {{timezone}}"
     },
     "detail": {
       "event_not_found": "Event not found",
@@ -645,15 +665,22 @@
       "open_in_maps": "Open in Google Maps",
       "share_button": "Share event",
       "share_link_copied": "Link copied",
-      "share_link_error": "Couldn't copy link"
+      "share_link_error": "Couldn't copy link",
+      "admin_notes_heading": "Admin notes",
+      "admin_notes_staff_only": "Internal, staff only",
+      "admin_notes_placeholder": "Notes about this event, visible only to backoffice staff",
+      "admin_notes_save_button": "Save notes",
+      "admin_notes_saving_button": "Saving",
+      "admin_notes_saved_toast": "Notes saved",
+      "admin_notes_error_toast": "Could not save notes"
     },
     "form": {
       "create_heading": "Create event",
       "create_subheading": "New event at {{cityName}}",
-      "create_subheading_with_tz": "New event at {{cityName}} — times in {{timezone}}",
+      "create_subheading_with_tz": "New event at {{cityName}}, times in {{timezone}}",
       "edit_heading": "Edit event",
       "edit_subheading": "Update your event at {{cityName}}",
-      "edit_subheading_with_tz": "Update your event at {{cityName}} — times in {{timezone}}",
+      "edit_subheading_with_tz": "Update your event at {{cityName}}, times in {{timezone}}",
       "venue_label": "Venue",
       "venue_placeholder": "No venue",
       "venue_not_bookable": "This venue is not bookable.",
@@ -661,7 +688,7 @@
       "venue_setup_teardown": "Venue is blocked {{setupTime}}min before & after each scheduled session for setup/teardown",
       "venue_closed_warning": "The selected date falls on a day the venue is closed.",
       "view_pictures_button": "View pictures",
-      "venue_pictures_heading": "{{venue}} — pictures",
+      "venue_pictures_heading": "{{venue}}: pictures",
       "no_venue_pictures": "This venue has no pictures yet.",
       "title_label": "Title",
       "title_placeholder": "Event name",
@@ -774,7 +801,7 @@
         "venue_not_available": "Venue creation is not available",
         "venue_not_available_message": "The organizer has not enabled venue creation for {{cityName}}.",
         "back_to_venues": "Back to venues",
-        "venue_submitted_success": "Venue submitted — waiting for admin approval",
+        "venue_submitted_success": "Venue submitted, waiting for admin approval",
         "venue_created_success": "Venue created",
         "no_popup_error": "No popup",
         "failed_to_create": "Failed to create venue",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -501,7 +501,7 @@
     "list": {
       "heading": "Eventos",
       "subheading": "Próximos eventos en {{cityName}}",
-      "subheading_with_tz": "Próximos eventos en {{cityName}} — horarios en {{timezone}}",
+      "subheading_with_tz": "Próximos eventos en {{cityName}}, horarios en {{timezone}}",
       "empty_state": "Aún no hay eventos",
       "events_disabled_heading": "Eventos desactivados",
       "events_disabled_message": "El organizador desactivó los eventos para {{cityName}}.",
@@ -590,6 +590,26 @@
       "checked_in": "Check-in realizado",
       "action_error": "No pudimos actualizar tu RSVP. Por favor intentá de nuevo."
     },
+    "recurrence": {
+      "daily_one": "Se repite diariamente",
+      "daily_other": "Se repite cada {{count}} días",
+      "weekly_one": "Se repite semanalmente",
+      "weekly_other": "Se repite cada {{count}} semanas",
+      "weekly_on_one": "Se repite cada semana el {{days}}",
+      "weekly_on_other": "Se repite cada {{count}} semanas el {{days}}",
+      "monthly_one": "Se repite mensualmente",
+      "monthly_other": "Se repite cada {{count}} meses",
+      "count_suffix_one": ", por {{count}} ocurrencia",
+      "count_suffix_other": ", por {{count}} ocurrencias",
+      "until_suffix": ", hasta el {{date}}",
+      "weekday_MO": "lunes",
+      "weekday_TU": "martes",
+      "weekday_WE": "miércoles",
+      "weekday_TH": "jueves",
+      "weekday_FR": "viernes",
+      "weekday_SA": "sábado",
+      "weekday_SU": "domingo"
+    },
     "login_required": {
       "title": "Iniciá sesión para ver el evento",
       "message": "Los detalles del evento solo son visibles para usuarios con sesión iniciada. Se requiere un ticket de {{popupName}} para participar.",
@@ -601,7 +621,7 @@
       "page_title": "{{popupName}} - Calendario",
       "page_title_fallback": "Calendario",
       "subheading": "Próximos eventos en {{popupName}}",
-      "subheading_with_tz": "Próximos eventos en {{popupName}} — horarios en {{timezone}}"
+      "subheading_with_tz": "Próximos eventos en {{popupName}}, horarios en {{timezone}}"
     },
     "detail": {
       "event_not_found": "Evento no encontrado",
@@ -644,15 +664,22 @@
       "open_in_maps": "Abrir en Google Maps",
       "share_button": "Compartir evento",
       "share_link_copied": "Link copiado",
-      "share_link_error": "No se pudo copiar el link"
+      "share_link_error": "No se pudo copiar el link",
+      "admin_notes_heading": "Notas de admin",
+      "admin_notes_staff_only": "Interno, solo personal",
+      "admin_notes_placeholder": "Notas sobre este evento, visibles solo para el personal del backoffice",
+      "admin_notes_save_button": "Guardar notas",
+      "admin_notes_saving_button": "Guardando",
+      "admin_notes_saved_toast": "Notas guardadas",
+      "admin_notes_error_toast": "No se pudieron guardar las notas"
     },
     "form": {
       "create_heading": "Crear evento",
       "create_subheading": "Nuevo evento en {{cityName}}",
-      "create_subheading_with_tz": "Nuevo evento en {{cityName}} — horario en {{timezone}}",
+      "create_subheading_with_tz": "Nuevo evento en {{cityName}}, horario en {{timezone}}",
       "edit_heading": "Editar evento",
       "edit_subheading": "Actualizá tu evento en {{cityName}}",
-      "edit_subheading_with_tz": "Actualizá tu evento en {{cityName}} — horario en {{timezone}}",
+      "edit_subheading_with_tz": "Actualizá tu evento en {{cityName}}, horario en {{timezone}}",
       "venue_label": "Lugar",
       "venue_placeholder": "Sin lugar",
       "venue_not_bookable": "Este lugar no es reservable.",
@@ -660,7 +687,7 @@
       "venue_setup_teardown": "Bloqueado {{setupTime}}m antes de inicio y {{teardownTime}}m después del fin para setup/teardown.",
       "venue_closed_warning": "La fecha elegida cae en un día que el lugar está cerrado.",
       "view_pictures_button": "Ver fotos",
-      "venue_pictures_heading": "{{venue}} — fotos",
+      "venue_pictures_heading": "{{venue}}: fotos",
       "no_venue_pictures": "Este lugar todavía no tiene fotos.",
       "title_label": "Título",
       "title_placeholder": "Nombre del evento",
@@ -773,7 +800,7 @@
         "venue_not_available": "La creación de lugares no está disponible",
         "venue_not_available_message": "El organizador no habilitó la creación de lugares para {{cityName}}.",
         "back_to_venues": "Volver a lugares",
-        "venue_submitted_success": "Lugar enviado — esperando aprobación del admin",
+        "venue_submitted_success": "Lugar enviado, esperando aprobación del admin",
         "venue_created_success": "Lugar creado",
         "no_popup_error": "Sin popup",
         "failed_to_create": "No se pudo crear el lugar",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -477,7 +477,7 @@
     "list": {
       "heading": "Viðburðir",
       "subheading": "Komandi viðburðir í {{cityName}}",
-      "subheading_with_tz": "Komandi viðburðir í {{cityName}} — tímar sýndir í {{timezone}}",
+      "subheading_with_tz": "Komandi viðburðir í {{cityName}}, tímar sýndir í {{timezone}}",
       "empty_state": "Engir viðburðir enn",
       "events_disabled_heading": "Viðburðir eru óvirkir",
       "events_disabled_message": "Skipuleggjandinn hefur slökkt á viðburðum fyrir {{cityName}}.",
@@ -577,7 +577,7 @@
       "page_title": "{{popupName}} - Dagatal",
       "page_title_fallback": "Dagatal",
       "subheading": "Komandi viðburðir í {{popupName}}",
-      "subheading_with_tz": "Komandi viðburðir í {{popupName}} — tímar sýndir í {{timezone}}"
+      "subheading_with_tz": "Komandi viðburðir í {{popupName}}, tímar sýndir í {{timezone}}"
     },
     "detail": {
       "event_not_found": "Viðburður fannst ekki",
@@ -625,10 +625,10 @@
     "form": {
       "create_heading": "Búa til viðburð",
       "create_subheading": "Nýr viðburður í {{cityName}}",
-      "create_subheading_with_tz": "Nýr viðburður í {{cityName}} — tímar í {{timezone}}",
+      "create_subheading_with_tz": "Nýr viðburður í {{cityName}}, tímar í {{timezone}}",
       "edit_heading": "Breyta viðburði",
       "edit_subheading": "Uppfæra viðburðinn þinn í {{cityName}}",
-      "edit_subheading_with_tz": "Uppfæra viðburðinn þinn í {{cityName}} — tímar í {{timezone}}",
+      "edit_subheading_with_tz": "Uppfæra viðburðinn þinn í {{cityName}}, tímar í {{timezone}}",
       "venue_label": "Staður",
       "venue_placeholder": "Enginn staður",
       "venue_not_bookable": "Þessi staður er ekki bókanlegur.",
@@ -636,7 +636,7 @@
       "venue_setup_teardown": "Staðurinn er læstur {{setupTime}} mín fyrir og eftir hverja áætlaða lotu fyrir uppsetningu/niðurtekt",
       "venue_closed_warning": "Valin dagsetning fellur á dag þegar staðurinn er lokaður.",
       "view_pictures_button": "Skoða myndir",
-      "venue_pictures_heading": "{{venue}} — myndir",
+      "venue_pictures_heading": "{{venue}}: myndir",
       "no_venue_pictures": "Þessi staður hefur ekki myndir enn.",
       "title_label": "Titill",
       "title_placeholder": "Nafn viðburðar",
@@ -749,7 +749,7 @@
         "venue_not_available": "Gerð staðar er ekki í boði",
         "venue_not_available_message": "Skipuleggjandinn hefur ekki virkjað gerð staða fyrir {{cityName}}.",
         "back_to_venues": "Til baka á staði",
-        "venue_submitted_success": "Staður sendur — bíður samþykkis stjórnanda",
+        "venue_submitted_success": "Staður sendur, bíður samþykkis stjórnanda",
         "venue_created_success": "Staður búinn til",
         "no_popup_error": "Enginn popup",
         "failed_to_create": "Mistókst að búa til stað",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -487,7 +487,7 @@
     "list": {
       "heading": "活动",
       "subheading": "{{cityName}} 即将举行的活动",
-      "subheading_with_tz": "{{cityName}} 即将举行的活动 — 时间显示为 {{timezone}}",
+      "subheading_with_tz": "{{cityName}} 即将举行的活动，时间显示为 {{timezone}}",
       "empty_state": "暂无活动",
       "events_disabled_heading": "活动已停用",
       "events_disabled_message": "组织者已关闭 {{cityName}} 的活动功能。",
@@ -587,7 +587,7 @@
       "page_title": "{{popupName}} - 日历",
       "page_title_fallback": "日历",
       "subheading": "{{popupName}} 的即将到来的活动",
-      "subheading_with_tz": "{{popupName}} 的即将到来的活动 — 时间显示为 {{timezone}}"
+      "subheading_with_tz": "{{popupName}} 的即将到来的活动，时间显示为 {{timezone}}"
     },
     "detail": {
       "event_not_found": "未找到活动",
@@ -635,10 +635,10 @@
     "form": {
       "create_heading": "创建活动",
       "create_subheading": "{{cityName}} 的新活动",
-      "create_subheading_with_tz": "{{cityName}} 的新活动 — 时间为 {{timezone}}",
+      "create_subheading_with_tz": "{{cityName}} 的新活动，时间为 {{timezone}}",
       "edit_heading": "编辑活动",
       "edit_subheading": "更新你在 {{cityName}} 的活动",
-      "edit_subheading_with_tz": "更新你在 {{cityName}} 的活动 — 时间为 {{timezone}}",
+      "edit_subheading_with_tz": "更新你在 {{cityName}} 的活动，时间为 {{timezone}}",
       "venue_label": "场地",
       "venue_placeholder": "无场地",
       "venue_not_bookable": "此场地不可预订。",
@@ -646,7 +646,7 @@
       "venue_setup_teardown": "开始前锁定 {{setupTime}} 分钟,结束后锁定 {{teardownTime}} 分钟用于布置/撤场。",
       "venue_closed_warning": "所选日期为场地不营业的日期。",
       "view_pictures_button": "查看图片",
-      "venue_pictures_heading": "{{venue}} — 图片",
+      "venue_pictures_heading": "{{venue}}：图片",
       "no_venue_pictures": "此场地尚未上传图片。",
       "title_label": "标题",
       "title_placeholder": "活动名称",
@@ -759,7 +759,7 @@
         "venue_not_available": "无法创建场地",
         "venue_not_available_message": "组织者尚未为 {{cityName}} 开启场地创建功能。",
         "back_to_venues": "返回场地列表",
-        "venue_submitted_success": "场地已提交 — 等待管理员审核",
+        "venue_submitted_success": "场地已提交，等待管理员审核",
         "venue_created_success": "场地已创建",
         "no_popup_error": "无 popup",
         "failed_to_create": "创建场地失败",


### PR DESCRIPTION
## Summary

- Pagination control now clamps the target page to `[1, totalPages]`, so it can never send a negative `skip` to the API (which caused a 422).
- Pagination labels and the page indicator now use i18n keys instead of hardcoded strings.
- Attendees `useGetData` keeps the previous page's data while the next page loads, so the page count no longer collapses to 0 mid-navigation.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

| File | Change |
|------|--------|
| `portal/src/components/common/Pagination.tsx` | Clamp page navigation to valid range, disable controls at bounds, i18n labels and page indicator |
| `portal/src/app/portal/[popupSlug]/attendees/hooks/useGetData.tsx` | Use `keepPreviousData` placeholder to avoid page-count collapse while paginating |

## Testing

- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [x] Portal linting passes (`pnpm --filter portal run lint`)
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] All new and existing tests pass