### PR TITLE
fix(events): keep schedule when changing venue on portal edit form

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/EditEventForm.tsx
@@ -160,8 +160,10 @@ export function EditEventForm({
     excludeEventId: event.id,
     isDateOutsidePopupWindow,
     popupStartKey,
-    setDateStr,
-    setTimeStr,
+    // Intentionally omit setDateStr/setTimeStr: on the edit form, changing the
+    // venue must keep the user's saved schedule. Availability is still
+    // re-checked against the new venue (conflict check, withinOpenHours,
+    // selectedDateIsClosed all key off venueId) and surfaced as warnings.
   })
 
   const updateMutation = useMutation({


### PR DESCRIPTION
## Context

On the portal, editing your own event and changing the **venue** silently overwrote the saved **time** (and sometimes the **day**). In the edit flow the user expects their saved schedule to stay put — only re-checking whether that schedule is available at the newly-selected venue. The auto-snap is intentional **for creating** an event, but not for editing.

## Root cause

`useVenueAvailability` has two effects that snap the schedule when the venue changes (time → first free slot, date → first open day). Both are gated on optional `setDateStr`/`setTimeStr` setters — *not passing them* is the hook's built-in off-switch. The edit form was passing both, so it inherited the create-time snap behavior.

## Change

In `EditEventForm.tsx`, remove `setDateStr`/`setTimeStr` from the `useVenueAvailability({ ... })` call (with a comment explaining why, so they aren't re-added). Availability is still re-checked against the new venue — conflict check, `withinOpenHours`, and `selectedDateIsClosed` all key off `venueId` — and surfaced as warnings. The local setters from `useEventScheduling` stay wired to `EventScheduleFields` (`onDateChange`, `onTimeChange`, `onSuggestionPick`) so manual date/time edits and suggested-slot picks still work.

No changes to `useVenueAvailability.ts`, the create form, or the backend.

## Verification

- [x] `pnpm lint` (Biome) passes — only pre-existing unrelated warning remains.
- [x] Edit an own event, change venue → date/time stay; conflict / "venue closed" / outside-open-hours warnings appear and block submit when applicable.
- [x] Manual date/time edit + suggested-slot pick still work.
- [ ] Regression: create flow still auto-fills first available slot and snaps off closed days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)