### PR TITLE
feat: quitar "Chef's choice" de Meal Plans (backoffice + portal)

### DIFF
--- a/backoffice/src/components/ticketing-step-builder/template-configs/MealPlanSelectConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/MealPlanSelectConfig.tsx
@@ -17,7 +17,6 @@ import { useQuery } from "@tanstack/react-query"
 import {
   AlertTriangle,
   CalendarRange,
-  ChefHat,
   GripVertical,
   Package,
   Plus,
@@ -40,7 +39,7 @@ import type { TemplateConfigProps } from "./types"
 
 // ---------------------------------------------------------------------------
 // Types — mirror backend MealPlanSection / MealPlanSectionProduct /
-// MealPlanMenuOption / MealPlanChefChoiceOption.
+// MealPlanMenuOption.
 // ---------------------------------------------------------------------------
 
 interface MealPlanMenuOption {
@@ -66,23 +65,8 @@ interface MealPlanSection {
   products: MealPlanSectionProduct[]
 }
 
-interface MealPlanChefChoice {
-  key: "chef"
-  icon?: string
-  title: string
-  description?: string
-}
-
 interface MealPlanConfig {
   sections: MealPlanSection[]
-  chef_choice_option: MealPlanChefChoice
-}
-
-const DEFAULT_CHEF_CHOICE: MealPlanChefChoice = {
-  key: "chef",
-  icon: "👨‍🍳",
-  title: "Chef's choice",
-  description: "Surprise me with what's freshest that day",
 }
 
 const MEAL_PLAN_CATEGORY = "meal_plan"
@@ -139,24 +123,7 @@ function parseConfig(config: Record<string, unknown> | null): MealPlanConfig {
     }
   })
 
-  const chefRaw = (raw.chef_choice_option ?? {}) as Record<string, unknown>
-  const chef_choice_option: MealPlanChefChoice = {
-    key: "chef",
-    icon:
-      typeof chefRaw.icon === "string"
-        ? chefRaw.icon
-        : DEFAULT_CHEF_CHOICE.icon,
-    title:
-      typeof chefRaw.title === "string" && chefRaw.title.trim() !== ""
-        ? chefRaw.title
-        : DEFAULT_CHEF_CHOICE.title,
-    description:
-      typeof chefRaw.description === "string"
-        ? chefRaw.description
-        : DEFAULT_CHEF_CHOICE.description,
-  }
-
-  return { sections, chef_choice_option }
+  return { sections }
 }
 
 interface PickerProduct {
@@ -487,7 +454,7 @@ function MealPlanProductCard({
         {product.menu_options.length === 0 ? (
           <div className="rounded border border-dashed p-3 text-center text-xs text-muted-foreground">
             No menu options yet. Add at least one — buyers will pick from these
-            per day. Chef's choice is added automatically.
+            per day.
           </div>
         ) : (
           <DndContext
@@ -733,59 +700,6 @@ function SortableSectionCard({
 }
 
 // ---------------------------------------------------------------------------
-// Chef's choice card
-// ---------------------------------------------------------------------------
-
-function ChefChoiceCard({
-  chef,
-  onUpdate,
-}: {
-  chef: MealPlanChefChoice
-  onUpdate: (updates: Partial<MealPlanChefChoice>) => void
-}) {
-  return (
-    <div className="rounded-lg border bg-background shadow-sm p-3 flex flex-col gap-3">
-      <div className="flex items-center gap-2">
-        <ChefHat className="h-4 w-4 text-muted-foreground" />
-        <Label className="text-sm font-medium">Chef's choice fallback</Label>
-        <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-wide text-muted-foreground">
-          key: chef
-        </span>
-      </div>
-      <p className="text-xs text-muted-foreground -mt-2">
-        Shown alongside menu options for every day. The key is locked to
-        <code className="mx-1 font-mono">chef</code> in v0 — cart logic relies
-        on the literal string.
-      </p>
-
-      <div className="grid grid-cols-[auto_1fr] gap-2 items-start">
-        <Input
-          value={chef.icon ?? ""}
-          onChange={(e) => onUpdate({ icon: e.target.value.slice(0, 4) })}
-          placeholder="👨‍🍳"
-          className="h-9 w-14 text-center text-base"
-          aria-label="Chef's choice icon"
-        />
-        <Input
-          value={chef.title}
-          onChange={(e) => onUpdate({ title: e.target.value })}
-          placeholder="Chef's choice"
-          className="h-9 text-sm"
-          aria-label="Chef's choice title"
-        />
-      </div>
-
-      <Textarea
-        value={chef.description ?? ""}
-        onChange={(e) => onUpdate({ description: e.target.value })}
-        placeholder="Surprise me with what's freshest that day"
-        className="min-h-12 text-sm"
-      />
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -841,8 +755,6 @@ export function MealPlanSelectConfig({
     onChange({
       ...config,
       sections: updates.sections ?? parsed.sections,
-      chef_choice_option:
-        updates.chef_choice_option ?? parsed.chef_choice_option,
     })
   }
 
@@ -886,16 +798,6 @@ export function MealPlanSelectConfig({
       (s, i) => ({ ...s, order: i }),
     )
     updateConfig({ sections: reordered })
-  }
-
-  const handleChefUpdate = (updates: Partial<MealPlanChefChoice>) => {
-    updateConfig({
-      chef_choice_option: {
-        ...parsed.chef_choice_option,
-        ...updates,
-        key: "chef", // immutable in v0
-      },
-    })
   }
 
   const noMealPlanProducts = !productsLoading && productList.length === 0
@@ -965,13 +867,6 @@ export function MealPlanSelectConfig({
           </SortableContext>
         </DndContext>
       )}
-
-      <Separator />
-
-      <ChefChoiceCard
-        chef={parsed.chef_choice_option}
-        onUpdate={handleChefUpdate}
-      />
     </div>
   )
 }

--- a/portal/src/components/checkout-flow/variants/VariantMealPlanSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMealPlanSelect.tsx
@@ -56,14 +56,6 @@ interface MealPlanProduct {
 /** Identifies which (attendee, product) cell is expanded for editing. */
 type OpenCell = { attendeeId: string; productId: string } | null
 
-const DEFAULT_CHEF_CHOICE: MenuOption = {
-  key: "chef",
-  title: "Chef's choice",
-  description: "Surprise me with what's freshest that day",
-  icon: "👨‍🍳",
-  tags: [],
-}
-
 // ---------------------------------------------------------------------------
 // templateConfig parsing
 // ---------------------------------------------------------------------------
@@ -89,13 +81,6 @@ interface RawSectionProduct {
   }>
 }
 
-interface RawChefChoice {
-  key?: string
-  icon?: string | null
-  title?: string
-  description?: string | null
-}
-
 interface MealPlanSection {
   key: string
   label: string
@@ -107,22 +92,10 @@ interface MealPlanSection {
 function parseMealPlanTemplateConfig(
   templateConfig: VariantProps["templateConfig"],
   products: ProductsPass[],
-): { sections: MealPlanSection[]; chefChoice: MenuOption } {
+): { sections: MealPlanSection[] } {
   const productById = new Map(products.map((p) => [p.id, p]))
 
   const rawSections = (templateConfig?.sections ?? []) as RawSection[]
-  const rawChef = (templateConfig?.chef_choice_option ??
-    null) as RawChefChoice | null
-
-  const chefChoice: MenuOption = rawChef
-    ? {
-        key: rawChef.key || "chef",
-        icon: rawChef.icon || DEFAULT_CHEF_CHOICE.icon,
-        title: rawChef.title || DEFAULT_CHEF_CHOICE.title,
-        description: rawChef.description || DEFAULT_CHEF_CHOICE.description,
-        tags: [],
-      }
-    : DEFAULT_CHEF_CHOICE
 
   const sections: MealPlanSection[] = [...rawSections]
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
@@ -163,7 +136,7 @@ function parseMealPlanTemplateConfig(
       }
     })
 
-  return { sections, chefChoice }
+  return { sections }
 }
 
 // ---------------------------------------------------------------------------
@@ -218,9 +191,7 @@ function formatCoverageRange(product: MealPlanProduct): string {
 function findMenuOption(
   product: MealPlanProduct,
   key: string,
-  chefChoice: MenuOption,
 ): MenuOption | null {
-  if (key === chefChoice.key) return chefChoice
   return product.menuOptions.find((o) => o.key === key) ?? null
 }
 
@@ -263,16 +234,6 @@ function isWeekFullyPlanned(
   return filledDayCount(item, product) === weekdayDates(product).length
 }
 
-function allDaysMatchKey(
-  item: SelectedMealPlanItem | undefined,
-  product: MealPlanProduct,
-  key: string,
-): boolean {
-  if (!item?.dailyChoices) return false
-  const dates = weekdayDates(product)
-  return dates.every((d) => item.dailyChoices?.[d] === key)
-}
-
 // ---------------------------------------------------------------------------
 // Pre-purchased detection
 // ---------------------------------------------------------------------------
@@ -313,7 +274,7 @@ export default function VariantMealPlanSelect({
     [products],
   )
 
-  const { sections, chefChoice } = useMemo(
+  const { sections } = useMemo(
     () => parseMealPlanTemplateConfig(templateConfig, mealPlanProducts),
     [templateConfig, mealPlanProducts],
   )
@@ -343,7 +304,12 @@ export default function VariantMealPlanSelect({
       product.id,
     )
     if (!selected) {
-      addMealPlan(attendee.id, product.id, weekdayDates(product))
+      addMealPlan(
+        attendee.id,
+        product.id,
+        weekdayDates(product),
+        product.menuOptions[0]?.key,
+      )
       setOpenCell({ attendeeId: attendee.id, productId: product.id })
       return
     }
@@ -420,7 +386,6 @@ export default function VariantMealPlanSelect({
             key={attendee.id}
             attendee={attendee}
             weeklyProducts={weeklyProducts}
-            chefChoice={chefChoice}
             mealPlans={cart.mealPlans}
             openCell={openCell}
             onCellClick={handleCellClick}
@@ -447,7 +412,6 @@ export default function VariantMealPlanSelect({
 interface AttendeeRowProps {
   attendee: AttendeePassState
   weeklyProducts: MealPlanProduct[]
-  chefChoice: MenuOption
   mealPlans: SelectedMealPlanItem[]
   openCell: OpenCell
   onCellClick: (a: AttendeePassState, p: MealPlanProduct) => void
@@ -466,7 +430,6 @@ interface AttendeeRowProps {
 function AttendeeRow({
   attendee,
   weeklyProducts,
-  chefChoice,
   mealPlans,
   openCell,
   onCellClick,
@@ -591,7 +554,6 @@ function AttendeeRow({
                   isLocked={isLocked}
                   isOpen={isOpen}
                   item={item}
-                  chefChoice={chefChoice}
                   onClick={() => onCellClick(attendee, product)}
                 />
               </div>
@@ -604,7 +566,6 @@ function AttendeeRow({
                     attendee={attendee}
                     product={product}
                     item={cartItem(mealPlans, attendee.id, product.id)}
-                    chefChoice={chefChoice}
                     onClose={onCloseEditor}
                     removeMealPlan={removeMealPlan}
                     setMealPlanDailyChoice={setMealPlanDailyChoice}
@@ -636,7 +597,6 @@ function AttendeeRow({
             attendee={attendee}
             product={openProduct}
             item={cartItem(mealPlans, attendee.id, openProduct.id)}
-            chefChoice={chefChoice}
             onClose={onCloseEditor}
             removeMealPlan={removeMealPlan}
             setMealPlanDailyChoice={setMealPlanDailyChoice}
@@ -711,7 +671,6 @@ function WeekCell({
   isLocked,
   isOpen,
   item,
-  chefChoice,
   onClick,
 }: {
   attendee: AttendeePassState
@@ -720,7 +679,6 @@ function WeekCell({
   isLocked: boolean
   isOpen: boolean
   item: SelectedMealPlanItem | undefined
-  chefChoice: MenuOption
   onClick: () => void
 }) {
   if (isLocked) {
@@ -819,7 +777,6 @@ function WeekCell({
       <DayEmojiStrip
         product={product}
         dailyChoices={item?.dailyChoices ?? null}
-        chefChoice={chefChoice}
       />
       <div className="flex items-center gap-1.5 leading-tight">
         {allSet ? (
@@ -845,18 +802,16 @@ function WeekCell({
 function DayEmojiStrip({
   product,
   dailyChoices,
-  chefChoice,
 }: {
   product: MealPlanProduct
   dailyChoices: Record<string, string> | null
-  chefChoice: MenuOption
 }) {
   const dates = weekdayDates(product)
   return (
     <div className="flex items-center justify-center gap-0.5">
       {dates.map((d) => {
         const pick = dailyChoices?.[d] ?? null
-        const opt = pick ? findMenuOption(product, pick, chefChoice) : null
+        const opt = pick ? findMenuOption(product, pick) : null
         return (
           <div
             key={d}
@@ -890,7 +845,6 @@ function DayPlanEditor({
   attendee,
   product,
   item,
-  chefChoice,
   onClose,
   removeMealPlan,
   setMealPlanDailyChoice,
@@ -898,7 +852,6 @@ function DayPlanEditor({
   attendee: AttendeePassState
   product: MealPlanProduct
   item: SelectedMealPlanItem | undefined
-  chefChoice: MenuOption
   onClose: () => void
   removeMealPlan: (attendeeId: string, productId: string) => void
   setMealPlanDailyChoice: (
@@ -908,23 +861,12 @@ function DayPlanEditor({
     menuKey: string,
   ) => void
 }) {
-  // True after the buyer has clicked "Customize per day" on the chef-default
-  // summary card. Stays true for the life of this editor instance so the
-  // expanded view persists while the buyer is overriding days.
-  const [isCustomizing, setIsCustomizing] = useState(false)
-
   if (!item) return null
 
   const dates = weekdayDates(product)
 
   // Pool of options the buyer can tap for any day this week.
-  const menuPool: MenuOption[] = [...product.menuOptions, chefChoice]
-
-  // Show the compact "Chef's choice for all days" summary as long as every day
-  // is still chef AND the buyer hasn't explicitly entered customize mode.
-  // Any override (or clicking "Customize per day") expands the per-day editor.
-  const allChef = allDaysMatchKey(item, product, chefChoice.key)
-  const showCompactDefault = allChef && !isCustomizing
+  const menuPool: MenuOption[] = product.menuOptions
 
   return (
     <div className="space-y-3 max-w-4xl mx-auto">
@@ -957,77 +899,51 @@ function DayPlanEditor({
           (rendered by AttendeeMetaSection above the editor) — they apply to
           every week, so they don't belong inside the per-week editor. */}
 
-      {/* Default state: chef's choice for all days. One slim row with an
-          escape hatch to per-day customization. */}
-      {showCompactDefault ? (
-        <div className="rounded-lg border border-border bg-card px-3 py-2 flex items-center gap-3">
-          <span className="text-lg leading-none shrink-0">
-            {chefChoice.icon}
-          </span>
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-semibold text-foreground leading-tight">
-              Chef's choice for all {dates.length} days
-            </div>
-            <div className="text-[11px] text-muted-foreground">
-              We'll surprise {attendee.name} with what's freshest each day.
-            </div>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setIsCustomizing(true)}
-          >
-            Customize per day
-          </Button>
-        </div>
-      ) : (
-        // Customize mode — all 5 days always expanded. Desktop: one row per
-        // day with the date label inline-left of the 5 dish buttons. Mobile:
-        // date label stacks above the buttons (6 columns crush at 390px).
-        // No per-day "card" wrapper — the buttons themselves are the visual
-        // elements and the row is just flex layout with light separators.
-        <div className="rounded-lg border border-border bg-card divide-y divide-border/60">
-          {dates.map((d) => {
-            const dayPick = item.dailyChoices?.[d] ?? null
-            return (
-              <div
-                key={d}
-                className="flex flex-col md:flex-row md:items-center md:gap-2 p-1.5"
-              >
-                {/* Date label — plain inline text, no nested card. */}
-                <div className="md:min-w-[44px] md:text-center px-1 mb-1 md:mb-0">
-                  <span className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
-                    {formatWeekdayShort(d)} {formatDayNum(d)}
-                  </span>
-                </div>
-                <div
-                  className="grid gap-1 md:flex-1"
-                  style={{
-                    gridTemplateColumns: `repeat(${menuPool.length},minmax(0,1fr))`,
-                  }}
-                >
-                  {menuPool.map((opt) => (
-                    <DishButton
-                      key={opt.key}
-                      option={opt}
-                      isActive={dayPick === opt.key}
-                      onClick={() =>
-                        setMealPlanDailyChoice(
-                          attendee.id,
-                          product.id,
-                          d,
-                          opt.key,
-                        )
-                      }
-                    />
-                  ))}
-                </div>
+      {/* All 5 days always expanded. Desktop: one row per day with the date
+          label inline-left of the dish buttons. Mobile: date label stacks above
+          the buttons (6 columns crush at 390px). No per-day "card" wrapper —
+          the buttons themselves are the visual elements and the row is just
+          flex layout with light separators. */}
+      <div className="rounded-lg border border-border bg-card divide-y divide-border/60">
+        {dates.map((d) => {
+          const dayPick = item.dailyChoices?.[d] ?? null
+          return (
+            <div
+              key={d}
+              className="flex flex-col md:flex-row md:items-center md:gap-2 p-1.5"
+            >
+              {/* Date label — plain inline text, no nested card. */}
+              <div className="md:min-w-[44px] md:text-center px-1 mb-1 md:mb-0">
+                <span className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+                  {formatWeekdayShort(d)} {formatDayNum(d)}
+                </span>
               </div>
-            )
-          })}
-        </div>
-      )}
+              <div
+                className="grid gap-1 md:flex-1"
+                style={{
+                  gridTemplateColumns: `repeat(${menuPool.length},minmax(0,1fr))`,
+                }}
+              >
+                {menuPool.map((opt) => (
+                  <DishButton
+                    key={opt.key}
+                    option={opt}
+                    isActive={dayPick === opt.key}
+                    onClick={() =>
+                      setMealPlanDailyChoice(
+                        attendee.id,
+                        product.id,
+                        d,
+                        opt.key,
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/portal/src/hooks/checkout/useMealPlanSelection.ts
+++ b/portal/src/hooks/checkout/useMealPlanSelection.ts
@@ -7,8 +7,10 @@ import type { ProductsPass } from "@/types/Products"
  *
  * One entry per (attendee, weekly product). The reducer mirrors
  * `cart-state.prototype.ts`:
- *   - `addMealPlan` seeds `dailyChoices` to {date: "chef"} for every weekday
- *     in the coverage range; the buyer overrides per day from the editor.
+ *   - `addMealPlan` seeds `dailyChoices` to {date: defaultKey} for every
+ *     weekday in the coverage range (the variant passes the product's first
+ *     menu option as the default); the buyer overrides per day from the editor.
+ *     When the product has no menu options, days start unset.
  *   - `removeMealPlan` drops the entry.
  *   - `setMealPlanDailyChoice` updates a single date's pick.
  *   - `setMealPlanDietaryRestriction` / `setMealPlanSpecialRequest` apply at
@@ -22,7 +24,12 @@ export function useMealPlanSelection(allActiveProducts: ProductsPass[]) {
   const [mealPlans, setMealPlans] = useState<SelectedMealPlanItem[]>([])
 
   const addMealPlan = useCallback(
-    (attendeeId: string, productId: string, weekdayDates: string[]) => {
+    (
+      attendeeId: string,
+      productId: string,
+      weekdayDates: string[],
+      defaultKey?: string,
+    ) => {
       const product = allActiveProducts.find((p) => p.id === productId)
       if (!product) return
       setMealPlans((prev) => {
@@ -37,9 +44,11 @@ export function useMealPlanSelection(allActiveProducts: ProductsPass[]) {
         // Inherit per-attendee dietary + special request from any sibling
         // entry so previously typed values stick when adding another week.
         const sibling = prev.find((m) => m.attendeeId === attendeeId)
-        const dailyChoices = Object.fromEntries(
-          weekdayDates.map((d) => [d, "chef"]),
-        )
+        // Pre-select every weekday with the product's first menu option so the
+        // week reads as complete on add. Products with no menu start unset.
+        const dailyChoices = defaultKey
+          ? Object.fromEntries(weekdayDates.map((d) => [d, defaultKey]))
+          : {}
         return [
           ...prev,
           {

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -90,11 +90,13 @@ interface CheckoutContextValue {
   /** Add a meal-plan cart entry for (attendee, weekly product). `weekdayDates`
    *  are the Mon–Fri ISO dates derived by the variant from the step's
    *  template_config coverage range. The reducer seeds dailyChoices to
-   *  {date: "chef"} for every weekday. */
+   *  {date: defaultKey} for every weekday (the variant passes the product's
+   *  first menu option); days start unset when `defaultKey` is omitted. */
   addMealPlan: (
     attendeeId: string,
     productId: string,
     weekdayDates: string[],
+    defaultKey?: string,
   ) => void
   removeMealPlan: (attendeeId: string, productId: string) => void
   setMealPlanDailyChoice: (


### PR DESCRIPTION
## Resumen

Elimina la opción **"Chef's choice"** de los meal plans para que ya no se muestre al usuario, ni en el builder del backoffice ni en el checkout del portal. Cambio **solo de UI** — el backend no se toca.

- **Portal:** en lugar de pre-seleccionar `"chef"`, cada día de la semana se rellena con la **primera opción del menú** del producto al agregar el meal plan (la semana queda "completa"). Productos sin menú quedan sin pre-selección.
- **Backend:** intacto. `MealPlanChefChoiceOption` y la validación que **reserva la key `"chef"`** se mantienen por backward-compat con configs/compras existentes.

## Cambios

### Backoffice — `MealPlanSelectConfig.tsx`
- Elimina el componente `ChefChoiceCard` y su render.
- Elimina la interface `MealPlanChefChoice`, el campo `chef_choice_option` de `MealPlanConfig` y `DEFAULT_CHEF_CHOICE`.
- `parseConfig` ya no arma/devuelve `chef_choice_option`.
- Elimina `handleChefUpdate` y la serialización de `chef_choice_option`.
- Limpia el texto "Chef's choice is added automatically." y el import `ChefHat`.
- **Mantiene** la guarda de key reservada `"chef"`.

### Portal — `VariantMealPlanSelect.tsx`
- Elimina `DEFAULT_CHEF_CHOICE`, `RawChefChoice`, el helper sin uso `allDaysMatchKey` y el prop `chefChoice` de todos los componentes.
- `DayPlanEditor` renderiza siempre la grilla por día; se quita la tarjeta compacta "Chef's choice for all N days".
- `handleCellClick` siembra con `product.menuOptions[0]?.key`.

### Portal — `useMealPlanSelection.ts` / `checkoutProvider.tsx`
- `addMealPlan` recibe un 4º parámetro opcional `defaultKey` para sembrar `dailyChoices`.

## Verificación
- ✅ Biome limpio en los 4 archivos.
- ✅ `tsc --noEmit` en ambos frontends sin errores (sin referencias colgantes a `chefChoice` / `chef_choice_option`).
- ⏳ Pruebas manuales pendientes: builder del backoffice (ya no aparece la tarjeta) y checkout del portal (semana pre-seleccionada con la primera opción del menú).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
