### PR TITLE
fix(coupons): release held coupon use when payment expires or is cancelled

### DIFF
--- a/backend/app/api/coupon/crud.py
+++ b/backend/app/api/coupon/crud.py
@@ -172,6 +172,23 @@ class CouponsCRUD(BaseCRUD[Coupons, CouponCreate, CouponUpdate]):
         session.refresh(coupon)
         return coupon
 
+    def release_use(self, session: Session, coupon_id: uuid.UUID) -> None:
+        """Release a previously-claimed coupon use, clamped at zero.
+
+        Mirrors stock restoration: a coupon use is held at payment creation and
+        returned when the payment moves to a terminal non-approved state
+        (expired/cancelled/rejected). Does NOT commit — the caller's transaction
+        commits alongside the payment status change. The zero clamp is a
+        structural backstop against double-release drift below zero; the caller
+        guards semantic double-release via the PENDING-only status check.
+        """
+        coupon = self.get(session, coupon_id)
+        if not coupon:
+            return
+
+        coupon.current_uses = max(coupon.current_uses - 1, 0)
+        session.add(coupon)
+
     def find_by_popup(
         self,
         session: Session,

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -2353,6 +2353,11 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             and old_status == PaymentStatus.PENDING.value
         ):
             self._restore_payment_stock(session, payment)
+            # Release the coupon use held since payment creation. Same guard as
+            # stock (PENDING-only) prevents semantic double-release. APPROVED is
+            # out of scope: a paid coupon use must stay consumed.
+            if payment.coupon_id:
+                coupons_crud.release_use(session, payment.coupon_id)
 
         payment.status = new_status.value
 

--- a/backend/tests/api/payment/test_coupon_release_on_terminal.py
+++ b/backend/tests/api/payment/test_coupon_release_on_terminal.py
@@ -1,0 +1,271 @@
+"""Integration tests — coupon release on terminal payment status transitions.
+
+Covers CouponsCRUD.release_use wired into PaymentsCRUD.update_status:
+  1. PENDING + coupon → EXPIRED decrements current_uses by 1
+  2. PENDING + coupon → CANCELLED decrements current_uses by 1
+  3. PENDING + coupon → REJECTED decrements current_uses by 1
+  4. PENDING + coupon → APPROVED does NOT change current_uses
+  5. Idempotency: PENDING→EXPIRED (uses decremented), then EXPIRED→EXPIRED (no further decrement)
+  6. PENDING payment with NO coupon → EXPIRED without error, no coupon touched
+
+All tests operate directly against the CRUD layer against a real PostgreSQL
+container (testcontainers), exactly like test_stock_restoration.py.
+"""
+
+import uuid
+from decimal import Decimal
+
+from sqlmodel import Session
+
+from app.api.coupon.models import Coupons
+from app.api.payment.crud import payments_crud
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentStatus
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+INITIAL_USES = 2
+MAX_USES = 5
+
+
+def _make_direct_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"Coupon Release Popup {uuid.uuid4().hex[:6]}",
+        slug=f"cpn-rel-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.direct.value,
+        status="active",
+        currency="ARS",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_coupon(
+    db: Session,
+    popup: Popups,
+    *,
+    current_uses: int = INITIAL_USES,
+    max_uses: int = MAX_USES,
+) -> Coupons:
+    coupon = Coupons(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        code=f"TEST{uuid.uuid4().hex[:6].upper()}",
+        discount_value=10,
+        is_active=True,
+        current_uses=current_uses,
+        max_uses=max_uses,
+    )
+    db.add(coupon)
+    db.flush()
+    return coupon
+
+
+def _make_pending_payment_with_coupon(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    coupon: Coupons | None,
+) -> Payments:
+    """Create a minimal PENDING payment, optionally linked to a coupon.
+
+    products_snapshot is intentionally empty — _restore_payment_stock returns
+    early when products_snapshot is empty, so stock never interferes with the
+    coupon-only assertion.
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+    from app.api.attendee.models import Attendees
+    from app.api.human.models import Humans
+
+    suffix = uuid.uuid4().hex[:8]
+
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"cpn-rel-{suffix}@test.com",
+        first_name="Coupon",
+        last_name="Test",
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.flush()
+
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        name="Coupon Attendee",
+        category="main",
+        email=f"att-cpn-{suffix}@test.com",
+    )
+    db.add(attendee)
+    db.flush()
+
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        status=PaymentStatus.PENDING.value,
+        amount=Decimal("90"),
+        currency="ARS",
+        external_id=f"sf-cpn-{suffix}",
+        coupon_id=coupon.id if coupon else None,
+        coupon_code=coupon.code if coupon else None,
+        discount_value=Decimal("10") if coupon else None,
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _fresh_coupon_uses(db: Session, coupon_id: uuid.UUID) -> int:
+    """Force-refresh the coupon and return its current_uses."""
+    db.expire_all()
+    coupon = db.get(Coupons, coupon_id)
+    assert coupon is not None
+    return coupon.current_uses
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCouponReleaseOnTerminalStatus:
+    """PaymentsCRUD.update_status releases coupon use for non-approved terminals."""
+
+    def test_pending_to_expired_decrements_uses(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING + coupon → EXPIRED: current_uses decremented by 1."""
+        popup = _make_direct_popup(db, tenant_a)
+        coupon = _make_coupon(db, popup)
+        payment = _make_pending_payment_with_coupon(db, tenant_a, popup, coupon)
+
+        coupon_id = coupon.id
+        uses_before = _fresh_coupon_uses(db, coupon_id)
+        assert uses_before == INITIAL_USES
+
+        payments_crud.update_status(db, payment.id, PaymentStatus.EXPIRED)
+
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES - 1
+
+    def test_pending_to_cancelled_decrements_uses(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING + coupon → CANCELLED: current_uses decremented by 1."""
+        popup = _make_direct_popup(db, tenant_a)
+        coupon = _make_coupon(db, popup)
+        payment = _make_pending_payment_with_coupon(db, tenant_a, popup, coupon)
+
+        coupon_id = coupon.id
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES
+
+        payments_crud.update_status(db, payment.id, PaymentStatus.CANCELLED)
+
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES - 1
+
+    def test_pending_to_rejected_decrements_uses(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING + coupon → REJECTED: current_uses decremented by 1."""
+        popup = _make_direct_popup(db, tenant_a)
+        coupon = _make_coupon(db, popup)
+        payment = _make_pending_payment_with_coupon(db, tenant_a, popup, coupon)
+
+        coupon_id = coupon.id
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES
+
+        payments_crud.update_status(db, payment.id, PaymentStatus.REJECTED)
+
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES - 1
+
+    def test_pending_to_approved_does_not_change_uses(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING + coupon → APPROVED: current_uses NOT changed (paid use stays consumed)."""
+        popup = _make_direct_popup(db, tenant_a)
+        coupon = _make_coupon(db, popup)
+        payment = _make_pending_payment_with_coupon(db, tenant_a, popup, coupon)
+
+        coupon_id = coupon.id
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES
+
+        payments_crud.update_status(db, payment.id, PaymentStatus.APPROVED)
+
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES
+
+    def test_idempotency_second_terminal_does_not_decrement_further(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING→EXPIRED releases once; EXPIRED→EXPIRED must NOT release again.
+
+        The PENDING-only guard in update_status is what prevents the double-release.
+        After the first transition old_status is no longer PENDING, so the release
+        branch is skipped entirely on the second call.
+        """
+        popup = _make_direct_popup(db, tenant_a)
+        coupon = _make_coupon(db, popup)
+        payment = _make_pending_payment_with_coupon(db, tenant_a, popup, coupon)
+
+        coupon_id = coupon.id
+        assert _fresh_coupon_uses(db, coupon_id) == INITIAL_USES
+
+        # First transition: PENDING → EXPIRED — decrements
+        payments_crud.update_status(db, payment.id, PaymentStatus.EXPIRED)
+        uses_after_first = _fresh_coupon_uses(db, coupon_id)
+        assert uses_after_first == INITIAL_USES - 1
+
+        # Second call: EXPIRED → EXPIRED — must be no-op for coupon
+        payments_crud.update_status(db, payment.id, PaymentStatus.EXPIRED)
+        uses_after_second = _fresh_coupon_uses(db, coupon_id)
+        assert uses_after_second == uses_after_first, (
+            f"Second terminal transition must not decrement coupon again. "
+            f"Expected {uses_after_first}, got {uses_after_second}."
+        )
+
+    def test_pending_no_coupon_expires_without_error(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING payment with NO coupon → EXPIRED: no error, payment status updated."""
+        popup = _make_direct_popup(db, tenant_a)
+        payment = _make_pending_payment_with_coupon(db, tenant_a, popup, coupon=None)
+
+        assert payment.coupon_id is None
+
+        # Must not raise; coupon path is skipped entirely
+        payments_crud.update_status(db, payment.id, PaymentStatus.EXPIRED)
+
+        db.expire_all()
+        refreshed = db.get(Payments, payment.id)
+        assert refreshed is not None
+        assert refreshed.status == PaymentStatus.EXPIRED.value

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -3,9 +3,10 @@
 import { useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import type { CheckoutMode } from "@/checkout/popupCheckoutPolicy"
-import { CheckoutService, PaymentsService } from "@/client"
+import { ApiError, CheckoutService, PaymentsService } from "@/client"
 import { getMetaAttribution, trackMetaPurchase } from "@/lib/meta-pixel"
 import { queryKeys } from "@/lib/query-keys"
 import type { AttendeePassState } from "@/types/Attendee"
@@ -41,6 +42,7 @@ interface UsePaymentSubmitParams {
   clearCart: () => void
   setCurrentStep: (step: CheckoutStep) => void
   setPromoError: (error: string | null) => void
+  clearPromoCode: () => void
   paymentCompleteRef: React.MutableRefObject<boolean>
   submitMode: "application" | "open-ticketing"
   buyerData: {
@@ -79,12 +81,14 @@ export function usePaymentSubmit({
   clearCart,
   setCurrentStep,
   setPromoError,
+  clearPromoCode,
   paymentCompleteRef,
   submitMode,
   buyerData,
   creditsEnabled,
   popupName,
 }: UsePaymentSubmitParams) {
+  const { t } = useTranslation()
   const queryClient = useQueryClient()
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -304,8 +308,21 @@ export function usePaymentSubmit({
       return { success: true }
     } catch (err: unknown) {
       console.error("Payment failed:", err)
-      const errorMsg =
-        "Something went wrong with your payment. Please try again."
+      const apiDetail =
+        err instanceof ApiError &&
+        typeof (err.body as Record<string, unknown> | null)?.detail === "string"
+          ? ((err.body as Record<string, unknown>).detail as string)
+          : null
+      const isCouponError = apiDetail?.startsWith("Coupon code")
+      if (isCouponError) {
+        clearPromoCode()
+        const errorMsg = t("checkout.coupon_no_longer_valid")
+        setPromoError(errorMsg)
+        toast.error(errorMsg)
+        setIsSubmitting(false)
+        return { success: false, error: errorMsg }
+      }
+      const errorMsg = t("checkout.payment_error")
       setPromoError(errorMsg)
       toast.error(errorMsg)
       setIsSubmitting(false)
@@ -326,6 +343,7 @@ export function usePaymentSubmit({
     promoCode,
     insurance,
     clearCart,
+    clearPromoCode,
     isEditing,
     attendeePasses,
     toggleEditing,
@@ -340,6 +358,7 @@ export function usePaymentSubmit({
     router,
     creditsEnabled,
     isSubmitting,
+    t,
   ])
 
   return { submitPayment, isSubmitting }

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -268,7 +268,9 @@
     "discount": {
       "not_eligible_caption": "Not eligible for discount",
       "promo_discount_eligible_label": "Promo Discount (eligible items)"
-    }
+    },
+    "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
+    "payment_error": "Something went wrong with your payment. Please try again."
   },
   "openCheckout": {
     "loading": "Loading checkout...",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -268,7 +268,9 @@
     "discount": {
       "not_eligible_caption": "No aplica descuento",
       "promo_discount_eligible_label": "Descuento (items elegibles)"
-    }
+    },
+    "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
+    "payment_error": "Something went wrong with your payment. Please try again."
   },
   "openCheckout": {
     "loading": "Cargando checkout...",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -244,7 +244,9 @@
     "discount": {
       "not_eligible_caption": "Ekki gjaldgengt fyrir afslátt",
       "promo_discount_eligible_label": "Afsláttur (gjaldgengar vörur)"
-    }
+    },
+    "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
+    "payment_error": "Something went wrong with your payment. Please try again."
   },
   "openCheckout": {
     "loading": "Hleður greiðslu...",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -254,7 +254,9 @@
     "discount": {
       "not_eligible_caption": "不符合折扣条件",
       "promo_discount_eligible_label": "促销折扣（符合条件的商品）"
-    }
+    },
+    "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
+    "payment_error": "Something went wrong with your payment. Please try again."
   },
   "openCheckout": {
     "loading": "正在加载结账...",

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -1093,6 +1093,7 @@ export function CheckoutProvider({
     clearCart,
     setCurrentStep,
     setPromoError,
+    clearPromoCode,
     paymentCompleteRef,
     submitMode,
     creditsEnabled,


### PR DESCRIPTION
## Problem
Coupon `current_uses` is incremented at payment **creation** (`create_payment`) but never released. Abandoned or expired checkouts permanently consume coupon uses, so single-use and low-cap coupons drain without real sales.

Confirmed in production: coupon `PL-AGENT` (max_uses=5) was exhausted largely by the same buyers creating multiple pending payments for the same application (3 + 2 re-creates) that were never paid. Real buyers then hit `400 Coupon code has reached maximum uses` at checkout, which the portal masked as a generic "Something went wrong with your payment".

## Fix
**Backend** — mirror the existing stock restoration: when a payment transitions out of `PENDING` into `EXPIRED`/`CANCELLED`/`REJECTED`, release the held coupon use. `APPROVED` stays consumed. Hooked into `update_status` (the same guard that restores stock), so it covers webhook expiry, admin cancel, and reject consistently. The hold is now bounded by the SimpleFI payment window (~15 min) instead of being eternal.

**Portal** — when payment creation fails because the applied coupon became invalid, strip the coupon, recompute the total, and show a specific i18n message instead of the generic payment error.

## Relationship to #334
Complementary, not overlapping. #334 makes the coupon *claim* atomic (prevents oversell). This PR fixes the *release* (prevents the leak). Both edit `coupon/crud.py` adjacently (this adds `release_use` right after `use_coupon`); expect a trivial adjacency conflict for whichever lands second.

## Tests
`backend/tests/api/payment/test_coupon_release_on_terminal.py`: release on EXPIRED/CANCELLED/REJECTED, no release on APPROVED, idempotent (PENDING-only guard), no-coupon payments expire cleanly. Existing stock-restoration and expiry tests still pass.

## Follow-ups (not in this PR)
- One-time backfill to release coupon uses stuck on already-dead pending payments.
- One-hold-per-application (supersede prior pending on re-create) to cut simultaneous holds.