### PR TITLE
fix(events): host/collaborator parity for portal listings and backoffice chips

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -917,7 +917,7 @@ async def get_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
-    return _with_collaborators(db, _to_public(event), event)
+    return _with_collaborators(db, _to_public(event), event, include_email=True)
 
 
 # ---------------------------------------------------------------------------
@@ -1045,7 +1045,7 @@ async def create_event(
         actor=actor_from_user(current_user),
     )
 
-    return _with_collaborators(db, _to_public(event), event)
+    return _with_collaborators(db, _to_public(event), event, include_email=True)
 
 
 @router.patch("/{event_id}", response_model=EventPublic)
@@ -1122,7 +1122,7 @@ async def update_event(
         changes=compute_changes(audit_before, audit_after),
     )
 
-    return _with_collaborators(db, _to_public(updated), updated)
+    return _with_collaborators(db, _to_public(updated), updated, include_email=True)
 
 
 @router.post("/{event_id}/cancel", response_model=EventPublic)
@@ -1907,11 +1907,18 @@ def _human_manages_event(event, current_human) -> bool:
     return _human_id_manages_event(event, current_human.id)
 
 
-def _resolve_collaborators(db, event) -> list[EventCollaboratorPublic]:
+def _resolve_collaborators(
+    db, event, *, include_email: bool = False
+) -> list[EventCollaboratorPublic]:
     """Resolve an event's ``collaborator_ids`` to slim human profiles.
 
     Preserves the stored order and silently skips ids that no longer resolve
     to a human in the tenant. Returns ``[]`` when there are no collaborators.
+
+    ``include_email`` adds the human's email to each profile so a nameless
+    collaborator chip can fall back to it. Only the admin (backoffice)
+    endpoints set this; the portal leaves it off so organizer emails aren't
+    exposed to every viewer of a public event.
     """
     ids = _event_collaborator_ids(event)
     if not ids:
@@ -1934,15 +1941,22 @@ def _resolve_collaborators(db, event) -> list[EventCollaboratorPublic]:
                 first_name=human.first_name,
                 last_name=human.last_name,
                 picture_url=human.picture_url,
+                email=human.email if include_email else None,
             )
         )
     return resolved
 
 
-def _with_collaborators(db, public: EventPublic, event) -> EventPublic:
+def _with_collaborators(
+    db, public: EventPublic, event, *, include_email: bool = False
+) -> EventPublic:
     """Attach resolved collaborator profiles to a single-event response."""
     return public.model_copy(
-        update={"collaborators": _resolve_collaborators(db, event)}
+        update={
+            "collaborators": _resolve_collaborators(
+                db, event, include_email=include_email
+            )
+        }
     )
 
 

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -1889,17 +1889,22 @@ def _event_collaborator_ids(event) -> list[uuid.UUID]:
     return out
 
 
-def _human_manages_event(event, current_human) -> bool:
-    """Whether a human may manage an event (edit / cancel / invitations).
+def _human_id_manages_event(event, human_id: uuid.UUID) -> bool:
+    """Whether the human id may manage an event (edit / cancel / invitations).
 
     True for the event's owner (creator), its designated host, or any of its
     collaborators — all carry the same responsibility over the event even
     though they didn't create it. ``host_id`` is NULL when no directory human
     was assigned; ``collaborator_ids`` is empty when none were added.
     """
-    if current_human.id in (event.owner_id, event.host_id):
+    if human_id in (event.owner_id, event.host_id):
         return True
-    return current_human.id in _event_collaborator_ids(event)
+    return human_id in _event_collaborator_ids(event)
+
+
+def _human_manages_event(event, current_human) -> bool:
+    """``_human_id_manages_event`` for an authenticated human object."""
+    return _human_id_manages_event(event, current_human.id)
 
 
 def _resolve_collaborators(db, event) -> list[EventCollaboratorPublic]:
@@ -2241,10 +2246,11 @@ def _portal_visibility_filter(db, events: list, human_id: uuid.UUID) -> list:
 
     Rules:
     - public: visible to all.
-    - private: only owner + invited humans.
-    - unlisted: hidden from public listings, but the owner still sees their
-      own unlisted events (e.g. pending_approval requests they created).
-      Detail is reachable via direct link for non-owners.
+    - private: only managers (owner / host / collaborators) + invited humans.
+    - unlisted: hidden from public listings, but managers (owner / host /
+      collaborators) still see their own unlisted events (e.g.
+      pending_approval requests they created). Detail is reachable via direct
+      link for non-managers.
     """
     from sqlmodel import select
 
@@ -2270,10 +2276,12 @@ def _portal_visibility_filter(db, events: list, human_id: uuid.UUID) -> list:
         if e.visibility == EventVisibility.PUBLIC:
             visible.append(e)
         elif e.visibility == EventVisibility.UNLISTED:
-            if e.owner_id == human_id:
+            if _human_id_manages_event(e, human_id):
                 visible.append(e)
         elif e.visibility == EventVisibility.PRIVATE:
-            if _invitation_visible_to_human(e, human_id, invited_map.get(e.id, set())):
+            if _human_id_manages_event(e, human_id) or _invitation_visible_to_human(
+                e, human_id, invited_map.get(e.id, set())
+            ):
                 visible.append(e)
     return visible
 
@@ -2926,9 +2934,8 @@ async def export_portal_event_ics(
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
     # Re-use the same visibility gate as the detail endpoint.
-    if (
-        event.visibility == EventVisibility.PRIVATE
-        and event.owner_id != current_human.id
+    if event.visibility == EventVisibility.PRIVATE and not _human_manages_event(
+        event, current_human
     ):
         from sqlmodel import select
 

--- a/backend/app/api/event/schemas.py
+++ b/backend/app/api/event/schemas.py
@@ -195,12 +195,18 @@ class EventCollaboratorPublic(BaseModel):
     for already-saved collaborators. Resolved from ``Events.collaborator_ids``
     by the portal get/create/update endpoints (the list endpoints leave it
     empty — collaborators aren't shown on cards).
+
+    ``email`` is only populated by the admin (backoffice) endpoints so a chip
+    for a human with no name can fall back to their email; the portal
+    endpoints leave it ``None`` to avoid exposing organizer emails to every
+    viewer of a public event.
     """
 
     id: uuid.UUID
     first_name: str | None = None
     last_name: str | None = None
     picture_url: str | None = None
+    email: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/tests/test_event_collaborators.py
+++ b/backend/tests/test_event_collaborators.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
@@ -171,3 +172,67 @@ class TestCollaboratorsPermissions:
         )
         assert resp.status_code == 200, resp.text
         assert resp.json()["title"] == "Edited by newcomer"
+
+
+class TestCollaboratorsListVisibility:
+    """Host and collaborators see private/unlisted events in portal listings.
+
+    The owner has always seen their own private/unlisted events; managers
+    (host / collaborators) now get the same listing visibility — mirroring
+    ``_human_manages_event`` — while a stranger still does not see them.
+    """
+
+    def _create(
+        self,
+        client: TestClient,
+        popup: Popups,
+        owner: Humans,
+        *,
+        visibility: str,
+        host_id: uuid.UUID | None = None,
+        collaborator_ids: list[uuid.UUID] | None = None,
+    ) -> str:
+        payload = _create_payload(popup, collaborator_ids=collaborator_ids or [])
+        payload["visibility"] = visibility
+        if host_id is not None:
+            payload["host_id"] = str(host_id)
+        resp = client.post(PORTAL_EVENTS, headers=_human_auth(owner), json=payload)
+        assert resp.status_code == 201, resp.text
+        return resp.json()["id"]
+
+    def _list_ids(self, client: TestClient, popup: Popups, human: Humans) -> set[str]:
+        resp = client.get(
+            PORTAL_EVENTS,
+            params={"popup_id": str(popup.id)},
+            headers=_human_auth(human),
+        )
+        assert resp.status_code == 200, resp.text
+        return {item["id"] for item in resp.json()["results"]}
+
+    @pytest.mark.parametrize("visibility", ["private", "unlisted"])
+    def test_host_and_collaborator_see_restricted_event(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        visibility: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a, first="Owner")
+        host = _make_human(db, tenant_a, first="Host")
+        collab = _make_human(db, tenant_a, first="Collab")
+        stranger = _make_human(db, tenant_a, first="Stranger")
+
+        event_id = self._create(
+            client,
+            popup,
+            owner,
+            visibility=visibility,
+            host_id=host.id,
+            collaborator_ids=[collab.id],
+        )
+
+        assert event_id in self._list_ids(client, popup, owner)
+        assert event_id in self._list_ids(client, popup, host)
+        assert event_id in self._list_ids(client, popup, collab)
+        assert event_id not in self._list_ids(client, popup, stranger)

--- a/backend/tests/test_event_collaborators.py
+++ b/backend/tests/test_event_collaborators.py
@@ -236,3 +236,56 @@ class TestCollaboratorsListVisibility:
         assert event_id in self._list_ids(client, popup, host)
         assert event_id in self._list_ids(client, popup, collab)
         assert event_id not in self._list_ids(client, popup, stranger)
+
+
+class TestCollaboratorEmailResolution:
+    """A nameless collaborator's chip falls back to email in the backoffice.
+
+    The admin (backoffice) endpoints resolve ``email`` so a human with no
+    name shows their email instead of a raw id; the portal endpoints leave it
+    ``None`` so organizer emails aren't exposed to every viewer.
+    """
+
+    def test_admin_resolves_email_portal_does_not(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        owner = _make_human(db, tenant_a, first="Owner")
+        # Nameless human: the chip has nothing but the email to fall back to.
+        nameless = Humans(
+            tenant_id=tenant_a.id,
+            email=f"nameless-{uuid.uuid4().hex[:8]}@test.com",
+            first_name=None,
+            last_name=None,
+        )
+        db.add(nameless)
+        db.commit()
+        db.refresh(nameless)
+
+        created = client.post(
+            PORTAL_EVENTS,
+            headers=_human_auth(owner),
+            json=_create_payload(popup, collaborator_ids=[nameless.id]),
+        ).json()
+
+        # Admin (backoffice) GET exposes the email for the fallback.
+        admin_resp = client.get(
+            f"/api/v1/events/{created['id']}",
+            headers={"Authorization": f"Bearer {admin_token_tenant_a}"},
+        )
+        assert admin_resp.status_code == 200, admin_resp.text
+        collab = admin_resp.json()["collaborators"][0]
+        assert collab["id"] == str(nameless.id)
+        assert collab["email"] == nameless.email
+
+        # Portal GET must not leak the organizer email.
+        portal_resp = client.get(
+            f"{PORTAL_EVENTS}/{created['id']}",
+            headers=_human_auth(owner),
+        )
+        assert portal_resp.status_code == 200, portal_resp.text
+        assert portal_resp.json()["collaborators"][0]["email"] is None

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -5460,6 +5460,17 @@ export const EventCollaboratorPublicSchema = {
                 }
             ],
             title: 'Picture Url'
+        },
+        email: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
         }
     },
     type: 'object',
@@ -5470,7 +5481,12 @@ export const EventCollaboratorPublicSchema = {
 Mirrors \`\`HumanPortalPublic\`\` so the same picker/avatar rendering works
 for already-saved collaborators. Resolved from \`\`Events.collaborator_ids\`\`
 by the portal get/create/update endpoints (the list endpoints leave it
-empty — collaborators aren't shown on cards).`
+empty — collaborators aren't shown on cards).
+
+\`\`email\`\` is only populated by the admin (backoffice) endpoints so a chip
+for a human with no name can fall back to their email; the portal
+endpoints leave it \`\`None\`\` to avoid exposing organizer emails to every
+viewer of a public event.`
 } as const;
 
 export const EventCreateSchema = {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1266,12 +1266,18 @@ export type EventCalendarTrack = {
  * for already-saved collaborators. Resolved from ``Events.collaborator_ids``
  * by the portal get/create/update endpoints (the list endpoints leave it
  * empty — collaborators aren't shown on cards).
+ *
+ * ``email`` is only populated by the admin (backoffice) endpoints so a chip
+ * for a human with no name can fall back to their email; the portal
+ * endpoints leave it ``None`` to avoid exposing organizer emails to every
+ * viewer of a public event.
  */
 export type EventCollaboratorPublic = {
     id: string;
     first_name?: (string | null);
     last_name?: (string | null);
     picture_url?: (string | null);
+    email?: (string | null);
 };
 
 /**

--- a/backoffice/src/components/forms/EventForm.tsx
+++ b/backoffice/src/components/forms/EventForm.tsx
@@ -219,7 +219,9 @@ export function EventForm({
     Object.fromEntries(
       (defaultValues?.collaborators ?? []).map((c) => [
         c.id,
-        [c.first_name, c.last_name].filter(Boolean).join(" ").trim() || c.id,
+        [c.first_name, c.last_name].filter(Boolean).join(" ").trim() ||
+          c.email ||
+          c.id,
       ]),
     ),
   )

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -5460,6 +5460,17 @@ export const EventCollaboratorPublicSchema = {
                 }
             ],
             title: 'Picture Url'
+        },
+        email: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
         }
     },
     type: 'object',
@@ -5470,7 +5481,12 @@ export const EventCollaboratorPublicSchema = {
 Mirrors \`\`HumanPortalPublic\`\` so the same picker/avatar rendering works
 for already-saved collaborators. Resolved from \`\`Events.collaborator_ids\`\`
 by the portal get/create/update endpoints (the list endpoints leave it
-empty — collaborators aren't shown on cards).`
+empty — collaborators aren't shown on cards).
+
+\`\`email\`\` is only populated by the admin (backoffice) endpoints so a chip
+for a human with no name can fall back to their email; the portal
+endpoints leave it \`\`None\`\` to avoid exposing organizer emails to every
+viewer of a public event.`
 } as const;
 
 export const EventCreateSchema = {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1266,12 +1266,18 @@ export type EventCalendarTrack = {
  * for already-saved collaborators. Resolved from ``Events.collaborator_ids``
  * by the portal get/create/update endpoints (the list endpoints leave it
  * empty — collaborators aren't shown on cards).
+ *
+ * ``email`` is only populated by the admin (backoffice) endpoints so a chip
+ * for a human with no name can fall back to their email; the portal
+ * endpoints leave it ``None`` to avoid exposing organizer emails to every
+ * viewer of a public event.
  */
 export type EventCollaboratorPublic = {
     id: string;
     first_name?: (string | null);
     last_name?: (string | null);
     picture_url?: (string | null);
+    email?: (string | null);
 };
 
 /**


### PR DESCRIPTION
Two follow-ups to the merged event-collaborators work (PR #275 / #278), where the owner, host, and collaborators share the same manage rights over an event.

## 1. Private/unlisted events now list for host and collaborators
The portal visibility filter still revealed private/unlisted events to the **owner only**, so a host or collaborator could not find an event they manage in **My events** or the full list — even though the detail route already let them in via `_human_manages_event`.

- Extracted a by-id `_human_id_manages_event` helper.
- `_portal_visibility_filter` (private and unlisted branches) and the ICS export gate now allow every manager (owner / host / collaborator). Strangers are unaffected.

## 2. Nameless collaborator chips fall back to email in the backoffice
A collaborator whose human had no first/last name rendered as a raw UUID in the backoffice event form, because the resolved `EventCollaboratorPublic` only carried name + avatar.

- Added `email` to `EventCollaboratorPublic`, populated **only** by the admin (backoffice) endpoints via a new `include_email` flag on `_resolve_collaborators`. The portal endpoints leave it `None` so organizer emails are not exposed to every viewer of a public event.
- The backoffice chip seed now falls back to `name -> email -> id`.
- Clients regenerated (no schema change visible to the portal beyond the optional field).

## Verification
- Backend: `test_event_collaborators` passes (7 tests, incl. new host/collaborator listing visibility across private+unlisted, and admin-returns-email / portal-hides-email).
- Backoffice + portal: `tsc` build clean, biome clean on changed files.

## Out of scope (reported separately)
An audit surfaced a pre-existing lost-update race on `collaborator_ids` (the event PATCH replaces the whole array with no locking, so a stale edit form can silently drop a concurrently-added collaborator). Left as-is per decision; not addressed here.