### PR TITLE
feat(portal): expand participants list when "+N more" is clicked

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -1084,33 +1084,33 @@ export default function EventDetailPage() {
               ? activeParticipants
               : activeParticipants.slice(0, 10)
             ).map((p: EventParticipantPublic) => {
-                const name = [p.first_name, p.last_name]
-                  .filter(Boolean)
-                  .join(" ")
-                  .trim()
-                return (
-                  <div key={p.id} className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <div className="h-7 w-7 rounded-full bg-muted flex items-center justify-center">
-                        <Users className="h-3 w-3 text-muted-foreground" />
-                      </div>
-                      <span className="text-sm">
-                        {name || t("events.detail.unnamed_participant")}
-                      </span>
+              const name = [p.first_name, p.last_name]
+                .filter(Boolean)
+                .join(" ")
+                .trim()
+              return (
+                <div key={p.id} className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <div className="h-7 w-7 rounded-full bg-muted flex items-center justify-center">
+                      <Users className="h-3 w-3 text-muted-foreground" />
                     </div>
-                    <div className="flex items-center gap-1.5">
-                      {p.role !== "attendee" && (
-                        <Badge variant="outline" className="text-xs">
-                          {p.role}
-                        </Badge>
-                      )}
-                      {p.status === "checked_in" && (
-                        <CheckCircle className="h-3 w-3 text-green-500" />
-                      )}
-                    </div>
+                    <span className="text-sm">
+                      {name || t("events.detail.unnamed_participant")}
+                    </span>
                   </div>
-                )
-              })}
+                  <div className="flex items-center gap-1.5">
+                    {p.role !== "attendee" && (
+                      <Badge variant="outline" className="text-xs">
+                        {p.role}
+                      </Badge>
+                    )}
+                    {p.status === "checked_in" && (
+                      <CheckCircle className="h-3 w-3 text-green-500" />
+                    )}
+                  </div>
+                </div>
+              )
+            })}
             {activeParticipants.length > 10 && (
               <button
                 type="button"

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -280,6 +280,8 @@ export default function EventDetailPage() {
   const [cancelEventOpen, setCancelEventOpen] = useState(false)
   const [copied, setCopied] = useState(false)
   const [copyingEmails, setCopyingEmails] = useState(false)
+  // Whether the participants list is expanded to show everyone or truncated.
+  const [participantsExpanded, setParticipantsExpanded] = useState(false)
   const cancelEventMutation = useMutation({
     mutationFn: () =>
       EventsService.cancelPortalEvent({ eventId: params.eventId }),
@@ -1078,9 +1080,10 @@ export default function EventDetailPage() {
           </p>
         ) : (
           <div className="space-y-2">
-            {activeParticipants
-              .slice(0, 10)
-              .map((p: EventParticipantPublic) => {
+            {(participantsExpanded
+              ? activeParticipants
+              : activeParticipants.slice(0, 10)
+            ).map((p: EventParticipantPublic) => {
                 const name = [p.first_name, p.last_name]
                   .filter(Boolean)
                   .join(" ")
@@ -1109,11 +1112,18 @@ export default function EventDetailPage() {
                 )
               })}
             {activeParticipants.length > 10 && (
-              <p className="text-xs text-muted-foreground text-center">
-                {t("events.detail.participants_more", {
-                  count: activeParticipants.length - 10,
-                })}
-              </p>
+              <button
+                type="button"
+                aria-expanded={participantsExpanded}
+                onClick={() => setParticipantsExpanded((prev) => !prev)}
+                className="block w-full text-center text-xs text-muted-foreground hover:text-foreground hover:underline cursor-pointer transition-colors"
+              >
+                {participantsExpanded
+                  ? t("events.detail.participants_show_less")
+                  : t("events.detail.participants_more", {
+                      count: activeParticipants.length - 10,
+                    })}
+              </button>
             )}
           </div>
         )}

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -648,6 +648,7 @@
       "participants_heading": "Participants",
       "no_participants_yet": "No participants yet",
       "participants_more": "+{{count}} more",
+      "participants_show_less": "Show less",
       "unnamed_participant": "Unnamed",
       "copy_attendee_emails": "Copy attendee emails",
       "copy_attendee_emails_done": "Copied {{count}} attendee emails",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -645,6 +645,7 @@
       "participants_heading": "Participantes",
       "no_participants_yet": "Aún no hay participantes",
       "participants_more": "+{{count}} más",
+      "participants_show_less": "Mostrar menos",
       "unnamed_participant": "Sin nombre",
       "copy_attendee_emails": "Copiar emails de asistentes",
       "copy_attendee_emails_done": "Se copiaron {{count}} emails de asistentes",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -601,6 +601,7 @@
       "participants_heading": "Þátttakendur",
       "no_participants_yet": "Engir þátttakendur enn",
       "participants_more": "+{{count}} fleiri",
+      "participants_show_less": "Sýna minna",
       "unnamed_participant": "Ónafngreindur",
       "bulk_invite_success": "Boðið {{invited}} · Sleppt {{skipped}} · Ekki fundið {{notFound}}",
       "bulk_invite_error": "Mistókst að bjóða",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -611,6 +611,7 @@
       "participants_heading": "参与者",
       "no_participants_yet": "暂无参与者",
       "participants_more": "+ 另 {{count}} 人",
+      "participants_show_less": "收起",
       "unnamed_participant": "未命名",
       "bulk_invite_success": "已邀请 {{invited}} · 已跳过 {{skipped}} · 未找到 {{notFound}}",
       "bulk_invite_error": "邀请失败",


### PR DESCRIPTION
## Summary

On the event detail page, the Participants list showed the first 10 people followed by a static `+N more` line that **wasn't clickable**. This makes it an interactive toggle — clicking `+N more` expands the list to show every participant; clicking again ("Show less") collapses it back to the first 10.

## Changes

- **`portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx`**
  - Add `participantsExpanded` state (the page is already a client component, so no new `"use client"` boundary needed).
  - The participant `.map()` now iterates the full `activeParticipants` list when expanded, otherwise the first 10.
  - The static `+N more` `<p>` becomes a `<button type="button">` with `aria-expanded`, keyboard activation, `cursor-pointer`, and hover styling; label toggles between `+N more` and `Show less`.
- **`portal/src/i18n/locales/{en,es,zh,is}.json`** — add the `participants_show_less` key.

The `+N more` threshold (10) and count math are unchanged.

## Testing

- [ ] `tsc --noEmit` + lint — not run locally (change authored in a fresh worktree without `node_modules`); relying on CI. The change is small and inspection-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)