### PR TITLE
fix(dashboard): report net revenue by category so it reconciles with total revenue

### DIFF
--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -2,7 +2,7 @@ import uuid
 from decimal import ROUND_HALF_UP, Decimal
 
 from fastapi import APIRouter, Query
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlmodel import select
 
 from app.api.application.models import Applications
@@ -31,7 +31,7 @@ from app.api.payment.models import PaymentProducts, Payments
 from app.api.payment.schemas import PaymentStatus, PaymentType
 from app.api.popup.crud import popups_crud
 from app.api.product.models import Products
-from app.api.product.schemas import CATEGORY_HOUSING, CATEGORY_TICKET
+from app.api.product.schemas import CATEGORY_HOUSING, CATEGORY_PATREON, CATEGORY_TICKET
 from app.core.dependencies.users import CurrentOperator, TenantSession
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
@@ -366,16 +366,45 @@ def _get_cumulative_trends(
 
 
 def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBreakdown:
-    """Revenue and quantity breakdown by product and category."""
+    """Net revenue and quantity breakdown by product and category.
+
+    Revenue here is the money actually collected per line, so the categories
+    reconcile with the Total Revenue KPI (sum of Payments.amount) rather than
+    inflating it with pre-discount list prices. Per-line net revenue mirrors the
+    pricing logic in payment.crud._calculate_price:
+      - patreon donations carry their amount on effective_unit_price
+        (product_price is always 0 for patreon);
+      - discountable products are reduced by the payment's best-of-three
+        discount percentage (coupon / group / scholarship);
+      - non-discountable products are charged at full list price.
+    Insurance and contribution fees are excluded on purpose: they are not
+    product lines, so the category total equals Total Revenue minus those fees
+    (and minus edit-pass credits, which are not attributable per line).
+    """
+    discount_factor = 1 - func.coalesce(Payments.discount_value, Decimal("0")) / 100
+    net_line_revenue = case(
+        (
+            PaymentProducts.product_category == CATEGORY_PATREON,
+            func.coalesce(PaymentProducts.effective_unit_price, Decimal("0"))
+            * PaymentProducts.quantity,
+        ),
+        (
+            Products.discountable.is_(True),
+            PaymentProducts.product_price * PaymentProducts.quantity * discount_factor,
+        ),
+        else_=PaymentProducts.product_price * PaymentProducts.quantity,
+    )
+
     rows = db.exec(
         select(
             PaymentProducts.product_id,
             PaymentProducts.product_name,
             PaymentProducts.product_category,
             func.sum(PaymentProducts.quantity),
-            func.sum(PaymentProducts.product_price * PaymentProducts.quantity),
+            func.sum(net_line_revenue),
         )
         .join(Payments, PaymentProducts.payment_id == Payments.id)
+        .join(Products, PaymentProducts.product_id == Products.id, isouter=True)
         .where(
             Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
@@ -400,13 +429,14 @@ def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBre
     }
 
     for product_id, name, category, qty, rev in rows:
+        revenue = (rev or Decimal("0")).quantize(TWO_DECIMAL, ROUND_HALF_UP)
         by_product.append(
             ProductBreakdownItem(
                 product_id=str(product_id),
                 product_name=name,
                 product_category=category,
                 quantity=qty or 0,
-                revenue=rev or Decimal("0"),
+                revenue=revenue,
             )
         )
 
@@ -416,7 +446,7 @@ def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBre
                 label=category_labels.get(category, category.title()),
             )
         category_agg[category].quantity += qty or 0
-        category_agg[category].revenue += rev or Decimal("0")
+        category_agg[category].revenue += revenue
 
     return RevenueBreakdown(
         by_product=by_product,

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -6,8 +6,18 @@ query surfaces as a 500 instead of silently shipping.
 """
 
 import uuid
+from decimal import Decimal
 
 from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.attendee.models import Attendees
+from app.api.dashboard.router import _get_revenue_breakdown
+from app.api.payment.models import PaymentProducts, Payments
+from app.api.payment.schemas import PaymentStatus, PaymentType
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.tenant.models import Tenants
 
 
 class TestDashboardEnrichedSmoke:
@@ -26,3 +36,134 @@ class TestDashboardEnrichedSmoke:
             f"GET /dashboard/enriched must execute, "
             f"got {response.status_code}: {response.text}"
         )
+
+
+class TestRevenueBreakdownNetReconciliation:
+    """Revenue by category must report net money collected, not gross list price.
+
+    Regression guard: the breakdown used to sum product_price * quantity (the
+    pre-discount catalog snapshot), so the category total dwarfed the Total
+    Revenue KPI (sum of Payments.amount). It must now apply the payment discount
+    to discountable lines, charge non-discountable lines in full, and read the
+    patreon donation off effective_unit_price.
+    """
+
+    def test_breakdown_is_net_of_discounts(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = Popups(
+            name="Revenue Breakdown Popup",
+            slug="revenue-breakdown-net",
+            tenant_id=tenant_a.id,
+        )
+        db.add(popup)
+        db.flush()
+
+        ticket = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Week Ticket",
+            slug="rb-week-ticket",
+            price=Decimal("100.00"),
+            category="ticket",
+            discountable=True,
+        )
+        merch = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="T-Shirt",
+            slug="rb-tshirt",
+            price=Decimal("50.00"),
+            category="merch",
+            discountable=False,
+        )
+        patreon = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Donation",
+            slug="rb-donation",
+            price=Decimal("0.00"),
+            category="patreon",
+            discountable=False,
+        )
+        db.add_all([ticket, merch, patreon])
+        db.flush()
+
+        attendee = Attendees(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Buyer One",
+        )
+        db.add(attendee)
+        db.flush()
+
+        # amount = net products (240) + insurance (10) + contribution (5).
+        # Net products = 2*100*(1-0.20) + 1*50 + 30 = 160 + 50 + 30.
+        payment = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.APPROVED.value,
+            payment_type=PaymentType.PASS_PURCHASE.value,
+            amount=Decimal("255.00"),
+            insurance_amount=Decimal("10.00"),
+            contribution_amount=Decimal("5.00"),
+            discount_value=Decimal("20"),
+        )
+        db.add(payment)
+        db.flush()
+
+        db.add_all(
+            [
+                PaymentProducts(
+                    tenant_id=tenant_a.id,
+                    payment_id=payment.id,
+                    product_id=ticket.id,
+                    attendee_id=attendee.id,
+                    quantity=2,
+                    product_name=ticket.name,
+                    product_price=Decimal("100.00"),
+                    product_category="ticket",
+                ),
+                PaymentProducts(
+                    tenant_id=tenant_a.id,
+                    payment_id=payment.id,
+                    product_id=merch.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                    product_name=merch.name,
+                    product_price=Decimal("50.00"),
+                    product_category="merch",
+                ),
+                PaymentProducts(
+                    tenant_id=tenant_a.id,
+                    payment_id=payment.id,
+                    product_id=patreon.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                    product_name=patreon.name,
+                    product_price=Decimal("0.00"),
+                    effective_unit_price=Decimal("30.00"),
+                    product_category="patreon",
+                ),
+            ]
+        )
+        db.commit()
+
+        breakdown = _get_revenue_breakdown(db, popup.id)
+        by_category = {c.category: c.revenue for c in breakdown.by_category}
+
+        # Discountable ticket reduced by 20%, non-discountable merch full price,
+        # patreon donation read off effective_unit_price.
+        assert by_category["ticket"] == Decimal("160.00")
+        assert by_category["merch"] == Decimal("50.00")
+        assert by_category["patreon"] == Decimal("30.00")
+
+        # The category total reconciles with the product portion of
+        # Payments.amount (amount minus insurance and contribution fees).
+        net_products = (
+            payment.amount - payment.insurance_amount - payment.contribution_amount
+        )
+        assert sum(by_category.values()) == net_products
+
+        # And it is no longer the inflated gross (2*100 + 50 + 0 = 250).
+        assert sum(by_category.values()) != Decimal("250.00")


### PR DESCRIPTION
## Problem

The dashboard showed **Total Revenue $378K** but **Revenue by Category $1.19M** (~3x). The two totals never reconciled.

Root cause: `Total Revenue` sums `Payments.amount` (net money actually collected, after discounts), while `Revenue by Category` / `Revenue by Product` summed `product_price * quantity` — the pre-discount catalog snapshot. So the breakdown was reporting gross list value, not revenue.

## Fix

Rewrote `_get_revenue_breakdown` to compute **net per-line revenue**, mirroring `payment/crud.py` pricing:

- **patreon** donations carry their amount on `effective_unit_price` (`product_price` is always 0 for patreon)
- **discountable** products are reduced by the payment's best-of-three discount percentage (`Payments.discount_value`)
- **non-discountable** products are charged at full list price

Insurance and contribution fees stay excluded on purpose — they are not product lines — so the category total reconciles with `Payments.amount` minus those fees (and minus edit-pass credits, which are not attributable per line).

## Notes

- `effective_unit_price` only holds the patreon donation override, not a generic post-discount price.
- `Payments.discount_value` is a percentage applied only to the discountable bucket.

## Tests

- Added `tests/test_dashboard.py::TestRevenueBreakdownNetReconciliation`: builds a discountable ticket + non-discountable merch + patreon donation with a 20% discount and fees, and asserts each category is net and the category total reconciles with `amount - insurance - contribution`.
- `ruff check` + `ruff format` pass; targeted dashboard tests pass.