### PR TITLE
fix(checkout): section image aspect ratio + non-truncating step nav

### DIFF
--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Check } from "lucide-react"
-import type { ReactNode } from "react"
+import { type ReactNode, useEffect, useRef, useState } from "react"
 import { getRegistryIcon, resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -77,7 +77,30 @@ export default function ScrollySectionNav({
     0,
     sections.findIndex((s) => s.id === activeSection),
   )
-  const segmentWidthPct = sections.length > 0 ? 100 / sections.length : 100
+
+  // Tabs size to their own label width (no equal-width columns), so a long
+  // step name never gets truncated while a short one wastes space. The
+  // sliding pill can't ride a fixed segment fraction anymore, so we measure
+  // the active button and position the pill over its real box. Recomputed on
+  // active change and whenever the track resizes (viewport, font load, the
+  // sm-breakpoint label reveal).
+  const listRef = useRef<HTMLDivElement>(null)
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const [pill, setPill] = useState<{ left: number; width: number } | null>(null)
+
+  useEffect(() => {
+    const measure = () => {
+      const btn = buttonRefs.current[activeIndex]
+      if (!btn) return
+      setPill({ left: btn.offsetLeft, width: btn.offsetWidth })
+    }
+    measure()
+    const list = listRef.current
+    if (!list) return
+    const ro = new ResizeObserver(measure)
+    ro.observe(list)
+    return () => ro.disconnect()
+  }, [activeIndex])
 
   return (
     <div data-snap-nav className="sticky top-0 z-20">
@@ -94,18 +117,22 @@ export default function ScrollySectionNav({
               className="size-7 shrink-0 rounded-md object-contain"
             />
           ) : null}
-          <div className="relative flex-1 overflow-hidden rounded-xl border border-white/10 bg-checkout-badge-bg-disabled/60 p-0.5">
+          <div className="relative flex-1 overflow-x-auto rounded-xl border border-white/10 bg-checkout-badge-bg-disabled/60 p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             <div
-              aria-hidden
-              className="absolute inset-y-0.5 rounded-lg bg-checkout-badge-bg shadow-sm transition-[transform,width] duration-300 ease-out"
-              style={{
-                width: `calc(${segmentWidthPct}% - 0.125rem)`,
-                transform: `translateX(calc(${activeIndex * 100}% + ${activeIndex * 0.125}rem))`,
-                left: "0.125rem",
-              }}
-            />
-            <div className="relative grid auto-cols-fr grid-flow-col">
-              {sections.map((section) => {
+              ref={listRef}
+              className="relative flex w-max min-w-full justify-center"
+            >
+              {pill && (
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute inset-y-0 left-0 rounded-lg bg-checkout-badge-bg shadow-sm transition-[transform,width] duration-300 ease-out"
+                  style={{
+                    width: `${pill.width}px`,
+                    transform: `translateX(${pill.left}px)`,
+                  }}
+                />
+              )}
+              {sections.map((section, index) => {
                 const Icon = resolveIcon(section)
                 const isActive = section.id === activeSection
                 const isComplete =
@@ -123,12 +150,15 @@ export default function ScrollySectionNav({
                 return (
                   <button
                     key={section.id}
+                    ref={(el) => {
+                      buttonRefs.current[index] = el
+                    }}
                     type="button"
                     onClick={() => onSectionClick(section.id)}
                     aria-current={isActive ? "step" : undefined}
                     aria-invalid={isIncomplete || undefined}
                     className={cn(
-                      "relative z-10 flex h-7 min-w-0 items-center justify-center gap-1 px-1.5 text-xs font-semibold transition-[color,opacity] duration-200",
+                      "relative z-10 flex h-7 shrink-0 items-center justify-center gap-1.5 px-3 text-xs font-semibold transition-[color,opacity] duration-200",
                       isActive
                         ? "text-checkout-badge-title"
                         : isIncomplete
@@ -155,7 +185,7 @@ export default function ScrollySectionNav({
                     ) : (
                       <Icon className="size-3.5 shrink-0" />
                     )}
-                    <span className="hidden truncate sm:inline">
+                    <span className="hidden whitespace-nowrap sm:inline">
                       {section.label}
                     </span>
                     {isComplete && (

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -1,7 +1,13 @@
 "use client"
 
 import { Check } from "lucide-react"
-import { type ReactNode, useEffect, useRef, useState } from "react"
+import {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 import { getRegistryIcon, resolveStepIcon } from "@/lib/checkoutStepIcons"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -15,6 +21,13 @@ export type WatermarkStyle = "none" | "ghost" | "stroke" | "bold"
 // the step-type / template lookup tables.
 const resolveIcon = (section: { id: string; template?: string | null }) =>
   resolveStepIcon({ stepType: section.id, template: section.template })
+
+// Measuring the active tab to place the sliding pill must happen before the
+// browser paints (otherwise the pill lands a frame late on first render).
+// useLayoutEffect does that on the client; fall back to useEffect on the
+// server so SSR doesn't warn about a no-op layout effect.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect
 
 interface NavSection {
   id: string
@@ -88,7 +101,7 @@ export default function ScrollySectionNav({
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
   const [pill, setPill] = useState<{ left: number; width: number } | null>(null)
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const measure = () => {
       const btn = buttonRefs.current[activeIndex]
       if (!btn) return
@@ -100,7 +113,9 @@ export default function ScrollySectionNav({
     const ro = new ResizeObserver(measure)
     ro.observe(list)
     return () => ro.disconnect()
-  }, [activeIndex])
+    // sections.length re-runs the measure when tabs are added/removed even if
+    // the active index stays numerically the same (different button, same slot).
+  }, [activeIndex, sections.length])
 
   return (
     <div data-snap-nav className="sticky top-0 z-20">

--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -109,6 +109,16 @@ function parseSurface(
   return "theme"
 }
 
+/** Tenant-wide aspect, set once at template_config root and applied to every
+ *  section's hero image (the backoffice copy reads "Applied to every section's
+ *  hero image"). A per-section `image_aspect` still wins when present. */
+function parseImageAspect(
+  templateConfig: VariantProps["templateConfig"],
+): SectionImageAspect | undefined {
+  const a = templateConfig?.image_aspect
+  return a === "16:9" || a === "3:2" ? a : undefined
+}
+
 function resolveAspectClass(aspect?: SectionImageAspect): string {
   return ASPECT_CLASSES[aspect ?? "16:9"]
 }
@@ -313,11 +323,13 @@ function SectionCard({
   products,
   stepType,
   surface,
+  imageAspect,
 }: {
   section: TicketCardSection
   products: ProductsPass[]
   stepType: string
   surface: TicketCardSurface
+  imageAspect?: SectionImageAspect
 }) {
   if (products.length === 0) return null
 
@@ -330,7 +342,7 @@ function SectionCard({
         <div
           className={cn(
             "relative w-full bg-muted",
-            resolveAspectClass(section.image_aspect),
+            resolveAspectClass(section.image_aspect ?? imageAspect),
           )}
         >
           <Image
@@ -388,9 +400,15 @@ interface LayoutProps {
   groups: { section: TicketCardSection; products: ProductsPass[] }[]
   stepType: string
   surface: TicketCardSurface
+  imageAspect?: SectionImageAspect
 }
 
-function StackedLayout({ groups, stepType, surface }: LayoutProps) {
+function StackedLayout({
+  groups,
+  stepType,
+  surface,
+  imageAspect,
+}: LayoutProps) {
   return (
     <div className="space-y-4">
       {groups.map(({ section, products }) => (
@@ -400,6 +418,7 @@ function StackedLayout({ groups, stepType, surface }: LayoutProps) {
           products={products}
           stepType={stepType}
           surface={surface}
+          imageAspect={imageAspect}
         />
       ))}
     </div>
@@ -432,7 +451,7 @@ function CompactLayout({ groups, stepType, surface }: LayoutProps) {
   )
 }
 
-function TabsLayout({ groups, stepType, surface }: LayoutProps) {
+function TabsLayout({ groups, stepType, surface, imageAspect }: LayoutProps) {
   // Renders section labels as a horizontal anchor strip; sections all
   // stay visible below. Kept server-renderable — no client-side tab state.
   const { t } = useTranslation()
@@ -458,6 +477,7 @@ function TabsLayout({ groups, stepType, surface }: LayoutProps) {
               products={products}
               stepType={stepType}
               surface={surface}
+              imageAspect={imageAspect}
             />
           </div>
         ))}
@@ -478,6 +498,7 @@ export default function VariantTicketCard({
   const sections = parseSections(templateConfig)
   const variant = parseVariant(templateConfig)
   const surface = parseSurface(templateConfig)
+  const imageAspect = parseImageAspect(templateConfig)
   const { t } = useTranslation()
 
   // No sections configured — show every product in a single ungrouped
@@ -527,7 +548,21 @@ export default function VariantTicketCard({
     )
   }
   if (variant === "tabs") {
-    return <TabsLayout groups={groups} stepType={stepType} surface={surface} />
+    return (
+      <TabsLayout
+        groups={groups}
+        stepType={stepType}
+        surface={surface}
+        imageAspect={imageAspect}
+      />
+    )
   }
-  return <StackedLayout groups={groups} stepType={stepType} surface={surface} />
+  return (
+    <StackedLayout
+      groups={groups}
+      stepType={stepType}
+      surface={surface}
+      imageAspect={imageAspect}
+    />
+  )
 }


### PR DESCRIPTION
## Summary

- Fixes the section image aspect ratio (16:9 / 3:2) not taking effect in portal `/checkout`.
- Fixes the checkout step nav being cramped and truncating long step titles.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Aspect ratio:** `template_config.image_aspect` was stored by the backoffice but never read by the portal, so section hero images always rendered at the 16:9 fallback. Added `parseImageAspect()` to read the root-level value and threaded it through `StackedLayout` / `TabsLayout` into `SectionCard`. A per-section `image_aspect` still wins when present.
- **Step nav:** equal-width grid columns (`auto-cols-fr`) plus `truncate` cut off long step labels while short ones wasted space. Tabs now size to their own label (content-width flex), and the sliding active "pill" is positioned from a measured `ResizeObserver` over the active button instead of a fixed segment fraction, so it tracks the real box. Track scrolls horizontally instead of clipping when there are many steps.

## Changes Table

| File | Change |
|------|--------|
| `portal/src/components/checkout-flow/variants/VariantTicketCard.tsx` | Read root `image_aspect` and thread it into section cards |
| `portal/src/components/checkout-flow/ScrollySectionNav.tsx` | Content-width tabs + measured sliding pill indicator |

## Testing

- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [x] Portal linting passes (`pnpm --filter portal run lint`)
- [ ] Manual testing pending: verify in `/checkout` with a popup that has multiple steps and long names, on desktop and mobile, that the pill follows the active step and 3:2 vs 16:9 changes section image height
