### PR TITLE
feat(portal): default the new-event host to the logged-in creator

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/new/page.tsx
@@ -215,6 +215,21 @@ function NewPortalEventForm({
   const [hostId, setHostId] = useState<string | null>(null)
   const [collaboratorIds, setCollaboratorIds] = useState<string[]>([])
 
+  // Default the Displayed-host field to the creator (the logged-in human),
+  // mirroring the field's "Use my name" quick-fill, so a freshly created event
+  // reads "Hosted by <creator>" instead of falling back to the popup name.
+  // One-shot and guarded on an untouched field, so a manual edit — even one
+  // typed before `currentHuman` resolved — is never clobbered. host_id is left
+  // null exactly like "Use my name": the creator is already the owner and
+  // carries full manage rights without it.
+  const didDefaultHostRef = useRef(false)
+  useEffect(() => {
+    if (didDefaultHostRef.current) return
+    if (!currentHumanName) return
+    didDefaultHostRef.current = true
+    setHostDisplayName((prev) => (prev.trim() ? prev : currentHumanName))
+  }, [currentHumanName])
+
   // ---- venue + availability ------------------------------------------
   const {
     venues,


### PR DESCRIPTION
## Summary

When creating an event in the portal, the **Displayed host** field started blank, so the event page fell back to showing the **popup name** (e.g. "Edge Esmeralda") as "Hosted by …". This defaults the field to the **logged-in creator** instead.

## Change

`portal/src/app/portal/[popupSlug]/events/new/page.tsx` — a one-shot effect prefills the host field with the current user's name (`currentHumanName`) once `currentHuman` resolves, mirroring the field's existing **"Use my name"** quick-fill. It's guarded so it never clobbers a manual edit (even one typed before the user loads), and leaves `host_id` null exactly like "Use my name" — the creator is already the event owner and has full manage rights.

```tsx
const didDefaultHostRef = useRef(false)
useEffect(() => {
  if (didDefaultHostRef.current) return
  if (!currentHumanName) return
  didDefaultHostRef.current = true
  setHostDisplayName((prev) => (prev.trim() ? prev : currentHumanName))
}, [currentHumanName])
```

The event-detail fallback (`host_display_name?.trim() || city?.name?.trim()`) is unchanged — pre-existing events with a blank host still show the popup name.

## Testing
- `pnpm --filter portal exec tsc --noEmit` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)