### PR TITLE
fix(events) visibility on approval + feat(backoffice) bug-report fields

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -2211,7 +2211,10 @@ async def approve_event(
             detail=f"Event is not pending approval (status={event.status})",
         )
     event.status = EventStatus.PUBLISHED
-    event.visibility = EventVisibility.PUBLIC
+    # Preserve the visibility the creator chose at submission — approval only
+    # flips the status to published. Pending events are kept out of the public
+    # feed by the status gate in ``_portal_visibility_filter``, not by
+    # overwriting their visibility here.
     db.add(event)
     db.commit()
     db.refresh(event)
@@ -2361,12 +2364,15 @@ def _portal_visibility_filter(db, events: list, human_id: uuid.UUID) -> list:
     """Apply visibility rules to a portal event list.
 
     Rules:
+    - non-published (draft / pending_approval): only managers (owner / host /
+      collaborators) see them in listings, whatever their stored visibility.
+      This keeps a pending event out of the public feed while preserving the
+      visibility the creator chose (restored once approved + published).
     - public: visible to all.
     - private: only managers (owner / host / collaborators) + invited humans.
     - unlisted: hidden from public listings, but managers (owner / host /
-      collaborators) still see their own unlisted events (e.g.
-      pending_approval requests they created). Detail is reachable via direct
-      link for non-managers.
+      collaborators) still see their own unlisted events. Detail is reachable
+      via direct link for non-managers.
     """
     from sqlmodel import select
 
@@ -2389,13 +2395,20 @@ def _portal_visibility_filter(db, events: list, human_id: uuid.UUID) -> list:
 
     visible = []
     for e in events:
+        manages = _human_id_manages_event(e, human_id)
+        # Draft / pending_approval events are never listed to non-managers,
+        # regardless of their stored visibility.
+        if e.status != EventStatus.PUBLISHED:
+            if manages:
+                visible.append(e)
+            continue
         if e.visibility == EventVisibility.PUBLIC:
             visible.append(e)
         elif e.visibility == EventVisibility.UNLISTED:
-            if _human_id_manages_event(e, human_id):
+            if manages:
                 visible.append(e)
         elif e.visibility == EventVisibility.PRIVATE:
-            if _human_id_manages_event(e, human_id) or _invitation_visible_to_human(
+            if manages or _invitation_visible_to_human(
                 e, human_id, invited_map.get(e.id, set())
             ):
                 visible.append(e)
@@ -3018,8 +3031,11 @@ async def create_portal_event(
             )
 
     if requires_approval:
+        # Keep the visibility the creator chose so it survives the pending
+        # state and is honored once approved. Hiding the still-pending event
+        # from the public feed is handled by the status gate in
+        # ``_portal_visibility_filter`` (non-published => managers only).
         event_data["status"] = EventStatus.PENDING_APPROVAL
-        event_data["visibility"] = EventVisibility.UNLISTED
 
     event = Events(**event_data)
 

--- a/backend/app/api/task/router.py
+++ b/backend/app/api/task/router.py
@@ -107,11 +107,12 @@ async def report_bug(
 ) -> TaskPublic:
     """File a bug report (any authenticated backoffice user).
 
-    Creates a to-do bug attributed to the reporter, scoped to the reporter's
+    Creates a to-do task attributed to the reporter, scoped to the reporter's
     tenant (``visibility='tenant'``) so that tenant's users can see it. A
-    superadmin reporter (no tenant) falls back to an ``internal`` bug. Optional
-    attachments are screenshots / screen-recordings already uploaded to S3 via
-    POST /uploads/presigned-url.
+    superadmin reporter (no tenant) falls back to an ``internal`` task. The
+    reporter classifies it via ``type`` (defaults to ``bug``), ``priority``
+    and ``app``. Optional attachments are screenshots / screen-recordings
+    already uploaded to S3 via POST /uploads/presigned-url.
     """
     if current_user.tenant_id is not None:
         visibility = TaskVisibility.TENANT.value
@@ -120,11 +121,15 @@ async def report_bug(
         visibility = TaskVisibility.INTERNAL.value
         target_tenant_id = None
 
+    # ``use_enum_values=True`` on BugReportCreate means type/priority/app are
+    # already plain column strings (app may be None = unspecified).
     task = Task(
         title=report_in.title,
         detail=report_in.detail,
         status=TaskStatus.TO_DO.value,
-        type=TaskType.BUG.value,
+        type=report_in.type,
+        priority=report_in.priority,
+        app=report_in.app,
         visibility=visibility,
         target_tenant_id=target_tenant_id,
         created_by=current_user.id,

--- a/backend/app/api/task/schemas.py
+++ b/backend/app/api/task/schemas.py
@@ -150,15 +150,21 @@ class TaskArchiveResult(BaseModel):
 class BugReportCreate(BaseModel):
     """The 'report a bug' payload, open to every backoffice user.
 
-    Always produces an internal bug in the to-do column. Attachments are
-    optional screenshots / screen-recordings already uploaded to S3.
+    Produces a to-do task in the reporter's tenant scope. The reporter can
+    classify it (type / priority / which app it relates to); type defaults to
+    ``bug`` so the plain "report a bug" flow keeps working unchanged.
+    Attachments are optional screenshots / screen-recordings already uploaded
+    to S3.
     """
 
     title: str = Field(min_length=1, max_length=200)
     detail: str | None = None
+    type: TaskType = TaskType.BUG
+    priority: TaskPriority = TaskPriority.MEDIUM
+    app: TaskApp | None = None
     attachments: list[TaskAttachmentCreate] = Field(default_factory=list)
 
-    model_config = ConfigDict(str_strip_whitespace=True)
+    model_config = ConfigDict(use_enum_values=True, str_strip_whitespace=True)
 
 
 class TaskPublic(BaseModel):

--- a/backend/tests/api/task/test_task_access.py
+++ b/backend/tests/api/task/test_task_access.py
@@ -184,6 +184,32 @@ def test_report_bug_is_scoped_to_reporter_tenant(
     assert body["type"] == "bug"
     assert body["visibility"] == "tenant"
     assert body["target_tenant_id"] == str(tenant_a.id)
+    # Unspecified classification falls back to sensible defaults.
+    assert body["priority"] == "medium"
+    assert body["app"] is None
+
+
+def test_report_bug_accepts_classification_fields(
+    client, admin_token_tenant_a
+) -> None:
+    """A reporter can classify the report: type / priority / app."""
+    r = client.post(
+        "/api/v1/tasks/report-bug",
+        headers=_auth(admin_token_tenant_a),
+        json={
+            "title": "add dark mode",
+            "type": "feature",
+            "priority": "high",
+            "app": "portal",
+        },
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["type"] == "feature"
+    assert body["priority"] == "high"
+    assert body["app"] == "portal"
+    # Still routed to the to-do column regardless of classification.
+    assert body["status"] == TaskStatus.TO_DO.value
 
 
 def test_app_field_roundtrips_and_clears(client, superadmin_token) -> None:

--- a/backend/tests/test_event_custom_location.py
+++ b/backend/tests/test_event_custom_location.py
@@ -303,7 +303,9 @@ class TestCreateCustomLocation:
         assert resp.status_code == 201, resp.text
         body = resp.json()
         assert body["status"] == EventStatus.PENDING_APPROVAL.value
-        assert body["visibility"] == EventVisibility.UNLISTED.value
+        # Visibility the creator chose (default public) is preserved through
+        # the pending state; the status gate keeps it out of the public feed.
+        assert body["visibility"] == EventVisibility.PUBLIC.value
         assert body["custom_location_name"] == "Mi casa"
 
     def test_create_portal_event_with_custom_location_skips_venue_approval_gate(

--- a/backend/tests/test_events_approval.py
+++ b/backend/tests/test_events_approval.py
@@ -16,10 +16,12 @@ Event creation / approval (events/portal/events + /approve + /reject)
 - ``event_enabled=False`` blocks portal creation.
 - ``can_publish_event=admin_only`` blocks all portal creation (draft or
   published); only admins can create events via the backoffice.
-- A venue with ``booking_mode=approval_required`` forces
-  ``status=PENDING_APPROVAL`` and ``visibility=UNLISTED`` regardless of
-  the payload.
-- POST /events/{id}/approve promotes the event to PUBLISHED + PUBLIC.
+- A venue with ``booking_mode=approval_required`` (or popup-level
+  ``events_require_approval``) forces ``status=PENDING_APPROVAL`` while
+  preserving the creator's chosen visibility; pending events are hidden from
+  non-managers by the status gate, not by overwriting visibility.
+- POST /events/{id}/approve promotes the event to PUBLISHED and keeps the
+  creator's visibility unchanged.
 - POST /events/{id}/reject marks the event as REJECTED.
 - Both endpoints reject non-pending events with 400.
 
@@ -31,6 +33,7 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
@@ -353,9 +356,10 @@ class TestEventCreationGate:
 
 
 class TestApprovalRequiredVenue:
-    """`booking_mode=approval_required` forces PENDING_APPROVAL + UNLISTED."""
+    """`booking_mode=approval_required` forces PENDING_APPROVAL but keeps the
+    creator's chosen visibility (hiding is enforced by the status gate)."""
 
-    def test_published_payload_downgraded_to_pending_and_unlisted(
+    def test_published_payload_downgraded_to_pending_keeps_visibility(
         self,
         client: TestClient,
         db: Session,
@@ -385,8 +389,10 @@ class TestApprovalRequiredVenue:
 
         assert resp.status_code == 201, resp.text
         body = resp.json()
+        # Status is downgraded to pending, but the creator's visibility choice
+        # is preserved (status gate keeps it out of the public feed meanwhile).
         assert body["status"] == EventStatus.PENDING_APPROVAL.value
-        assert body["visibility"] == EventVisibility.UNLISTED.value
+        assert body["visibility"] == EventVisibility.PUBLIC.value
 
 
 class TestApproveRejectTransitions:
@@ -414,7 +420,7 @@ class TestApproveRejectTransitions:
         db.refresh(event)
         return event
 
-    def test_approve_promotes_to_published_and_public(
+    def test_approve_promotes_to_published_and_preserves_visibility(
         self,
         client: TestClient,
         db: Session,
@@ -422,7 +428,11 @@ class TestApproveRejectTransitions:
         admin_token_tenant_a: str,
     ) -> None:
         popup = _make_popup(db, tenant_a)
+        # Creator asked for a public event; approval must keep that choice.
         event = self._pending_event(db, tenant_a, popup)
+        event.visibility = EventVisibility.PUBLIC
+        db.add(event)
+        db.commit()
 
         resp = client.post(
             f"/api/v1/events/{event.id}/approve",
@@ -433,7 +443,32 @@ class TestApproveRejectTransitions:
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["status"] == EventStatus.PUBLISHED.value
+        # Approval flips status only; the creator's visibility is preserved.
         assert body["visibility"] == EventVisibility.PUBLIC.value
+
+    def test_approve_preserves_non_public_visibility(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        # A creator who deliberately chose a private/unlisted event keeps it
+        # after approval — approval no longer forces it public.
+        event = self._pending_event(db, tenant_a, popup)
+        assert event.visibility == EventVisibility.UNLISTED
+
+        resp = client.post(
+            f"/api/v1/events/{event.id}/approve",
+            headers=_auth(admin_token_tenant_a),
+            json={"reason": "Looks good"},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == EventStatus.PUBLISHED.value
+        assert body["visibility"] == EventVisibility.UNLISTED.value
 
     def test_reject_sets_status_to_rejected(
         self,
@@ -589,3 +624,90 @@ class TestApproveRejectTransitions:
         )
 
         assert resp.status_code == 400, resp.text
+
+
+class TestEndToEndVisibilityConsistency:
+    """Full portal-create → approve chain over HTTP.
+
+    Validates that the visibility the creator picks survives the whole
+    lifecycle: it is preserved while the event sits in PENDING_APPROVAL, the
+    pending event is hidden from non-managers' listings by the status gate
+    (not by overwriting visibility), and approval flips only the status —
+    never the visibility.
+    """
+
+    def _list_ids(
+        self, client: TestClient, popup: Popups, human: Humans
+    ) -> set[str]:
+        resp = client.get(
+            "/api/v1/events/portal/events",
+            params={"popup_id": str(popup.id)},
+            headers=_human_auth(human),
+        )
+        assert resp.status_code == 200, resp.text
+        return {item["id"] for item in resp.json()["results"]}
+
+    @pytest.mark.parametrize(
+        "chosen",
+        [
+            EventVisibility.PUBLIC,
+            EventVisibility.PRIVATE,
+            EventVisibility.UNLISTED,
+        ],
+    )
+    def test_create_then_approve_preserves_visibility(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+        chosen: EventVisibility,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        # Default event settings already set events_require_approval=True, so a
+        # portal-created event is routed through the approval gate.
+        _set_event_settings(db, tenant_a, popup)
+        creator = _make_human(db, tenant_a)
+        bystander = _make_human(db, tenant_a)
+
+        # 1. Creator submits a "published" event with their chosen visibility.
+        create = client.post(
+            "/api/v1/events/portal/events",
+            headers=_human_auth(creator),
+            json=_event_payload(
+                popup, status=EventStatus.PUBLISHED, visibility=chosen
+            ),
+        )
+        assert create.status_code == 201, create.text
+        body = create.json()
+        event_id = body["id"]
+        # Routed to pending, but the visibility choice is untouched.
+        assert body["status"] == EventStatus.PENDING_APPROVAL.value
+        assert body["visibility"] == chosen.value
+
+        # 2. While pending, a bystander never sees it (status gate), whatever
+        #    the chosen visibility; the creator (manager) still sees their own.
+        assert event_id not in self._list_ids(client, popup, bystander)
+        assert event_id in self._list_ids(client, popup, creator)
+
+        # 3. Admin approves.
+        approve = client.post(
+            f"/api/v1/events/{event_id}/approve",
+            headers=_auth(admin_token_tenant_a),
+            json={"reason": "ok"},
+        )
+        assert approve.status_code == 200, approve.text
+        approved = approve.json()
+        # 4. Published, with the exact visibility the creator chose at submit.
+        assert approved["status"] == EventStatus.PUBLISHED.value
+        assert approved["visibility"] == chosen.value
+
+        # 5. Post-approval listing matches the chosen visibility: a public
+        #    event now shows to the bystander; private/unlisted stay hidden
+        #    from a non-manager's listing. The creator always sees their own.
+        bystander_ids = self._list_ids(client, popup, bystander)
+        if chosen == EventVisibility.PUBLIC:
+            assert event_id in bystander_ids
+        else:
+            assert event_id not in bystander_ids
+        assert event_id in self._list_ids(client, popup, creator)

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -790,6 +790,9 @@ export type BaseFieldConfigUpdate = {
 export type BugReportCreate = {
     title: string;
     detail?: (string | null);
+    type?: TaskType;
+    priority?: TaskPriority;
+    app?: (TaskApp | null);
     attachments?: Array<TaskAttachmentCreate>;
 };
 

--- a/backoffice/src/components/Tasks/ReportBugButton.tsx
+++ b/backoffice/src/components/Tasks/ReportBugButton.tsx
@@ -2,7 +2,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Bug } from "lucide-react"
 import { useState } from "react"
 
-import { type TaskAttachmentCreate, TasksService } from "@/client"
+import {
+  type TaskApp,
+  type TaskAttachmentCreate,
+  type TaskPriority,
+  TasksService,
+  type TaskType,
+} from "@/client"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -16,11 +22,29 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { LoadingButton } from "@/components/ui/loading-button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import useCustomToast from "@/hooks/useCustomToast"
 import { createErrorHandler } from "@/utils"
 import { AttachmentField } from "./AttachmentField"
 import { AttachmentGrid } from "./AttachmentGrid"
+import {
+  APP_LABELS,
+  PRIORITY_LABELS,
+  TASK_APPS,
+  TASK_PRIORITIES,
+  TASK_TYPES,
+  TYPE_LABELS,
+} from "./taskMeta"
+
+/** Select sentinel for "no app specified" (empty string isn't a valid item). */
+const NONE = "none"
 
 const DETAIL_GUIDE = `Help us reproduce it:
 1. What you did (steps).
@@ -38,11 +62,17 @@ export function ReportBugButton() {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState("")
   const [detail, setDetail] = useState("")
+  const [type, setType] = useState<TaskType>("bug")
+  const [priority, setPriority] = useState<TaskPriority>("medium")
+  const [app, setApp] = useState<TaskApp | "">("")
   const [attachments, setAttachments] = useState<TaskAttachmentCreate[]>([])
 
   const reset = () => {
     setTitle("")
     setDetail("")
+    setType("bug")
+    setPriority("medium")
+    setApp("")
     setAttachments([])
   }
 
@@ -52,6 +82,9 @@ export function ReportBugButton() {
         requestBody: {
           title: title.trim(),
           detail: detail.trim() || null,
+          type,
+          priority,
+          app: app || null,
           attachments,
         },
       }),
@@ -125,6 +158,66 @@ export function ReportBugButton() {
               and where it happened. Screenshots or a screen recording help a
               lot.
             </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Type</Label>
+              <Select
+                value={type}
+                onValueChange={(v) => setType(v as TaskType)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TASK_TYPES.map((t) => (
+                    <SelectItem key={t} value={t}>
+                      {TYPE_LABELS[t]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Priority</Label>
+              <Select
+                value={priority}
+                onValueChange={(v) => setPriority(v as TaskPriority)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TASK_PRIORITIES.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {PRIORITY_LABELS[p]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="col-span-2 space-y-2">
+              <Label>App</Label>
+              <Select
+                value={app || NONE}
+                onValueChange={(v) => setApp(v === NONE ? "" : (v as TaskApp))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Unspecified" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NONE}>Unspecified</SelectItem>
+                  {TASK_APPS.map((a) => (
+                    <SelectItem key={a} value={a}>
+                      {APP_LABELS[a]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
           <div className="space-y-2">


### PR DESCRIPTION
Two atomic, independent changes (disjoint files), each in its own commit.

## 1. `fix(events)`: preserve creator visibility through event approval
Approving a submitted event hardcoded `visibility=PUBLIC`, and the portal submission step had already overwritten the creator's choice to `UNLISTED` — so the visibility picked at creation never survived.

- Submission no longer forces `UNLISTED`; approval only flips `status → PUBLISHED`.
- Hiding a still-pending event from the public feed is now enforced by a **status gate** in `_portal_visibility_filter` (non-published ⇒ managers only), not by mutating visibility.
- Adds an end-to-end create→approve test over all three visibilities; updates the unit tests that encoded the old behavior.

## 2. `feat(backoffice)`: add priority, type & app fields to bug reports
The "Report a bug" flow hardcoded `type=bug` and never set `priority`/`app`, although the `Task` model already has those columns.

- `BugReportCreate` accepts `type` (default `bug`), `priority` (default `medium`), `app` (optional); `report_bug` persists them.
- `ReportBugButton` gains Type / Priority / App selects, reusing the shared `taskMeta` enums and the `TaskDialog` select pattern.
- **No DB migration** — the columns already exist.

## Tests
- Backend: events approval + custom-location suites green; task access suite green (incl. new report-bug classification test).
- Frontend: `tsc` clean, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)