### PR TITLE
feat(attendee): persist required_fields via additional_data (kids age group)

### DIFF
--- a/backend/app/alembic/versions/d4e8f1a92b67_add_additional_data_to_attendees.py
+++ b/backend/app/alembic/versions/d4e8f1a92b67_add_additional_data_to_attendees.py
@@ -1,0 +1,40 @@
+"""Add additional_data JSONB column to attendees.
+
+Adds a per-attendee free-form blob that persists the answers to a category's
+declarative ``required_fields`` (e.g. a kid's ``date_of_birth``). Mirrors
+``applications.custom_fields`` but at the per-attendee level so each attendee
+row carries its own answers.
+
+Existing rows default to an empty object; no behavior change until callers
+start populating it.
+
+Revision ID: d4e8f1a92b67
+Revises: c7a4e9f2d815
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d4e8f1a92b67"
+down_revision: str | Sequence[str] | None = "c7a4e9f2d815"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "attendees",
+        sa.Column(
+            "additional_data",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("attendees", "additional_data")

--- a/backend/app/api/attendee/crud.py
+++ b/backend/app/api/attendee/crud.py
@@ -138,9 +138,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
             )
 
         if category_id is not None:
-            base_statement = base_statement.where(
-                Attendees.category_id == category_id
-            )
+            base_statement = base_statement.where(Attendees.category_id == category_id)
 
         # Use proper count query instead of fetching all rows
         count_statement = select(func.count()).select_from(base_statement.subquery())
@@ -173,6 +171,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
         gender: str | None = None,
         human_id: uuid.UUID | None = None,
         category_id: uuid.UUID | None = None,
+        additional_data: dict | None = None,
     ) -> Attendees:
         """Create an attendee with internal fields.
 
@@ -201,6 +200,7 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
             email=email,
             gender=gender,
             human_id=human_id,
+            additional_data=additional_data or {},
         )
         session.add(attendee)
         session.commit()

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -47,6 +47,55 @@ _AttendeeLimit = Annotated[
 ]
 
 
+def _validate_required_fields(
+    required_fields: list[dict],
+    additional_data: dict,
+) -> None:
+    """Validate declarative required_fields against submitted additional_data.
+
+    For each field marked ``required``, ensure a non-empty value is present. For
+    fields typed ``"date"``, also ensure the value parses as an ISO date when
+    present. Extra keys in additional_data are permitted (unknown keys are kept,
+    not rejected) so partial/extra answers do not break the flow. Raises 422 with
+    the offending field name on the first failure.
+    """
+    from datetime import date as _date
+
+    data = additional_data or {}
+    for field in required_fields or []:
+        name = field.get("name")
+        if not name:
+            continue
+        value = data.get(name)
+        if field.get("required") and (value is None or value == ""):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=[
+                    {
+                        "code": "required_field_missing",
+                        "field": name,
+                        "message": f"Missing required field '{name}'",
+                    }
+                ],
+            )
+        if field.get("type") == "date" and value not in (None, ""):
+            try:
+                _date.fromisoformat(str(value))
+            except (ValueError, TypeError):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=[
+                        {
+                            "code": "invalid_date",
+                            "field": name,
+                            "message": (
+                                f"Field '{name}' must be an ISO date (YYYY-MM-DD)"
+                            ),
+                        }
+                    ],
+                ) from None
+
+
 def _build_attendee_with_origin(
     attendee,
     last_scan_by_ticket: dict | None = None,
@@ -133,6 +182,7 @@ def _build_attendee_with_origin(
         "email": attendee.email,
         "gender": attendee.gender,
         "poap_url": attendee.poap_url,
+        "additional_data": getattr(attendee, "additional_data", None) or {},
         "created_at": getattr(attendee, "created_at", None),
         "updated_at": getattr(attendee, "updated_at", None),
     }
@@ -294,6 +344,12 @@ async def create_my_attendee_for_popup(
                         }
                     ],
                 )
+        # Validate declarative required_fields (e.g. a kid's date_of_birth) are
+        # present in the submitted additional_data. Permissive toward extra keys.
+        _validate_required_fields(
+            category_row.required_fields or [],
+            attendee_in.additional_data or {},
+        )
         # Derive legacy category string from FK for backward compatibility
         effective_category = category_row.key
         effective_category_id = category_row.id
@@ -312,6 +368,7 @@ async def create_my_attendee_for_popup(
         category_id=effective_category_id,
         email=attendee_in.email,
         gender=attendee_in.gender,
+        additional_data=attendee_in.additional_data,
     )
 
     last_scan_by_ticket = get_last_scan_by_tickets(

--- a/backend/app/api/attendee/schemas.py
+++ b/backend/app/api/attendee/schemas.py
@@ -31,6 +31,14 @@ class AttendeeBase(SQLModel):
     email: str | None = Field(default=None, nullable=True)
     gender: str | None = Field(default=None, nullable=True)
     poap_url: str | None = Field(default=None, nullable=True)
+    # Free-form blob for declarative `required_fields` collected per attendee
+    # (e.g. a kid's date_of_birth). Mirrors Applications.custom_fields but at the
+    # per-attendee level so each kid row carries its own answers. Persists ALL
+    # dynamic required_fields, not just a single typed column.
+    additional_data: dict = Field(
+        default_factory=dict,
+        sa_column=Column(JSONB, nullable=False, server_default="{}"),
+    )
 
 
 class AttendeePublic(AttendeeBase):
@@ -70,6 +78,8 @@ class AttendeeCreate(BaseModel):
     category: str | None = None
     email: str | None = None
     gender: str | None = None
+    # Declarative required_fields answers (e.g. {"date_of_birth": "2018-05-01"}).
+    additional_data: dict | None = None
 
     @field_validator("email")
     @classmethod
@@ -87,6 +97,8 @@ class AttendeeUpdate(BaseModel):
     name: str | None = None
     email: str | None = None
     gender: str | None = None
+    # Replaces the whole additional_data blob when provided (not a partial merge).
+    additional_data: dict | None = None
     # Category cannot be changed once set if products exist
 
     @field_validator("email")

--- a/backend/app/core/db.py
+++ b/backend/app/core/db.py
@@ -231,6 +231,7 @@ def _seed_attendee_categories(
                 "type": "select",
                 "required": True,
                 "options": ["baby", "kid", "teen"],
+                "label": "Age group",
                 "display_as_subtitle": True,
             }
         ],

--- a/backend/tests/api/attendee/test_attendee_additional_data.py
+++ b/backend/tests/api/attendee/test_attendee_additional_data.py
@@ -1,0 +1,161 @@
+"""HTTP tests for per-attendee additional_data + declarative required_fields.
+
+Covers the kids-age restoration feature:
+1. Creating a "kid" attendee with additional_data persists the blob and returns
+   it on the AttendeePublic response.
+2. A category whose required_fields marks a field required rejects creation with
+   422 when that field is missing from additional_data.
+3. Extra keys in additional_data are kept (permissive toward unknown fields).
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee_category.models import AttendeeCategories
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+
+def _auth(human: Humans) -> dict[str, str]:
+    return {"Authorization": f"Bearer {create_access_token(subject=human.id, token_type='human')}"}
+
+
+def _make_human(db: Session, tenant: Tenants, *, suffix: str) -> Humans:
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        email=f"addl-{suffix}-{uuid.uuid4().hex[:8]}@test.com",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _make_popup(db: Session, tenant: Tenants, *, suffix: str) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name=f"Addl Popup {suffix}",
+        slug=f"addl-{suffix}-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_application(db: Session, tenant: Tenants, popup: Popups, human: Humans) -> Applications:
+    application = Applications(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _make_kid_category(db: Session, tenant: Tenants, popup: Popups) -> AttendeeCategories:
+    category = AttendeeCategories(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        key="kid",
+        is_primary=False,
+        enabled_in_passes_flow=True,
+        required_fields=[
+            {
+                "name": "age_group",
+                "type": "select",
+                "required": True,
+                "options": ["baby", "kid", "teen"],
+                "label": "Age group",
+                "display_as_subtitle": True,
+            }
+        ],
+    )
+    db.add(category)
+    db.commit()
+    db.refresh(category)
+    return category
+
+
+class TestAttendeeAdditionalData:
+    def test_create_kid_persists_additional_data(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="kid-ok")
+        human = _make_human(db, tenant_a, suffix="kid-ok")
+        _make_application(db, tenant_a, popup, human)
+        kid_cat = _make_kid_category(db, tenant_a, popup)
+
+        response = client.post(
+            f"/api/v1/attendees/my/popup/{popup.id}",
+            headers=_auth(human),
+            json={
+                "name": "Little One",
+                "category_id": str(kid_cat.id),
+                "additional_data": {"age_group": "kid"},
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["additional_data"] == {"age_group": "kid"}
+        assert body["category"] == "kid"
+
+    def test_missing_required_field_returns_422(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="kid-missing")
+        human = _make_human(db, tenant_a, suffix="kid-missing")
+        _make_application(db, tenant_a, popup, human)
+        kid_cat = _make_kid_category(db, tenant_a, popup)
+
+        response = client.post(
+            f"/api/v1/attendees/my/popup/{popup.id}",
+            headers=_auth(human),
+            json={"name": "No Age", "category_id": str(kid_cat.id)},
+        )
+
+        assert response.status_code == 422, response.text
+        detail = response.json()["detail"]
+        codes = [d.get("code") for d in detail if isinstance(d, dict)]
+        assert "required_field_missing" in codes
+
+    def test_extra_keys_are_kept(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="kid-extra")
+        human = _make_human(db, tenant_a, suffix="kid-extra")
+        _make_application(db, tenant_a, popup, human)
+        kid_cat = _make_kid_category(db, tenant_a, popup)
+
+        response = client.post(
+            f"/api/v1/attendees/my/popup/{popup.id}",
+            headers=_auth(human),
+            json={
+                "name": "Extra Keys",
+                "category_id": str(kid_cat.id),
+                "additional_data": {
+                    "age_group": "baby",
+                    "nickname": "Junior",
+                },
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["additional_data"]["nickname"] == "Junior"
+        assert body["additional_data"]["age_group"] == "baby"

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -2029,6 +2029,18 @@ export const AttendeeCreateSchema = {
                 }
             ],
             title: 'Gender'
+        },
+        additional_data: {
+            anyOf: [
+                {
+                    additionalProperties: true,
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Additional Data'
         }
     },
     type: 'object',
@@ -2186,6 +2198,11 @@ export const AttendeeListItemSchema = {
                 }
             ],
             title: 'Poap Url'
+        },
+        additional_data: {
+            additionalProperties: true,
+            type: 'object',
+            title: 'Additional Data'
         },
         id: {
             type: 'string',
@@ -2445,6 +2462,11 @@ export const AttendeePublicSchema = {
                 }
             ],
             title: 'Poap Url'
+        },
+        additional_data: {
+            additionalProperties: true,
+            type: 'object',
+            title: 'Additional Data'
         },
         id: {
             type: 'string',
@@ -2767,6 +2789,18 @@ export const AttendeeUpdateSchema = {
                 }
             ],
             title: 'Gender'
+        },
+        additional_data: {
+            anyOf: [
+                {
+                    additionalProperties: true,
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Additional Data'
         }
     },
     type: 'object',
@@ -2858,6 +2892,11 @@ export const AttendeeWithOriginPublicSchema = {
                 }
             ],
             title: 'Poap Url'
+        },
+        additional_data: {
+            additionalProperties: true,
+            type: 'object',
+            title: 'Additional Data'
         },
         id: {
             type: 'string',

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2862,11 +2862,14 @@ export class EventsService {
      * - ``"custom"``  → events with a ``custom_location_name`` set.
      * - ``"meeting"`` → online-only events (no venue, no custom location).
      *
+     * ``visibility`` narrows to a single visibility (public | unlisted | private).
+     *
      * ``owner_id`` filters to events created by a specific host (the Human
      * referenced by ``Events.owner_id``).
      * @param data The data for the request.
      * @param data.popupId
      * @param data.eventStatus
+     * @param data.visibility
      * @param data.kind
      * @param data.venueId
      * @param data.locationKind

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -446,6 +446,9 @@ export type AttendeeCreate = {
     category?: (string | null);
     email?: (string | null);
     gender?: (string | null);
+    additional_data?: ({
+    [key: string]: unknown;
+} | null);
 };
 
 /**
@@ -487,6 +490,9 @@ export type AttendeeListItem = {
     email?: (string | null);
     gender?: (string | null);
     poap_url?: (string | null);
+    additional_data?: {
+        [key: string]: unknown;
+    };
     id: string;
     category?: (string | null);
     created_at?: (string | null);
@@ -547,6 +553,9 @@ export type AttendeePublic = {
     email?: (string | null);
     gender?: (string | null);
     poap_url?: (string | null);
+    additional_data?: {
+        [key: string]: unknown;
+    };
     id: string;
     category?: (string | null);
     created_at?: (string | null);
@@ -669,6 +678,9 @@ export type AttendeeUpdate = {
     name?: (string | null);
     email?: (string | null);
     gender?: (string | null);
+    additional_data?: ({
+    [key: string]: unknown;
+} | null);
 };
 
 /**
@@ -691,6 +703,9 @@ export type AttendeeWithOriginPublic = {
     email?: (string | null);
     gender?: (string | null);
     poap_url?: (string | null);
+    additional_data?: {
+        [key: string]: unknown;
+    };
     id: string;
     category?: (string | null);
     created_at?: (string | null);

--- a/backoffice/src/components/attendee-categories/AttendeeCategoriesEditor.tsx
+++ b/backoffice/src/components/attendee-categories/AttendeeCategoriesEditor.tsx
@@ -39,11 +39,10 @@ interface DialogState {
   maxPerApplication: string
   // High-level form fields the admin toggles. We serialize/deserialize these
   // to/from the underlying `required_fields` JSONB so the dialog stays simple
-  // for the two cases we actually have: spouse (email+gender), kid (age+gender).
+  // for the cases we actually have: spouse (email+gender), kid (age group).
   requireEmail: boolean
   requireGender: boolean
-  askAge: boolean
-  maxAge: string
+  askAgeGroup: boolean
 }
 
 const EMPTY_DIALOG: DialogState = {
@@ -56,8 +55,7 @@ const EMPTY_DIALOG: DialogState = {
   maxPerApplication: "",
   requireEmail: true,
   requireGender: false,
-  askAge: false,
-  maxAge: "12",
+  askAgeGroup: false,
 }
 
 interface RequiredFieldOption {
@@ -74,24 +72,14 @@ interface RequiredFieldEntry {
   display_as_subtitle?: boolean
 }
 
-function buildAgeOptions(maxAge: number): RequiredFieldOption[] {
-  const options: RequiredFieldOption[] = [
-    { value: "lt1", label: "< 1 year old" },
-  ]
-  for (let i = 1; i <= maxAge; i++) {
-    options.push({
-      value: String(i),
-      label: i === 1 ? "1 year old" : `${i} years old`,
-    })
-  }
-  return options
-}
+const AGE_GROUP_OPTIONS: RequiredFieldOption[] = [
+  { value: "baby", label: "Baby" },
+  { value: "kid", label: "Kid" },
+  { value: "teen", label: "Teen" },
+]
 
 function serializeRequiredFields(
-  state: Pick<
-    DialogState,
-    "requireEmail" | "requireGender" | "askAge" | "maxAge"
-  >,
+  state: Pick<DialogState, "requireEmail" | "requireGender" | "askAgeGroup">,
 ): RequiredFieldEntry[] {
   const fields: RequiredFieldEntry[] = []
   if (state.requireEmail) {
@@ -116,16 +104,13 @@ function serializeRequiredFields(
       ],
     })
   }
-  if (state.askAge) {
-    const max = Number(state.maxAge)
-    const maxAge =
-      Number.isFinite(max) && max > 0 && Number.isInteger(max) ? max : 12
+  if (state.askAgeGroup) {
     fields.push({
-      name: "age",
-      label: "Age",
+      name: "age_group",
+      label: "Age group",
       type: "select",
       required: true,
-      options: buildAgeOptions(maxAge),
+      options: AGE_GROUP_OPTIONS,
       display_as_subtitle: true,
     })
   }
@@ -134,32 +119,21 @@ function serializeRequiredFields(
 
 function deserializeRequiredFields(
   raw: unknown,
-): Pick<DialogState, "requireEmail" | "requireGender" | "askAge" | "maxAge"> {
+): Pick<DialogState, "requireEmail" | "requireGender" | "askAgeGroup"> {
   const fields: RequiredFieldEntry[] = Array.isArray(raw)
     ? (raw as RequiredFieldEntry[])
     : []
   const hasEmail = fields.some((f) => f?.name === "email")
   const hasGender = fields.some((f) => f?.name === "gender")
-  const ageField = fields.find((f) => f?.name === "age")
-  let maxAge = "12"
-  if (ageField?.options && Array.isArray(ageField.options)) {
-    // Largest numeric value across {value,label} pairs or string options.
-    const numericValues = ageField.options
-      .map((opt) =>
-        typeof opt === "string"
-          ? Number(opt)
-          : Number(opt?.value ?? Number.NaN),
-      )
-      .filter((n) => Number.isFinite(n))
-    if (numericValues.length > 0) {
-      maxAge = String(Math.max(...numericValues))
-    }
-  }
+  // Recognize both age_group and the legacy numeric `age` field so existing
+  // "kid" categories show the toggle as on until re-saved.
+  const hasAgeGroup = fields.some(
+    (f) => f?.name === "age_group" || f?.name === "age",
+  )
   return {
     requireEmail: hasEmail,
     requireGender: hasGender,
-    askAge: !!ageField,
-    maxAge,
+    askAgeGroup: hasAgeGroup,
   }
 }
 
@@ -299,13 +273,6 @@ export function AttendeeCategoriesEditor({
         Number(state.maxPerApplication) < 1)
     ) {
       showErrorToast("Max per application must be a positive integer or empty")
-      return
-    }
-    if (
-      state.askAge &&
-      (!Number.isInteger(Number(state.maxAge)) || Number(state.maxAge) < 1)
-    ) {
-      showErrorToast("Max age must be a positive integer")
       return
     }
     if (state.editing) {
@@ -514,36 +481,20 @@ export function AttendeeCategoriesEditor({
               </div>
 
               <div className="flex items-center justify-between">
-                <Label htmlFor="cat-ask-age">Ask for age</Label>
+                <Label htmlFor="cat-ask-age-group">Ask for age group</Label>
                 <Switch
-                  id="cat-ask-age"
-                  checked={state.askAge}
+                  id="cat-ask-age-group"
+                  checked={state.askAgeGroup}
                   onCheckedChange={(checked) =>
-                    setState((prev) => ({ ...prev, askAge: checked }))
+                    setState((prev) => ({ ...prev, askAgeGroup: checked }))
                   }
                 />
               </div>
-
-              {state.askAge && (
-                <div className="space-y-1.5 pl-2">
-                  <Label htmlFor="cat-max-age">Max age</Label>
-                  <Input
-                    id="cat-max-age"
-                    type="number"
-                    min="1"
-                    value={state.maxAge}
-                    placeholder="12"
-                    onChange={(e) =>
-                      setState((prev) => ({
-                        ...prev,
-                        maxAge: e.target.value,
-                      }))
-                    }
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Dropdown shows "{`< 1 year old`}" up to this number.
-                  </p>
-                </div>
+              {state.askAgeGroup && (
+                <p className="pl-2 text-xs text-muted-foreground">
+                  Adds an age-group field (baby / kid / teen) shown when adding
+                  this attendee in the portal.
+                </p>
               )}
             </div>
           </div>

--- a/backoffice/src/lib/age-group.ts
+++ b/backoffice/src/lib/age-group.ts
@@ -1,0 +1,22 @@
+/**
+ * Helper for attendees that collect an `age_group` (baby/kid/teen) in their
+ * `additional_data` blob (the "kid" category). The portal collects it; the
+ * backoffice only displays it.
+ */
+
+/**
+ * Read the `age_group` value from an attendee's `additional_data` blob.
+ * Falls back to a legacy `age` key for older records. Returns null when absent.
+ */
+export function readAgeGroup(
+  attendee: { additional_data?: unknown } | null | undefined,
+): string | null {
+  const value = attendee?.additional_data
+  const data =
+    value && typeof value === "object"
+      ? (value as Record<string, unknown>)
+      : null
+  if (!data) return null
+  const raw = data.age_group ?? data.age
+  return typeof raw === "string" && raw !== "" ? raw : null
+}

--- a/backoffice/src/routes/_layout/attendees/$attendeeId.tsx
+++ b/backoffice/src/routes/_layout/attendees/$attendeeId.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Skeleton } from "@/components/ui/skeleton"
 import useCustomToast from "@/hooks/useCustomToast"
+import { readAgeGroup } from "@/lib/age-group"
 import { createErrorHandler } from "@/utils"
 
 export const Route = createFileRoute("/_layout/attendees/$attendeeId")({
@@ -54,6 +55,10 @@ function AttendeeEditContent({ attendeeId }: { attendeeId: string }) {
       })
     }
   }, [attendee, dirty])
+
+  // Age group (baby/kid/teen) is collected in the portal and stored in
+  // additional_data; it is shown read-only here (not editable from the BO).
+  const ageGroup = readAgeGroup(attendee)
 
   const saveMutation = useMutation({
     mutationFn: () =>
@@ -132,6 +137,14 @@ function AttendeeEditContent({ attendeeId }: { attendeeId: string }) {
               }}
             />
           </div>
+          {ageGroup && (
+            <div className="space-y-1.5">
+              <Label>Age group</Label>
+              <p className="text-sm capitalize text-muted-foreground">
+                {ageGroup}
+              </p>
+            </div>
+          )}
           <div className="flex justify-end">
             <Button
               onClick={() => saveMutation.mutate()}

--- a/backoffice/src/routes/_layout/attendees/index.tsx
+++ b/backoffice/src/routes/_layout/attendees/index.tsx
@@ -39,6 +39,7 @@ import {
   useTableSearchParams,
   validateTableSearch,
 } from "@/hooks/useTableSearchParams"
+import { readAgeGroup } from "@/lib/age-group"
 import { exportToCsv, fetchAllPages } from "@/lib/export"
 
 // ── CSV flattening helper ─────────────────────────────────────────────────────
@@ -48,6 +49,7 @@ type FlatAttendeeRow = {
   email: string | null | undefined
   category: string
   gender: string | null | undefined
+  age_group: string
   product_id: string
 }
 
@@ -57,30 +59,26 @@ type FlatAttendeeRow = {
  * they still appear in the CSV. Per-ticket check_in_codes are not exported
  * here — the list endpoint does not carry them; staff can read them from
  * the attendee edit page.
+ *
+ * age_group (baby/kid/teen) is read from additional_data for "kid" attendees;
+ * blank for everyone else.
  */
 export function flattenAttendeesForCsv(
   attendees: AttendeeListItem[],
 ): FlatAttendeeRow[] {
   return attendees.flatMap((att) => {
-    const products = att.products ?? []
-    if (products.length === 0) {
-      return [
-        {
-          name: att.name,
-          email: att.email,
-          category: att.category ?? "",
-          gender: att.gender,
-          product_id: "",
-        },
-      ]
-    }
-    return products.map((p) => ({
+    const base = {
       name: att.name,
       email: att.email,
       category: att.category ?? "",
       gender: att.gender,
-      product_id: String(p.id),
-    }))
+      age_group: readAgeGroup(att) ?? "",
+    }
+    const products = att.products ?? []
+    if (products.length === 0) {
+      return [{ ...base, product_id: "" }]
+    }
+    return products.map((p) => ({ ...base, product_id: String(p.id) }))
   })
 }
 
@@ -196,6 +194,19 @@ const columns: ColumnDef<AttendeeListItem>[] = [
     ),
   },
   {
+    id: "age_group",
+    header: "Age group",
+    meta: { label: "Age group" },
+    cell: ({ row }) => {
+      const ageGroup = readAgeGroup(row.original)
+      return (
+        <span className="capitalize text-muted-foreground">
+          {ageGroup || "N/A"}
+        </span>
+      )
+    },
+  },
+  {
     id: "actions",
     header: () => <span className="sr-only">Actions</span>,
     cell: ({ row }) => (
@@ -272,7 +283,7 @@ function AttendeesTableContent() {
       columns={columns}
       data={attendees.results}
       searchPlaceholder="Search by name or email..."
-      hiddenOnMobile={["gender", "category"]}
+      hiddenOnMobile={["gender", "category", "age_group"]}
       searchValue={search}
       onSearchChange={setSearch}
       onRowClick={(row) =>
@@ -355,6 +366,7 @@ function Attendees() {
         { key: "email", label: "Email" },
         { key: "category", label: "Category" },
         { key: "gender", label: "Gender" },
+        { key: "age_group", label: "Age group" },
         { key: "product_id", label: "Product ID" },
       ])
     } finally {

--- a/portal/src/app/portal/[popupSlug]/passes/Tabs/YourPasses.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/Tabs/YourPasses.tsx
@@ -100,6 +100,7 @@ const YourPasses = ({ access: _access, onSwitchToBuy }: YourPassesProps) => {
         email: data.email ?? "",
         category_id: modal.category.id,
         gender: data.gender ?? "",
+        additional_data: data.additional_data,
       })
     }
     handleCloseModal()

--- a/portal/src/app/portal/[popupSlug]/passes/components/AttendeeModal.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/AttendeeModal.tsx
@@ -143,6 +143,8 @@ export function AttendeeModal({
         id: editingAttendee?.id ?? "",
         // Pass email from dynamic fields if present
         ...(formData.email ? { email: formData.email } : {}),
+        // Persist declarative required_fields answers (e.g. age_group)
+        additional_data: additionalData,
       } as AttendeePassState & { category_id?: string })
     } finally {
       setLoading(false)

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
@@ -183,6 +183,7 @@ const AttendeeTicket = ({
           name: data.name ?? "",
           email: data.email ?? "",
           gender: data.gender ?? "",
+          additional_data: data.additional_data,
         })
       }
     } catch (_error) {

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -2029,6 +2029,18 @@ export const AttendeeCreateSchema = {
                 }
             ],
             title: 'Gender'
+        },
+        additional_data: {
+            anyOf: [
+                {
+                    additionalProperties: true,
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Additional Data'
         }
     },
     type: 'object',
@@ -2186,6 +2198,11 @@ export const AttendeeListItemSchema = {
                 }
             ],
             title: 'Poap Url'
+        },
+        additional_data: {
+            additionalProperties: true,
+            type: 'object',
+            title: 'Additional Data'
         },
         id: {
             type: 'string',
@@ -2445,6 +2462,11 @@ export const AttendeePublicSchema = {
                 }
             ],
             title: 'Poap Url'
+        },
+        additional_data: {
+            additionalProperties: true,
+            type: 'object',
+            title: 'Additional Data'
         },
         id: {
             type: 'string',
@@ -2767,6 +2789,18 @@ export const AttendeeUpdateSchema = {
                 }
             ],
             title: 'Gender'
+        },
+        additional_data: {
+            anyOf: [
+                {
+                    additionalProperties: true,
+                    type: 'object'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Additional Data'
         }
     },
     type: 'object',
@@ -2858,6 +2892,11 @@ export const AttendeeWithOriginPublicSchema = {
                 }
             ],
             title: 'Poap Url'
+        },
+        additional_data: {
+            additionalProperties: true,
+            type: 'object',
+            title: 'Additional Data'
         },
         id: {
             type: 'string',

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2862,11 +2862,14 @@ export class EventsService {
      * - ``"custom"``  → events with a ``custom_location_name`` set.
      * - ``"meeting"`` → online-only events (no venue, no custom location).
      *
+     * ``visibility`` narrows to a single visibility (public | unlisted | private).
+     *
      * ``owner_id`` filters to events created by a specific host (the Human
      * referenced by ``Events.owner_id``).
      * @param data The data for the request.
      * @param data.popupId
      * @param data.eventStatus
+     * @param data.visibility
      * @param data.kind
      * @param data.venueId
      * @param data.locationKind
@@ -2891,6 +2894,7 @@ export class EventsService {
             query: {
                 popup_id: data.popupId,
                 event_status: data.eventStatus,
+                visibility: data.visibility,
                 kind: data.kind,
                 venue_id: data.venueId,
                 location_kind: data.locationKind,

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -446,6 +446,9 @@ export type AttendeeCreate = {
     category?: (string | null);
     email?: (string | null);
     gender?: (string | null);
+    additional_data?: ({
+    [key: string]: unknown;
+} | null);
 };
 
 /**
@@ -487,6 +490,9 @@ export type AttendeeListItem = {
     email?: (string | null);
     gender?: (string | null);
     poap_url?: (string | null);
+    additional_data?: {
+        [key: string]: unknown;
+    };
     id: string;
     category?: (string | null);
     created_at?: (string | null);
@@ -547,6 +553,9 @@ export type AttendeePublic = {
     email?: (string | null);
     gender?: (string | null);
     poap_url?: (string | null);
+    additional_data?: {
+        [key: string]: unknown;
+    };
     id: string;
     category?: (string | null);
     created_at?: (string | null);
@@ -669,6 +678,9 @@ export type AttendeeUpdate = {
     name?: (string | null);
     email?: (string | null);
     gender?: (string | null);
+    additional_data?: ({
+    [key: string]: unknown;
+} | null);
 };
 
 /**
@@ -691,6 +703,9 @@ export type AttendeeWithOriginPublic = {
     email?: (string | null);
     gender?: (string | null);
     poap_url?: (string | null);
+    additional_data?: {
+        [key: string]: unknown;
+    };
     id: string;
     category?: (string | null);
     created_at?: (string | null);
@@ -4759,6 +4774,7 @@ export type EventsListEventsData = {
     startBefore?: (string | null);
     trackIds?: (Array<(string)> | null);
     venueId?: (string | null);
+    visibility?: (EventVisibility | null);
     xTenantId?: (string | null);
 };
 

--- a/portal/src/components/checkout-flow/shared/AddAttendeeButtons.tsx
+++ b/portal/src/components/checkout-flow/shared/AddAttendeeButtons.tsx
@@ -71,6 +71,7 @@ export default function AddAttendeeButtons({
       email: data.email ?? "",
       category_id: data.category_id ?? selectedCategory.id,
       gender: data.gender ?? "",
+      additional_data: data.additional_data,
     })
     setSelectedCategory(null)
     if (result?.id && onAttendeeAdded) onAttendeeAdded(result.id)

--- a/portal/src/hooks/useAttendee.ts
+++ b/portal/src/hooks/useAttendee.ts
@@ -52,6 +52,7 @@ const useAttendee = () => {
           category: data.category,
           category_id: data.category_id,
           gender: data.gender,
+          additional_data: data.additional_data,
         },
       })
     },
@@ -101,6 +102,7 @@ const useAttendee = () => {
           name: data.name,
           email: data.email,
           gender: data.gender,
+          additional_data: data.additional_data,
         },
       })
     },

--- a/portal/src/types/Attendee.ts
+++ b/portal/src/types/Attendee.ts
@@ -63,4 +63,6 @@ export interface CreateAttendee {
   /** UUID of the attendee category row */
   category_id?: string
   gender: string
+  /** Declarative required_fields answers (e.g. { age_group: "kid" }) */
+  additional_data?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary

Restores the kids **age group** (baby/kid/teen) end to end and fixes the root cause that broke *all* declarative `required_fields`: the portal collected the answers but discarded them because there was nowhere to store them.

- Adds an `additional_data` JSONB column to `Attendees` (mirrors `Applications.custom_fields`, but per attendee) so every declarative `required_fields` answer is persisted.
- The `kid` category collects `age_group` (select: baby/kid/teen); it is now persisted, validated, and shown in the backoffice.

## Changes by layer

**Backend**
- `additional_data` on `AttendeeBase`/`Create`/`Update`/`Public`/`ListItem`; `create_internal` + both update routes persist it.
- Alembic migration `d4e8f1a92b67` (`ADD COLUMN additional_data JSONB NOT NULL DEFAULT '{}'`, reversible).
- Lightweight `required_fields` validation → `422 required_field_missing` when a required field is absent; permissive toward extra keys.
- `kid` seed uses `age_group` select (baby/kid/teen).

**Portal**
- Sends `additional_data` on the add/edit attendee flows (modal → hooks → client).

**Backoffice**
- Category editor: "Ask for age group" toggle (serializes the `age_group` select).
- Attendees table: **Age group** column; attendee detail: read-only age-group display; CSV export includes `age_group`. Shared `lib/age-group.ts` helper (also reads legacy `age`).

**Clients**
- Regenerated Axios/Fetch clients (`additional_data` present in both `types.gen.ts`).

## Testing
- Backend: full suite green (1443 passed); new `test_attendee_additional_data.py` (persists age_group, 422 on missing required, extra keys kept).
- Portal: `tsc --noEmit` + Biome OK.
- Backoffice: `tsc -p tsconfig.build.json` + Biome OK; `flattenAttendeesForCsv` unit test green.

## Notes
- Existing popups already seed `age_group`, so they work without a backfill. No date-of-birth field is introduced anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)