### PR TITLE
fix(portal): scroll to the next open day when collapsing a day in the events list

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.test.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { nextOpenDayTarget } from "./ListBody"
+
+// The events list collapses one day at a time; on collapse we scroll to the
+// header returned here. These guard the selection logic of that fix.
+describe("nextOpenDayTarget", () => {
+  const days = ["2026-06-10", "2026-06-11", "2026-06-12"]
+
+  it("targets the immediately-following day when it is open", () => {
+    expect(nextOpenDayTarget("2026-06-10", days, new Set())).toBe("2026-06-11")
+  })
+
+  it("skips already-collapsed days to reach the next open one", () => {
+    expect(
+      nextOpenDayTarget("2026-06-10", days, new Set(["2026-06-11"])),
+    ).toBe("2026-06-12")
+  })
+
+  it("falls back to the collapsed day itself when no open day follows", () => {
+    // Collapsing the last day...
+    expect(nextOpenDayTarget("2026-06-12", days, new Set())).toBe("2026-06-12")
+    // ...or every later day is already collapsed.
+    expect(
+      nextOpenDayTarget(
+        "2026-06-10",
+        days,
+        new Set(["2026-06-11", "2026-06-12"]),
+      ),
+    ).toBe("2026-06-10")
+  })
+
+  it("returns null when the collapsed day isn't in the list (no scroll)", () => {
+    expect(nextOpenDayTarget("1999-01-01", days, new Set())).toBeNull()
+  })
+})

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.test.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.test.ts
@@ -11,9 +11,9 @@ describe("nextOpenDayTarget", () => {
   })
 
   it("skips already-collapsed days to reach the next open one", () => {
-    expect(
-      nextOpenDayTarget("2026-06-10", days, new Set(["2026-06-11"])),
-    ).toBe("2026-06-12")
+    expect(nextOpenDayTarget("2026-06-10", days, new Set(["2026-06-11"]))).toBe(
+      "2026-06-12",
+    )
   })
 
   it("falls back to the collapsed day itself when no open day follows", () => {

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -135,6 +135,9 @@ export function ListBody({
   const { t } = useTranslation()
   const isAuthed = mode === "authed"
   const [collapsedDays, setCollapsedDays] = useState<Set<string>>(new Set())
+  // Day-header elements keyed by day key, so collapsing a day can scroll the
+  // next still-open day's header to the top of the viewport.
+  const dayHeaderRefs = useRef<Map<string, HTMLElement>>(new Map())
 
   // "Now" reference for the today divider + auto-scroll. Ticks once a
   // minute so the divider creeps down as events start, without re-rendering
@@ -199,6 +202,31 @@ export function ListBody({
     })
   }
 
+  // Collapsing a day strands the viewport in the gap its removed events left
+  // behind. Toggle as usual, but on collapse snap to the top of the next
+  // still-open day (or this day's own header when nothing open follows) so the
+  // next day reads from the start. `orderedDays` is the rendered day order;
+  // `willBeOpen` is Radix's next open state (false ⇒ we're collapsing). The
+  // collapse is instant (no height animation), so one rAF after the commit is
+  // enough for layout to settle before we scroll.
+  const handleDayToggle = (
+    date: string,
+    willBeOpen: boolean,
+    orderedDays: string[],
+  ) => {
+    toggleDay(date)
+    if (willBeOpen) return
+    const startIdx = orderedDays.indexOf(date)
+    if (startIdx === -1) return
+    const targetDate =
+      orderedDays.slice(startIdx + 1).find((d) => !collapsedDays.has(d)) ?? date
+    requestAnimationFrame(() => {
+      dayHeaderRefs.current
+        .get(targetDate)
+        ?.scrollIntoView({ block: "start", behavior: "auto" })
+    })
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -217,6 +245,7 @@ export function ListBody({
   }
 
   const grouped = groupByDate(events, formatDayKey)
+  const orderedDays = grouped.map(([day]) => day)
 
   return (
     <div className="space-y-6">
@@ -244,7 +273,7 @@ export function ListBody({
           <Collapsible
             key={date}
             open={isOpen}
-            onOpenChange={() => toggleDay(date)}
+            onOpenChange={(open) => handleDayToggle(date, open, orderedDays)}
           >
             <CollapsibleTrigger asChild>
               <button
@@ -261,7 +290,11 @@ export function ListBody({
                 // it arrives (and pulls it back when scrolling up). `top`
                 // matches the sticky toolbar height; z-10 keeps it under the
                 // toolbar (z-20) so the outgoing header slides beneath it.
-                style={{ top: stickyTop }}
+                ref={(el) => {
+                  if (el) dayHeaderRefs.current.set(date, el)
+                  else dayHeaderRefs.current.delete(date)
+                }}
+                style={{ top: stickyTop, scrollMarginTop: stickyTop }}
                 className="sticky z-10 w-full flex items-center gap-3 mb-3 py-1.5 bg-background group cursor-pointer"
               >
                 <div className="h-2 w-2 rounded-full bg-primary" />

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -55,6 +55,30 @@ function groupByDate(
   return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b))
 }
 
+/**
+ * Pick the day-header to scroll to after the user collapses `collapsedDate`:
+ * the first still-open day after it (in render order), or — when no open day
+ * follows — the collapsed day itself, so its own header pins to the top
+ * instead of leaving the viewport stranded in the gap the events left behind.
+ * Returns null only when `collapsedDate` isn't in `orderedDays` (defensive;
+ * the caller then skips scrolling).
+ *
+ * `collapsedDays` is the set BEFORE `collapsedDate` is added; days after it are
+ * unaffected by this toggle, so their membership reflects their open state.
+ */
+export function nextOpenDayTarget(
+  collapsedDate: string,
+  orderedDays: string[],
+  collapsedDays: Set<string>,
+): string | null {
+  const startIdx = orderedDays.indexOf(collapsedDate)
+  if (startIdx === -1) return null
+  return (
+    orderedDays.slice(startIdx + 1).find((d) => !collapsedDays.has(d)) ??
+    collapsedDate
+  )
+}
+
 interface ListBodyProps {
   events: EventPublic[]
   slug: string | undefined


### PR DESCRIPTION
## Summary

When scrolled part-way down the events **list** and you collapse a day (the `^` → `v` toggle on a day header), the viewport stayed put — stranded in the gap the now-removed events left behind — so you had to scroll back up to find the start of the next day.

Now, collapsing a day **instantly snaps the next still-open day's header to the top** of the viewport (just below the sticky filter toolbar), so the next day reads from the start. Expanding is unchanged.

## How

`portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx`:
- Track each day header element in a ref map (`dayHeaderRefs`).
- `onOpenChange` now routes through `handleDayToggle(date, willBeOpen, orderedDays)`. On collapse (`willBeOpen === false`) it finds the first day after the collapsed one that's still open and `scrollIntoView({ block: "start" })`s its header inside a `requestAnimationFrame` (collapse is instant — no height animation — so one frame is enough for layout to settle). Falls back to the collapsed day's own header when nothing open follows (e.g. you collapsed the last day).
- `scrollMarginTop: stickyTop` on the header so it lands below the sticky toolbar instead of behind it.

Same component backs the public calendar's list view, so that benefits too.

## Testing
- `pnpm --filter portal exec tsc --noEmit` → clean.
- Note: `events/page.test.tsx` fails in my local checkout due to a **pre-existing** `@/client` test-mock missing its `OpenAPI` export — it fails identically on `main` without this change, so it's unrelated. CI (which regenerates the client) should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)