### PR TITLE
fix(portal): event share button always copies link to clipboard

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -444,14 +444,6 @@ export default function EventDetailPage() {
       : sharePath
 
   const handleShare = async () => {
-    if (typeof navigator !== "undefined" && navigator.share) {
-      try {
-        await navigator.share({ title: event.title, url: shareUrl })
-        return
-      } catch (err) {
-        if (err instanceof Error && err.name === "AbortError") return
-      }
-    }
     try {
       await navigator.clipboard.writeText(shareUrl)
       setCopied(true)


### PR DESCRIPTION
## Problema

El botón de compartir en el detalle de evento (portal) priorizaba la **Web Share API** (`navigator.share`) y solo caía al clipboard como fallback. Resultado: comportamiento inconsistente según el navegador.

- Chrome desktop / Linux (sin `navigator.share`): copiaba el link directo + toast "copiado" ✅
- Safari / macOS (con `navigator.share`): abría el share sheet nativo de Apple (AirDrop, Mail, Messages…), que los usuarios reportaron como confuso y poco intuitivo.

## Cambio

Se elimina la rama `navigator.share`. Ahora el botón **siempre** copia el link del evento al clipboard y muestra el feedback (ícono Check por 2s + toast), idéntico en todos los dispositivos.

| Archivo | Cambio |
|---------|--------|
| `portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx` | `handleShare` ahora solo usa `navigator.clipboard.writeText`; se quitó el bloque `navigator.share` |

## Test plan

- [x] `pnpm --filter portal run build` pasa
- [x] Biome lint del archivo pasa
- [ ] Verificar en Safari/macOS que el botón ahora copia el link en vez de abrir el share sheet