### PR TITLE
fix(auth): compare OTP codes in constant time

### DIFF
--- a/backend/app/api/auth/utils.py
+++ b/backend/app/api/auth/utils.py
@@ -1,3 +1,4 @@
+import hmac
 import secrets
 from datetime import UTC, datetime, timedelta
 
@@ -62,8 +63,9 @@ def is_code_valid(
     if is_code_expired(expiration):
         return False, "Code has expired"
 
-    # Check if codes match
-    if stored_code != provided_code:
+    # Check if codes match. Constant-time compare so response latency does not
+    # leak how many leading digits of the code were correct.
+    if not hmac.compare_digest(stored_code, provided_code):
         return False, "Invalid code"
 
     return True, None

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -4,6 +4,7 @@ Configure via REDIS_URL environment variable:
 - Local: redis://redis:6379
 """
 
+import hmac
 import uuid
 from datetime import timedelta
 
@@ -233,7 +234,9 @@ class AuthCodeStore:
             if stored_code is None:
                 return False, "No authentication code pending or code has expired"
 
-            if stored_code != code:
+            # Constant-time compare so response latency does not leak how many
+            # leading digits matched. decode_responses=True, so both are str.
+            if not hmac.compare_digest(stored_code, code):
                 # Increment attempts
                 client.incr(attempts_key)
                 return False, "Invalid authentication code"

--- a/backend/tests/test_auth_code_constant_time.py
+++ b/backend/tests/test_auth_code_constant_time.py
@@ -1,0 +1,37 @@
+"""Regression test: auth-code comparison is constant-time.
+
+The 6-digit OTP comparison used plain ``!=``, which short-circuits on the
+first differing byte and leaks (via timing) how many leading digits were
+correct. Both verification paths (DB fallback in ``auth/utils.py`` and the
+Redis path in ``core/redis.py``) now use ``hmac.compare_digest``.
+
+We can't assert timing here, but we lock in that the constant-time primitive
+is used and that valid/invalid/expired outcomes are unchanged.
+"""
+
+import inspect
+from datetime import UTC, datetime, timedelta
+
+from app.api.auth import utils as auth_utils
+from app.api.auth.utils import is_code_valid
+from app.core import redis as redis_module
+
+
+def test_is_code_valid_outcomes_unchanged() -> None:
+    future = datetime.now(UTC) + timedelta(minutes=5)
+    past = datetime.now(UTC) - timedelta(minutes=5)
+
+    assert is_code_valid("123456", "123456", future) == (True, None)
+
+    ok, msg = is_code_valid("123456", "000000", future)
+    assert ok is False and msg == "Invalid code"
+
+    ok, msg = is_code_valid("123456", "123456", past)
+    assert ok is False and "expired" in msg.lower()
+
+
+def test_both_paths_use_constant_time_compare() -> None:
+    assert "compare_digest" in inspect.getsource(auth_utils.is_code_valid)
+    assert "compare_digest" in inspect.getsource(
+        redis_module.AuthCodeStore._verify_code
+    )


### PR DESCRIPTION
## Problem
Both auth-code verification paths compared the 6-digit code with plain `!=`, which short-circuits on the first differing byte and leaks (via response timing) how many leading digits were correct.

## Fix
Use `hmac.compare_digest` in `is_code_valid` (DB fallback, `auth/utils.py`) and `AuthCodeStore._verify_code` (Redis path, `core/redis.py`). `decode_responses=True`, so both operands are `str`. Outcomes are unchanged — this is defense-in-depth hardening.

## Tests
Adds `tests/test_auth_code_constant_time.py`: valid/invalid/expired outcomes unchanged, and both paths use `compare_digest`.

> Note: the backend suite requires Docker (testcontainers) which wasn't available in my local env, so I verified behaviour with standalone scripts; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)