### PR TITLE
fix(checkout): disable meal-plan weeks whose sale has ended

### DIFF
--- a/portal/src/components/checkout-flow/variants/VariantMealPlanSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMealPlanSelect.tsx
@@ -26,6 +26,7 @@ import { Sparkles } from "lucide-react"
 import { Fragment, useMemo, useState } from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { deriveProductState, type ProductSaleState } from "@/lib/product-state"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { usePassesProvider } from "@/providers/passesProvider"
@@ -41,6 +42,7 @@ import {
   type MealPlanProduct as SharedMealPlanProduct,
   weekdayDates,
 } from "./mealPlanShared"
+import { SaleStateBadge } from "./saleStateBadge"
 
 /** Weekly meal-plan product enriched with template_config metadata, with the
  *  product field narrowed to ProductsPass for this checkout step. */
@@ -103,6 +105,23 @@ function isPrePurchased(
 }
 
 // ---------------------------------------------------------------------------
+// Sale-state detection
+// ---------------------------------------------------------------------------
+
+/** Derive the weekly product's sale state from its pricing/stock window.
+ *  Mirrors VariantTicketSelect — the same backend logic gates payment, so a
+ *  non-`on_sale` week would 422 at checkout. */
+function saleStateOf(product: MealPlanProduct): ProductSaleState {
+  return deriveProductState(product.product)
+}
+
+/** True when the week is not currently on sale (ended / upcoming / sold out)
+ *  and therefore must not be selectable. */
+function isSaleClosed(product: MealPlanProduct): boolean {
+  return saleStateOf(product) !== "on_sale"
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -154,6 +173,9 @@ export default function VariantMealPlanSelect({
     product: MealPlanProduct,
   ) => {
     if (isPrePurchased(attendee, product.id)) return
+    // Defense in depth: never add a cart line for a week that isn't on sale —
+    // the backend payment gate would reject it with a 422.
+    if (isSaleClosed(product)) return
     const selected = selectedProductIdsFor(cart.mealPlans, attendee.id).has(
       product.id,
     )
@@ -230,6 +252,11 @@ export default function VariantMealPlanSelect({
               <div className="text-[10px] text-muted-foreground">
                 {formatCurrency(p.product.price)} / wk
               </div>
+              {isSaleClosed(p) && (
+                <div className="mt-1 flex justify-center">
+                  <SaleStateBadge state={saleStateOf(p)} />
+                </div>
+              )}
             </div>
           ))}
         </div>
@@ -361,6 +388,8 @@ function AttendeeRow({
         {weeklyProducts.map((product) => {
           const isPicked = selectedHere.has(product.id)
           const isLocked = isPrePurchased(attendee, product.id)
+          const saleState = saleStateOf(product)
+          const saleClosed = saleState !== "on_sale"
           const isOpen =
             openCell?.attendeeId === attendee.id &&
             openCell?.productId === product.id
@@ -406,6 +435,8 @@ function AttendeeRow({
                   product={product}
                   isPicked={isPicked}
                   isLocked={isLocked}
+                  saleState={saleState}
+                  saleClosed={saleClosed}
                   isOpen={isOpen}
                   item={item}
                   onClick={() => onCellClick(attendee, product)}
@@ -531,6 +562,8 @@ function WeekCell({
   product,
   isPicked,
   isLocked,
+  saleState,
+  saleClosed,
   isOpen,
   item,
   onClick,
@@ -539,6 +572,8 @@ function WeekCell({
   product: MealPlanProduct
   isPicked: boolean
   isLocked: boolean
+  saleState: ProductSaleState
+  saleClosed: boolean
   isOpen: boolean
   item: SelectedMealPlanItem | undefined
   onClick: () => void
@@ -570,6 +605,37 @@ function WeekCell({
             Purchased
           </span>
         </div>
+        {/* Mobile-only price on the right */}
+        <span className="md:hidden text-[10px] text-muted-foreground shrink-0">
+          {formatCurrency(product.product.price)}/wk
+        </span>
+      </div>
+    )
+  }
+
+  // Sale window closed (ended / upcoming / sold out) and not purchased: render
+  // a disabled cell with a state badge so the week reads as unavailable instead
+  // of clickable. Mirrors VariantTicketSelect's stateBlocked handling.
+  if (saleClosed) {
+    return (
+      <div
+        role="img"
+        aria-label={`${product.weekLabel} sale ${saleState}`}
+        aria-disabled="true"
+        className="h-full flex items-center justify-between md:justify-center gap-2 md:gap-1.5 md:min-h-[60px] min-h-[44px] bg-muted/30 px-3 md:px-2 py-1.5 select-none opacity-70 [background-image:repeating-linear-gradient(45deg,transparent,transparent_6px,rgba(0,0,0,0.03)_6px,rgba(0,0,0,0.03)_12px)]"
+        title={`${product.weekLabel} sale ${saleState}`}
+      >
+        {/* Mobile-only week info on the left */}
+        <div className="md:hidden flex flex-col items-start leading-tight min-w-0">
+          <span className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+            {product.weekLabel}
+          </span>
+          <span className="text-[10px] text-muted-foreground">
+            {formatCoverageRange(product)}
+          </span>
+        </div>
+        {/* Center: sale-state badge */}
+        <SaleStateBadge state={saleState} />
         {/* Mobile-only price on the right */}
         <span className="md:hidden text-[10px] text-muted-foreground shrink-0">
           {formatCurrency(product.product.price)}/wk

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -11,7 +11,7 @@ import QuantitySelector, {
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
 import { useAttendeeCategories } from "@/hooks/useAttendeeCategories"
-import { deriveProductState, type ProductSaleState } from "@/lib/product-state"
+import { deriveProductState } from "@/lib/product-state"
 import { cn } from "@/lib/utils"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -21,6 +21,7 @@ import type { AttendeePassState } from "@/types/Attendee"
 import { formatCurrency, formatPrice } from "@/types/checkout"
 import type { ProductsPass } from "@/types/Products"
 import type { VariantProps } from "../registries/variantRegistry"
+import { SaleStateBadge } from "./saleStateBadge"
 
 // ---------------------------------------------------------------------------
 // Types & constants
@@ -97,38 +98,6 @@ const getCategoryMeta = (cat: string) => {
       badge: "bg-gray-100 text-gray-700",
       tab: "text-gray-700 border-gray-700",
     }
-  )
-}
-
-function SaleStateBadge({ state }: { state: ProductSaleState }) {
-  if (state === "on_sale") return null
-  const config: Record<
-    Exclude<ProductSaleState, "on_sale">,
-    { label: string; classes: string }
-  > = {
-    upcoming: {
-      label: "UPCOMING",
-      classes: "bg-blue-100 text-blue-700 border-blue-200",
-    },
-    ended: {
-      label: "ENDED",
-      classes: "bg-slate-100 text-slate-500 border-slate-200",
-    },
-    sold_out: {
-      label: "SOLD OUT",
-      classes: "bg-rose-100 text-rose-700 border-rose-200",
-    },
-  }
-  const { label, classes } = config[state]
-  return (
-    <span
-      className={cn(
-        "px-2 py-0.5 text-[10px] font-semibold uppercase rounded tracking-wide border shrink-0",
-        classes,
-      )}
-    >
-      {label}
-    </span>
   )
 }
 

--- a/portal/src/components/checkout-flow/variants/mealPlanShared.test.ts
+++ b/portal/src/components/checkout-flow/variants/mealPlanShared.test.ts
@@ -130,4 +130,28 @@ describe("read-only week gating (deriveProductState)", () => {
   it("treats a NULL sale_ends_at as editable (on_sale)", () => {
     expect(deriveProductState({ ...base, sale_ends_at: null })).toBe("on_sale")
   })
+
+  // VariantMealPlanSelect disables every non-`on_sale` state (not just ended),
+  // matching VariantTicketSelect and the backend payment gate. These guard the
+  // symmetric upcoming / sold-out variants of the same checkout failure.
+  it("marks a week whose sale_starts_at is in the future as upcoming", () => {
+    expect(
+      deriveProductState({
+        ...base,
+        sale_ends_at: null,
+        sale_starts_at: "2999-01-01T00:00:00Z",
+      }),
+    ).toBe("upcoming")
+  })
+
+  it("marks a week with no remaining stock as sold_out", () => {
+    expect(
+      deriveProductState({
+        ...base,
+        sale_ends_at: null,
+        total_stock_cap: 10,
+        total_stock_remaining: 0,
+      }),
+    ).toBe("sold_out")
+  })
 })

--- a/portal/src/components/checkout-flow/variants/saleStateBadge.tsx
+++ b/portal/src/components/checkout-flow/variants/saleStateBadge.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+/**
+ * Small presentational badge for a product's non-`on_sale` sale state.
+ *
+ * Shared by the ticket and meal-plan checkout variants so both surface the
+ * same UPCOMING / ENDED / SOLD OUT chips with identical styling. Renders
+ * nothing while the product is `on_sale`.
+ */
+
+import type { ProductSaleState } from "@/lib/product-state"
+import { cn } from "@/lib/utils"
+
+export function SaleStateBadge({ state }: { state: ProductSaleState }) {
+  if (state === "on_sale") return null
+  const config: Record<
+    Exclude<ProductSaleState, "on_sale">,
+    { label: string; classes: string }
+  > = {
+    upcoming: {
+      label: "UPCOMING",
+      classes: "bg-blue-100 text-blue-700 border-blue-200",
+    },
+    ended: {
+      label: "ENDED",
+      classes: "bg-slate-100 text-slate-500 border-slate-200",
+    },
+    sold_out: {
+      label: "SOLD OUT",
+      classes: "bg-rose-100 text-rose-700 border-rose-200",
+    },
+  }
+  const { label, classes } = config[state]
+  return (
+    <span
+      className={cn(
+        "px-2 py-0.5 text-[10px] font-semibold uppercase rounded tracking-wide border shrink-0",
+        classes,
+      )}
+    >
+      {label}
+    </span>
+  )
+}


### PR DESCRIPTION
## Context

When a `meal_plan` product's `sale_ends_at` is in the past, the portal's meal-plan grid still let the buyer select that week, plan days, and proceed to payment. The backend payment gate then rejected it with HTTP 422 (`Product '...' is not on sale (state: ended)`), surfaced in the UI as a generic "Something went wrong with your payment."

Root cause: `VariantMealPlanSelect.tsx` only guarded cells with `isPrePurchased()`. Unlike `VariantTicketSelect.tsx`, it never computed the product's sale state, so ended (and upcoming / sold-out) weeks stayed clickable and reached checkout. The backend gate is authoritative; this fix is frontend-only.

## Changes

- **New `saleStateBadge.tsx`** — lifted `SaleStateBadge` out of `VariantTicketSelect.tsx` into a shared module reused by both checkout variants.
- **`VariantTicketSelect.tsx`** — imports the shared badge; removed the inline copy and the now-unused `ProductSaleState` import.
- **`VariantMealPlanSelect.tsx`** (primary fix):
  - Added `saleStateOf()` / `isSaleClosed()` helpers via `deriveProductState` (mirror of the backend logic).
  - `handleCellClick` early-returns for sale-closed weeks (defense in depth — never adds a cart line that would 422).
  - `WeekCell` renders a disabled, striped, non-interactive cell with a state badge (**ENDED** / **UPCOMING** / **SOLD OUT**) and an `aria-label`/`title` for closed weeks.
  - Desktop header shows the badge at the column level.
  - Disables **all** non-`on_sale` states for parity with `VariantTicketSelect`.
- **`mealPlanShared.test.ts`** — extended the gating tests to cover `upcoming` and `sold_out`.

## Verification

- `pnpm lint` (Biome): clean (one pre-existing, unrelated warning).
- `tsc --noEmit`: passes.
- `vitest` on `mealPlanShared.test.ts`: 13/13 passing.
- Manual portal check (seed a past `sale_ends_at` week + an on-sale week) still pending a running dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)