### PR TITLE
fix(events): make iTIP calendar sync reliable

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -1202,6 +1202,10 @@ async def update_event(
         "content": event.content,
         "custom_location_name": event.custom_location_name,
         "custom_location_url": event.custom_location_url,
+        "meeting_url": event.meeting_url,
+        "timezone": event.timezone,
+        "rrule": event.rrule,
+        "recurrence_exdates": event.recurrence_exdates,
     }
     updated = crud.events_crud.update(db, event, event_in)
 
@@ -3008,6 +3012,10 @@ async def update_portal_event(
         "content": event.content,
         "custom_location_name": event.custom_location_name,
         "custom_location_url": event.custom_location_url,
+        "meeting_url": event.meeting_url,
+        "timezone": event.timezone,
+        "rrule": event.rrule,
+        "recurrence_exdates": event.recurrence_exdates,
     }
     updated = crud.events_crud.update(db, event, event_in)
     if _event_calendar_fields_changed(before, updated):

--- a/backend/app/services/event_itip.py
+++ b/backend/app/services/event_itip.py
@@ -168,6 +168,12 @@ async def send_event_itip(
     service = get_email_service()
     from_address = popup.tenant.sender_email if popup and popup.tenant else None
     from_name = popup.tenant.sender_name if popup and popup.tenant else None
+    # ORGANIZER must always be present and match the actual From, or clients
+    # (Gmail especially) treat the REQUEST as malformed / from a different
+    # organiser and silently refuse to update the existing entry. The email
+    # service sends from ``from_address or settings.SENDER_EMAIL``, so mirror
+    # that exact resolution so ORGANIZER == From in every case.
+    organizer_email = from_address or settings.SENDER_EMAIL
     organizer_name = from_name or popup_name or None
 
     is_cancelled = method == "CANCEL"
@@ -222,7 +228,7 @@ async def send_event_itip(
                 event,
                 recipient_email=r["email"],
                 recipient_name=r["first_name"] or None,
-                organizer_email=from_address,
+                organizer_email=organizer_email,
                 organizer_name=organizer_name,
                 event_url=event_url or None,
                 method=method,
@@ -441,9 +447,17 @@ def calendar_fields_changed(before: dict, after) -> bool:
         "venue_id",
         "custom_location_name",
         "custom_location_url",
+        # Also material for what the calendar entry shows / when it recurs:
+        "meeting_url",  # the join link for online events (rendered as LOCATION)
+        "content",  # description
+        "timezone",
+        "rrule",
+        "recurrence_exdates",
     )
     for f in fields:
-        if before.get(f) != getattr(after, f, None):
+        # Only compare fields the caller actually snapshotted, so a partial
+        # ``before`` dict never reports a spurious change.
+        if f in before and before[f] != getattr(after, f, None):
             return True
     return False
 

--- a/backend/app/services/ical.py
+++ b/backend/app/services/ical.py
@@ -162,6 +162,15 @@ def build_event_ics(
             f"SUMMARY:{title}",
         ]
     )
+    # For a series master (not a single-occurrence update keyed by
+    # RECURRENCE-ID), carry the RRULE/EXDATE so the recipient's calendar
+    # expands every occurrence and later organiser updates reconcile the
+    # whole series instead of just the first instance.
+    if recurrence_id is None and getattr(event, "rrule", None):
+        lines.append(f"RRULE:{event.rrule}")
+        exdates = getattr(event, "recurrence_exdates", None) or []
+        if exdates:
+            lines.append(f"EXDATE:{','.join(_fmt_utc(d) for d in exdates)}")
     if description:
         lines.append(f"DESCRIPTION:{description}")
     if location:

--- a/backend/tests/test_event_itip.py
+++ b/backend/tests/test_event_itip.py
@@ -320,6 +320,31 @@ class TestBuildEventIcs:
         assert "RECURRENCE-ID:" not in invite
         assert "RECURRENCE-ID:" not in update
 
+    def test_recurring_master_invite_carries_rrule(self) -> None:
+        """A series-master REQUEST must carry RRULE so the recipient's calendar
+        expands every occurrence and later updates reconcile the whole series.
+        A single-occurrence message (keyed by RECURRENCE-ID) must NOT, so it
+        patches just that instance."""
+        start = datetime(2026, 5, 5, 14, 0, tzinfo=UTC)
+        event = self._minimal_event(start=start, end=start + timedelta(hours=1))
+        event.rrule = "FREQ=WEEKLY;BYDAY=MO"
+
+        master = build_event_ics(
+            event, recipient_email="alice@example.com", method="REQUEST", sequence=1
+        )
+        assert "RRULE:FREQ=WEEKLY;BYDAY=MO" in master
+        assert "RECURRENCE-ID:" not in master
+
+        occ = build_event_ics(
+            event,
+            recipient_email="alice@example.com",
+            method="REQUEST",
+            sequence=1,
+            occurrence_start=start + timedelta(days=7),
+        )
+        assert "RRULE:" not in occ
+        assert "RECURRENCE-ID:" in occ
+
     def test_add_to_calendar_export_uid_matches_itip_uid(self) -> None:
         """The "Add to calendar" .ics download and the emailed invite/cancel
         must share the SAME UID. Calendars key entries on UID, so a mismatch
@@ -657,6 +682,8 @@ class TestPatchBumpsSequenceAndDispatches:
         tenant_a: Tenants,
         admin_token_tenant_a: str,
     ) -> None:
+        """A field that doesn't change the calendar entry (e.g. `highlighted`)
+        must not bump SEQUENCE or re-send iTIP."""
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         _invite(db, event, _make_human(db, tenant_a))
@@ -667,15 +694,46 @@ class TestPatchBumpsSequenceAndDispatches:
             resp = client.patch(
                 f"/api/v1/events/{event.id}",
                 headers=_auth(admin_token_tenant_a),
-                json={"content": "Completely new description"},
+                json={"highlighted": True},
             )
 
         assert resp.status_code == 200, resp.text
         db.expire_all()
         refreshed = db.get(Events, event.id)
         assert refreshed.ical_sequence == before_sequence
-        assert refreshed.content == "Completely new description"
         assert send_mock.await_count == 0
+
+    def test_description_and_meeting_url_changes_bump_and_dispatch(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """Editing the description or the online join link is material — it must
+        bump SEQUENCE and re-send REQUEST so attendees' calendars update."""
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        _invite(db, event, _make_human(db, tenant_a))
+
+        for field, value in (
+            ("content", "Brand new description"),
+            ("meeting_url", "https://meet.example.com/new-link"),
+        ):
+            before_sequence = db.get(Events, event.id).ical_sequence
+            send_mock = AsyncMock(return_value=None)
+            with _patch_send_everywhere(send_mock):
+                resp = client.patch(
+                    f"/api/v1/events/{event.id}",
+                    headers=_auth(admin_token_tenant_a),
+                    json={field: value},
+                )
+            assert resp.status_code == 200, resp.text
+            db.expire_all()
+            refreshed = db.get(Events, event.id)
+            assert refreshed.ical_sequence == before_sequence + 1, field
+            assert send_mock.await_count == 1, field
+            assert send_mock.await_args.kwargs["method"] == "REQUEST"
 
     def test_patch_with_two_recipients_fans_out_once(
         self,


### PR DESCRIPTION
Fixes the "calendar sync via email is inconsistent — sometimes updates, sometimes not" reports. Three root causes in the iTIP path:

- **ORGANIZER omitted when a tenant has no `sender_email`** → invalid iTIP REQUEST that Gmail/Apple/Outlook silently refuse to apply. Now always set `ORGANIZER` to `from_address or settings.SENDER_EMAIL` (the address the email is actually sent from, so ORGANIZER == From).
- **Only title/time/venue bumped SEQUENCE & re-sent.** Edits to the meeting link, description, timezone or recurrence never reached attendees. `calendar_fields_changed` now also covers `meeting_url`, `content`, `timezone`, `rrule`, `recurrence_exdates` (guarded by presence in the before snapshot, which both update paths capture).
- **Recurring invites carried no RRULE** — only single occurrences synced. `build_event_ics` now emits `RRULE`/`EXDATE` for the series master (not when addressing one occurrence via RECURRENCE-ID).

## Verification
- `tests/test_event_itip.py` → 33 passed (added: description/meeting_url bump+dispatch, recurring master carries RRULE; fixed the non-material-field test). Event sweep (itip + collaborators + public ICS) → 46 passed. `ruff` clean. Backend-only; no migration.

Note: assumes `settings.SENDER_EMAIL` is a real, stable mailbox in each env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)