### PR TITLE
fix(checkout): use popup currency for runtime products

### DIFF
--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -124,7 +124,12 @@ def runtime_for_slug(
 
     return CheckoutRuntimeResponse(
         popup=PopupPublic.model_validate(popup),
-        products=[CheckoutRuntimeProduct.model_validate(p) for p in products],
+        products=[
+            CheckoutRuntimeProduct.model_validate(
+                {**p.model_dump(), "currency": popup.currency}
+            )
+            for p in products
+        ],
         buyer_form=[
             CheckoutBuyerSection(
                 id=sec.id,

--- a/backend/tests/api/checkout/test_bootstrap.py
+++ b/backend/tests/api/checkout/test_bootstrap.py
@@ -38,6 +38,7 @@ def _make_direct_popup(
     *,
     status: str = "active",
     slug_prefix: str = "boot",
+    currency: str = "USD",
 ) -> Popups:
     slug = f"{slug_prefix}-{uuid.uuid4().hex[:8]}"
     popup = Popups(
@@ -47,6 +48,7 @@ def _make_direct_popup(
         slug=slug,
         sale_type=SaleType.direct.value,
         status=status,
+        currency=currency,
     )
     db.add(popup)
     db.flush()
@@ -180,6 +182,25 @@ def test_runtime_valid_direct_popup(
     assert len(body["ticketing_steps"]) == 1
     assert body["ticketing_steps"][0]["step_type"] == "tickets"
     assert body["ticketing_steps"][0]["title"] == "Choose Tickets"
+
+
+def test_runtime_products_use_popup_currency(
+    client: TestClient, db: Session, tenant_a: Tenants
+) -> None:
+    """Runtime products inherit the popup currency."""
+    popup = _make_direct_popup(db, tenant_a, currency="ARS")
+    _make_product(db, popup, name="ARS Ticket")
+    db.commit()
+
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["popup"]["currency"] == "ARS"
+    assert body["products"][0]["currency"] == "ARS"
 
 
 def test_runtime_only_enabled_ticketing_steps(


### PR DESCRIPTION
Closes #364

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Sets checkout runtime product currency from the popup currency instead of the USD schema default.
- Adds regression coverage for ARS popup runtime products.

## Changes
| File | Change |
|------|--------|
| `backend/app/api/checkout/crud.py` | Builds runtime products with `popup.currency`. |
| `backend/tests/api/checkout/test_bootstrap.py` | Covers ARS runtime product currency. |

## Test Plan
- [x] `uv run pytest tests/api/checkout/test_bootstrap.py tests/test_meta_capi.py tests/api/checkout/test_purchase.py`
- [x] `uv run ruff check app/api/checkout/crud.py app/api/checkout/schemas.py tests/api/checkout/test_bootstrap.py`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers