### PR TITLE
feat(tracking): send CAPI InitiateCheckout for open checkout

### DIFF
--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -23,9 +23,33 @@ from app.api.payment.schemas import PaymentStatus
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import SessionDep
 from app.core.rate_limit import RateLimit
-from app.services.meta_capi import enqueue_purchase_event
+from app.services.meta_capi import (
+    enqueue_initiate_checkout_event,
+    enqueue_purchase_event,
+)
 
 router = APIRouter(prefix="/checkout", tags=["checkout"])
+
+
+def _enqueue_checkout_initiate_checkout_event(
+    background_tasks: BackgroundTasks,
+    *,
+    tenant: object,
+    payment: object,
+    popup: object,
+) -> None:
+    try:
+        enqueue_initiate_checkout_event(
+            background_tasks,
+            tenant=tenant,
+            payment=payment,
+            popup=popup,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to queue Meta CAPI InitiateCheckout event payment_id={}",
+            getattr(payment, "id", ""),
+        )
 
 
 def _enqueue_checkout_purchase_event(
@@ -100,6 +124,14 @@ async def purchase_open_ticketing(
             fbp=request_in.fbp,
         ),
     )
+
+    if checkout_url:
+        _enqueue_checkout_initiate_checkout_event(
+            background_tasks,
+            tenant=tenant,
+            payment=payment,
+            popup=popup,
+        )
 
     if payment.status == PaymentStatus.APPROVED.value:
         _enqueue_checkout_purchase_event(

--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -125,7 +125,7 @@ async def purchase_open_ticketing(
         ),
     )
 
-    if checkout_url:
+    if checkout_url and payment.status == PaymentStatus.PENDING.value:
         _enqueue_checkout_initiate_checkout_event(
             background_tasks,
             tenant=tenant,

--- a/backend/app/services/meta_capi.py
+++ b/backend/app/services/meta_capi.py
@@ -25,6 +25,10 @@ class PreparedMetaCapiPurchase:
     event_id: str
     payment_id: str
     popup_id: str
+    event_name: str = "Purchase"
+
+
+PreparedMetaCapiEvent = PreparedMetaCapiPurchase
 
 
 def prepare_purchase_event(
@@ -57,7 +61,11 @@ def prepare_purchase_event(
                 "event_time": int(time.time()),
                 "event_id": event_id,
                 "action_source": "website",
-                "custom_data": _custom_data(payment, resolved_popup),
+                "custom_data": _custom_data(
+                    payment,
+                    resolved_popup,
+                    include_order_id=True,
+                ),
                 "user_data": _user_data(payment),
             }
         ]
@@ -69,6 +77,56 @@ def prepare_purchase_event(
         event_id=event_id,
         payment_id=str(getattr(payment, "id", "")),
         popup_id=str(getattr(resolved_popup, "id", "")),
+    )
+
+
+def prepare_initiate_checkout_event(
+    tenant: Any, payment: Any, popup: Any | None = None
+) -> PreparedMetaCapiEvent | None:
+    """Prepare a Meta CAPI InitiateCheckout event from a pending payment."""
+    encrypted_access_token = getattr(tenant, "meta_capi_access_token_encrypted", None)
+    pixel_id = _normalize_pixel_id(getattr(tenant, "meta_pixel_id", None))
+    if (
+        not getattr(tenant, "meta_tracking_enabled", False)
+        or not pixel_id
+        or not encrypted_access_token
+    ):
+        return None
+
+    resolved_popup = popup or getattr(payment, "popup", None)
+    if resolved_popup is None:
+        logger.warning(
+            "Skipping Meta CAPI InitiateCheckout: popup missing event_id={} payment_id={}",
+            _initiate_checkout_event_id(payment),
+            str(getattr(payment, "id", "")),
+        )
+        return None
+
+    event_id = _initiate_checkout_event_id(payment)
+    payload = {
+        "data": [
+            {
+                "event_name": "InitiateCheckout",
+                "event_time": int(time.time()),
+                "event_id": event_id,
+                "action_source": "website",
+                "custom_data": _custom_data(
+                    payment,
+                    resolved_popup,
+                    include_order_id=False,
+                ),
+                "user_data": _user_data(payment),
+            }
+        ]
+    }
+    return PreparedMetaCapiEvent(
+        pixel_id=pixel_id,
+        encrypted_access_token=str(encrypted_access_token),
+        payload=payload,
+        event_id=event_id,
+        payment_id=str(getattr(payment, "id", "")),
+        popup_id=str(getattr(resolved_popup, "id", "")),
+        event_name="InitiateCheckout",
     )
 
 
@@ -92,6 +150,32 @@ def enqueue_purchase_event(
 
     background_tasks.add_task(
         prepare_and_send_purchase_event,
+        tenant_snapshot,
+        payment_snapshot,
+        popup_snapshot,
+    )
+
+
+def enqueue_initiate_checkout_event(
+    background_tasks: Any,
+    tenant: Any,
+    payment: Any,
+    popup: Any | None = None,
+) -> None:
+    """Queue Meta CAPI InitiateCheckout without affecting checkout."""
+    try:
+        tenant_snapshot = _tenant_snapshot(tenant)
+        payment_snapshot = _payment_snapshot(payment)
+        popup_snapshot = _popup_snapshot(popup) if popup is not None else None
+    except Exception:
+        logger.exception(
+            "Failed to queue Meta CAPI InitiateCheckout event payment_id={}",
+            _safe_object_id(payment),
+        )
+        return
+
+    background_tasks.add_task(
+        prepare_and_send_initiate_checkout_event,
         tenant_snapshot,
         payment_snapshot,
         popup_snapshot,
@@ -144,16 +228,37 @@ async def prepare_and_send_purchase_event(
         )
 
 
-async def send_prepared_purchase_event(event: PreparedMetaCapiPurchase | None) -> None:
-    """Send a prepared Purchase event to Meta without blocking checkout success."""
+async def prepare_and_send_initiate_checkout_event(
+    tenant: Any, payment: Any, popup: Any | None = None
+) -> None:
+    """Prepare and send an InitiateCheckout event in the background."""
+    try:
+        event = prepare_initiate_checkout_event(
+            tenant=tenant,
+            payment=payment,
+            popup=popup,
+        )
+        await send_prepared_purchase_event(event)
+    except Exception:
+        logger.exception(
+            "Meta CAPI InitiateCheckout background task failed payment_id={}",
+            _safe_object_id(payment),
+        )
+
+
+async def send_prepared_purchase_event(event: PreparedMetaCapiEvent | None) -> None:
+    """Send a prepared event to Meta without blocking checkout success."""
     if event is None:
         return
+
+    event_name = event.event_name
 
     try:
         access_token = decrypt(event.encrypted_access_token)
     except Exception:
         logger.exception(
-            "Failed to decrypt Meta CAPI token event_id={} payment_id={} popup_id={}",
+            "Failed to decrypt Meta CAPI token event_name={} event_id={} payment_id={} popup_id={}",
+            event_name,
             event.event_id,
             event.payment_id,
             event.popup_id,
@@ -170,7 +275,8 @@ async def send_prepared_purchase_event(event: PreparedMetaCapiPurchase | None) -
         trace_id = response.headers.get("x-fb-trace-id")
         response.raise_for_status()
         logger.info(
-            "Meta CAPI Purchase sent event_id={} payment_id={} popup_id={} meta_trace_id={}",
+            "Meta CAPI {} sent event_id={} payment_id={} popup_id={} meta_trace_id={}",
+            event_name,
             event.event_id,
             event.payment_id,
             event.popup_id,
@@ -179,7 +285,8 @@ async def send_prepared_purchase_event(event: PreparedMetaCapiPurchase | None) -
     except httpx.HTTPStatusError as exc:
         trace_id = exc.response.headers.get("x-fb-trace-id") or "-"
         logger.warning(
-            "Meta CAPI Purchase rejected event_id={} payment_id={} popup_id={} status={} meta_trace_id={}",
+            "Meta CAPI {} rejected event_id={} payment_id={} popup_id={} status={} meta_trace_id={}",
+            event_name,
             event.event_id,
             event.payment_id,
             event.popup_id,
@@ -188,7 +295,8 @@ async def send_prepared_purchase_event(event: PreparedMetaCapiPurchase | None) -
         )
     except httpx.RequestError:
         logger.exception(
-            "Meta CAPI Purchase request failed event_id={} payment_id={} popup_id={}",
+            "Meta CAPI {} request failed event_id={} payment_id={} popup_id={}",
+            event_name,
             event.event_id,
             event.payment_id,
             event.popup_id,
@@ -287,16 +395,24 @@ def _purchase_event_id(payment: Any) -> str:
     return f"EVT_PURCHASE_{getattr(payment, 'id', '')}"
 
 
-def _custom_data(payment: Any, popup: Any) -> dict[str, Any]:
+def _initiate_checkout_event_id(payment: Any) -> str:
+    return f"EVT_INITIATE_CHECKOUT_{getattr(payment, 'id', '')}"
+
+
+def _custom_data(
+    payment: Any,
+    popup: Any,
+    *,
+    include_order_id: bool,
+) -> dict[str, Any]:
     contents = _contents(payment)
     value = getattr(payment, "amount_charged", None) or getattr(
         payment, "amount", Decimal("0")
     )
-    return {
+    custom_data = {
         "currency": getattr(payment, "currency", None)
         or getattr(popup, "currency", "USD"),
         "value": float(value or Decimal("0")),
-        "order_id": str(getattr(payment, "id", "")),
         "content_ids": [item["id"] for item in contents],
         "contents": contents,
         "num_items": sum(item["quantity"] for item in contents),
@@ -304,6 +420,9 @@ def _custom_data(payment: Any, popup: Any) -> dict[str, Any]:
         "popup_slug": getattr(popup, "slug", "") or "",
         "popup_name": getattr(popup, "name", "") or "",
     }
+    if include_order_id:
+        custom_data["order_id"] = str(getattr(payment, "id", ""))
+    return custom_data
 
 
 def _contents(payment: Any) -> list[dict[str, Any]]:

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -276,6 +276,65 @@ def test_purchase_pending_open_checkout_sends_initiate_checkout_capi(
     assert user_data["client_user_agent"] == "Checkout Test UA"
 
 
+def test_purchase_non_pending_open_checkout_does_not_send_initiate_checkout_capi(
+    client: TestClient,
+    db: Session,
+) -> None:
+    tenant = Tenants(
+        id=uuid.uuid4(),
+        name="CAPI Approved Checkout Tenant",
+        slug=f"capi-approved-checkout-{uuid.uuid4().hex[:6]}",
+        meta_tracking_enabled=True,
+        meta_pixel_id="123456789",
+        meta_capi_access_token_encrypted=encrypt("test-token"),
+    )
+    db.add(tenant)
+    db.flush()
+    popup = _make_popup(db, tenant, slug_prefix="capi-approved-checkout")
+    product = _make_product(db, popup, price="100.00")
+    db.commit()
+
+    async def noop_send_confirmation(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    with (
+        patch(
+            "app.api.checkout.router.enqueue_initiate_checkout_event"
+        ) as mock_initiate,
+        patch("app.api.checkout.router.enqueue_purchase_event"),
+        patch(
+            "app.api.checkout.router._send_payment_confirmed_email",
+            noop_send_confirmation,
+        ),
+        patch("app.services.simplefi.get_simplefi_client") as mock_get_client,
+    ):
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_capi_approved_checkout_1",
+            status="approved",
+            checkout_url="https://simplefi.test/checkout/approved",
+            is_installment_plan=False,
+        )
+
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Meta",
+                    "last_name": "Buyer",
+                    "form_data": {},
+                },
+            },
+            headers={"X-Tenant-Id": str(tenant.id)},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "approved"
+    assert response.json()["checkout_url"] == "https://simplefi.test/checkout/approved"
+    mock_initiate.assert_not_called()
+
+
 def test_purchase_initiate_checkout_capi_failure_does_not_block_response(
     client: TestClient,
     db: Session,

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -18,6 +18,7 @@ from app.api.popup.models import Popups
 from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
+from app.utils.encryption import encrypt
 from tests.conftest import with_origin
 
 
@@ -183,6 +184,146 @@ def test_purchase_happy_path_creates_payment_and_attendees(
     )
     # New design: 1 attendee per (human, popup), 2 AttendeeProducts rows for qty=2
     assert len(attendees) == 1
+
+
+def test_purchase_pending_open_checkout_sends_initiate_checkout_capi(
+    client: TestClient,
+    db: Session,
+) -> None:
+    tenant = Tenants(
+        id=uuid.uuid4(),
+        name="CAPI Checkout Tenant",
+        slug=f"capi-checkout-{uuid.uuid4().hex[:6]}",
+        meta_tracking_enabled=True,
+        meta_pixel_id="123456789",
+        meta_capi_access_token_encrypted=encrypt("test-token"),
+    )
+    db.add(tenant)
+    db.flush()
+    popup = _make_popup(db, tenant, slug_prefix="capi-checkout")
+    popup.currency = "ARS"
+    product = _make_product(db, popup, name="ARS Pass", price="7500.00")
+    db.commit()
+
+    sent_events: list[object] = []
+
+    async def capture_event(event: object) -> None:
+        sent_events.append(event)
+
+    with (
+        patch("app.services.meta_capi.send_prepared_purchase_event", capture_event),
+        patch("app.services.simplefi.get_simplefi_client") as mock_get_client,
+    ):
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_capi_checkout_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/capi",
+            is_installment_plan=False,
+        )
+
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 2}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Meta",
+                    "last_name": "Buyer",
+                    "form_data": {},
+                },
+                "fbc": "fb.1.1710000000.click",
+                "fbp": "fb.1.1710000000.browser",
+            },
+            headers={
+                "X-Tenant-Id": str(tenant.id),
+                "User-Agent": "Checkout Test UA",
+                "X-Forwarded-For": "203.0.113.20",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "pending"
+    assert len(sent_events) == 1
+    event = sent_events[0]
+    payload_event = event.payload["data"][0]
+    payment_id = response.json()["payment_id"]
+    assert event.event_id == f"EVT_INITIATE_CHECKOUT_{payment_id}"
+    assert payload_event["event_name"] == "InitiateCheckout"
+    assert payload_event["custom_data"] == {
+        "currency": "ARS",
+        "value": 15000.0,
+        "content_ids": [str(product.id)],
+        "contents": [
+            {
+                "id": str(product.id),
+                "quantity": 2,
+                "item_price": 7500.0,
+                "title": "ARS Pass",
+            }
+        ],
+        "num_items": 2,
+        "popup_id": str(popup.id),
+        "popup_slug": popup.slug,
+        "popup_name": popup.name,
+    }
+    user_data = payload_event["user_data"]
+    assert user_data["em"]
+    assert user_data["fn"]
+    assert user_data["ln"]
+    assert user_data["fbc"] == "fb.1.1710000000.click"
+    assert user_data["fbp"] == "fb.1.1710000000.browser"
+    assert user_data["client_ip_address"] == "203.0.113.20"
+    assert user_data["client_user_agent"] == "Checkout Test UA"
+
+
+def test_purchase_initiate_checkout_capi_failure_does_not_block_response(
+    client: TestClient,
+    db: Session,
+) -> None:
+    tenant = Tenants(
+        id=uuid.uuid4(),
+        name="CAPI Failure Tenant",
+        slug=f"capi-failure-{uuid.uuid4().hex[:6]}",
+        meta_tracking_enabled=True,
+        meta_pixel_id="123456789",
+        meta_capi_access_token_encrypted=encrypt("test-token"),
+    )
+    db.add(tenant)
+    db.flush()
+    popup = _make_popup(db, tenant, slug_prefix="capi-failure")
+    product = _make_product(db, popup, price="100.00")
+    db.commit()
+
+    async def fail_send(_event: object) -> None:
+        raise RuntimeError("Meta is unavailable")
+
+    with (
+        patch("app.services.meta_capi.send_prepared_purchase_event", fail_send),
+        patch("app.services.simplefi.get_simplefi_client") as mock_get_client,
+    ):
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_capi_failure_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/failure",
+            is_installment_plan=False,
+        )
+
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Meta",
+                    "last_name": "Buyer",
+                    "form_data": {},
+                },
+            },
+            headers={"X-Tenant-Id": str(tenant.id)},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "pending"
 
 
 def test_purchase_unknown_slug_returns_404(

--- a/backend/tests/test_meta_capi.py
+++ b/backend/tests/test_meta_capi.py
@@ -9,6 +9,7 @@ import pytest
 from app.services import meta_capi
 from app.services.meta_capi import (
     prepare_and_send_purchase_event,
+    prepare_initiate_checkout_event,
     prepare_purchase_event,
     send_prepared_purchase_event,
 )
@@ -116,6 +117,84 @@ def test_prepare_purchase_event_includes_popup_purchase_metadata() -> None:
     assert "Lovelace" not in serialized_payload
     assert DUMMY_ACCESS_TOKEN not in serialized_payload
     assert DUMMY_ACCESS_TOKEN not in serialized_event
+
+
+def test_prepare_initiate_checkout_event_uses_payment_currency_without_order_id() -> (
+    None
+):
+    payment_id = uuid4()
+    popup_id = uuid4()
+    product_id = uuid4()
+    payment = SimpleNamespace(
+        id=payment_id,
+        amount=Decimal("15000.00"),
+        amount_charged=None,
+        currency="ARS",
+        products_snapshot=[
+            SimpleNamespace(
+                product_id=product_id,
+                quantity=2,
+                effective_unit_price=None,
+                product_price=Decimal("7500.00"),
+                product_name="General Admission",
+                attendee=SimpleNamespace(
+                    human=SimpleNamespace(
+                        id=uuid4(),
+                        email="buyer@example.com",
+                        first_name="Ada",
+                        last_name="Lovelace",
+                    )
+                ),
+            )
+        ],
+        application=None,
+        buyer_email="buyer@example.com",
+        buyer_name="Ada Lovelace",
+        buyer_snapshot=None,
+        meta_fbc="fb.1.1710000000.click",
+        meta_fbp="fb.1.1710000000.browser",
+        meta_client_ip="203.0.113.10",
+        meta_client_user_agent="Mozilla/5.0 Test",
+    )
+    popup = SimpleNamespace(
+        id=popup_id,
+        slug="summer-popup",
+        name="Summer Popup",
+        currency="ARS",
+    )
+    tenant = SimpleNamespace(
+        meta_tracking_enabled=True,
+        meta_pixel_id="123456789",
+        meta_capi_access_token_encrypted=encrypt(DUMMY_ACCESS_TOKEN),
+    )
+
+    event = prepare_initiate_checkout_event(tenant, payment, popup)
+
+    assert event is not None
+    assert event.event_name == "InitiateCheckout"
+    assert event.event_id == f"EVT_INITIATE_CHECKOUT_{payment_id}"
+    payload_event = event.payload["data"][0]
+    assert payload_event["event_name"] == "InitiateCheckout"
+    assert payload_event["custom_data"] == {
+        "currency": "ARS",
+        "value": 15000.0,
+        "content_ids": [str(product_id)],
+        "contents": [
+            {
+                "id": str(product_id),
+                "quantity": 2,
+                "item_price": 7500.0,
+                "title": "General Admission",
+            }
+        ],
+        "num_items": 2,
+        "popup_id": str(popup_id),
+        "popup_slug": "summer-popup",
+        "popup_name": "Summer Popup",
+    }
+    assert "order_id" not in payload_event["custom_data"]
+    assert payload_event["user_data"]["fbc"] == "fb.1.1710000000.click"
+    assert payload_event["user_data"]["fbp"] == "fb.1.1710000000.browser"
 
 
 def test_prepare_purchase_event_skips_invalid_pixel_id() -> None:


### PR DESCRIPTION
Closes #368

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Sends CAPI-only InitiateCheckout when open checkout creates a pending payment with a SimpleFI checkout URL.
- Reuses payment/product snapshots for value, currency, contents, popup metadata, and attribution.
- Keeps the event best-effort so CAPI failures do not block checkout responses.

## Changes
| File | Change |
|------|--------|
| `backend/app/services/meta_capi.py` | Adds InitiateCheckout event payload and sender support. |
| `backend/app/api/checkout/router.py` | Schedules InitiateCheckout after pending open-checkout payment creation. |
| `backend/tests/test_meta_capi.py` | Covers InitiateCheckout CAPI payload/event id. |
| `backend/tests/api/checkout/test_purchase.py` | Covers scheduling, failure isolation, and pending-status guard. |

## Test Plan
- [x] `uv run pytest tests/test_meta_capi.py tests/api/checkout/test_purchase.py`
- [x] `uv run pytest tests/test_payment_settlement_metadata.py`
- [x] `uv run pytest tests/api/checkout/test_purchase.py -k "initiate_checkout_capi or non_pending_open_checkout"`
- [x] `uv run ruff check ...`
- [x] `uv run ruff format --check ...`
- [x] Fresh risk/reliability review completed

## Notes
- Checkout-only scope.
- No browser Pixel InitiateCheckout.
- No AddPaymentInfo because payment method selection happens inside SimpleFI.
- Duplicate-submit idempotency is intentionally not solved in this PR.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers