### PR TITLE
fix(tasks): scope superadmin board to active workspace tenant

### DIFF
--- a/backend/app/api/task/crud.py
+++ b/backend/app/api/task/crud.py
@@ -62,12 +62,13 @@ class TasksCRUD(BaseCRUD[Task, TaskCreate, TaskUpdate]):
         release: str | None = None,
         search: str | None = None,
         viewer: "UserPublic | None" = None,
+        active_tenant_id: uuid.UUID | None = None,
     ) -> tuple[list[Task], int]:
         statement = select(Task)
 
         # Visibility gate for non-superadmin viewers: only universal tasks and
-        # tenant tasks targeting their own tenant. Superadmins (or no viewer)
-        # see everything. internal tasks never reach non-superadmins.
+        # tenant tasks targeting their own tenant. internal tasks never reach
+        # non-superadmins.
         if viewer is not None and viewer.role != UserRole.SUPERADMIN:
             statement = statement.where(
                 (col(Task.visibility) == TaskVisibility.UNIVERSAL.value)
@@ -75,6 +76,15 @@ class TasksCRUD(BaseCRUD[Task, TaskCreate, TaskUpdate]):
                     (col(Task.visibility) == TaskVisibility.TENANT.value)
                     & (col(Task.target_tenant_id) == viewer.tenant_id)
                 )
+            )
+        # Superadmin with an active workspace (X-Tenant-Id) sees the board scoped
+        # to that tenant: tenant tasks of other tenants are hidden, while global
+        # tasks (universal/internal) stay visible. Without an active tenant the
+        # superadmin keeps the cross-tenant view (no filter).
+        elif active_tenant_id is not None:
+            statement = statement.where(
+                (col(Task.visibility) != TaskVisibility.TENANT.value)
+                | (col(Task.target_tenant_id) == active_tenant_id)
             )
 
         if status is not None:

--- a/backend/app/api/task/router.py
+++ b/backend/app/api/task/router.py
@@ -10,8 +10,9 @@ The ``tasks`` table is global, so every endpoint uses the privileged main engine
 
 import uuid
 from datetime import UTC, datetime
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, Header, HTTPException, Query, status
 
 from app.api.shared.enums import UserRole
 from app.api.shared.response import (
@@ -160,8 +161,22 @@ async def list_tasks(
     search: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
+    x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> ListModel[TaskPublic]:
-    """List tasks the current user may see (filtered by visibility)."""
+    """List tasks the current user may see (filtered by visibility).
+
+    For a superadmin, the active workspace header (``X-Tenant-Id``) scopes the
+    board to that tenant: tenant tasks of other tenants are hidden, while global
+    (universal/internal) tasks stay visible. A malformed/absent header keeps the
+    cross-tenant view.
+    """
+    active_tenant_id: uuid.UUID | None = None
+    if x_tenant_id:
+        try:
+            active_tenant_id = uuid.UUID(x_tenant_id)
+        except ValueError:
+            active_tenant_id = None
+
     tasks, total = crud.tasks_crud.find_tasks(
         db,
         skip=skip,
@@ -173,6 +188,7 @@ async def list_tasks(
         release=release,
         search=search,
         viewer=current_user,
+        active_tenant_id=active_tenant_id,
     )
     return ListModel[TaskPublic](
         results=crud.to_public_list(db, tasks),

--- a/backend/tests/api/task/test_task_access.py
+++ b/backend/tests/api/task/test_task_access.py
@@ -79,6 +79,21 @@ def test_superadmin_sees_all_visibilities(
         assert str(visibility_tasks[key].id) in ids
 
 
+def test_superadmin_board_scoped_to_active_workspace(
+    client, superadmin_token, tenant_a: Tenants, visibility_tasks
+) -> None:
+    """With an active workspace (X-Tenant-Id), the superadmin board hides other
+    tenants' tasks but keeps global (universal/internal) ones visible."""
+    headers = _auth(superadmin_token) | {"X-Tenant-Id": str(tenant_a.id)}
+    r = client.get("/api/v1/tasks?limit=1000", headers=headers)
+    assert r.status_code == 200
+    ids = {t["id"] for t in r.json()["results"]}
+    assert str(visibility_tasks["universal"].id) in ids
+    assert str(visibility_tasks["internal"].id) in ids
+    assert str(visibility_tasks["tenant_a"].id) in ids
+    assert str(visibility_tasks["tenant_b"].id) not in ids
+
+
 def test_get_task_404_when_not_viewable(
     client, admin_token_tenant_a, visibility_tasks
 ) -> None:

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -6395,6 +6395,11 @@ export class TasksService {
     /**
      * List Tasks
      * List tasks the current user may see (filtered by visibility).
+     *
+     * For a superadmin, the active workspace header (``X-Tenant-Id``) scopes the
+     * board to that tenant: tenant tasks of other tenants are hidden, while global
+     * (universal/internal) tasks stay visible. A malformed/absent header keeps the
+     * cross-tenant view.
      * @param data The data for the request.
      * @param data.status
      * @param data.type
@@ -6404,6 +6409,7 @@ export class TasksService {
      * @param data.search
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
+     * @param data.xTenantId
      * @returns ListModel_TaskPublic_ Successful Response
      * @throws ApiError
      */
@@ -6411,6 +6417,9 @@ export class TasksService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/tasks',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
             query: {
                 status: data.status,
                 type: data.type,

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -5711,6 +5711,7 @@ export type TasksListTasksData = {
     status?: (TaskStatus | null);
     type?: (TaskType | null);
     visibility?: (TaskVisibility | null);
+    xTenantId?: (string | null);
 };
 
 export type TasksListTasksResponse = (ListModel_TaskPublic_);

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -6395,6 +6395,11 @@ export class TasksService {
     /**
      * List Tasks
      * List tasks the current user may see (filtered by visibility).
+     *
+     * For a superadmin, the active workspace header (``X-Tenant-Id``) scopes the
+     * board to that tenant: tenant tasks of other tenants are hidden, while global
+     * (universal/internal) tasks stay visible. A malformed/absent header keeps the
+     * cross-tenant view.
      * @param data The data for the request.
      * @param data.status
      * @param data.type
@@ -6404,6 +6409,7 @@ export class TasksService {
      * @param data.search
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
+     * @param data.xTenantId
      * @returns ListModel_TaskPublic_ Successful Response
      * @throws ApiError
      */
@@ -6411,6 +6417,9 @@ export class TasksService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/tasks',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
             query: {
                 status: data.status,
                 type: data.type,

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -5711,6 +5711,7 @@ export type TasksListTasksData = {
     status?: (TaskStatus | null);
     type?: (TaskType | null);
     visibility?: (TaskVisibility | null);
+    xTenantId?: (string | null);
 };
 
 export type TasksListTasksResponse = (ListModel_TaskPublic_);


### PR DESCRIPTION
## Problem

In the backoffice **/tasks** board, tasks targeting one tenant (`visibility='tenant'`) stayed visible after switching the workspace to a different tenant.

Root cause: the `tasks` table is **global by design** (no RLS — read via the privileged main engine, authorization enforced in the app layer through `visibility` + `target_tenant_id`). Two gaps made tenant tasks leak for superadmins:

- `find_tasks` bypassed the visibility gate entirely when the viewer was a SUPERADMIN, so it returned every tenant's tasks.
- `list_tasks` never read the `X-Tenant-Id` header, so changing the active workspace did not change the query.

## Fix

Replicate the RLS behavior in the app layer for the list endpoint:

- `list_tasks` now reads the active workspace from the `X-Tenant-Id` header (parsed defensively; a missing/malformed value is treated as "no workspace").
- `find_tasks` takes an `active_tenant_id`. For a superadmin **with** an active workspace, tenant tasks of other tenants are hidden while global tasks (`universal` / `internal`) stay visible. **Without** a workspace the cross-tenant view is unchanged. Non-superadmins keep their existing own-tenant scoping.

No frontend change required: the backoffice axios interceptor already injects `X-Tenant-Id` from `workspace_tenant_id` and wins the header merge over the generated SDK. The OpenAPI client was regenerated (an optional `xTenantId` param was added to `ListTasks`).

## Changes

| File | Change |
|------|--------|
| `backend/app/api/task/crud.py` | `find_tasks` gains `active_tenant_id`; superadmin-with-workspace branch scopes tenant tasks |
| `backend/app/api/task/router.py` | `list_tasks` reads and parses the `X-Tenant-Id` header |
| `backend/tests/api/task/test_task_access.py` | New test: superadmin board scoped to the active workspace |
| `*/src/client/{sdk,types}.gen.ts` | Regenerated client (optional `xTenantId` on `ListTasks`) |

## Verification

- `ruff check` + `ruff format --check` clean on the task module and tests.
- `uv run pytest tests/api/task/test_task_access.py` — 9/9 passed.
- `pnpm --filter backoffice run build` — tsc + build clean.