### PR TITLE
fix(events): parse EXDATE strings in emailed iTIP calendar invites

### DIFF
--- a/backend/app/services/ical.py
+++ b/backend/app/services/ical.py
@@ -168,7 +168,15 @@ def build_event_ics(
     # whole series instead of just the first instance.
     if recurrence_id is None and getattr(event, "rrule", None):
         lines.append(f"RRULE:{event.rrule}")
-        exdates = getattr(event, "recurrence_exdates", None) or []
+        # recurrence_exdates is a JSONB array, so values arrive as ISO strings
+        # (not datetimes). Parse them before stamping — _fmt_utc reads .tzinfo
+        # and would otherwise raise AttributeError on a str, which the caller's
+        # try/except swallows, silently dropping the calendar invite from
+        # series-update/cancel emails. Mirrors the public ICS feed fix.
+        exdates = [
+            datetime.fromisoformat(d) if isinstance(d, str) else d
+            for d in getattr(event, "recurrence_exdates", None) or []
+        ]
         if exdates:
             lines.append(f"EXDATE:{','.join(_fmt_utc(d) for d in exdates)}")
     if description:

--- a/backend/tests/test_event_itip.py
+++ b/backend/tests/test_event_itip.py
@@ -345,6 +345,39 @@ class TestBuildEventIcs:
         assert "RRULE:" not in occ
         assert "RECURRENCE-ID:" in occ
 
+    def test_recurring_master_emits_exdate_from_stored_strings(self) -> None:
+        """recurrence_exdates is JSONB, so values arrive as ISO strings.
+
+        Regression: ``_fmt_utc`` reads ``.tzinfo`` and raised AttributeError on
+        a str, which the iTIP send path swallowed in a try/except — silently
+        dropping the calendar invite from series-update/cancel emails for any
+        recurring event that had a cancelled/detached occurrence. The strings
+        must be parsed so a valid EXDATE line is emitted.
+        """
+        start = datetime(2026, 5, 5, 14, 0, tzinfo=UTC)
+        event = self._minimal_event(start=start, end=start + timedelta(hours=1))
+        event.rrule = "FREQ=WEEKLY;BYDAY=MO"
+        # As persisted in JSONB: ISO strings, not datetimes.
+        event.recurrence_exdates = [
+            "2026-05-12T14:00:00Z",
+            "2026-05-19T14:00:00+00:00",
+        ]
+
+        master = build_event_ics(
+            event, recipient_email="alice@example.com", method="REQUEST", sequence=2
+        )
+
+        assert "EXDATE:20260512T140000Z,20260519T140000Z" in master
+        # A single-occurrence (RECURRENCE-ID) message must still omit EXDATE.
+        occ = build_event_ics(
+            event,
+            recipient_email="alice@example.com",
+            method="REQUEST",
+            sequence=2,
+            occurrence_start=start + timedelta(days=7),
+        )
+        assert "EXDATE:" not in occ
+
     def test_add_to_calendar_export_uid_matches_itip_uid(self) -> None:
         """The "Add to calendar" .ics download and the emailed invite/cancel
         must share the SAME UID. Calendars key entries on UID, so a mismatch


### PR DESCRIPTION
## Problem
`build_event_ics` formatted `recurrence_exdates` with `_fmt_utc`, which reads `.tzinfo` — but `recurrence_exdates` is a JSONB array, so values arrive as ISO **strings** and `_fmt_utc` raised `AttributeError`. The iTIP send path swallows that in a `try/except`, so a recurring event with any cancelled/detached occurrence silently lost its calendar invite from every series update/cancel email — recipients' calendars never reflected the change.

## Fix
Parse the strings to datetimes before stamping, mirroring the recently-merged public ICS feed fix (`87b26d21`), which only patched the feed path and not this per-recipient email builder.

## Tests
Extends `tests/test_event_itip.py` with a regression test that a series-master REQUEST emits a valid `EXDATE:` line from stored ISO strings (and that a single-occurrence/RECURRENCE-ID message still omits it). Existing ICS tests covered RRULE but never EXDATE.

> Note: the backend suite requires Docker (testcontainers) which wasn't available in my local env, so I verified the builder output with standalone scripts; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)