### PR TITLE
fix(events): restore edit route + stop backoffice calendar truncating events

### DIFF
--- a/backoffice/src/components/events/EventsCalendarView.tsx
+++ b/backoffice/src/components/events/EventsCalendarView.tsx
@@ -24,8 +24,9 @@ import {
   Users,
 } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
-import { type EventPublic, type EventStatus, EventsService } from "@/client"
+import type { EventPublic, EventStatus } from "@/client"
 import { Button } from "@/components/ui/button"
+import { fetchAllEvents } from "@/lib/events/fetchAllEvents"
 import { summarizeRrule } from "@/lib/events/summarizeRrule"
 import { useEventTimezone } from "@/lib/events/useEventTimezone"
 import { cn } from "@/lib/utils"
@@ -145,8 +146,10 @@ export function EventsCalendarView({
       venueId,
       search,
     ],
+    // Walk every page so a dense month is never truncated at a fixed limit
+    // (the cause of the calendar showing fewer events than the list/day).
     queryFn: () =>
-      EventsService.listEvents({
+      fetchAllEvents({
         popupId,
         eventStatus: status,
         venueId:
@@ -154,16 +157,17 @@ export function EventsCalendarView({
             ? venueId
             : undefined,
         locationKind:
-          venueId === "custom" || venueId === "meeting" ? venueId : undefined,
+          venueId === "custom" || venueId === "meeting"
+            ? (venueId as "custom" | "meeting")
+            : undefined,
         search: search || undefined,
         startAfter: monthBounds.start.toISOString(),
         startBefore: monthBounds.end.toISOString(),
-        limit: 200,
       }),
     enabled: !!popupId && !tzLoading,
   })
 
-  const events = data?.results ?? []
+  const events = data ?? []
 
   // Grid cells are calendar days (number labels) — match them against
   // events by formatting both sides in the popup's timezone, so an event

--- a/backoffice/src/components/events/EventsListView.tsx
+++ b/backoffice/src/components/events/EventsListView.tsx
@@ -1,3 +1,4 @@
+import { dayBoundsInTz } from "@edgeos/shared-events"
 import { useQuery } from "@tanstack/react-query"
 import {
   CalendarDays,
@@ -8,10 +9,11 @@ import {
   Repeat,
   Tag,
 } from "lucide-react"
-import { useEffect, useRef } from "react"
-import { type EventPublic, type EventStatus, EventsService } from "@/client"
+import { useEffect, useMemo, useRef } from "react"
+import type { EventPublic, EventStatus } from "@/client"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { fetchAllEvents } from "@/lib/events/fetchAllEvents"
 import { summarizeRrule } from "@/lib/events/summarizeRrule"
 import { useEventTimezone } from "@/lib/events/useEventTimezone"
 import { cn } from "@/lib/utils"
@@ -22,6 +24,8 @@ interface EventsListViewProps {
   status: EventStatus | undefined
   venueId: string | undefined
   search: string
+  popupStart?: string | null
+  popupEnd?: string | null
   onEventClick: (event: EventPublic) => void
 }
 
@@ -67,19 +71,46 @@ export function EventsListView({
   status,
   venueId,
   search,
+  popupStart,
+  popupEnd,
   onEventClick,
 }: EventsListViewProps) {
   const {
     formatTime,
     formatDateFull,
     formatDayKey,
+    timezone,
     isLoading: tzLoading,
   } = useEventTimezone(popupId)
 
+  // Bound to the popup's date range (in its timezone). A window makes the
+  // backend expand recurring series into concrete occurrences — matching the
+  // day/calendar views — instead of showing each series once at its master.
+  // Falls back to no window (no expansion) when the popup has no dates.
+  const listWindow = useMemo(() => {
+    const startYmd = popupStart?.slice(0, 10)
+    const endYmd = popupEnd?.slice(0, 10)
+    if (!startYmd || !endYmd || !timezone) return null
+    return {
+      startAfter: dayBoundsInTz(startYmd, timezone).start.toISOString(),
+      startBefore: dayBoundsInTz(endYmd, timezone).end.toISOString(),
+    }
+  }, [popupStart, popupEnd, timezone])
+
   const { data, isLoading } = useQuery({
-    queryKey: ["events", "list", popupId, status, venueId, search],
+    queryKey: [
+      "events",
+      "list",
+      popupId,
+      status,
+      venueId,
+      search,
+      listWindow?.startAfter,
+      listWindow?.startBefore,
+    ],
+    // Walk every page so a dense popup is never truncated at a fixed limit.
     queryFn: () =>
-      EventsService.listEvents({
+      fetchAllEvents({
         popupId,
         eventStatus: status,
         venueId:
@@ -87,9 +118,12 @@ export function EventsListView({
             ? venueId
             : undefined,
         locationKind:
-          venueId === "custom" || venueId === "meeting" ? venueId : undefined,
+          venueId === "custom" || venueId === "meeting"
+            ? (venueId as "custom" | "meeting")
+            : undefined,
         search: search || undefined,
-        limit: 500,
+        startAfter: listWindow?.startAfter,
+        startBefore: listWindow?.startBefore,
       }),
     enabled: !!popupId && !tzLoading,
   })
@@ -111,7 +145,7 @@ export function EventsListView({
     return <Skeleton className="h-64 w-full" />
   }
 
-  const events = data?.results ?? []
+  const events = data ?? []
 
   if (events.length === 0) {
     return (

--- a/backoffice/src/lib/events/fetchAllEvents.ts
+++ b/backoffice/src/lib/events/fetchAllEvents.ts
@@ -1,0 +1,56 @@
+import { type EventPublic, type EventStatus, EventsService } from "@/client"
+
+/** Page size for the paginated events fetch loop. */
+const PAGE = 100
+
+export interface FetchAllEventsParams {
+  popupId: string
+  /** Omit for all statuses (backoffice default). */
+  eventStatus?: EventStatus
+  venueId?: string
+  locationKind?: "custom" | "meeting"
+  startAfter?: string
+  startBefore?: string
+  search?: string
+}
+
+/**
+ * Fetches EVERY event matching the window/filters across all pages, sorted
+ * ascending by ``start_time``.
+ *
+ * The backend paginates DB rows first, THEN expands recurring occurrences
+ * within each page and sorts only within that page. So a single capped request
+ * silently truncates a dense window (the bug behind the calendar showing fewer
+ * events than the list/day). We walk every page — ``paging.total`` counts DB
+ * rows, so we loop while ``skip < total`` — and re-sort the merged set.
+ *
+ * Passing ``startAfter``/``startBefore`` also triggers the backend to expand
+ * recurring series into concrete occurrences inside the window; without a
+ * window, recurring events render only at their master's start.
+ */
+export async function fetchAllEvents(
+  params: FetchAllEventsParams,
+): Promise<EventPublic[]> {
+  const all: EventPublic[] = []
+  let skip = 0
+  let total = Number.POSITIVE_INFINITY
+
+  while (skip < total) {
+    const { results, paging } = await EventsService.listEvents({
+      popupId: params.popupId,
+      eventStatus: params.eventStatus,
+      venueId: params.venueId,
+      locationKind: params.locationKind,
+      startAfter: params.startAfter,
+      startBefore: params.startBefore,
+      search: params.search,
+      limit: PAGE,
+      skip,
+    })
+    all.push(...results)
+    total = paging.total
+    skip += PAGE
+  }
+
+  return all.sort((a, b) => a.start_time.localeCompare(b.start_time))
+}

--- a/backoffice/src/routeTree.gen.ts
+++ b/backoffice/src/routeTree.gen.ts
@@ -64,7 +64,7 @@ import { Route as LayoutFormBuilderSectionsNewRouteImport } from './routes/_layo
 import { Route as LayoutFormBuilderIdEditRouteImport } from './routes/_layout/form-builder/$id.edit'
 import { Route as LayoutEventsVenuesNewRouteImport } from './routes/_layout/events/venues/new'
 import { Route as LayoutEventsTracksNewRouteImport } from './routes/_layout/events/tracks/new'
-import { Route as LayoutEventsEventIdEditRouteImport } from './routes/_layout/events/$eventId.edit'
+import { Route as LayoutEventsEventIdEditRouteImport } from './routes/_layout/events/$eventId_.edit'
 import { Route as LayoutEmailTemplatesTypeEditRouteImport } from './routes/_layout/email-templates/$type.edit'
 import { Route as LayoutCouponsIdEditRouteImport } from './routes/_layout/coupons/$id.edit'
 import { Route as LayoutAdminIdEditRouteImport } from './routes/_layout/admin/$id.edit'
@@ -356,9 +356,9 @@ const LayoutEventsTracksNewRoute = LayoutEventsTracksNewRouteImport.update({
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutEventsEventIdEditRoute = LayoutEventsEventIdEditRouteImport.update({
-  id: '/edit',
-  path: '/edit',
-  getParentRoute: () => LayoutEventsEventIdRoute,
+  id: '/events/$eventId_/edit',
+  path: '/events/$eventId/edit',
+  getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutEmailTemplatesTypeEditRoute =
   LayoutEmailTemplatesTypeEditRouteImport.update({
@@ -417,7 +417,7 @@ export interface FileRoutesByFullPath {
   '/applications/review-queue': typeof LayoutApplicationsReviewQueueRoute
   '/attendees/$attendeeId': typeof LayoutAttendeesAttendeeIdRoute
   '/coupons/new': typeof LayoutCouponsNewRoute
-  '/events/$eventId': typeof LayoutEventsEventIdRouteWithChildren
+  '/events/$eventId': typeof LayoutEventsEventIdRoute
   '/events/day-by-venue': typeof LayoutEventsDayByVenueRoute
   '/events/new': typeof LayoutEventsNewRoute
   '/events/properties': typeof LayoutEventsPropertiesRoute
@@ -481,7 +481,7 @@ export interface FileRoutesByTo {
   '/applications/review-queue': typeof LayoutApplicationsReviewQueueRoute
   '/attendees/$attendeeId': typeof LayoutAttendeesAttendeeIdRoute
   '/coupons/new': typeof LayoutCouponsNewRoute
-  '/events/$eventId': typeof LayoutEventsEventIdRouteWithChildren
+  '/events/$eventId': typeof LayoutEventsEventIdRoute
   '/events/day-by-venue': typeof LayoutEventsDayByVenueRoute
   '/events/new': typeof LayoutEventsNewRoute
   '/events/properties': typeof LayoutEventsPropertiesRoute
@@ -547,7 +547,7 @@ export interface FileRoutesById {
   '/_layout/applications/review-queue': typeof LayoutApplicationsReviewQueueRoute
   '/_layout/attendees/$attendeeId': typeof LayoutAttendeesAttendeeIdRoute
   '/_layout/coupons/new': typeof LayoutCouponsNewRoute
-  '/_layout/events/$eventId': typeof LayoutEventsEventIdRouteWithChildren
+  '/_layout/events/$eventId': typeof LayoutEventsEventIdRoute
   '/_layout/events/day-by-venue': typeof LayoutEventsDayByVenueRoute
   '/_layout/events/new': typeof LayoutEventsNewRoute
   '/_layout/events/properties': typeof LayoutEventsPropertiesRoute
@@ -577,7 +577,7 @@ export interface FileRoutesById {
   '/_layout/admin/$id/edit': typeof LayoutAdminIdEditRoute
   '/_layout/coupons/$id/edit': typeof LayoutCouponsIdEditRoute
   '/_layout/email-templates/$type/edit': typeof LayoutEmailTemplatesTypeEditRoute
-  '/_layout/events/$eventId/edit': typeof LayoutEventsEventIdEditRoute
+  '/_layout/events/$eventId_/edit': typeof LayoutEventsEventIdEditRoute
   '/_layout/events/tracks/new': typeof LayoutEventsTracksNewRoute
   '/_layout/events/venues/new': typeof LayoutEventsVenuesNewRoute
   '/_layout/form-builder/$id/edit': typeof LayoutFormBuilderIdEditRoute
@@ -772,7 +772,7 @@ export interface FileRouteTypes {
     | '/_layout/admin/$id/edit'
     | '/_layout/coupons/$id/edit'
     | '/_layout/email-templates/$type/edit'
-    | '/_layout/events/$eventId/edit'
+    | '/_layout/events/$eventId_/edit'
     | '/_layout/events/tracks/new'
     | '/_layout/events/venues/new'
     | '/_layout/form-builder/$id/edit'
@@ -1183,12 +1183,12 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutEventsTracksNewRouteImport
       parentRoute: typeof LayoutRoute
     }
-    '/_layout/events/$eventId/edit': {
-      id: '/_layout/events/$eventId/edit'
-      path: '/edit'
+    '/_layout/events/$eventId_/edit': {
+      id: '/_layout/events/$eventId_/edit'
+      path: '/events/$eventId/edit'
       fullPath: '/events/$eventId/edit'
       preLoaderRoute: typeof LayoutEventsEventIdEditRouteImport
-      parentRoute: typeof LayoutEventsEventIdRoute
+      parentRoute: typeof LayoutRoute
     }
     '/_layout/email-templates/$type/edit': {
       id: '/_layout/email-templates/$type/edit'
@@ -1242,17 +1242,6 @@ declare module '@tanstack/react-router' {
   }
 }
 
-interface LayoutEventsEventIdRouteChildren {
-  LayoutEventsEventIdEditRoute: typeof LayoutEventsEventIdEditRoute
-}
-
-const LayoutEventsEventIdRouteChildren: LayoutEventsEventIdRouteChildren = {
-  LayoutEventsEventIdEditRoute: LayoutEventsEventIdEditRoute,
-}
-
-const LayoutEventsEventIdRouteWithChildren =
-  LayoutEventsEventIdRoute._addFileChildren(LayoutEventsEventIdRouteChildren)
-
 interface LayoutRouteChildren {
   LayoutAbandonedCartsRoute: typeof LayoutAbandonedCartsRoute
   LayoutActivityRoute: typeof LayoutActivityRoute
@@ -1268,7 +1257,7 @@ interface LayoutRouteChildren {
   LayoutApplicationsReviewQueueRoute: typeof LayoutApplicationsReviewQueueRoute
   LayoutAttendeesAttendeeIdRoute: typeof LayoutAttendeesAttendeeIdRoute
   LayoutCouponsNewRoute: typeof LayoutCouponsNewRoute
-  LayoutEventsEventIdRoute: typeof LayoutEventsEventIdRouteWithChildren
+  LayoutEventsEventIdRoute: typeof LayoutEventsEventIdRoute
   LayoutEventsDayByVenueRoute: typeof LayoutEventsDayByVenueRoute
   LayoutEventsNewRoute: typeof LayoutEventsNewRoute
   LayoutEventsPropertiesRoute: typeof LayoutEventsPropertiesRoute
@@ -1298,6 +1287,7 @@ interface LayoutRouteChildren {
   LayoutAdminIdEditRoute: typeof LayoutAdminIdEditRoute
   LayoutCouponsIdEditRoute: typeof LayoutCouponsIdEditRoute
   LayoutEmailTemplatesTypeEditRoute: typeof LayoutEmailTemplatesTypeEditRoute
+  LayoutEventsEventIdEditRoute: typeof LayoutEventsEventIdEditRoute
   LayoutEventsTracksNewRoute: typeof LayoutEventsTracksNewRoute
   LayoutEventsVenuesNewRoute: typeof LayoutEventsVenuesNewRoute
   LayoutFormBuilderIdEditRoute: typeof LayoutFormBuilderIdEditRoute
@@ -1331,7 +1321,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutApplicationsReviewQueueRoute: LayoutApplicationsReviewQueueRoute,
   LayoutAttendeesAttendeeIdRoute: LayoutAttendeesAttendeeIdRoute,
   LayoutCouponsNewRoute: LayoutCouponsNewRoute,
-  LayoutEventsEventIdRoute: LayoutEventsEventIdRouteWithChildren,
+  LayoutEventsEventIdRoute: LayoutEventsEventIdRoute,
   LayoutEventsDayByVenueRoute: LayoutEventsDayByVenueRoute,
   LayoutEventsNewRoute: LayoutEventsNewRoute,
   LayoutEventsPropertiesRoute: LayoutEventsPropertiesRoute,
@@ -1361,6 +1351,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAdminIdEditRoute: LayoutAdminIdEditRoute,
   LayoutCouponsIdEditRoute: LayoutCouponsIdEditRoute,
   LayoutEmailTemplatesTypeEditRoute: LayoutEmailTemplatesTypeEditRoute,
+  LayoutEventsEventIdEditRoute: LayoutEventsEventIdEditRoute,
   LayoutEventsTracksNewRoute: LayoutEventsTracksNewRoute,
   LayoutEventsVenuesNewRoute: LayoutEventsVenuesNewRoute,
   LayoutFormBuilderIdEditRoute: LayoutFormBuilderIdEditRoute,

--- a/backoffice/src/routes/_layout/events/$eventId_.edit.tsx
+++ b/backoffice/src/routes/_layout/events/$eventId_.edit.tsx
@@ -166,7 +166,7 @@ function CreatedByCard({ event }: { event: EventPublic }) {
   )
 }
 
-export const Route = createFileRoute("/_layout/events/$eventId/edit")({
+export const Route = createFileRoute("/_layout/events/$eventId_/edit")({
   component: EditEventPage,
   head: () => ({
     meta: [{ title: "Edit Event - EdgeOS" }],

--- a/backoffice/src/routes/_layout/events/index.tsx
+++ b/backoffice/src/routes/_layout/events/index.tsx
@@ -1326,6 +1326,8 @@ function EventsPage() {
                   status={searchParams.status}
                   venueId={searchParams.venueId}
                   search={searchParams.search ?? ""}
+                  popupStart={popupStart}
+                  popupEnd={popupEnd}
                   onEventClick={handleRowClick}
                 />
               </div>


### PR DESCRIPTION
Two fixes for the backoffice events views:

**1. Restore the event edit route** (`e2485973`)
Adding the read-only view route (`$eventId.tsx`) had turned `$eventId` into a parent layout route, nesting `$eventId.edit.tsx` with no `<Outlet />` — so Edit only re-rendered the view. Renames `$eventId.edit.tsx` → `$eventId_.edit.tsx` (trailing-underscore convention) to un-nest it while keeping the same `/events/$eventId/edit` URL.

**2. Stop the calendar truncating events; unify fetching** (`40de9f9a`)
The calendar fetched the whole month with `limit: 200`, so a dense month (e.g. Edge Esmeralda) dropped later days — June 13 showed ~4 events while list/day showed 13. New `fetchAllEvents` helper (mirrors the portal's `fetchAllPortalEvents`) walks every page; the calendar now uses it. The list view also gets a popup-range window so the backend expands recurring series into occurrences (matching day/calendar) and fetches all pages too.

Status default unchanged (all statuses); all three views already share the filter toolbar.

Verified: `biome ci` clean, `tsc -p tsconfig.build.json` 0 errors, full backoffice build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)