### PR TITLE
feat(events): allow host and collaborators to edit events from the portal

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/page.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next"
 
 import { EventsService, HumansService } from "@/client"
 import { useCityProvider } from "@/providers/cityProvider"
+import { canManageEvent } from "../../lib/eventPermissions"
 import { EditEventForm } from "./EditEventForm"
 
 export default function EditPortalEventPage() {
@@ -47,9 +48,7 @@ export default function EditPortalEventPage() {
     )
   }
 
-  const canManage =
-    !!currentHuman &&
-    (event.owner_id === currentHuman.id || event.host_id === currentHuman.id)
+  const canManage = canManageEvent(event, currentHuman?.id)
   if (!canManage) {
     return (
       <div className="max-w-2xl mx-auto p-4 sm:p-6 text-center py-20">

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -61,6 +61,7 @@ import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
 import { AddToCalendarModal } from "../lib/AddToCalendarModal"
 import { CoverImage } from "../lib/CoverImage"
+import { canManageEvent } from "../lib/eventPermissions"
 import { summarizeRrule } from "../lib/summarizeRrule"
 import { useCalendarAddedFlag } from "../lib/useCalendarAddedFlag"
 import {
@@ -218,8 +219,7 @@ export default function EventDetailPage() {
     (p: EventParticipantPublic) => p.status !== "cancelled",
   )
 
-  const isOwner =
-    !!event && !!currentHuman && event.owner_id === currentHuman.id
+  const canManage = !!event && canManageEvent(event, currentHuman?.id)
 
   // RSVP state is sourced from the event's own `my_rsvp_status` field so
   // this page agrees with the list/day/calendar views (which read the
@@ -312,7 +312,7 @@ export default function EventDetailPage() {
     queryKey: ["portal-event-invitations", params.eventId],
     queryFn: () =>
       EventsService.listPortalInvitations({ eventId: params.eventId }),
-    enabled: !!params.eventId && isOwner,
+    enabled: !!params.eventId && canManage,
   })
 
   const [emailsInput, setEmailsInput] = useState("")
@@ -482,7 +482,7 @@ export default function EventDetailPage() {
           <ArrowLeft className="h-4 w-4" /> {t("events.common.back_to_events")}
         </Link>
         <div className="flex items-center gap-2 shrink-0">
-          {isOwner && event.status !== "cancelled" && (
+          {canManage && event.status !== "cancelled" && (
             <Dialog open={cancelEventOpen} onOpenChange={setCancelEventOpen}>
               <DialogTrigger asChild>
                 <Button
@@ -526,7 +526,7 @@ export default function EventDetailPage() {
               </DialogContent>
             </Dialog>
           )}
-          {isOwner && (
+          {canManage && (
             <Button asChild variant="outline" size="sm">
               <Link
                 href={`/portal/${city?.slug}/events/${event.id}/edit`}
@@ -554,7 +554,7 @@ export default function EventDetailPage() {
         </div>
       )}
 
-      {isOwner && event.status === "rejected" && event.rejection_reason && (
+      {canManage && event.status === "rejected" && event.rejection_reason && (
         <div className="flex items-start gap-2.5 rounded-xl border border-red-300 bg-red-50 p-3 text-red-900 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-100">
           <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-red-600 dark:text-red-400" />
           <div className="text-sm">
@@ -930,8 +930,8 @@ export default function EventDetailPage() {
         </div>
       )}
 
-      {/* Owner-only: Paste attendees to invite */}
-      {isOwner && (
+      {/* Managers only (owner / host / collaborators): paste attendees to invite */}
+      {canManage && (
         <div className="rounded-xl border bg-card p-4 space-y-3">
           <div className="flex items-center gap-2">
             <Mail className="h-4 w-4 text-primary" />

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/collapsible"
 import { cn } from "@/lib/utils"
 import { CoverImage } from "./CoverImage"
+import { canManageEvent } from "./eventPermissions"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
 
@@ -267,6 +268,10 @@ export function ListBody({
                     isAuthed &&
                     currentHumanId != null &&
                     event.owner_id === currentHumanId
+                  // Edit affordance follows manage rights (owner / host /
+                  // collaborator); the crown badge stays owner-only.
+                  const canManage =
+                    isAuthed && canManageEvent(event, currentHumanId)
                   const domId = event.occurrence_id
                     ? `event-card-${event.id}__${event.start_time}`
                     : `event-card-${event.id}`
@@ -486,7 +491,7 @@ export function ListBody({
                                 <Eye className="h-3.5 w-3.5" />
                               )}
                             </button>
-                            {isOwner && (
+                            {canManage && (
                               <Link
                                 href={`/portal/${slug}/events/${event.id}/edit`}
                                 onClick={(e) => e.stopPropagation()}

--- a/portal/src/app/portal/[popupSlug]/events/lib/eventPermissions.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/eventPermissions.ts
@@ -1,0 +1,18 @@
+import type { EventPublic } from "@/client"
+
+/**
+ * Whether a human may manage an event (edit / cancel / invitations).
+ *
+ * Mirrors the backend's ``_human_manages_event``: the creator (owner), the
+ * designated host, and any collaborator all carry the same rights over the
+ * event. ``host_id`` is null when no directory human was assigned;
+ * ``collaborator_ids`` is empty when none were added.
+ */
+export function canManageEvent(
+  event: Pick<EventPublic, "owner_id" | "host_id" | "collaborator_ids">,
+  humanId: string | null | undefined,
+): boolean {
+  if (humanId == null) return false
+  if (event.owner_id === humanId || event.host_id === humanId) return true
+  return event.collaborator_ids?.includes(humanId) ?? false
+}

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -20,6 +20,7 @@ import { useCityProvider } from "@/providers/cityProvider"
 import { CalendarBody } from "./lib/CalendarBody"
 import { DayBody } from "./lib/DayBody"
 import { EventsToolbar, type EventsView } from "./lib/EventsToolbar"
+import { canManageEvent } from "./lib/eventPermissions"
 import {
   consumeEventsViewState,
   type EventsScrollSnapshot,
@@ -350,8 +351,9 @@ export default function EventsPage() {
   // "My events" + "My RSVPs" together shows the *union* (everything I
   // own + everything I'm going to) rather than the intersection.
   // - all:    no filter on → published events for everyone
-  // - mine:   "My events" on → events I own (any status, filtered locally
-  //           since the API has no owner filter)
+  // - mine:   "My events" on → events I manage as owner, host, or
+  //           collaborator (any status, filtered locally since the API
+  //           has no owner filter)
   // - rsvped: "My RSVPs" on → published events I'm registered for
   const useAllChannel = !mineOnly && !rsvpedOnly
   const useMineChannel = mineOnly
@@ -483,8 +485,8 @@ export default function EventsPage() {
     // recurring instance and its master don't collapse into one row.
     const byKey = new Map<string, EventPublic>()
     if (useMineChannel) {
-      const mine = (mineQuery.data?.results ?? []).filter(
-        (e) => currentHuman != null && e.owner_id === currentHuman.id,
+      const mine = (mineQuery.data?.results ?? []).filter((e) =>
+        canManageEvent(e, currentHuman?.id),
       )
       for (const e of mine) byKey.set(`${e.id}:${e.start_time}`, e)
     }


### PR DESCRIPTION
## Context

PR #275 added event collaborators and the backend \`_human_manages_event\` check, where the **owner, host, and collaborators all share the same edit / cancel / invite rights** over an event. The portal half was incomplete: editing was still gated on \`owner_id\`/\`host_id\` only, so collaborators were blocked even though the backend allowed them.

## What this does

Adds a single \`canManageEvent(event, humanId)\` helper that mirrors the backend rule (\`owner || host || collaborator_ids.includes\`) and routes every portal management affordance through it:

- **\`/events/[eventId]/edit\` route guard** — collaborators no longer hit "not your event".
- **Event detail page** — edit / cancel buttons, the invitations query, the rejection-reason notice, and the paste-to-invite block.
- **List view** — the edit pencil action.
- **"My events" filter** — now includes events you host or collaborate on, not just ones you own.

The ownership **crown badge** (list / day / calendar views) stays owner-only by design: it marks "created by you", which is narrower than manage rights. Venues are a separate feature with no collaborators and were left untouched.

## Verification

- \`pnpm --filter portal run build\` — tsc + next build clean, no new errors.
- Biome clean on changed files (pre-commit hook passed).