### PR TITLE
fix(events): eliminate portal calendar event duplication on scroll

### DIFF
--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -28,7 +28,7 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
         session: Session,
         popup_id: uuid.UUID,
         skip: int = 0,
-        limit: int = 100,
+        limit: int | None = 100,
         event_status: EventStatus | None = None,
         kind: str | None = None,
         start_after: datetime | None = None,
@@ -128,8 +128,17 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.order_by(asc(Events.start_time))
-        statement = statement.offset(skip).limit(limit)
+        # Order by start_time with ``id`` as a unique tiebreaker so the row
+        # order is deterministic across requests. Without the tiebreaker,
+        # events sharing a start_time order arbitrarily, which makes any
+        # offset/limit paging unstable (the same boundary row can repeat or
+        # vanish between pages).
+        statement = statement.order_by(asc(Events.start_time), asc(Events.id))
+        # ``limit=None`` returns the full filtered set in one query (no paging
+        # boundaries). The portal events list uses this so recurring expansion
+        # runs once over the complete window instead of per page.
+        if limit is not None:
+            statement = statement.offset(skip).limit(limit)
         results = list(session.exec(statement).all())
 
         want_expansion = bool(expand_occurrences) or (

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -2646,15 +2646,16 @@ async def list_portal_events(
     rsvped_only: bool = False,
     managed_only: bool = False,
     include_hidden: bool = False,
-    skip: PaginationSkip = 0,
-    limit: PaginationLimit = 100,
 ) -> ListModel[EventPublic]:
     if popup_id:
+        # The portal list always consumes the full window (it groups by day and
+        # sorts globally client-side), so we fetch every matching row in one
+        # query (``limit=None``). Paging this endpoint only created boundaries
+        # where recurring expansion and tie-ordered rows could duplicate.
         events, total = crud.events_crud.find_by_popup(
             db,
             popup_id=popup_id,
-            skip=skip,
-            limit=limit,
+            limit=None,
             event_status=event_status,
             kind=kind,
             venue_id=venue_id,
@@ -2665,15 +2666,13 @@ async def list_portal_events(
             start_before=start_before,
             search=search,
             # "My events" channel: restrict to events the caller manages
-            # (owner / host / collaborator) in SQL, so pagination counts the
-            # managed set instead of post-filtering a truncated page.
+            # (owner / host / collaborator) in SQL, so the query returns the
+            # managed set directly instead of post-filtering in Python.
             managed_by_human_id=current_human.id if managed_only else None,
         )
     else:
         events, total = crud.events_crud.find(
             db,
-            skip=skip,
-            limit=limit,
             search=search,
             search_fields=["title"],
         )
@@ -2758,14 +2757,13 @@ async def list_portal_events(
             pub = pub.model_copy(update=updates)
         return pub
 
+    results = [_publicize(e) for e in visible]
     return ListModel[EventPublic](
-        results=[_publicize(e) for e in visible],
-        # ``total`` is the pre-pagination DB-row count from find_by_popup, not
-        # ``len(visible)``: post-filtering (visibility/cancelled/hidden) and
-        # recurrence expansion make the visible page size an unreliable cursor,
-        # so clients paging through the full set need the row count to know when
-        # to stop.
-        paging=Paging(offset=skip, limit=limit, total=total),
+        results=results,
+        # The list is returned unpaginated, so ``paging`` is informational only.
+        # ``total`` is the pre-expansion DB-row count from find_by_popup; the
+        # returned count differs after recurrence expansion and post-filtering.
+        paging=Paging(offset=0, limit=len(results), total=total),
     )
 
 

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -35,7 +35,7 @@ export class AdminApiKeysService {
             }
         });
     }
-
+    
     /**
      * List Admin Api Keys
      * List admin API keys.
@@ -60,7 +60,7 @@ export class AdminApiKeysService {
             }
         });
     }
-
+    
     /**
      * Get Admin Api Key
      * Retrieve a specific admin API key.
@@ -89,7 +89,7 @@ export class AdminApiKeysService {
             }
         });
     }
-
+    
     /**
      * Revoke Admin Api Key
      * Revoke an admin API key by setting revoked_at.
@@ -3558,8 +3558,6 @@ export class EventsService {
      * @param data.rsvpedOnly
      * @param data.managedOnly
      * @param data.includeHidden
-     * @param data.skip Number of items to skip
-     * @param data.limit Maximum number of items to return
      * @returns ListModel_EventPublic_ Successful Response
      * @throws ApiError
      */
@@ -3580,9 +3578,7 @@ export class EventsService {
                 search: data.search,
                 rsvped_only: data.rsvpedOnly,
                 managed_only: data.managedOnly,
-                include_hidden: data.includeHidden,
-                skip: data.skip,
-                limit: data.limit
+                include_hidden: data.includeHidden
             },
             errors: {
                 422: 'Validation Error'
@@ -3704,7 +3700,7 @@ export class EventsService {
             }
         });
     }
-
+    
     /**
      * Portal Calendar Summary
      * Per-day event counts for a popup's calendar grid.

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -5002,18 +5002,10 @@ export type EventsListPortalEventsData = {
     eventStatus?: (EventStatus | null);
     includeHidden?: boolean;
     kind?: (string | null);
-    /**
-     * Maximum number of items to return
-     */
-    limit?: number;
     managedOnly?: boolean;
     popupId?: (string | null);
     rsvpedOnly?: boolean;
     search?: (string | null);
-    /**
-     * Number of items to skip
-     */
-    skip?: number;
     startAfter?: (string | null);
     startBefore?: (string | null);
     tags?: (Array<(string)> | null);

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -389,7 +389,10 @@ export function ListBody({
                     placeholderUrl ||
                     null
                   return (
-                    <Fragment key={event.id}>
+                    // Key by occurrence (id + start_time), not just id: a
+                    // recurring series shares one id across instances, so a
+                    // plain id key would collide between sibling occurrences.
+                    <Fragment key={domId}>
                       {idx === dividerAt && nowDivider(dividerIsAnchor)}
                       <div
                         id={domId}

--- a/portal/src/app/portal/[popupSlug]/events/lib/fetchAllPortalEvents.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/fetchAllPortalEvents.ts
@@ -1,12 +1,8 @@
 import { type EventPublic, EventsService } from "@/client"
 
-/** Page size for the paginated portal-events fetch loop. */
-const PAGE = 100
-
 /**
  * Filters accepted by {@link fetchAllPortalEvents}. Mirrors the subset of
- * ``listPortalEvents`` params the calendar/day callers need — no ``limit`` or
- * ``skip``, since the loop owns pagination.
+ * ``listPortalEvents`` params the calendar/day callers need.
  */
 export interface FetchAllPortalEventsParams {
   popupId: string
@@ -23,50 +19,37 @@ export interface FetchAllPortalEventsParams {
 }
 
 /**
- * Fetches EVERY portal event matching the given window/filters, across all
- * pages, and returns them sorted ascending by ``start_time``.
+ * Fetches EVERY portal event matching the given window/filters and returns them
+ * sorted ascending by ``start_time``.
  *
- * Why the loop + merge + re-sort: the backend paginates over DB rows first,
- * THEN expands recurring occurrences within each page and sorts only within
- * that page. So a single capped request silently truncates, and even an
- * uncapped page is only locally ordered. To get a correct, complete, globally
- * ordered list we must walk every page (``paging.total`` counts DB rows, so we
- * loop while ``skip < total``) and re-sort the merged set client-side.
+ * The backend returns the full window in one unpaginated response, with
+ * recurring occurrences already expanded over the complete set. We dedupe by
+ * ``id + start_time`` as a safety net (a recurring occurrence and its master
+ * share an id but differ by start_time) and re-sort to guarantee a stable,
+ * globally ordered list regardless of backend ordering.
  */
 export async function fetchAllPortalEvents(
   params: FetchAllPortalEventsParams,
 ): Promise<EventPublic[]> {
-  const all: EventPublic[] = []
-  let skip = 0
-  // `paging.total` is the pre-pagination DB-row count. We advance `skip` by PAGE
-  // (in DB-row units) until we've walked every row. We must NOT stop on an empty
-  // page: a middle page can legitimately filter down to zero (hidden /
-  // visibility / recurring masters with no occurrence in the window) while later
-  // pages still hold events, so the DB-row total is the only reliable stop.
-  let total = Number.POSITIVE_INFINITY
+  const { results } = await EventsService.listPortalEvents({
+    popupId: params.popupId,
+    eventStatus: params.eventStatus,
+    startAfter: params.startAfter,
+    startBefore: params.startBefore,
+    rsvpedOnly: params.rsvpedOnly,
+    managedOnly: params.managedOnly,
+    includeHidden: params.includeHidden,
+    search: params.search,
+    tags: params.tags,
+    trackIds: params.trackIds,
+    venueIds: params.venueIds,
+  })
 
-  while (skip < total) {
-    const { results, paging } = await EventsService.listPortalEvents({
-      popupId: params.popupId,
-      eventStatus: params.eventStatus,
-      startAfter: params.startAfter,
-      startBefore: params.startBefore,
-      rsvpedOnly: params.rsvpedOnly,
-      managedOnly: params.managedOnly,
-      includeHidden: params.includeHidden,
-      search: params.search,
-      tags: params.tags,
-      trackIds: params.trackIds,
-      venueIds: params.venueIds,
-      limit: PAGE,
-      skip,
-    })
-    all.push(...results)
-    total = paging.total
-    skip += PAGE
+  const byKey = new Map<string, EventPublic>()
+  for (const e of results) {
+    byKey.set(`${e.id}:${e.start_time}`, e)
   }
-
-  // `paging.total` counts DB rows but recurring expansion can yield more rows
-  // per page, so the merged set is only locally ordered until we re-sort it.
-  return all.sort((a, b) => a.start_time.localeCompare(b.start_time))
+  return Array.from(byKey.values()).sort((a, b) =>
+    a.start_time.localeCompare(b.start_time),
+  )
 }

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -422,8 +422,7 @@ export default function EventsPage() {
       listWindow.startAfter,
       listWindow.startBefore,
     ],
-    // fetchAllPortalEvents pages through every row — a single capped request
-    // silently truncates once the window holds more DB rows than the cap.
+    // fetchAllPortalEvents returns the full window in one request.
     queryFn: async () => ({
       results: await fetchAllPortalEvents({
         popupId: city!.id,

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -3558,8 +3558,6 @@ export class EventsService {
      * @param data.rsvpedOnly
      * @param data.managedOnly
      * @param data.includeHidden
-     * @param data.skip Number of items to skip
-     * @param data.limit Maximum number of items to return
      * @returns ListModel_EventPublic_ Successful Response
      * @throws ApiError
      */
@@ -3580,9 +3578,7 @@ export class EventsService {
                 search: data.search,
                 rsvped_only: data.rsvpedOnly,
                 managed_only: data.managedOnly,
-                include_hidden: data.includeHidden,
-                skip: data.skip,
-                limit: data.limit
+                include_hidden: data.includeHidden
             },
             errors: {
                 422: 'Validation Error'

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -5002,18 +5002,10 @@ export type EventsListPortalEventsData = {
     eventStatus?: (EventStatus | null);
     includeHidden?: boolean;
     kind?: (string | null);
-    /**
-     * Maximum number of items to return
-     */
-    limit?: number;
     managedOnly?: boolean;
     popupId?: (string | null);
     rsvpedOnly?: boolean;
     search?: (string | null);
-    /**
-     * Number of items to skip
-     */
-    skip?: number;
     startAfter?: (string | null);
     startBefore?: (string | null);
     tags?: (Array<(string)> | null);


### PR DESCRIPTION
## Problem

Portal calendar/list view duplicated events while scrolling (same event rendered multiple times), clearing on refresh. Reported on a popup with 600+ events.

## Root cause

A chain of issues, none sufficient alone:

1. **Unstable backend ordering** — `find_by_popup` ordered only by `start_time` with no unique tiebreaker, so events sharing a `start_time` ordered non-deterministically across requests.
2. **Per-page HTTP loop** — `fetchAllPortalEvents` walked every page (`skip`/`limit`) and merged without dedup. With unstable ordering, a boundary row could repeat or vanish between pages.
3. **Per-page recurrence expansion** — a recurring master landing on a page boundary could be fetched in two pages, duplicating its occurrences wholesale.
4. **No dedup on the `all` channel** — `page.tsx` returned the raw results for the all-events channel (only the mine/rsvped channels deduped).

The frontend already eagerly fetched *every* page, so pagination bought nothing while creating the boundaries where duplication was born.

## Fix

- **Backend `find_by_popup`**: order by `(start_time, id)` for deterministic ordering (benefits all callers); `limit=None` returns the full filtered window in one query.
- **Portal endpoint `list_portal_events`**: drop `skip`/`limit`, fetch the full window unpaginated so recurrence expansion runs once over the complete set. No page boundaries → duplication cannot occur.
- **Portal client `fetchAllPortalEvents`**: single request instead of the page loop, plus a dedup safety net keyed by `id + start_time`. Shared by list/calendar/day views.
- **`ListBody`**: key event fragments by occurrence (`id + start_time`) instead of `id`, so recurring siblings cannot collide on the React key.

## Validation

- Backend `ruff check` + `format`: pass
- Portal `build` (TypeScript): pass
- 38 targeted backend tests (recurrence, popup window, crud, managed_only): pass
- OpenAPI client regenerated for both frontends

## Notes

- This is **step 1 of 2**. Step 2 (deferred, separate PR) is virtualizing the list render, since 600+ image cards mount in the DOM with no windowing. It touches the day-grouping and scroll-restore UX, so it is kept isolated.
- The no-`popup_id` branch of `list_portal_events` returns informational-only `paging` metadata; this is pre-existing and unreachable from the portal client (which always sends `popup_id`).