### PR TITLE
docs: point old repo references at p2p-lanes/edgeos-monorepo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/muvinai/edgeos#readme
+    url: https://github.com/p2p-lanes/edgeos-monorepo#readme
     about: Check the README for setup and usage instructions

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ EdgeOS provides a complete solution for managing events (called "popups"), atten
 ### 1. Clone and Start
 
 ```bash
-git clone <repository-url>
-cd EdgeOS
+git clone https://github.com/p2p-lanes/edgeos-monorepo.git
+cd edgeos-monorepo
 
 # Copy environment template (works out of the box for local dev)
 cp .env.example .env

--- a/portal/src/components/Sidebar/FooterMenu.tsx
+++ b/portal/src/components/Sidebar/FooterMenu.tsx
@@ -9,12 +9,13 @@ import {
   SidebarMenuItem,
 } from "./SidebarComponents"
 
-const REPO_URL = "https://github.com/p2p-lanes/EdgeOS"
+const REPO_URL_SUFFIX = "p2p-lanes/edgeos-monorepo"
+const REPO_URL        = "https://github.com/" + REPO_URL_SUFFIX
 
 async function getGitHubStars() {
   try {
     const response = await fetch(
-      "https://api.github.com/repos/p2p-lanes/EdgeOS",
+      "https://api.github.com/repos/" + REPO_URL_SUFFIX,
     )
     const data = await response.json()
     return data.stargazers_count as number

--- a/portal/src/components/Sidebar/FooterMenu.tsx
+++ b/portal/src/components/Sidebar/FooterMenu.tsx
@@ -10,7 +10,7 @@ import {
 } from "./SidebarComponents"
 
 const REPO_URL_SUFFIX = "p2p-lanes/edgeos-monorepo"
-const REPO_URL        = "https://github.com/" + REPO_URL_SUFFIX
+const REPO_URL = "https://github.com/" + REPO_URL_SUFFIX
 
 async function getGitHubStars() {
   try {


### PR DESCRIPTION
## Summary

The project was consolidated from the old `p2p-lanes/EdgeOS` and `p2p-lanes/EdgeOS_API` repos into this monorepo (`p2p-lanes/edgeos-monorepo`). This updates the remaining stale references that still pointed at the old (and in one case dead) locations.

## Changes

- **`portal/src/components/Sidebar/FooterMenu.tsx`** — sidebar "GitHub" link and the stars API call now use `p2p-lanes/edgeos-monorepo`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — Documentation contact link pointed at `github.com/muvinai/edgeos`, which now **404s**; repointed to `github.com/p2p-lanes/edgeos-monorepo#readme`.
- **`README.md`** — Quick Start clone step replaced the `<repository-url>` placeholder and `cd EdgeOS` with the concrete `git clone https://github.com/p2p-lanes/edgeos-monorepo.git` / `cd edgeos-monorepo`.

## Verification

- Repo-wide sweep for `p2p-lanes/EdgeOS`, `EdgeOS_API`, and `muvinai/edgeos` returns zero hits.
- New URLs resolve (repo page → 200); old `muvinai/edgeos` confirmed 404.
- Left untouched (legitimate, not repo links): the "EdgeOS" product name, DB/bucket names, `@edgeos/*` package scope, and CI job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)