### PR TITLE
fix(portal): match 'Join on Geo' button height with RSVP

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -684,14 +684,14 @@ export default function EventDetailPage() {
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <Button asChild variant="outline" size="sm">
+                  <Button asChild variant="outline">
                     <a
                       href={`https://ee26.geobrowser.io/events/${event.id}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       aria-label={t("events.detail.join_on_geo")}
                     >
-                      <Globe className="mr-2 h-3.5 w-3.5" />
+                      <Globe className="mr-2 h-4 w-4" />
                       {t("events.detail.join_on_geo")}
                     </a>
                   </Button>


### PR DESCRIPTION
Iguala la altura del botón "Join on Geo" con el de RSVP en el detalle de evento del Portal.

- **Dónde:** `portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx` (botón "Join on Geo").
- **Causa:** el botón de Geo usaba `size="sm"` (h-8, ícono h-3.5) mientras que RSVP usa el default (h-9, ícono h-4), por lo que se veía más bajo.
- **Solución:** se quitó el `size="sm"` (queda en default h-9) y se subió el ícono Globe a h-4 w-4 para que matchee visualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)