### PR TITLE
fix(events): derive portal domain from host for backoffice share button

### DIFF
--- a/backoffice/src/lib/portal-urls.ts
+++ b/backoffice/src/lib/portal-urls.ts
@@ -2,6 +2,31 @@ import type { TenantPublic } from "@/client"
 
 const PORTAL_DOMAIN = import.meta.env.VITE_PORTAL_DOMAIN ?? ""
 
+/**
+ * The portal's root domain for the current environment. Tenants live at
+ * `{slug}.{root}` (e.g. `demo.dev.edgeos.world`, `edgecity.edgeos.world`).
+ *
+ * Prefers an explicit `VITE_PORTAL_DOMAIN`; otherwise derives it from the
+ * backoffice's own hostname. The backoffice sits at a sibling subdomain of
+ * the portal (`app.<root>`), so dropping the first label yields the root —
+ * which keeps dev (`app.dev.edgeos.world` → `dev.edgeos.world`) and prod
+ * (`app.edgeos.world` → `edgeos.world`) working with no extra config.
+ * Returns "" on hosts we can't derive from (localhost, preview domains),
+ * where an explicit env var is still needed.
+ */
+function getPortalRootDomain(): string {
+  if (PORTAL_DOMAIN) return PORTAL_DOMAIN
+  if (typeof window === "undefined") return ""
+  const host = window.location.hostname
+  if (host !== "edgeos.world" && !host.endsWith(".edgeos.world")) return ""
+  const firstDot = host.indexOf(".")
+  if (firstDot <= 0) return ""
+  const root = host.slice(firstDot + 1)
+  // Require a real apex (still has a dot) so e.g. the bare apex never
+  // collapses to a TLD.
+  return root.includes(".") ? root : ""
+}
+
 /** Returns the portal base URL for a tenant, or null if it can't be built. */
 export function getPortalBaseUrl(
   tenant:
@@ -13,8 +38,9 @@ export function getPortalBaseUrl(
   if (tenant.custom_domain_active && tenant.custom_domain) {
     return `https://${tenant.custom_domain}`
   }
-  if (tenant.slug && PORTAL_DOMAIN) {
-    return `https://${tenant.slug}.${PORTAL_DOMAIN}`
+  const root = getPortalRootDomain()
+  if (tenant.slug && root) {
+    return `https://${tenant.slug}.${root}`
   }
   return null
 }


### PR DESCRIPTION
The backoffice event **Share** button errored with _"Set a portal domain for this tenant to share events"_ whenever the tenant had no `custom_domain` **and** `VITE_PORTAL_DOMAIN` wasn't set in the deployment (the case on `dev`).

Fix: derive the portal root domain from the backoffice's own hostname. The backoffice lives at `app.<root>`, a sibling subdomain of the portal's `{slug}.<root>`, so dropping the first label yields the root:
- dev: `app.dev.edgeos.world` → root `dev.edgeos.world` → `demo.dev.edgeos.world`
- prod: `app.edgeos.world` → root `edgeos.world` → `edgecity.edgeos.world`

`custom_domain` (active) and an explicit `VITE_PORTAL_DOMAIN` still take precedence; derivation is the fallback and only triggers on `*.edgeos.world` hosts (localhost/preview still need the env var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)