### PR TITLE
fix(tenant): omit landing_mode from admin tenant updates

### DIFF
--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -169,9 +169,13 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           logo_url: value.logo_url || null,
           // Map empty string to null for domain; never send custom_domain_active
           custom_domain: value.custom_domain || null,
-          landing_mode: value.landing_mode,
           meta_tracking_enabled: value.meta_tracking_enabled,
           meta_pixel_id: value.meta_pixel_id || null,
+        }
+        // landing_mode is a SUPERADMIN-only field; the backend rejects any
+        // non-null value sent by an ADMIN. Only include it for superadmins.
+        if (isSuperadmin) {
+          updateData.landing_mode = value.landing_mode
         }
         if (value.meta_capi_access_token) {
           updateData.meta_capi_access_token = value.meta_capi_access_token


### PR DESCRIPTION
## Problem

When an ADMIN edits an organization (e.g. just to change branding images) and clicks **Save Changes**, the request fails with a 403:

> Something went wrong! Only superadmin can modify landing_mode

The admin never sees or touches a Landing Mode field — that control is rendered for SUPERADMIN only.

## Root cause

Contract mismatch between the form UI and its submit payload:

- The backend (`tenant/router.py`) rejects **any** non-null `landing_mode` sent by an ADMIN — it treats field presence as intent to modify.
- The frontend (`TenantForm.tsx`) gated the Landing Mode **input** by role, but the `onSubmit` serialized `landing_mode` into the PATCH **unconditionally** (defaulting to `"portal"`).

So every admin save included `landing_mode`, and the backend rejected it with a 403.

## Fix

Only include `landing_mode` in the update payload when the user is a superadmin — mirroring how `custom_domain_active` is already withheld from the admin path.

## Scope / audit

Swept all role-gated field guards in the backend. `landing_mode` was the only active bug:
- `custom_domain_active` uses the same pure-presence backend check, but the frontend only sends it via the superadmin-gated Activate/Deactivate button, so it is safe.
- Every other role-gated field (`popup.sale_type`, `popup.status`, `user.role`, `tenant.custom_domain`) uses value-aware guards (`!= current` or hierarchy validation), so re-sending an unchanged value is a no-op.

## Verification

- `pnpm --filter backoffice run build` passes.
- `pnpm --filter backoffice run lint` clean (only a pre-existing Biome schema-version info).