### PR TITLE
fix(events): repair public calendar feed + render all events in portal list view

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -648,7 +648,11 @@ def _ics_vevent_lines(
         lines.append(f"LOCATION:{location}")
     if include_recurrence and getattr(event, "rrule", None):
         lines.append(f"RRULE:{event.rrule}")
-        exdates = getattr(event, "recurrence_exdates", None) or []
+        # recurrence_exdates is a JSONB array, so values arrive as ISO strings.
+        exdates = [
+            datetime.fromisoformat(d) if isinstance(d, str) else d
+            for d in getattr(event, "recurrence_exdates", None) or []
+        ]
         if exdates:
             lines.append(f"EXDATE:{','.join(_ics_utc_stamp(d) for d in exdates)}")
     lines.append(

--- a/backend/tests/test_public_calendar_ics.py
+++ b/backend/tests/test_public_calendar_ics.py
@@ -41,6 +41,7 @@ def _event(
     visibility: EventVisibility,
     status: EventStatus = EventStatus.PUBLISHED,
     rrule: str | None = None,
+    recurrence_exdates: list[str] | None = None,
 ) -> Events:
     start = datetime.now(UTC) + timedelta(days=3)
     event = Events(
@@ -54,6 +55,7 @@ def _event(
         visibility=visibility,
         status=status,
         rrule=rrule,
+        recurrence_exdates=recurrence_exdates or [],
     )
     db.add(event)
     db.commit()
@@ -99,6 +101,27 @@ def test_feed_emits_rrule_for_recurring(client, db: Session, tenant_a: Tenants):
     r = client.get(f"/api/v1/events/public/calendar.ics?popup_id={popup.id}")
     assert r.status_code == 200
     assert "RRULE:FREQ=WEEKLY;BYDAY=MO" in r.text
+
+
+def test_feed_emits_exdates_for_recurring(client, db: Session, tenant_a: Tenants):
+    """recurrence_exdates is a JSONB array of ISO strings; the feed must
+    stamp them as RFC-5545 UTC values instead of crashing (regression)."""
+    popup = _popup(db, tenant_a)
+    _event(
+        db,
+        tenant_a,
+        popup,
+        title="Weekly with skips",
+        visibility=EventVisibility.PUBLIC,
+        rrule="FREQ=WEEKLY;BYDAY=MO",
+        recurrence_exdates=[
+            "2026-06-15T19:00:00+00:00",
+            "2026-06-22T19:00:00Z",
+        ],
+    )
+    r = client.get(f"/api/v1/events/public/calendar.ics?popup_id={popup.id}")
+    assert r.status_code == 200
+    assert "EXDATE:20260615T190000Z,20260622T190000Z" in r.text
 
 
 def test_feed_404_for_unknown_popup(client):

--- a/portal/src/app/portal/[popupSlug]/events/lib/fetchAllPortalEvents.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/fetchAllPortalEvents.ts
@@ -18,6 +18,7 @@ export interface FetchAllPortalEventsParams {
   trackIds?: string[]
   rsvpedOnly?: boolean
   managedOnly?: boolean
+  includeHidden?: boolean
 }
 
 /**
@@ -51,6 +52,7 @@ export async function fetchAllPortalEvents(
       startBefore: params.startBefore,
       rsvpedOnly: params.rsvpedOnly,
       managedOnly: params.managedOnly,
+      includeHidden: params.includeHidden,
       search: params.search,
       tags: params.tags,
       trackIds: params.trackIds,

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -27,6 +27,7 @@ import {
   type EventsViewSnapshot,
   saveEventsViewState,
 } from "./lib/eventsViewState"
+import { fetchAllPortalEvents } from "./lib/fetchAllPortalEvents"
 import { ListBody } from "./lib/ListBody"
 import { eventListWindowForPopup } from "./lib/listWindow"
 import { SubscribeCalendarButton } from "./lib/SubscribeCalendarButton"
@@ -378,8 +379,10 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    queryFn: () =>
-      EventsService.listPortalEvents({
+    // fetchAllPortalEvents pages through every row — a single capped request
+    // silently truncates once the window holds more DB rows than the cap.
+    queryFn: async () => ({
+      results: await fetchAllPortalEvents({
         popupId: city!.id,
         search: search || undefined,
         eventStatus: "published",
@@ -388,8 +391,8 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
       }),
+    }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useAllChannel,
   })
 
@@ -405,8 +408,8 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    queryFn: () =>
-      EventsService.listPortalEvents({
+    queryFn: async () => ({
+      results: await fetchAllPortalEvents({
         popupId: city!.id,
         search: search || undefined,
         // No status filter: include my drafts / pending / rejected.
@@ -420,8 +423,8 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
       }),
+    }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useMineChannel,
   })
 
@@ -437,8 +440,8 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    queryFn: () =>
-      EventsService.listPortalEvents({
+    queryFn: async () => ({
+      results: await fetchAllPortalEvents({
         popupId: city!.id,
         search: search || undefined,
         eventStatus: "published",
@@ -448,8 +451,8 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
       }),
+    }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useRsvpedChannel,
   })
 


### PR DESCRIPTION
## Summary

Two small fixes for the two highest-impact calendar bugs found during an extensive QA pass on a full local mirror of the Edge City tenant (2,686 events, 62 recurrence masters).

### 1. Public ICS feed returned HTTP 500 (currently broken on prod)

`GET /api/v1/events/public/calendar.ics` crashed with `AttributeError: 'str' object has no attribute 'tzinfo'` whenever **any** event in the popup had non-empty `recurrence_exdates` — i.e. as soon as an organizer edited or cancelled a single occurrence of a recurring event. One bad event killed the whole subscribe feed for everyone (verified 500 against prod for edge-esmeralda-2026).

`recurrence_exdates` is a JSONB array, so values arrive as ISO **strings**; `_ics_vevent_lines` passed them straight into `_ics_utc_stamp()`. Fix: parse to datetimes first (+5/−1). Added the regression test the feed was missing — existing tests covered RRULE but never EXDATE.

### 2. Portal list view silently dropped events past the 200-row cap

The list view fetched the entire remaining popup window with a single `listPortalEvents` call at `limit: 200`. The backend paginates DB rows **before** expanding recurrences, so once the window held >200 rows the tail — the latest events by start_time — silently vanished. Days still *looked* populated (recurring occurrences expand from the fetched rows), so only one-off events disappeared, and a search made them reappear. This is the reported *"my event doesn't show up unless you search for it"*.

Fix: switch all three list channels (all / My events / My RSVPs) to `fetchAllPortalEvents` — the same pagination loop the calendar and day views have used since #293 — and add the `includeHidden` pass-through it lacked (+14/−9, `{results}` shape preserved so no consumer changes).

## Test plan

- [x] `pytest tests/test_public_calendar_ics.py` — 4/4 (3 existing + new EXDATE regression); ruff check/format clean
- [x] Live feed on the EdgeCity mirror: 500 → 200, 382 balanced VEVENTs, every EXDATE line RFC-5545-valid, values cross-checked against DB rows; per-event ICS unaffected
- [x] Browser (agent-browser) on the mirror: list view now renders **363/363** events vs a fully-paginated reference fetch (was 300, with 61 occurrences missing); all previously-invisible probe events ("Solarpunk Soirée", "Apoc Talk + Workshop", late-June one-offs) render under their correct days
- [x] Search, My events, My RSVPs channels verified; hide → vanishes, Hidden toggle → reappears (exercises new `includeHidden` path)
- [x] `tsc` via `next build` (typecheck on) and `biome check` clean on changed files

Note: the list view now issues ~4 requests of 100 instead of 1 of 200 for a window this size — same pattern as the calendar/day views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)