### PR TITLE
perf(api): gzip-compress responses to speed up large payloads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 
 import app.models  # noqa: F401 - Register all models with SQLAlchemy
 from app.api.router import api_router
@@ -138,6 +139,25 @@ application.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "X-Tenant-Id", "Accept-Language"],
+)
+
+# Compress responses for clients that advertise gzip support. Event/calendar
+# payloads are large and highly repetitive JSON/ICS — e.g. a popup's public
+# .ics feed measured ~310 KB uncompressed, ~100 KB gzipped (~68% smaller) — and
+# the API previously sent everything uncompressed, so transfer time dominated
+# page load on slower connections. ``minimum_size`` skips tiny responses
+# (health checks, CORS preflights, error bodies) where compression isn't worth
+# the overhead; ``compresslevel=6`` is the usual ratio/CPU sweet spot (vs
+# Starlette's default 9). Starlette adds ``Vary: Accept-Encoding``, rewrites
+# Content-Length, and skips responses that already carry ``Content-Encoding``
+# or are Server-Sent Events (``text/event-stream``). Note: it does not skip by
+# content type otherwise, so already-compressed binaries (e.g. the invoice PDF
+# download) get re-gzipped — wasteful but harmless, and those endpoints are
+# rare. Added before RequestContextMiddleware so that middleware stays outermost.
+application.add_middleware(
+    GZipMiddleware,  # type: ignore[arg-type]
+    minimum_size=1000,
+    compresslevel=6,
 )
 
 # Outermost middleware: assigns a request_id, binds it to all logs in the

--- a/backend/tests/test_gzip_compression.py
+++ b/backend/tests/test_gzip_compression.py
@@ -1,0 +1,84 @@
+"""Tests for gzip response compression (GZipMiddleware).
+
+The API previously sent every response uncompressed; large, repetitive
+JSON/ICS payloads (e.g. a popup's ~310 KB public calendar feed) dominated
+page-load time on slow connections. GZipMiddleware compresses responses for
+clients that advertise gzip, skipping tiny payloads via ``minimum_size``.
+
+The behavioural tests build a minimal app with the same config (so they don't
+need the Docker-backed DB fixtures); a final test asserts the real application
+wires the middleware with RequestContextMiddleware still outermost.
+"""
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from starlette.middleware.gzip import GZipMiddleware
+from starlette.testclient import TestClient
+
+MIN_SIZE = 1000
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(GZipMiddleware, minimum_size=MIN_SIZE)
+
+    @app.get("/big")
+    def big() -> PlainTextResponse:
+        return PlainTextResponse("x" * 5000)
+
+    @app.get("/small")
+    def small() -> PlainTextResponse:
+        return PlainTextResponse("tiny")
+
+    return app
+
+
+def test_large_response_is_gzipped() -> None:
+    client = TestClient(_app())
+    r = client.get("/big", headers={"Accept-Encoding": "gzip"})
+    assert r.status_code == 200
+    assert r.headers.get("content-encoding") == "gzip"
+    assert "accept-encoding" in r.headers.get("vary", "").lower()
+    # httpx transparently decodes, so the body is intact.
+    assert r.text == "x" * 5000
+
+
+def test_large_response_body_is_actually_gzip_on_the_wire() -> None:
+    """Stronger proof: the raw bytes are gzip-compressed (magic 1f 8b), not just
+    a header httpx might preserve, and decompress back to the original."""
+    import gzip
+
+    client = TestClient(_app())
+    with client.stream("GET", "/big", headers={"Accept-Encoding": "gzip"}) as r:
+        raw = b"".join(r.iter_raw())
+    assert raw[:2] == b"\x1f\x8b"  # gzip magic bytes
+    assert len(raw) < 5000  # actually smaller than the plaintext
+    assert gzip.decompress(raw) == b"x" * 5000
+
+
+def test_small_response_not_gzipped() -> None:
+    client = TestClient(_app())
+    r = client.get("/small", headers={"Accept-Encoding": "gzip"})
+    assert r.status_code == 200
+    assert r.headers.get("content-encoding") != "gzip"
+
+
+def test_client_without_gzip_gets_plain_response() -> None:
+    client = TestClient(_app())
+    r = client.get("/big", headers={"Accept-Encoding": "identity"})
+    assert r.status_code == 200
+    assert r.headers.get("content-encoding") != "gzip"
+    assert r.text == "x" * 5000
+
+
+def test_real_app_wires_gzip_inside_request_context() -> None:
+    from app.core.logging import RequestContextMiddleware
+    from app.main import application
+
+    classes = [m.cls for m in application.user_middleware]
+    assert GZipMiddleware in classes, "GZipMiddleware not registered"
+    # Starlette inserts each add_middleware() at index 0, so user_middleware[0]
+    # is the outermost. RequestContextMiddleware must stay outermost (it logs
+    # every request), with GZip nested inside it.
+    assert classes[0] is RequestContextMiddleware
+    assert classes.index(GZipMiddleware) > classes.index(RequestContextMiddleware)


### PR DESCRIPTION
## Problem
The portal events list (e.g. `/portal/edge-esmeralda-2026/events`) takes several seconds to load on slower connections. The API served **every response uncompressed** — there was no compression middleware (`app/main.py` had only CORS + the request-context logger).

## Evidence (measured against production)
The popup's public calendar feed (`GET /api/v1/events/portal/.../calendar.ics`) for edge-esmeralda-2026:
- **310 KB / 393 events, served uncompressed**, ~4.1s total on a weak link (~0.55s connect, ~1.7s TTFB/server, **~2.35s body transfer**).
- gzip (level 6) shrinks the body to **99.8 KB — 68% smaller**.
- At the measured wire rate, body transfer drops **2.35s → 0.76s (~1.6s saved)**, total request **4.06s → 2.47s (~39% faster)**.

The JSON list endpoint returns ~40 fields/event (incl. full `content` HTML) so it's at least as heavy, and the list view fetches several pages sequentially, so the savings compound.

Notably **not** a DB/index problem: the `events` table already has `ix_events_popup_status_start (popup_id, status, start_time)` covering the published list query.

## Fix
Add Starlette `GZipMiddleware(minimum_size=1000, compresslevel=6)`, nested **inside** `RequestContextMiddleware` so request-id/access logging stays outermost. Compresses every large response (events JSON, ICS feed, etc.) for clients advertising gzip — i.e. all browsers.

- Starlette adds `Vary: Accept-Encoding`, rewrites `Content-Length`, and skips responses already carrying `Content-Encoding` or Server-Sent Events (`text/event-stream`) — the codebase has no SSE endpoints.
- `minimum_size=1000` leaves tiny responses (health checks, CORS preflights, error bodies) uncompressed.
- `compresslevel=6` is the usual ratio/CPU sweet spot (vs Starlette's default 9).
- Known, harmless trade-off: the rare invoice-PDF download gets re-gzipped (already-compressed bytes — wasteful but correct; browsers decode transparently).

## Tests
`tests/test_gzip_compression.py`: large response is gzipped (header + raw gzip magic-bytes round-trip), small response and `Accept-Encoding: identity` are not, and the real app wires GZip with `RequestContextMiddleware` outermost.

## Deliberately out of scope
The portal's sequential fetch-all-before-render (and any response field-trimming) lives in the files two in-flight branches are already reworking (`fix/calendar-feed-and-list-pagination`, `fix/portal-events-server-side-filtering`), so this PR stays backend-only to avoid conflicts. Progressive rendering is the natural follow-up to coordinate once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)