### PR TITLE
fix(checkout): offer installment plans on open-ticketing express checkout (to main)

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -735,6 +735,24 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 ],
             }
 
+            # Same installment-plan eligibility as the pass-purchase path —
+            # open-ticketing buyers are anonymous but provide an email, which
+            # is all SimpleFi needs to create a plan.
+            max_installments: int | None = None
+            if (
+                popup.installments_enabled
+                and popup.installments_deadline is not None
+                and popup.installments_max is not None
+            ):
+                computed = _calculate_max_installments(
+                    popup.installments_deadline,
+                    popup.installments_max,
+                    popup.installments_interval,
+                    popup.installments_interval_count,
+                )
+                if computed >= 2:
+                    max_installments = computed
+
             simplefi_response = simplefi_client.create_payment(
                 amount=payment.amount,
                 popup_slug=popup.slug,
@@ -745,11 +763,23 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 portal_base_override=portal_base,
                 success_path=success_url,
                 cancel_path=cancel_url,
+                max_installments=max_installments,
+                installment_interval=popup.installments_interval,
+                installment_interval_count=popup.installments_interval_count,
+                user_email=buyer.email,
+                plan_name=popup.name,
             )
 
             payment.external_id = simplefi_response.id
             payment.status = simplefi_response.status
             payment.checkout_url = simplefi_response.checkout_url
+            # When the response signals an installment plan, external_id is an
+            # installment_plan_id and installments_total stays NULL until the
+            # installment_plan_activated webhook delivers the buyer's pick.
+            payment.is_installment_plan = simplefi_response.is_installment_plan
+            payment.installments_paid = (
+                0 if simplefi_response.is_installment_plan else None
+            )
             session.add(payment)
             session.commit()
             session.refresh(payment)

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -119,6 +119,7 @@ def test_purchase_happy_path_creates_payment_and_attendees(
             id="sf_purchase_1",
             status="pending",
             checkout_url="https://simplefi.test/checkout/happy",
+            is_installment_plan=False,
         )
 
         response = client.post(
@@ -386,6 +387,7 @@ def test_purchase_resolves_per_tenant(
             id="sf_per_tenant_1",
             status="pending",
             checkout_url="https://simplefi.test/checkout/per-tenant",
+            is_installment_plan=False,
         )
 
         response = client.post(
@@ -424,3 +426,105 @@ def test_purchase_unknown_origin_returns_404(
         },
     )
     assert response.status_code == 404, response.text
+
+
+def test_purchase_creates_installment_plan_when_popup_enabled(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Open-ticketing checkout must honor the popup's installments config —
+    the same eligibility the pass-purchase path applies."""
+    popup = _make_popup(db, tenant_a, slug_prefix="instplan")
+    popup.installments_enabled = True
+    popup.installments_deadline = datetime.now(UTC) + timedelta(days=365)
+    popup.installments_max = 6
+    popup.installments_interval = "month"
+    popup.installments_interval_count = 1
+    product = _make_product(db, popup, price="300.00")
+    db.commit()
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_plan_1",
+            status="pending",
+            checkout_url="https://simplefi.test/plan/sf_plan_1",
+            is_installment_plan=True,
+        )
+
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "plan-buyer@test.com",
+                    "first_name": "Plan",
+                    "last_name": "Buyer",
+                    "form_data": {},
+                },
+            },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
+        )
+
+    assert response.status_code == 200, response.text
+
+    call_kwargs = mock_get_client.return_value.create_payment.call_args.kwargs
+    assert call_kwargs["max_installments"] is not None
+    assert call_kwargs["max_installments"] >= 2
+    assert call_kwargs["user_email"] == "plan-buyer@test.com"
+    assert call_kwargs["plan_name"] == popup.name
+
+    payment = db.exec(select(Payments).where(Payments.popup_id == popup.id)).first()
+    assert payment is not None
+    assert payment.is_installment_plan is True
+    assert payment.installments_paid == 0
+    assert payment.external_id == "sf_plan_1"
+
+
+def test_purchase_one_shot_when_installments_deadline_too_close(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Installments enabled but fewer than 2 monthly cycles fit before the
+    deadline — fall back to a one-shot payment request."""
+    popup = _make_popup(db, tenant_a, slug_prefix="instclose")
+    popup.installments_enabled = True
+    popup.installments_deadline = datetime.now(UTC) + timedelta(days=20)
+    popup.installments_max = 6
+    popup.installments_interval = "month"
+    popup.installments_interval_count = 1
+    product = _make_product(db, popup, price="300.00")
+    db.commit()
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_oneshot_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/sf_oneshot_1",
+            is_installment_plan=False,
+        )
+
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "oneshot-buyer@test.com",
+                    "first_name": "One",
+                    "last_name": "Shot",
+                    "form_data": {},
+                },
+            },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
+        )
+
+    assert response.status_code == 200, response.text
+
+    call_kwargs = mock_get_client.return_value.create_payment.call_args.kwargs
+    assert call_kwargs["max_installments"] is None
+
+    payment = db.exec(select(Payments).where(Payments.popup_id == popup.id)).first()
+    assert payment is not None
+    assert payment.is_installment_plan is False
+    assert payment.installments_paid is None

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -193,6 +193,7 @@ def test_create_open_ticketing_payment_one_attendee_n_tickets(
         id="sf_open_ticketing_1",
         status="pending",
         checkout_url="https://simplefi.test/checkout/1",
+        is_installment_plan=False,
     )
 
     with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
@@ -272,10 +273,16 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
     )
 
     sf_resp1 = SimpleNamespace(
-        id="sf_reuse_1", status="pending", checkout_url="https://sf.test/1"
+        id="sf_reuse_1",
+        status="pending",
+        checkout_url="https://sf.test/1",
+        is_installment_plan=False,
     )
     sf_resp2 = SimpleNamespace(
-        id="sf_reuse_2", status="pending", checkout_url="https://sf.test/2"
+        id="sf_reuse_2",
+        status="pending",
+        checkout_url="https://sf.test/2",
+        is_installment_plan=False,
     )
 
     with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
@@ -339,6 +346,7 @@ def test_create_open_ticketing_payment_does_not_overwrite_existing_human(
             id="sf_open_ticketing_3",
             status="pending",
             checkout_url="https://simplefi.test/checkout/3",
+            is_installment_plan=False,
         )
 
         payments_crud.create_open_ticketing_payment(
@@ -437,6 +445,7 @@ def test_create_open_ticketing_payment_applies_coupon_discount(
             id="sf_open_ticketing_coupon",
             status="pending",
             checkout_url="https://simplefi.test/checkout/coupon",
+            is_installment_plan=False,
         )
 
         payment, _ = payments_crud.create_open_ticketing_payment(

--- a/backend/tests/api/product/test_enforcement_wiring.py
+++ b/backend/tests/api/product/test_enforcement_wiring.py
@@ -453,6 +453,7 @@ class TestOpenTicketingPaymentEnforcement:
             id=f"sf-{uuid.uuid4().hex[:8]}",
             status="pending",
             checkout_url="https://simplefi.test/checkout/enf",
+            is_installment_plan=False,
         )
 
         with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
@@ -489,6 +490,7 @@ class TestOpenTicketingPaymentEnforcement:
             id=f"sf-{uuid.uuid4().hex[:8]}",
             status="pending",
             checkout_url="https://simplefi.test/checkout/unlimited",
+            is_installment_plan=False,
         )
 
         with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
@@ -557,6 +559,7 @@ class TestOpenTicketingPaymentEnforcement:
                 id=f"sf-{uuid.uuid4().hex[:8]}",
                 status="pending",
                 checkout_url="https://simplefi.test/checkout/conc",
+                is_installment_plan=False,
             )
             with SyncSession(test_engine) as session:
                 with patch(


### PR DESCRIPTION
## Summary

Cherry-pick of #345 (already merged to dev) onto main — promotes only the installments fix, without the rest of dev.

`/checkout/<slug>` (open ticketing, `sale_type=direct`) called the SimpleFi client without `max_installments`, so popups with installments enabled — e.g. `amanita-festival-2026` — silently created one-shot payments and ignored their configuration. The fix applies the same eligibility computation as the portal pass path (enabled + deadline + max, ≥2 cycles fitting) and passes the buyer's email through; the payment records `is_installment_plan`/`installments_paid` like the pass path. Webhook handlers unchanged — they resolve payments by `external_id` regardless of flow.

Commits: `5db0698c` (fix + tests), `33f9e98d` (remaining SimpleFi mock updates) — cherry-picked from dev, so the next dev→main sync will merge cleanly over this.

## Deploy notes

- No new migrations (head stays `c7a4e9f2d815`)
- After deploy, Amanita's checkout offers plans immediately — capped at ~4 monthly installments by their Nov 3 deadline (expected deadline math)

## Testing

- Verified end-to-end locally against `apidev.simplefi.tech`: express purchase → real installment plan created (`is_installment_plan=true`, plan checkout offering deadline-capped cycles)
- 154 checkout/payment/enforcement tests pass on this branch (main base), ruff clean