### PR TITLE
fix(dashboard): reconcile Revenue by Category with Total Revenue

### DIFF
--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -2,7 +2,7 @@ import uuid
 from decimal import ROUND_HALF_UP, Decimal
 
 from fastapi import APIRouter, Query
-from sqlalchemy import case, func
+from sqlalchemy import and_, case, func
 from sqlmodel import select
 
 from app.api.application.models import Applications
@@ -31,7 +31,7 @@ from app.api.payment.models import PaymentProducts, Payments
 from app.api.payment.schemas import PaymentStatus, PaymentType
 from app.api.popup.crud import popups_crud
 from app.api.product.models import Products
-from app.api.product.schemas import CATEGORY_HOUSING, CATEGORY_PATREON, CATEGORY_TICKET
+from app.api.product.schemas import CATEGORY_HOUSING, CATEGORY_TICKET
 from app.core.dependencies.users import CurrentOperator, TenantSession
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
@@ -379,42 +379,62 @@ def _get_cumulative_trends(
 def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBreakdown:
     """Net revenue and quantity breakdown by product and category.
 
-    Revenue here is the money actually collected per line, so the categories
-    reconcile with the Total Revenue KPI (sum of COALESCE(amount_charged, amount))
-    rather than inflating it with pre-discount list prices. When SimpleFi applies
-    a per-rail price adjustment the per-line breakdown can't see it (it's a
-    payment-level adjustment), so categories may drift from the KPI by that delta. Per-line net revenue mirrors the
-    pricing logic in payment.crud._calculate_price:
-      - patreon donations carry their amount on effective_unit_price
-        (product_price is always 0 for patreon);
-      - discountable products are reduced by the payment's best-of-three
-        discount percentage (coupon / group / scholarship);
-      - non-discountable products are charged at full list price.
-    Insurance and contribution fees are excluded on purpose: they are not
-    product lines, so the category total equals Total Revenue minus those fees
-    (and minus edit-pass credits, which are not attributable per line).
+    Revenue is anchored on what was actually collected, never reconstructed from
+    list prices. For each approved pass-purchase payment we take the settled
+    total (COALESCE(amount_charged, amount) minus insurance and contribution
+    fees, which are not product lines) and split it across the payment's lines
+    the same way the pricing engine charged it (payment.crud._calculate_price):
+    non-discountable lines and patreon donations keep their full nominal value,
+    and only discountable lines absorb the discount, sharing whatever remains of
+    the settled total in proportion to their list price. This reconciles with
+    the Total Revenue KPI by construction, regardless of how a coupon, group
+    rate, scholarship or admin comp reduced the amount, none of which are
+    itemised per line.
+
+    Nominal value comes from effective_unit_price when set (patreon donations,
+    whose product_price is 0, and direct-sale unit-price overrides) and from the
+    snapshot product_price otherwise. When the settled total can't cover the
+    non-discountable lines at full price (a comp, or a legacy-migrated payment
+    whose snapshot price was overwritten with the current, higher catalog price)
+    the payment falls back to a plain proportional split so it still reconciles
+    and never goes negative.
     """
-    discount_factor = 1 - func.coalesce(Payments.discount_value, Decimal("0")) / 100
-    net_line_revenue = case(
-        (
-            PaymentProducts.product_category == CATEGORY_PATREON,
-            func.coalesce(PaymentProducts.effective_unit_price, Decimal("0"))
-            * PaymentProducts.quantity,
-        ),
-        (
-            Products.discountable.is_(True),
-            PaymentProducts.product_price * PaymentProducts.quantity * discount_factor,
-        ),
-        else_=PaymentProducts.product_price * PaymentProducts.quantity,
+    # Per-line nominal value: donation/override price when present, else the
+    # snapshot list price. Used as the allocation weight within a payment.
+    line_nominal = (
+        func.coalesce(
+            PaymentProducts.effective_unit_price, PaymentProducts.product_price
+        )
+        * PaymentProducts.quantity
+    )
+    # A product missing from the catalog (deleted) is treated as non-discountable.
+    is_discountable = case((Products.discountable.is_(True), 1), else_=0)
+    # Settled total per payment, excluding non-product fees. Same basis as the
+    # Total Revenue KPI in _get_payment_stats.
+    net_payment = (
+        func.coalesce(Payments.amount_charged, Payments.amount)
+        - Payments.insurance_amount
+        - Payments.contribution_amount
     )
 
-    rows = db.exec(
+    lines = (
         select(
-            PaymentProducts.product_id,
-            PaymentProducts.product_name,
-            PaymentProducts.product_category,
-            func.sum(PaymentProducts.quantity),
-            func.sum(net_line_revenue),
+            PaymentProducts.product_id.label("product_id"),
+            PaymentProducts.product_name.label("product_name"),
+            PaymentProducts.product_category.label("product_category"),
+            PaymentProducts.quantity.label("quantity"),
+            line_nominal.label("nominal"),
+            is_discountable.label("is_discountable"),
+            net_payment.label("net_payment"),
+            func.sum(line_nominal)
+            .over(partition_by=PaymentProducts.payment_id)
+            .label("nominal_total"),
+            func.sum(line_nominal * is_discountable)
+            .over(partition_by=PaymentProducts.payment_id)
+            .label("discountable_total"),
+            func.sum(line_nominal * (1 - is_discountable))
+            .over(partition_by=PaymentProducts.payment_id)
+            .label("non_discountable_total"),
         )
         .join(Payments, PaymentProducts.payment_id == Payments.id)
         .join(Products, PaymentProducts.product_id == Products.id, isouter=True)
@@ -423,10 +443,45 @@ def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBre
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
         )
-        .group_by(
-            PaymentProducts.product_id,
-            PaymentProducts.product_name,
-            PaymentProducts.product_category,
+        .subquery()
+    )
+
+    # Money left for the discountable bucket once non-discountable lines are paid
+    # in full.
+    remainder = lines.c.net_payment - lines.c.non_discountable_total
+    allocated_revenue = case(
+        (
+            # Normal path: non-discountable lines at full nominal; discountable
+            # lines share the remainder weighted by list price.
+            and_(lines.c.discountable_total > 0, remainder >= 0),
+            case(
+                (
+                    lines.c.is_discountable == 1,
+                    remainder * lines.c.nominal / lines.c.discountable_total,
+                ),
+                else_=lines.c.nominal,
+            ),
+        ),
+        # Fallback: settled total can't cover non-discountable lines (comp or
+        # inflated legacy snapshot) -> plain proportional split.
+        (
+            lines.c.nominal_total > 0,
+            lines.c.net_payment * lines.c.nominal / lines.c.nominal_total,
+        ),
+        else_=Decimal("0"),
+    )
+
+    rows = db.exec(
+        select(
+            lines.c.product_id,
+            lines.c.product_name,
+            lines.c.product_category,
+            func.sum(lines.c.quantity),
+            func.sum(allocated_revenue),
+        ).group_by(
+            lines.c.product_id,
+            lines.c.product_name,
+            lines.c.product_category,
         )
     ).all()
 

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -41,11 +41,13 @@ class TestDashboardEnrichedSmoke:
 class TestRevenueBreakdownNetReconciliation:
     """Revenue by category must report net money collected, not gross list price.
 
-    Regression guard: the breakdown used to sum product_price * quantity (the
-    pre-discount catalog snapshot), so the category total dwarfed the Total
-    Revenue KPI (sum of Payments.amount). It must now apply the payment discount
-    to discountable lines, charge non-discountable lines in full, and read the
-    patreon donation off effective_unit_price.
+    Regression guard: the breakdown used to reconstruct per-line revenue from
+    product_price and discount_value, so the category total dwarfed the Total
+    Revenue KPI whenever a discount, comp or migrated-snapshot price was not
+    captured in discount_value. It must now anchor on the settled payment total
+    (COALESCE(amount_charged, amount) minus fees), keep non-discountable lines
+    and patreon donations at full nominal value, and let discountable lines
+    absorb whatever remains.
     """
 
     def test_breakdown_is_net_of_discounts(
@@ -152,8 +154,8 @@ class TestRevenueBreakdownNetReconciliation:
         breakdown = _get_revenue_breakdown(db, popup.id)
         by_category = {c.category: c.revenue for c in breakdown.by_category}
 
-        # Discountable ticket reduced by 20%, non-discountable merch full price,
-        # patreon donation read off effective_unit_price.
+        # Non-discountable merch and the patreon donation stay at full nominal;
+        # the discountable ticket absorbs the discount (remainder = 240 - 80).
         assert by_category["ticket"] == Decimal("160.00")
         assert by_category["merch"] == Decimal("50.00")
         assert by_category["patreon"] == Decimal("30.00")
@@ -167,3 +169,121 @@ class TestRevenueBreakdownNetReconciliation:
 
         # And it is no longer the inflated gross (2*100 + 50 + 0 = 250).
         assert sum(by_category.values()) != Decimal("250.00")
+
+    def test_breakdown_anchors_on_amount_not_discount_value(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        # The real production bug: a discount that never reached discount_value
+        # (an unrecorded coupon/group/scholarship, a migrated snapshot, or an
+        # admin comp). The old reconstruction charged full list price; the new
+        # logic must still reconcile with the amount actually collected.
+        popup = Popups(
+            name="Revenue Breakdown Amount Anchor",
+            slug="revenue-breakdown-amount-anchor",
+            tenant_id=tenant_a.id,
+        )
+        db.add(popup)
+        db.flush()
+
+        ticket = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Week Ticket",
+            slug="rb-anchor-ticket",
+            price=Decimal("100.00"),
+            category="ticket",
+            discountable=True,
+        )
+        meal = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Meal Plan",
+            slug="rb-anchor-meal",
+            price=Decimal("50.00"),
+            category="meal_plan",
+            discountable=False,
+        )
+        db.add_all([ticket, meal])
+        db.flush()
+
+        attendee = Attendees(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Buyer Two",
+        )
+        db.add(attendee)
+        db.flush()
+
+        # Paid 130 on a 150 list (ticket 100 + meal 50) with NO discount_value:
+        # the 20 reduction is invisible to the per-line snapshot.
+        paid = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.APPROVED.value,
+            payment_type=PaymentType.PASS_PURCHASE.value,
+            amount=Decimal("130.00"),
+            insurance_amount=Decimal("0.00"),
+            contribution_amount=Decimal("0.00"),
+            discount_value=None,
+        )
+        # A full admin comp: collected nothing, must contribute nothing.
+        comp = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.APPROVED.value,
+            payment_type=PaymentType.PASS_PURCHASE.value,
+            amount=Decimal("0.00"),
+            insurance_amount=Decimal("0.00"),
+            contribution_amount=Decimal("0.00"),
+            discount_value=None,
+        )
+        db.add_all([paid, comp])
+        db.flush()
+
+        db.add_all(
+            [
+                PaymentProducts(
+                    tenant_id=tenant_a.id,
+                    payment_id=paid.id,
+                    product_id=ticket.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                    product_name=ticket.name,
+                    product_price=Decimal("100.00"),
+                    product_category="ticket",
+                ),
+                PaymentProducts(
+                    tenant_id=tenant_a.id,
+                    payment_id=paid.id,
+                    product_id=meal.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                    product_name=meal.name,
+                    product_price=Decimal("50.00"),
+                    product_category="meal_plan",
+                ),
+                PaymentProducts(
+                    tenant_id=tenant_a.id,
+                    payment_id=comp.id,
+                    product_id=ticket.id,
+                    attendee_id=attendee.id,
+                    quantity=1,
+                    product_name=ticket.name,
+                    product_price=Decimal("100.00"),
+                    product_category="ticket",
+                ),
+            ]
+        )
+        db.commit()
+
+        breakdown = _get_revenue_breakdown(db, popup.id)
+        by_category = {c.category: c.revenue for c in breakdown.by_category}
+
+        # Non-discountable meal plan stays whole; the discountable ticket eats
+        # the 20 reduction. The comp contributes nothing.
+        assert by_category["meal_plan"] == Decimal("50.00")
+        assert by_category["ticket"] == Decimal("80.00")
+
+        # Category total equals the money actually collected (130 + 0), not the
+        # 250 list total the old reconstruction would have reported.
+        assert sum(by_category.values()) == Decimal("130.00")


### PR DESCRIPTION
## Problem

"Revenue by Category" was overcounting versus the "Total Revenue" KPI. The breakdown reconstructed per-line revenue from `product_price * (1 - discount_value/100)` plus a live join to `products.discountable`. That reconstruction does not match what was actually collected:

- Discounts, comps and scholarships are frequently **not** recorded in `payments.discount_value` (they come from coupons, group rates, admin comps via `granted_by_user_id`, or zeroed carts).
- Legacy-migrated payments had their snapshot `product_price` overwritten with the **current** catalog price, inflating the list total.

Only `amount` (what was collected) is reliable end to end.

## Fix

Rewrite `_get_revenue_breakdown` to **anchor on the settled payment total** `COALESCE(amount_charged, amount) - insurance_amount - contribution_amount` (same basis as the Total Revenue KPI), then split it across each payment's lines the way the pricing engine charges them:

- Non-discountable lines and patreon donations keep their full nominal value.
- Discountable lines absorb the remainder, weighted by list price.
- Fallback to a plain proportional split when the settled total cannot cover the non-discountable lines (comps, inflated migrated snapshots) — so it never goes negative and always reconciles.

Drops the dependency on `discount_value` and the reconstruction join to `products`. Category totals now reconcile with Total Revenue by construction.

## Tests

- Existing net-reconciliation test still passes.
- New regression test: a payment with `amount` reduced **without** `discount_value` set, plus a zero-amount admin comp — proves non-discountable lines stay whole, discountable lines absorb the reduction, comps contribute nothing, and the category total equals the money actually collected.

## Notes

- No schema/migration change; OpenAPI response shape (`RevenueBreakdown`) is unchanged, so no client regeneration needed.
- The breakdown total equals Total Revenue **minus** insurance/contribution fees (those are not product lines) — a small intentional delta when fees are present.
