### PR TITLE
fix(events): correct RSVP lifecycle on cancel and capacity count

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -1133,6 +1133,12 @@ async def cancel_event(
     cancel_update = EventUpdate(status=EventStatus.CANCELLED)
     updated = crud.events_crud.update(db, event, cancel_update)
     await _bump_and_dispatch_itip_cancel(db, updated)
+    # Cancel the RSVPs themselves (after dispatch, so attendees still get the
+    # iTIP CANCEL): otherwise a later re-publish would resurface stale
+    # registrations even though their calendar entry was removed.
+    from app.api.event_participant.crud import event_participants_crud
+
+    event_participants_crud.cancel_all_for_event(db, updated.id)
     record_event_audit(
         db,
         event=updated,
@@ -2472,9 +2478,23 @@ async def get_portal_event(
         rsvp_q = rsvp_q.where(EventParticipants.occurrence_start == occurrence_start)
     rsvp = db.exec(rsvp_q).first()
 
+    # Active-registration count for the capacity badge. Mirrors the "Event is
+    # full" guard exactly: keys on this event's own id (the same path param the
+    # register endpoint counts against, NOT the recurrence master) and the same
+    # occurrence, counting non-cancelled rows with no privacy filtering. Keeps
+    # the badge consistent with what registration actually allows, even for a
+    # detached occurrence that carries its own capacity.
+    from app.api.event_participant.crud import event_participants_crud
+
+    attendee_count = event_participants_crud.count_active_for_event(
+        db, event.id, occurrence_start=occurrence_start
+    )
+
     pub = _to_public(event)
+    updates: dict[str, object] = {"attendee_count": attendee_count}
     if rsvp:
-        pub = pub.model_copy(update={"my_rsvp_status": rsvp})
+        updates["my_rsvp_status"] = rsvp
+    pub = pub.model_copy(update=updates)
     return pub
 
 
@@ -2809,6 +2829,12 @@ async def cancel_portal_event(
     cancel_update = EventUpdate(status=EventStatus.CANCELLED)
     updated = crud.events_crud.update(db, event, cancel_update)
     await _bump_and_dispatch_itip_cancel(db, updated)
+    # Cancel the RSVPs themselves (after dispatch, so attendees still get the
+    # iTIP CANCEL): otherwise a later re-publish would resurface stale
+    # registrations even though their calendar entry was removed.
+    from app.api.event_participant.crud import event_participants_crud
+
+    event_participants_crud.cancel_all_for_event(db, updated.id)
     record_event_audit(
         db,
         event=updated,

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -202,6 +202,11 @@ class EventPublic(EventBase):
     # list/get helpers. None means "not registered"; "registered" /
     # "checked_in" / "cancelled" mirror ParticipantStatus.
     my_rsvp_status: str | None = None
+    # Number of active (non-cancelled) registrations, i.e. the count that
+    # capacity is enforced against. Includes attendees who hid their name, so
+    # the displayed count stays consistent with "Event is full". Populated by
+    # the portal detail endpoint; None when not computed.
+    attendee_count: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/api/event_participant/crud.py
+++ b/backend/app/api/event_participant/crud.py
@@ -101,6 +101,45 @@ class EventParticipantsCRUD(
             )
         return session.exec(statement).one()
 
+    def cancel_all_for_event(
+        self,
+        session: Session,
+        event_id: uuid.UUID,
+        occurrence_start: datetime | None = None,
+        scope_to_occurrence: bool = False,
+    ) -> int:
+        """Cancel every active registration for an event.
+
+        Flips REGISTERED / CHECKED_IN rows to CANCELLED, mirroring the set of
+        attendees that receive the iTIP CANCEL. Called when an event (or a
+        single occurrence) is cancelled so a later re-publish does not
+        resurface stale RSVPs. ``registered_at`` is preserved so a later
+        re-registration keeps its original history.
+
+        Returns the number of rows cancelled. Must run AFTER the iTIP CANCEL
+        is dispatched, since recipient collection skips CANCELLED rows.
+        """
+        statement = select(EventParticipants).where(
+            EventParticipants.event_id == event_id,
+            EventParticipants.status != ParticipantStatus.CANCELLED,
+        )
+        if scope_to_occurrence:
+            if occurrence_start is None:
+                statement = statement.where(
+                    EventParticipants.occurrence_start.is_(None)  # type: ignore[union-attr]
+                )
+            else:
+                statement = statement.where(
+                    EventParticipants.occurrence_start == occurrence_start
+                )
+        rows = list(session.exec(statement).all())
+        for row in rows:
+            row.status = ParticipantStatus.CANCELLED
+            session.add(row)
+        if rows:
+            session.commit()
+        return len(rows)
+
     def find_by_profile(
         self,
         session: Session,

--- a/backend/tests/test_event_itip.py
+++ b/backend/tests/test_event_itip.py
@@ -753,6 +753,44 @@ class TestCancelAndDeleteDispatchCancel:
         assert send_mock.await_count == 1
         assert send_mock.await_args.kwargs["method"] == "CANCEL"
 
+    def test_cancel_cancels_rsvps_after_dispatching_email(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Cancelling an event flips its RSVPs to CANCELLED.
+
+        Prevents a later re-publish from resurfacing stale registrations
+        (the attendee's calendar entry was already removed). The flip MUST
+        happen after recipients are gathered, so the attendee still receives
+        the iTIP CANCEL.
+        """
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        human = _make_human(db, tenant_a, email="attendee@test.com")
+        participant = _register(db, event, human)
+
+        send_mock = AsyncMock(return_value=None)
+        with _patch_send_everywhere(send_mock):
+            resp = client.post(
+                f"/api/v1/events/{event.id}/cancel",
+                headers=_auth(admin_token_tenant_a),
+            )
+
+        assert resp.status_code == 200, resp.text
+        # The attendee was still active when recipients were collected, so the
+        # CANCEL email targets them (dispatch ran before the status flip).
+        recipients = send_mock.await_args.args[2]
+        assert any(r["email"] == human.email for r in recipients)
+        # The RSVP row is now cancelled, so the portal no longer reports the
+        # human as registered after a re-publish.
+        db.expire_all()
+        refreshed = db.get(EventParticipants, participant.id)
+        assert refreshed is not None
+        assert refreshed.status == ParticipantStatus.CANCELLED
+
     def test_cancel_endpoint_routes_to_send_event_cancelled(
         self,
         client: TestClient,

--- a/backend/tests/test_event_participants.py
+++ b/backend/tests/test_event_participants.py
@@ -27,6 +27,8 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
 from app.api.event.models import Events
 from app.api.event.schemas import EventStatus, EventVisibility
 from app.api.event_participant.models import EventParticipants
@@ -117,6 +119,75 @@ def _fetch_participant(
 # from app.services.event_itip inside _notify_rsvp, so patching the module
 # attribute intercepts every real dispatch.
 _ITIP_TARGET = "app.services.event_itip.send_itip_to_single_recipient"
+
+
+# ---------------------------------------------------------------------------
+# Portal: participant count vs. privacy-hidden list
+# ---------------------------------------------------------------------------
+
+
+class TestPortalAttendeeCount:
+    """The capacity badge must include name-hidden attendees.
+
+    Participants who hid their name are dropped from the participant LIST, but
+    they still occupy a slot and count toward "Event is full". The detail
+    endpoint exposes ``attendee_count`` so the displayed count stays consistent
+    with the capacity guard instead of being derived from the filtered list.
+    """
+
+    def test_attendee_count_includes_name_hidden_participants(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        viewer = _make_human(db, tenant_a)
+        visible = _make_human(db, tenant_a, email="visible@test.com")
+        hider = _make_human(db, tenant_a, email="hider@test.com")
+
+        for human in (visible, hider):
+            db.add(
+                EventParticipants(
+                    tenant_id=tenant_a.id,
+                    event_id=event.id,
+                    profile_id=human.id,
+                    status=ParticipantStatus.REGISTERED,
+                )
+            )
+        # The hider opted out of showing their name on their application.
+        db.add(
+            Applications(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a.id,
+                popup_id=popup.id,
+                human_id=hider.id,
+                status=ApplicationStatus.ACCEPTED.value,
+                info_not_shared=["first_name"],
+            )
+        )
+        db.commit()
+
+        # Detail count includes both registrations (capacity-consistent).
+        detail = client.get(
+            f"/api/v1/events/portal/events/{event.id}",
+            headers=_human_headers(viewer),
+        )
+        assert detail.status_code == 200, detail.text
+        assert detail.json()["attendee_count"] == 2
+
+        # ...but the participant list still hides the name-hider.
+        listing = client.get(
+            f"/api/v1/event-participants/portal/participants?event_id={event.id}",
+            headers=_human_headers(viewer),
+        )
+        assert listing.status_code == 200, listing.text
+        results = listing.json()["results"]
+        profile_ids = {r["profile_id"] for r in results}
+        assert str(hider.id) not in profile_ids
+        assert str(visible.id) in profile_ids
+        assert len(results) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -5153,7 +5153,7 @@ export const EmailTemplatePublicSchema = {
 
 export const EmailTemplateTypeSchema = {
     type: 'string',
-    enum: ['login_code_user', 'login_code_human', 'application_received', 'application_accepted', 'application_rejected', 'application_accepted_with_discount', 'application_accepted_with_incentive', 'application_accepted_scholarship_rejected', 'payment_confirmed', 'abandoned_cart', 'edit_passes_confirmed', 'event_invitation', 'event_updated', 'event_cancelled', 'event_approval_approved', 'event_approval_rejected', 'check_in_pass'],
+    enum: ['login_code_user', 'login_code_human', 'application_received', 'application_accepted', 'application_rejected', 'application_accepted_with_discount', 'application_accepted_with_incentive', 'application_accepted_scholarship_rejected', 'payment_confirmed', 'abandoned_cart', 'edit_passes_confirmed', 'event_invitation', 'event_updated', 'event_cancelled', 'event_rsvp_cancelled', 'event_approval_approved', 'event_approval_rejected', 'check_in_pass'],
     title: 'EmailTemplateType'
 } as const;
 
@@ -6264,6 +6264,17 @@ export const EventPublicSchema = {
                 }
             ],
             title: 'My Rsvp Status'
+        },
+        attendee_count: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Attendee Count'
         }
     },
     type: 'object',

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2927,7 +2927,7 @@ export class EventsService {
     
     /**
      * Update Event Admin Notes
-     * Set an event's staff-only notes (any backoffice user).
+     * Set an event's staff-only notes (requires events write access).
      * @param data The data for the request.
      * @param data.eventId
      * @param data.requestBody

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1187,7 +1187,7 @@ export type EmailTemplatePublic = {
     updated_at?: (string | null);
 };
 
-export type EmailTemplateType = 'login_code_user' | 'login_code_human' | 'application_received' | 'application_accepted' | 'application_rejected' | 'application_accepted_with_discount' | 'application_accepted_with_incentive' | 'application_accepted_scholarship_rejected' | 'payment_confirmed' | 'abandoned_cart' | 'edit_passes_confirmed' | 'event_invitation' | 'event_updated' | 'event_cancelled' | 'event_approval_approved' | 'event_approval_rejected' | 'check_in_pass';
+export type EmailTemplateType = 'login_code_user' | 'login_code_human' | 'application_received' | 'application_accepted' | 'application_rejected' | 'application_accepted_with_discount' | 'application_accepted_with_incentive' | 'application_accepted_scholarship_rejected' | 'payment_confirmed' | 'abandoned_cart' | 'edit_passes_confirmed' | 'event_invitation' | 'event_updated' | 'event_cancelled' | 'event_rsvp_cancelled' | 'event_approval_approved' | 'event_approval_rejected' | 'check_in_pass';
 
 export type EmailTemplateUpdate = {
     subject?: (string | null);
@@ -1404,6 +1404,7 @@ export type EventPublic = {
     track_title?: (string | null);
     hidden?: boolean;
     my_rsvp_status?: (string | null);
+    attendee_count?: (number | null);
 };
 
 /**

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -228,6 +228,14 @@ export default function EventDetailPage() {
   const myRsvpStatus = event?.my_rsvp_status ?? null
   const isRsvped = !!myRsvpStatus && myRsvpStatus !== "cancelled"
 
+  // Capacity is enforced server-side against every active registration,
+  // including attendees who hid their name (and are therefore absent from
+  // the roster above). Prefer the backend count so the badge and the "full"
+  // state stay consistent with what registration actually allows.
+  const goingCount = event?.attendee_count ?? activeParticipants.length
+  const isFull =
+    event?.max_participant != null && goingCount >= event.max_participant
+
   // Recurring events require occurrence_start so the RSVP targets a single
   // instance; one-off events must not send it (the backend rejects mixing
   // the two semantics). Prefer the ?occ= param (set when the user came from
@@ -656,6 +664,15 @@ export default function EventDetailPage() {
                   </Button>
                 )}
               </>
+            ) : isFull ? (
+              <Button
+                disabled
+                variant="secondary"
+                className="inline-flex items-center gap-2"
+              >
+                <Users className="h-4 w-4" />
+                {t("events.rsvp.full")}
+              </Button>
             ) : (
               <Button
                 onClick={() => registerMutation.mutate()}
@@ -998,7 +1015,7 @@ export default function EventDetailPage() {
             {t("events.detail.participants_heading")}
           </h3>
           <span className="text-sm text-muted-foreground">
-            {activeParticipants.length}
+            {goingCount}
             {event.max_participant ? ` / ${event.max_participant}` : ""}
           </span>
         </div>

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -5153,7 +5153,7 @@ export const EmailTemplatePublicSchema = {
 
 export const EmailTemplateTypeSchema = {
     type: 'string',
-    enum: ['login_code_user', 'login_code_human', 'application_received', 'application_accepted', 'application_rejected', 'application_accepted_with_discount', 'application_accepted_with_incentive', 'application_accepted_scholarship_rejected', 'payment_confirmed', 'abandoned_cart', 'edit_passes_confirmed', 'event_invitation', 'event_updated', 'event_cancelled', 'event_approval_approved', 'event_approval_rejected', 'check_in_pass'],
+    enum: ['login_code_user', 'login_code_human', 'application_received', 'application_accepted', 'application_rejected', 'application_accepted_with_discount', 'application_accepted_with_incentive', 'application_accepted_scholarship_rejected', 'payment_confirmed', 'abandoned_cart', 'edit_passes_confirmed', 'event_invitation', 'event_updated', 'event_cancelled', 'event_rsvp_cancelled', 'event_approval_approved', 'event_approval_rejected', 'check_in_pass'],
     title: 'EmailTemplateType'
 } as const;
 
@@ -6264,6 +6264,17 @@ export const EventPublicSchema = {
                 }
             ],
             title: 'My Rsvp Status'
+        },
+        attendee_count: {
+            anyOf: [
+                {
+                    type: 'integer'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Attendee Count'
         }
     },
     type: 'object',

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2927,7 +2927,7 @@ export class EventsService {
     
     /**
      * Update Event Admin Notes
-     * Set an event's staff-only notes (any backoffice user).
+     * Set an event's staff-only notes (requires events write access).
      * @param data The data for the request.
      * @param data.eventId
      * @param data.requestBody

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1187,7 +1187,7 @@ export type EmailTemplatePublic = {
     updated_at?: (string | null);
 };
 
-export type EmailTemplateType = 'login_code_user' | 'login_code_human' | 'application_received' | 'application_accepted' | 'application_rejected' | 'application_accepted_with_discount' | 'application_accepted_with_incentive' | 'application_accepted_scholarship_rejected' | 'payment_confirmed' | 'abandoned_cart' | 'edit_passes_confirmed' | 'event_invitation' | 'event_updated' | 'event_cancelled' | 'event_approval_approved' | 'event_approval_rejected' | 'check_in_pass';
+export type EmailTemplateType = 'login_code_user' | 'login_code_human' | 'application_received' | 'application_accepted' | 'application_rejected' | 'application_accepted_with_discount' | 'application_accepted_with_incentive' | 'application_accepted_scholarship_rejected' | 'payment_confirmed' | 'abandoned_cart' | 'edit_passes_confirmed' | 'event_invitation' | 'event_updated' | 'event_cancelled' | 'event_rsvp_cancelled' | 'event_approval_approved' | 'event_approval_rejected' | 'check_in_pass';
 
 export type EmailTemplateUpdate = {
     subject?: (string | null);
@@ -1404,6 +1404,7 @@ export type EventPublic = {
     track_title?: (string | null);
     hidden?: boolean;
     my_rsvp_status?: (string | null);
+    attendee_count?: (number | null);
 };
 
 /**

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -584,6 +584,7 @@
     "rsvp": {
       "going": "Going",
       "rsvp": "RSVP",
+      "full": "Full",
       "cancel": "Cancel RSVP",
       "check_in": "Check in",
       "check_in_opens_at_start": "Check-in opens at start time",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -583,6 +583,7 @@
     "rsvp": {
       "going": "Asistiré",
       "rsvp": "Anotarme",
+      "full": "Completo",
       "cancel": "Cancelar RSVP",
       "check_in": "Check-in",
       "check_in_opens_at_start": "El check-in se habilita al comenzar el evento",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -559,6 +559,7 @@
     "rsvp": {
       "going": "Mæti",
       "rsvp": "RSVP",
+      "full": "Fullbókað",
       "cancel": "Hætta við RSVP",
       "check_in": "Innrita",
       "check_in_opens_at_start": "Innritun opnar á upphafstíma",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -569,6 +569,7 @@
     "rsvp": {
       "going": "已报名",
       "rsvp": "报名",
+      "full": "已满",
       "cancel": "取消报名",
       "check_in": "签到",
       "check_in_opens_at_start": "签到将在活动开始时开放",


### PR DESCRIPTION
Two related fixes to the calendar-event RSVP lifecycle.

## Fix 1 — Re-published event resurfaced a stale RSVP

When an event was cancelled, only `event.status` changed to `CANCELLED`; the `EventParticipants` rows stayed `REGISTERED`. The iTIP CANCEL was sent and the calendar entry removed, but re-publishing the event (a plain `PATCH status=published`) left the stale registration, so the portal showed the user as still registered.

Now cancelling an event also cancels its RSVPs.

- `event_participant/crud.py` — new `cancel_all_for_event(...)` flips non-cancelled rows to `CANCELLED`, preserving `registered_at`.
- `event/router.py` — `cancel_event` and `cancel_portal_event` call it **after** `_bump_and_dispatch_itip_cancel`, so attendees still receive the cancellation email (recipient collection skips `CANCELLED`).

No frontend change: the portal already treats `my_rsvp_status == "cancelled"` as not-registered everywhere.

## Fix 2 — Full event displayed as incomplete

The participant count badge was derived client-side from the `/portal/participants` list, which **drops** attendees who hid their name (`info_not_shared`). The capacity guard counts everyone non-cancelled. So a 30/30 full event showed "29/30" and registration failed with "Event is full".

Decoupled the count from the name list:

- `event/schemas.py` — added `attendee_count` to `EventPublic`.
- `event/router.py` — `get_portal_event` populates it via `count_active_for_event`, keyed on the same event id + occurrence the register guard counts against (privacy-blind).
- `portal` detail page — badge uses `attendee_count`; shows a disabled "Full" button at capacity.
- i18n `en/es/is/zh` — added `events.rsvp.full`.
- Regenerated OpenAPI client (portal + backoffice).

## Tests
- `test_event_itip.py` — cancelling an event flips RSVPs to `CANCELLED` while the attendee still appears in the CANCEL recipients.
- `test_event_participants.py` — `attendee_count` includes a name-hidden registrant (2) while the participant list returns only the visible one (1).
- Backend ruff + pytest green; portal `build` (tsc) green.

## Known follow-ups (out of scope)
Per-occurrence cancel paths (`delete_occurrence` skip/EXDATE, `detach_occurrence`) do not yet cancel that occurrence's participant rows — same stale-RSVP potential, scoped out of this whole-event fix.