### PR TITLE
chore: release dev to main (v1.22.1)

### DIFF
--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -648,7 +648,11 @@ def _ics_vevent_lines(
         lines.append(f"LOCATION:{location}")
     if include_recurrence and getattr(event, "rrule", None):
         lines.append(f"RRULE:{event.rrule}")
-        exdates = getattr(event, "recurrence_exdates", None) or []
+        # recurrence_exdates is a JSONB array, so values arrive as ISO strings.
+        exdates = [
+            datetime.fromisoformat(d) if isinstance(d, str) else d
+            for d in getattr(event, "recurrence_exdates", None) or []
+        ]
         if exdates:
             lines.append(f"EXDATE:{','.join(_ics_utc_stamp(d) for d in exdates)}")
     lines.append(

--- a/backend/tests/test_public_calendar_ics.py
+++ b/backend/tests/test_public_calendar_ics.py
@@ -41,6 +41,7 @@ def _event(
     visibility: EventVisibility,
     status: EventStatus = EventStatus.PUBLISHED,
     rrule: str | None = None,
+    recurrence_exdates: list[str] | None = None,
 ) -> Events:
     start = datetime.now(UTC) + timedelta(days=3)
     event = Events(
@@ -54,6 +55,7 @@ def _event(
         visibility=visibility,
         status=status,
         rrule=rrule,
+        recurrence_exdates=recurrence_exdates or [],
     )
     db.add(event)
     db.commit()
@@ -99,6 +101,27 @@ def test_feed_emits_rrule_for_recurring(client, db: Session, tenant_a: Tenants):
     r = client.get(f"/api/v1/events/public/calendar.ics?popup_id={popup.id}")
     assert r.status_code == 200
     assert "RRULE:FREQ=WEEKLY;BYDAY=MO" in r.text
+
+
+def test_feed_emits_exdates_for_recurring(client, db: Session, tenant_a: Tenants):
+    """recurrence_exdates is a JSONB array of ISO strings; the feed must
+    stamp them as RFC-5545 UTC values instead of crashing (regression)."""
+    popup = _popup(db, tenant_a)
+    _event(
+        db,
+        tenant_a,
+        popup,
+        title="Weekly with skips",
+        visibility=EventVisibility.PUBLIC,
+        rrule="FREQ=WEEKLY;BYDAY=MO",
+        recurrence_exdates=[
+            "2026-06-15T19:00:00+00:00",
+            "2026-06-22T19:00:00Z",
+        ],
+    )
+    r = client.get(f"/api/v1/events/public/calendar.ics?popup_id={popup.id}")
+    assert r.status_code == 200
+    assert "EXDATE:20260615T190000Z,20260622T190000Z" in r.text
 
 
 def test_feed_404_for_unknown_popup(client):

--- a/portal/src/app/portal/[popupSlug]/events/lib/fetchAllPortalEvents.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/fetchAllPortalEvents.ts
@@ -18,6 +18,7 @@ export interface FetchAllPortalEventsParams {
   trackIds?: string[]
   rsvpedOnly?: boolean
   managedOnly?: boolean
+  includeHidden?: boolean
 }
 
 /**
@@ -51,6 +52,7 @@ export async function fetchAllPortalEvents(
       startBefore: params.startBefore,
       rsvpedOnly: params.rsvpedOnly,
       managedOnly: params.managedOnly,
+      includeHidden: params.includeHidden,
       search: params.search,
       tags: params.tags,
       trackIds: params.trackIds,

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -27,6 +27,7 @@ import {
   type EventsViewSnapshot,
   saveEventsViewState,
 } from "./lib/eventsViewState"
+import { fetchAllPortalEvents } from "./lib/fetchAllPortalEvents"
 import { ListBody } from "./lib/ListBody"
 import { eventListWindowForPopup } from "./lib/listWindow"
 import { SubscribeCalendarButton } from "./lib/SubscribeCalendarButton"
@@ -378,8 +379,10 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    queryFn: () =>
-      EventsService.listPortalEvents({
+    // fetchAllPortalEvents pages through every row — a single capped request
+    // silently truncates once the window holds more DB rows than the cap.
+    queryFn: async () => ({
+      results: await fetchAllPortalEvents({
         popupId: city!.id,
         search: search || undefined,
         eventStatus: "published",
@@ -388,8 +391,8 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
       }),
+    }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useAllChannel,
   })
 
@@ -405,8 +408,8 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    queryFn: () =>
-      EventsService.listPortalEvents({
+    queryFn: async () => ({
+      results: await fetchAllPortalEvents({
         popupId: city!.id,
         search: search || undefined,
         // No status filter: include my drafts / pending / rejected.
@@ -420,8 +423,8 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
       }),
+    }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useMineChannel,
   })
 
@@ -437,8 +440,8 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    queryFn: () =>
-      EventsService.listPortalEvents({
+    queryFn: async () => ({
+      results: await fetchAllPortalEvents({
         popupId: city!.id,
         search: search || undefined,
         eventStatus: "published",
@@ -448,8 +451,8 @@ export default function EventsPage() {
         trackIds: selectedTrackIds.length ? selectedTrackIds : undefined,
         startAfter: listWindow.startAfter,
         startBefore: listWindow.startBefore,
-        limit: 200,
       }),
+    }),
     enabled: !!city?.id && moduleEnabled && view === "list" && useRsvpedChannel,
   })
 


### PR DESCRIPTION
## Summary

Patch release on top of v1.22 carrying one fix (#325):

- **Public ICS feed 500** — `/events/public/calendar.ics` crashed (`AttributeError` on JSONB exdate strings) whenever any event in the popup had an edited/cancelled occurrence of a recurring event, killing the calendar-subscribe feed for the whole popup. Confirmed broken on prod for edge-esmeralda-2026 before the fix.
- **Portal list view truncation** — single `limit: 200` fetch silently dropped the latest events in the window (the "my event only shows up when I search" reports). List channels now use the same `fetchAllPortalEvents` pagination loop as the calendar/day views.

`git diff main..dev` is exactly these changes: 4 files, +42/−10 (incl. +23 regression test).

## Test plan

- [x] Full verification on a local mirror of the Edge City tenant — details in #325 (pytest 4/4, live feed 200 with RFC-valid EXDATEs, browser-verified 363/363 events rendering, search/My events/My RSVPs/Hidden unaffected)
- [ ] Post-deploy: confirm prod `calendar.ics` for edge-esmeralda-2026 returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)