### PR TITLE
fix(events): raise portal event query cap to API max so date-ranged views stop truncating

### DIFF
--- a/portal/src/app/[popupSlug]/calendar/usePublicCalendarEvents.ts
+++ b/portal/src/app/[popupSlug]/calendar/usePublicCalendarEvents.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query"
 
+import { EVENTS_QUERY_LIMIT } from "@/app/portal/[popupSlug]/events/lib/eventsQuery"
 import { type EventPublicCalendarResponse, EventsService } from "@/client"
 
 interface UsePublicCalendarEventsArgs {
@@ -50,7 +51,7 @@ export function usePublicCalendarEvents({
         search: search || undefined,
         tags: tags?.length ? tags : undefined,
         trackIds: trackIds?.length ? trackIds : undefined,
-        limit: 200,
+        limit: EVENTS_QUERY_LIMIT,
       }),
     enabled: !!popupSlug && !!tenantId,
     staleTime: 60 * 1000,

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -36,6 +36,7 @@ import { type EventPublic, EventsService, HumansService } from "@/client"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { CoverImage } from "./CoverImage"
+import { EVENTS_QUERY_LIMIT } from "./eventsQuery"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
 import { useEventRsvp } from "./useEventRsvp"
@@ -178,7 +179,7 @@ export function CalendarBody({
         search: search || undefined,
         tags: tags?.length ? tags : undefined,
         trackIds: trackIds?.length ? trackIds : undefined,
-        limit: 200,
+        limit: EVENTS_QUERY_LIMIT,
       }),
     enabled: isAuthed && !useOverride && !!popupId && !tzLoading,
   })

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -36,6 +36,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover"
 import { cn } from "@/lib/utils"
+import { EVENTS_QUERY_LIMIT } from "./eventsQuery"
 import type { EventsScrollSnapshot } from "./eventsViewState"
 import { summarizeRrule } from "./summarizeRrule"
 import { useEventRsvp } from "./useEventRsvp"
@@ -242,7 +243,7 @@ export function DayBody({
         search: search || undefined,
         tags: tags?.length ? tags : undefined,
         trackIds: trackIds?.length ? trackIds : undefined,
-        limit: 500,
+        limit: EVENTS_QUERY_LIMIT,
       }),
     enabled: isAuthed && !useOverride && !!popupId,
   })

--- a/portal/src/app/portal/[popupSlug]/events/lib/eventsQuery.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/eventsQuery.ts
@@ -1,0 +1,8 @@
+// The portal events views are each bounded by a date range — the list's popup
+// window, the calendar's month, the day view's day. That range is the real
+// limit on how many events come back. The API still requires a `limit` and
+// caps it at 1000, so we pass that ceiling instead of an arbitrary lower
+// number: within any realistic range the result set sits well below it, and a
+// range that genuinely held more than 1000 events would overwhelm these views
+// regardless. The range is the bound; this is just the API's required maximum.
+export const EVENTS_QUERY_LIMIT = 1000

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -21,6 +21,7 @@ import { useCityProvider } from "@/providers/cityProvider"
 import { CalendarBody } from "./lib/CalendarBody"
 import { DayBody } from "./lib/DayBody"
 import { EventsToolbar, type EventsView } from "./lib/EventsToolbar"
+import { EVENTS_QUERY_LIMIT } from "./lib/eventsQuery"
 import {
   consumeEventsViewState,
   type EventsScrollSnapshot,
@@ -382,7 +383,7 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
+        limit: EVENTS_QUERY_LIMIT,
       }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useAllChannel,
   })
@@ -414,7 +415,7 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
+        limit: EVENTS_QUERY_LIMIT,
       }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useMineChannel,
   })
@@ -442,7 +443,7 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
+        limit: EVENTS_QUERY_LIMIT,
       }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useRsvpedChannel,
   })


### PR DESCRIPTION
## Summary

The portal list, calendar, and day event views — plus the anonymous public calendar — each scope their query by a date range, then capped the result count at an arbitrary number (200, or 500 for day view). Within a busy popup window, month, or day, that cap silently dropped events past the limit, so events were missing from the views with no indication.

This raises the cap to the API's maximum (1000) via a shared `EVENTS_QUERY_LIMIT` constant. The date range is already the real bound on these queries; the count cap is now just the API's required ceiling, which a realistic range never approaches.

## Related Issue

N/A — no tracked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- New `events/lib/eventsQuery.ts` exporting `EVENTS_QUERY_LIMIT = 1000`, documenting that the date range is the bound and 1000 is the API ceiling (`PaginationLimit` = `ge=1, le=1000`).
- List view (`page.tsx`): all three channels (`all` / `mine` / `rsvped`) use the constant instead of `200`.
- Calendar view (`CalendarBody.tsx`): month query uses the constant instead of `200`.
- Day view (`DayBody.tsx`): events query uses the constant instead of `500` (the venues query stays at 200).
- Public calendar (`usePublicCalendarEvents.ts`): same fix, `200` → constant.

## Changes Table

| File | Change |
|------|--------|
| `portal/.../events/lib/eventsQuery.ts` | New shared `EVENTS_QUERY_LIMIT` constant |
| `portal/.../events/page.tsx` | List view 3 channels: `200` → constant |
| `portal/.../events/lib/CalendarBody.tsx` | Month query: `200` → constant |
| `portal/.../events/lib/DayBody.tsx` | Events query: `500` → constant |
| `portal/.../[popupSlug]/calendar/usePublicCalendarEvents.ts` | Public calendar: `200` → constant |

## Testing

- [ ] Backend tests pass (no backend changes)
- [ ] Backend linting passes (no backend changes)
- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [x] Portal linting passes (`pnpm --filter portal run lint`)
- [ ] Manual testing performed (not verified against a high-volume popup in runtime)

## Notes

Infinite scroll was intentionally not added: the date range already bounds each view, and a range exceeding 1000 events would overwhelm these client-side-rendered views regardless. A follow-up improvement (not in this PR) is to read `paging.total` so truncation is never silent; the escalation path for genuinely high volume is virtualization.
