### PR TITLE
fix(portal): self-RSVP cancel no longer sends "event cancelled" email

### DIFF
--- a/backend/app/api/email_template/schemas.py
+++ b/backend/app/api/email_template/schemas.py
@@ -24,6 +24,7 @@ class EmailTemplateType(StrEnum):
     EVENT_INVITATION = "event_invitation"
     EVENT_UPDATED = "event_updated"
     EVENT_CANCELLED = "event_cancelled"
+    EVENT_RSVP_CANCELLED = "event_rsvp_cancelled"
     EVENT_APPROVAL_APPROVED = "event_approval_approved"
     EVENT_APPROVAL_REJECTED = "event_approval_rejected"
     CHECK_IN_PASS = "check_in_pass"

--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -360,7 +360,11 @@ async def _notify_rsvp(
             human_id=human.id,
             method=method,
             occurrence_start=occurrence_start,
-            is_self_rsvp=method == "REQUEST",
+            # Always the human acting on their own registration, whether
+            # registering (REQUEST) or withdrawing (CANCEL). On CANCEL this
+            # selects the "registration cancelled" email instead of the
+            # organiser-driven "event cancelled" notice.
+            is_self_rsvp=True,
         )
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("iTIP {} delivery to {} failed: {}", method, human.email, exc)

--- a/backend/app/services/email/__init__.py
+++ b/backend/app/services/email/__init__.py
@@ -20,6 +20,7 @@ from app.services.email.templates import (
     EventApprovalRejectedContext,
     EventCancelledContext,
     EventInvitationContext,
+    EventRsvpCancelledContext,
     EventUpdatedContext,
     LoginCodeHumanContext,
     LoginCodeUserContext,
@@ -53,6 +54,7 @@ __all__ = [
     "EventInvitationContext",
     "EventUpdatedContext",
     "EventCancelledContext",
+    "EventRsvpCancelledContext",
     "EventApprovalApprovedContext",
     "EventApprovalRejectedContext",
     # Check-in contexts

--- a/backend/app/services/email/service.py
+++ b/backend/app/services/email/service.py
@@ -34,6 +34,7 @@ from app.services.email.templates import (
     EventApprovalRejectedContext,
     EventCancelledContext,
     EventInvitationContext,
+    EventRsvpCancelledContext,
     EventUpdatedContext,
     LoginCodeHumanContext,
     LoginCodeUserContext,
@@ -744,6 +745,39 @@ class EmailService:
             subject=subject,
             template_type=EmailTemplateType.EVENT_CANCELLED,
             template_name=EmailTemplates.EVENT_CANCELLED,
+            context=context.model_dump(exclude_none=True),
+            from_address=from_address,
+            from_name=from_name,
+            popup_id=popup_id,
+            db_session=db_session,
+            attachments=attachments,
+            ical_body=ical_body,
+            ical_method="CANCEL",
+        )
+
+    async def send_event_rsvp_cancelled(
+        self,
+        to: str,
+        subject: str,
+        context: EventRsvpCancelledContext,
+        from_address: str | None = None,
+        from_name: str | None = None,
+        popup_id: uuid.UUID | None = None,
+        db_session: Session | None = None,
+        attachments: list[EmailAttachment] | None = None,
+        ical_body: str | None = None,
+    ) -> bool:
+        """Send a self-service RSVP cancellation confirmation.
+
+        The recipient cancelled their own registration, so this carries the
+        iTIP CANCEL body to drop the entry from their calendar while the copy
+        makes clear the event itself was not cancelled.
+        """
+        return await self._send_with_fallback(
+            to=to,
+            subject=subject,
+            template_type=EmailTemplateType.EVENT_RSVP_CANCELLED,
+            template_name=EmailTemplates.EVENT_RSVP_CANCELLED,
             context=context.model_dump(exclude_none=True),
             from_address=from_address,
             from_name=from_name,

--- a/backend/app/services/email/templates.py
+++ b/backend/app/services/email/templates.py
@@ -232,6 +232,22 @@ class EventCancelledContext(BaseModel):
     venue_title: str = ""
 
 
+class EventRsvpCancelledContext(BaseModel):
+    """Context for event/rsvp_cancelled.html — self-service RSVP cancellation.
+
+    Sent when a human cancels their own registration. The event itself is not
+    cancelled, so the copy confirms the registration was removed rather than
+    announcing an event cancellation.
+    """
+
+    first_name: str = ""
+    event_title: str
+    popup_name: str = ""
+    event_when: str = ""
+    venue_title: str = ""
+    event_url: str = ""
+
+
 class EventApprovalApprovedContext(BaseModel):
     """Context for event/approval_approved.html template.
 
@@ -315,6 +331,7 @@ class EmailTemplates:
     EVENT_INVITATION = "event/invitation.html"
     EVENT_UPDATED = "event/updated.html"
     EVENT_CANCELLED = "event/cancelled.html"
+    EVENT_RSVP_CANCELLED = "event/rsvp_cancelled.html"
     EVENT_APPROVAL_APPROVED = "event/approval_approved.html"
     EVENT_APPROVAL_REJECTED = "event/approval_rejected.html"
 
@@ -337,6 +354,7 @@ TEMPLATE_TYPE_TO_FILE: dict[EmailTemplateType, str] = {
     EmailTemplateType.EVENT_INVITATION: "event/invitation.html",
     EmailTemplateType.EVENT_UPDATED: "event/updated.html",
     EmailTemplateType.EVENT_CANCELLED: "event/cancelled.html",
+    EmailTemplateType.EVENT_RSVP_CANCELLED: "event/rsvp_cancelled.html",
     EmailTemplateType.EVENT_APPROVAL_APPROVED: "event/approval_approved.html",
     EmailTemplateType.EVENT_APPROVAL_REJECTED: "event/approval_rejected.html",
     EmailTemplateType.CHECK_IN_PASS: "check_in/pass.html",
@@ -1124,6 +1142,56 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "label": "Venue",
                 "type": "string",
                 "description": "Venue name (may be empty)",
+                "required": False,
+                "group": "Event",
+            },
+            *_POPUP_EVENT_VARIABLES,
+        ],
+    },
+    {
+        "type": EmailTemplateType.EVENT_RSVP_CANCELLED,
+        "label": "Registration Cancelled",
+        "description": "Sent to a recipient who cancels their own registration to an event.",
+        "category": "Event",
+        "default_subject": "Your registration was cancelled: {{ event_title }}",
+        "variables": [
+            {
+                "name": "first_name",
+                "label": "First Name",
+                "type": "string",
+                "description": "Recipient's first name",
+                "required": False,
+                "group": "Recipient",
+            },
+            {
+                "name": "event_title",
+                "label": "Event Title",
+                "type": "string",
+                "description": "Title of the event",
+                "required": True,
+                "group": "Event",
+            },
+            {
+                "name": "event_when",
+                "label": "When",
+                "type": "string",
+                "description": "Formatted start date/time",
+                "required": False,
+                "group": "Event",
+            },
+            {
+                "name": "venue_title",
+                "label": "Venue",
+                "type": "string",
+                "description": "Venue name (may be empty)",
+                "required": False,
+                "group": "Event",
+            },
+            {
+                "name": "event_url",
+                "label": "Event URL",
+                "type": "string",
+                "description": "Link back to the event in the portal",
                 "required": False,
                 "group": "Event",
             },

--- a/backend/app/services/event_itip.py
+++ b/backend/app/services/event_itip.py
@@ -16,6 +16,7 @@ from app.core.config import settings
 from app.services.email import (
     EventCancelledContext,
     EventInvitationContext,
+    EventRsvpCancelledContext,
     EventUpdatedContext,
     get_email_service,
 )
@@ -170,7 +171,16 @@ async def send_event_itip(
     organizer_name = from_name or popup_name or None
 
     is_cancelled = method == "CANCEL"
-    if is_cancelled:
+    # A self-RSVP cancellation reuses the iTIP CANCEL method (so the entry
+    # leaves the recipient's calendar) but must NOT read as an event
+    # cancellation — the event still exists, only this registration was
+    # withdrawn. Organiser-driven cancellations leave is_self_rsvp False.
+    is_self_cancel = is_cancelled and is_self_rsvp
+    if is_self_cancel:
+        subject = f"Your registration was cancelled: {event.title or 'an event'}"
+        if popup_name:
+            subject += f" — {popup_name}"
+    elif is_cancelled:
         subject = f"Event cancelled: {event.title or 'an event'}"
         if popup_name:
             subject += f" — {popup_name}"
@@ -229,7 +239,25 @@ async def send_event_itip(
             ics_body = None
 
         try:
-            if is_cancelled:
+            if is_self_cancel:
+                await service.send_event_rsvp_cancelled(
+                    to=r["email"],
+                    subject=subject,
+                    context=EventRsvpCancelledContext(
+                        first_name=r["first_name"],
+                        event_title=event.title or "",
+                        popup_name=popup_name,
+                        event_when=when,
+                        venue_title=venue_title,
+                        event_url=event_url,
+                    ),
+                    from_address=from_address,
+                    from_name=from_name,
+                    popup_id=event.popup_id,
+                    db_session=db,
+                    ical_body=ics_body,
+                )
+            elif is_cancelled:
                 await service.send_event_cancelled(
                     to=r["email"],
                     subject=subject,

--- a/backend/app/templates/emails/event/rsvp_cancelled.html
+++ b/backend/app/templates/emails/event/rsvp_cancelled.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block title %}Your registration was cancelled: {{ event_title }}{% endblock %}
+
+{% block content %}
+<h1>Your registration was cancelled</h1>
+
+<p>Hi {{ first_name or "there" }},</p>
+
+<p>
+    You have cancelled your registration for the event below, and the entry has been removed from your calendar. The event itself is still taking place.
+</p>
+
+<div style="background-color: #f8f9fa; border-radius: 8px; padding: 20px; margin: 20px 0;">
+    <table style="width: 100%; border-collapse: collapse;">
+        <tr>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top; width: 110px;">Event:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">{{ event_title }}</td>
+        </tr>
+        {% if event_when %}
+        <tr>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Time:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">{{ event_when }}</td>
+        </tr>
+        {% endif %}
+        {% if venue_title %}
+        <tr>
+            <td style="padding: 8px 12px; color: #666; vertical-align: top;">Location:</td>
+            <td style="padding: 8px 12px; font-weight: 600;">{{ venue_title }}</td>
+        </tr>
+        {% endif %}
+    </table>
+</div>
+
+{% if event_url %}
+<p class="text-center">
+    <a href="{{ event_url }}" class="button">View event &amp; RSVP again</a>
+</p>
+{% endif %}
+{% endblock %}

--- a/backend/tests/test_event_itip.py
+++ b/backend/tests/test_event_itip.py
@@ -172,6 +172,7 @@ def _patch_email_service():
     service.send_event_invitation = AsyncMock(return_value=True)
     service.send_event_updated = AsyncMock(return_value=True)
     service.send_event_cancelled = AsyncMock(return_value=True)
+    service.send_event_rsvp_cancelled = AsyncMock(return_value=True)
 
     stack = ExitStack()
     stack.enter_context(
@@ -775,6 +776,9 @@ class TestCancelAndDeleteDispatchCancel:
         service.send_event_cancelled.assert_awaited_once()
         service.send_event_invitation.assert_not_awaited()
         service.send_event_updated.assert_not_awaited()
+        # Organiser cancellation must use the "event cancelled" template, never
+        # the self-service "registration cancelled" one.
+        service.send_event_rsvp_cancelled.assert_not_awaited()
 
     def test_double_cancel_returns_400(
         self,

--- a/backend/tests/test_event_participants.py
+++ b/backend/tests/test_event_participants.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -336,6 +336,59 @@ class TestPortalCancelRegistration:
         assert itip_mock.await_count == 1
         assert itip_mock.await_args.kwargs["method"] == "CANCEL"
         assert itip_mock.await_args.kwargs["email"] == human.email
+        # The human is cancelling their own RSVP, so the iTIP flow is flagged
+        # self-service. This is what routes to the "registration cancelled"
+        # email instead of the organiser "event cancelled" notice.
+        assert itip_mock.await_args.kwargs["is_self_rsvp"] is True
+
+    def test_cancel_routes_to_rsvp_cancelled_not_event_cancelled(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Self-cancel must use the "registration cancelled" email.
+
+        Regression guard: cancelling your own RSVP previously reused the
+        organiser "event cancelled" template, wrongly telling the user the
+        event itself had been cancelled.
+        """
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        human = _make_human(db, tenant_a)
+
+        # Register with the iTIP send fully stubbed so only the cancel below
+        # exercises the real template-routing path.
+        with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
+            client.post(
+                f"/api/v1/event-participants/portal/register/{event.id}",
+                headers=_human_headers(human),
+            )
+
+        from app.core.config import settings
+
+        service = MagicMock()
+        service.send_event_cancelled = AsyncMock(return_value=True)
+        service.send_event_rsvp_cancelled = AsyncMock(return_value=True)
+        service.send_event_invitation = AsyncMock(return_value=True)
+
+        with (
+            patch("app.services.event_itip.get_email_service", return_value=service),
+            patch.object(
+                type(settings),
+                "emails_enabled",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+        ):
+            resp = client.post(
+                f"/api/v1/event-participants/portal/cancel-registration/{event.id}",
+                headers=_human_headers(human),
+            )
+
+        assert resp.status_code == 200, resp.text
+        service.send_event_rsvp_cancelled.assert_awaited_once()
+        service.send_event_cancelled.assert_not_awaited()
 
     def test_cancel_without_registration_returns_404(
         self,


### PR DESCRIPTION
## Problem

In the portal, when a human **cancels their own RSVP** to a calendar event, they were receiving the organiser email *"This event was cancelled"*. That is false: the event still exists, only the user's registration was cancelled.

## Root cause

In `send_event_itip`, the template choice came from `is_cancelled = method == "CANCEL"`. But `method="CANCEL"` is shared by two flows:

- **Organiser cancels the event** → `bump_and_dispatch_cancel` (`is_self_rsvp=False`)
- **User removes their RSVP** → `_notify_rsvp` from `cancel-registration`

Both ended up in `send_event_cancelled` → `event/cancelled.html`.

## Fix

- New template **`event/rsvp_cancelled.html`** → *"Your registration was cancelled"*, making clear the event itself still stands. Customizable from the template editor (with its own subject).
- `_notify_rsvp` now passes `is_self_rsvp=True` always (it is always the human acting on their own registration).
- In `send_event_itip`: `is_self_cancel = is_cancelled and is_self_rsvp` routes to the new email. Organiser cancellation (`is_self_rsvp=False`) keeps using the "event cancelled" template.
- The self-cancel **keeps the iTIP `CANCEL`** body, so the entry is still removed from the user's calendar (they unregistered). Only the copy was wrong, not the calendar action.

## Files

- `backend/app/services/event_itip.py` — `is_self_cancel` routing + subject
- `backend/app/api/event_participant/router.py` — `is_self_rsvp=True`
- `backend/app/api/email_template/schemas.py` — `EVENT_RSVP_CANCELLED`
- `backend/app/services/email/{templates.py,service.py,__init__.py}` — template, context, method, export, preview metadata
- `backend/app/templates/emails/event/rsvp_cancelled.html` — new template

## Tests

- `test_event_participants.py`: assert `is_self_rsvp=True` on cancel + new routing test (self-cancel uses `send_event_rsvp_cancelled`, NOT `send_event_cancelled`).
- `test_event_itip.py`: organiser cancellation does NOT use the RSVP template.
- 56 passed, 1 skipped. ruff check + format clean.