### PR TITLE
fix(payments): authenticate SimpleFI webhooks before approving payments

### DIFF
--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -41,6 +41,7 @@ from app.services.email import (
     get_email_service,
 )
 from app.services.email_helpers import send_application_status_email
+from app.services.simplefi import get_simplefi_client, verify_webhook_signature
 
 if TYPE_CHECKING:
     from app.api.human.models import Humans
@@ -782,6 +783,83 @@ async def create_direct_payment_gone() -> None:
     )
 
 
+def _resolve_webhook_popup_secret(db: Session, raw_body: dict) -> str | None:
+    """Resolve the popup's SimpleFI API key (webhook secret) for an incoming payload.
+
+    Every webhook references a local payment via one of a few external ids
+    (the payment-request id, the installment-plan id, or a top-level
+    ``entity_id``). We look the payment up by whichever is present and return
+    its popup's ``simplefi_api_key`` so the body's HMAC signature can be
+    verified. Returns ``None`` when no matching payment/secret is found, in
+    which case signature verification is skipped (matching the existing
+    "no secret configured" behaviour of ``verify_webhook_signature``).
+    """
+    candidate_ids: list[str] = []
+    data = raw_body.get("data") or {}
+    payment_request = data.get("payment_request") or {}
+    for value in (
+        payment_request.get("installment_plan_id"),
+        payment_request.get("id"),
+        raw_body.get("entity_id"),
+    ):
+        if value and str(value) not in candidate_ids:
+            candidate_ids.append(str(value))
+
+    for external_id in candidate_ids:
+        payment = payments_crud.get_by_external_id(db, external_id)
+        if payment and payment.popup and payment.popup.simplefi_api_key:
+            return payment.popup.simplefi_api_key
+    return None
+
+
+def _confirm_simplefi_status(
+    payment: Payments,
+    payment_request_id: str,
+    *,
+    claimed_status: str,
+) -> str:
+    """Return the authoritative payment status, confirmed with SimpleFI.
+
+    The webhook payload is attacker-controllable, so before acting on a
+    high-value ``approved`` transition we re-fetch the real status from
+    SimpleFI server-side (authenticated with the popup's API key). If the
+    provider disagrees we trust the provider. If we cannot reach the provider
+    we fail closed for ``approved`` (raise so SimpleFI retries) and otherwise
+    fall back to the claimed status. When no API key is configured we cannot
+    confirm and return the claimed status unchanged.
+    """
+    from loguru import logger
+
+    popup = getattr(payment, "popup", None)
+    secret = getattr(popup, "simplefi_api_key", None) if popup else None
+    if not secret:
+        return claimed_status
+
+    client = get_simplefi_client(secret)
+    try:
+        authoritative = client.get_payment_request_status(payment_request_id)
+    except Exception as exc:  # pragma: no cover - network/dependency failure
+        logger.warning(
+            "Could not confirm SimpleFI status for {}: {}", payment_request_id, exc
+        )
+        if claimed_status == "approved":
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Could not confirm payment status with provider",
+            ) from exc
+        return claimed_status
+
+    if authoritative.status != claimed_status:
+        logger.warning(
+            "SimpleFI webhook claimed status={} but provider reports status={} "
+            "for payment_request_id={}; trusting provider",
+            claimed_status,
+            authoritative.status,
+            payment_request_id,
+        )
+    return authoritative.status
+
+
 @router.post("/webhook/simplefi", status_code=status.HTTP_200_OK)
 async def simplefi_webhook(
     request: Request,
@@ -793,11 +871,24 @@ async def simplefi_webhook(
     Routes by event_type to handle regular payments, installment payments,
     and installment plan lifecycle events.
     """
+    import json
+
     from loguru import logger
 
     from app.core.redis import webhook_cache
 
-    raw_body = await request.json()
+    # Read the raw bytes (needed for HMAC verification) and parse JSON from
+    # them — `request.json()` would re-read the body and give us no access to
+    # the exact bytes SimpleFI signed.
+    body_bytes = await request.body()
+    signature = request.headers.get("X-SimpleFI-Signature")
+    try:
+        raw_body = json.loads(body_bytes)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid JSON body"
+        )
+
     event_type = raw_body.get("event_type")
     logger.info(
         "SimpleFI webhook received: event_type={} entity_type={} entity_id={}",
@@ -805,6 +896,25 @@ async def simplefi_webhook(
         raw_body.get("entity_type"),
         raw_body.get("entity_id"),
     )
+
+    # Authenticate the webhook before mutating any state. The signature is an
+    # HMAC-SHA256 of the raw body keyed on the popup's SimpleFI API key, so we
+    # resolve that secret via the payment this webhook references. A
+    # *present-but-invalid* signature is rejected outright; a missing signature
+    # is allowed through so we never break legitimate traffic if SimpleFI is not
+    # configured to sign — the approval paths additionally re-confirm status
+    # with SimpleFI server-side (see `_confirm_simplefi_status`).
+    if signature is not None:
+        secret = _resolve_webhook_popup_secret(db, raw_body)
+        if not verify_webhook_signature(body_bytes, signature, secret):
+            logger.warning(
+                "Rejecting SimpleFI webhook with invalid signature: event_type={}",
+                event_type,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid webhook signature",
+            )
 
     if event_type == "installment_plan_completed":
         return await _handle_installment_plan_completed(raw_body, db, webhook_cache)
@@ -844,19 +954,13 @@ async def _handle_regular_payment(
 
     payment_request_id = payload.data.payment_request.id
     event_type = payload.event_type
-
-    fingerprint = f"simplefi:{payment_request_id}:{event_type}"
-    if not webhook_cache.add(fingerprint):
-        logger.info(
-            "Webhook already processed (fingerprint: %s). Skipping...", fingerprint
-        )
-        return {"message": "Webhook already processed"}
+    claimed_status = payload.data.payment_request.status
 
     logger.info(
         "SimpleFI regular payment webhook processing: payment_request_id=%s event_type=%s provider_status=%s",
         payment_request_id,
         event_type,
-        payload.data.payment_request.status,
+        claimed_status,
     )
 
     payment = payments_crud.get_by_external_id(db, payment_request_id)
@@ -867,7 +971,27 @@ async def _handle_regular_payment(
             detail="Payment not found",
         )
 
-    payment_request_status = payload.data.payment_request.status
+    # The payload is unauthenticated; for the high-value `approved` transition
+    # (which issues tickets + confirmation emails) confirm the status with
+    # SimpleFI server-side. Do this BEFORE consuming the idempotency
+    # fingerprint: _confirm_simplefi_status fails closed with 502 when the
+    # provider is unreachable, and SimpleFI retries that — but only if the
+    # fingerprint wasn't already burned. Other transitions trust the payload
+    # (signature-verified at the handler entry when SimpleFI signs).
+    if claimed_status == "approved":
+        payment_request_status = _confirm_simplefi_status(
+            payment, payment_request_id, claimed_status=claimed_status
+        )
+    else:
+        payment_request_status = claimed_status
+
+    # Idempotency: only consume the fingerprint once we're committed to acting.
+    fingerprint = f"simplefi:{payment_request_id}:{event_type}"
+    if not webhook_cache.add(fingerprint):
+        logger.info(
+            "Webhook already processed (fingerprint: %s). Skipping...", fingerprint
+        )
+        return {"message": "Webhook already processed"}
 
     logger.info(
         "SimpleFI payment matched local payment: payment_id={} external_id={} current_status={} provider_status={} payment_type={}",

--- a/backend/tests/test_simplefi_webhook_authenticity.py
+++ b/backend/tests/test_simplefi_webhook_authenticity.py
@@ -1,0 +1,213 @@
+"""Regression tests for SimpleFI webhook authenticity (forgery protection).
+
+The webhook endpoint approves payments and issues tickets based on the
+payload's ``status`` field. That payload is attacker-controllable, so two
+guards were added:
+
+1. Signature verification — a *present-but-invalid* ``X-SimpleFI-Signature``
+   is rejected (the secret is the popup's ``simplefi_api_key``).
+2. Authoritative status confirmation — before acting on an ``approved``
+   transition we re-fetch the real status from SimpleFI server-side and trust
+   the provider, so a forged ``approved`` payload cannot issue tickets.
+
+These tests exercise the two helpers in isolation (no DB / network) so they
+stay fast and deterministic.
+"""
+
+import hashlib
+import hmac
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.payment.router import (
+    _confirm_simplefi_status,
+    _resolve_webhook_popup_secret,
+)
+from app.services.simplefi import verify_webhook_signature
+
+# `app.api.payment.router` is re-exported from the package as the APIRouter
+# instance, so import the module explicitly for monkeypatching its globals.
+payment_router = importlib.import_module("app.api.payment.router")
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def test_valid_signature_accepted_invalid_rejected() -> None:
+    secret = "popup-secret-key"
+    body = b'{"event_type":"new_payment"}'
+
+    assert verify_webhook_signature(body, _sign(body, secret), secret) is True
+    assert verify_webhook_signature(body, "deadbeef", secret) is False
+    # Tampered body with an otherwise-valid-looking signature is rejected.
+    assert verify_webhook_signature(b'{"x":1}', _sign(body, secret), secret) is False
+
+
+def test_resolve_secret_prefers_payment_request_id(monkeypatch) -> None:
+    popup = SimpleNamespace(simplefi_api_key="key-123")
+    payment = SimpleNamespace(popup=popup)
+
+    looked_up: list[str] = []
+
+    class FakeCRUD:
+        def get_by_external_id(self, _db, external_id: str):
+            looked_up.append(external_id)
+            return payment if external_id == "pr-1" else None
+
+    monkeypatch.setattr(payment_router, "payments_crud", FakeCRUD())
+
+    raw_body = {"data": {"payment_request": {"id": "pr-1"}}, "entity_id": "ent-9"}
+    assert _resolve_webhook_popup_secret(object(), raw_body) == "key-123"
+    assert "pr-1" in looked_up
+
+
+def test_resolve_secret_none_when_no_payment(monkeypatch) -> None:
+    class FakeCRUD:
+        def get_by_external_id(self, _db, _external_id: str):
+            return None
+
+    monkeypatch.setattr(payment_router, "payments_crud", FakeCRUD())
+    assert _resolve_webhook_popup_secret(object(), {"entity_id": "x"}) is None
+
+
+def test_forged_approved_status_overridden_by_provider(monkeypatch) -> None:
+    """A forged ``approved`` payload is overridden by SimpleFI's real status."""
+    popup = SimpleNamespace(simplefi_api_key="key")
+    payment = SimpleNamespace(popup=popup)
+
+    class FakeClient:
+        def get_payment_request_status(self, _pr_id):
+            return SimpleNamespace(id=_pr_id, status="pending")
+
+    monkeypatch.setattr(payment_router, "get_simplefi_client", lambda _k: FakeClient())
+
+    result = _confirm_simplefi_status(payment, "pr-1", claimed_status="approved")
+    assert result == "pending"  # provider wins, so approval will NOT happen
+
+
+def test_confirm_returns_provider_approved_for_genuine_payment(monkeypatch) -> None:
+    popup = SimpleNamespace(simplefi_api_key="key")
+    payment = SimpleNamespace(popup=popup)
+
+    class FakeClient:
+        def get_payment_request_status(self, _pr_id):
+            return SimpleNamespace(id=_pr_id, status="approved")
+
+    monkeypatch.setattr(payment_router, "get_simplefi_client", lambda _k: FakeClient())
+    assert _confirm_simplefi_status(payment, "pr-1", claimed_status="approved") == (
+        "approved"
+    )
+
+
+def test_confirm_fails_closed_when_provider_unreachable_on_approved(
+    monkeypatch,
+) -> None:
+    from fastapi import HTTPException
+
+    popup = SimpleNamespace(simplefi_api_key="key")
+    payment = SimpleNamespace(popup=popup)
+
+    class FakeClient:
+        def get_payment_request_status(self, _pr_id):
+            raise RuntimeError("simplefi down")
+
+    monkeypatch.setattr(payment_router, "get_simplefi_client", lambda _k: FakeClient())
+
+    with pytest.raises(HTTPException) as exc:
+        _confirm_simplefi_status(payment, "pr-1", claimed_status="approved")
+    assert exc.value.status_code == 502
+
+
+def test_confirm_without_secret_trusts_claimed_status() -> None:
+    """No API key configured (or no popup loaded) → cannot confirm, fall back."""
+    payment = SimpleNamespace()  # no .popup attribute at all
+    assert _confirm_simplefi_status(payment, "pr-1", claimed_status="expired") == (
+        "expired"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handler ordering: status confirmation must run BEFORE the idempotency token
+# is consumed, so a fail-closed 502 doesn't suppress SimpleFI's retry.
+# ---------------------------------------------------------------------------
+
+
+def _approved_payload(payment_request_id: str = "pr-1"):
+    from app.api.payment.schemas import SimpleFIWebhookPayload
+
+    return SimpleFIWebhookPayload.model_validate(
+        {
+            "id": "evt-1",
+            "event_type": "new_payment",
+            "entity_type": "payment_request",
+            "entity_id": payment_request_id,
+            "data": {
+                "payment_request": {
+                    "id": payment_request_id,
+                    "order_id": 1,
+                    "amount": 100.0,
+                    "amount_paid": 0,
+                    "currency": "USD",
+                    "reference": {},
+                    "status": "approved",
+                    "status_detail": "approved",
+                    "transactions": [],
+                    "card_payment": None,
+                    "payments": [],
+                    "installment_plan_id": None,
+                },
+                "new_payment": None,
+            },
+        }
+    )
+
+
+class _FakeCache:
+    def __init__(self):
+        self.keys: set[str] = set()
+
+    def add(self, fingerprint: str) -> bool:
+        if fingerprint in self.keys:
+            return False
+        self.keys.add(fingerprint)
+        return True
+
+
+def test_unreachable_provider_does_not_consume_fingerprint(monkeypatch) -> None:
+    """Regression: a 502 (provider unreachable) on an approved webhook must not
+    burn the idempotency fingerprint, or SimpleFI's retry would be dropped as
+    "already processed" and the genuine payment would never be approved.
+    """
+    import asyncio
+
+    from fastapi import HTTPException
+
+    payment = SimpleNamespace(
+        id="p1",
+        external_id="pr-1",
+        status="pending",
+        payment_type="regular",
+        popup=SimpleNamespace(simplefi_api_key="key"),
+    )
+
+    class _CRUD:
+        def get_by_external_id(self, _db, _external_id):
+            return payment
+
+    class _DownClient:
+        def get_payment_request_status(self, _pr_id):
+            raise RuntimeError("simplefi down")
+
+    monkeypatch.setattr(payment_router, "payments_crud", _CRUD())
+    monkeypatch.setattr(payment_router, "get_simplefi_client", lambda _k: _DownClient())
+
+    cache = _FakeCache()
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            payment_router._handle_regular_payment(_approved_payload(), object(), cache)
+        )
+    assert exc.value.status_code == 502
+    assert cache.keys == set()  # fingerprint NOT consumed → retry will be honored


### PR DESCRIPTION
## Problem
The SimpleFI webhook (`POST /api/v1/payments/webhook/simplefi`) approves payments and issues tickets based solely on the payload's `status` field, which is attacker-controllable. It never verifies the request signature and never re-confirms status with SimpleFI. A forged POST claiming `status: "approved"` for a known/guessed `payment_request.id` could approve a payment that was never made and issue tickets. (`verify_webhook_signature` already existed in `services/simplefi/client.py` but was never wired up.)

## Fix
Extends the recent payment hardening with two complementary, fail-safe guards:

1. **Signature verification** — the handler reads the raw body bytes + `X-SimpleFI-Signature`, resolves the popup's `simplefi_api_key` (the webhook secret) via the referenced payment, and rejects a *present-but-invalid* signature. A *missing* signature is allowed through, so legitimate traffic is never broken if signing isn't configured.
2. **Authoritative status confirmation** — before acting on an `approved` transition, the regular-payment path re-fetches the real status from SimpleFI server-side (`get_payment_request_status`) and trusts the provider. Fails closed (502, so SimpleFI retries) when the provider is unreachable.

Confirmation runs **before** the idempotency fingerprint is consumed, so a transient 502 doesn't burn the fingerprint and suppress SimpleFI's retry. Only the `approved` transition is confirmed (other statuses trust the signed payload), keeping the extra API call off the hot path. Both guards degrade safely when a popup/secret isn't loaded, so existing handler behaviour is preserved.

## Tests
Adds `tests/test_simplefi_webhook_authenticity.py`: valid/invalid/tampered signature, secret resolution, forged-`approved` overridden by provider, fail-closed 502, and a regression test that a 502 does **not** consume the idempotency fingerprint.

> Note: the backend suite requires Docker (testcontainers) which wasn't available in my local env, so I verified the new logic with standalone scripts; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)