### PR TITLE
feat: allow ADMIN to edit landing_mode

### DIFF
--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -183,13 +183,6 @@ async def update_tenant(
             detail="Only superadmin can modify custom_domain_active",
         )
 
-    # 3b. ADMIN cannot set landing_mode (only SUPERADMIN may — ADR-4)
-    if current_user.role == UserRole.ADMIN and tenant_in.landing_mode is not None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only superadmin can modify landing_mode",
-        )
-
     # 4. ADMIN cannot change custom_domain while it is active
     if (
         current_user.role == UserRole.ADMIN

--- a/backend/tests/api/tenant/test_tenant_landing_mode_integration.py
+++ b/backend/tests/api/tenant/test_tenant_landing_mode_integration.py
@@ -68,20 +68,20 @@ def _make_active_direct_popup(db: Session, tenant: Tenants, *, slug: str) -> Pop
 # ---------------------------------------------------------------------------
 
 
-def test_admin_cannot_set_landing_mode(
+def test_admin_can_set_landing_mode_checkout_when_domain_active(
     client: TestClient,
     db: Session,
     admin_token_tenant_a: str,
     tenant_a: Tenants,
 ) -> None:
-    """Scenario T-5: ADMIN PATCH landing_mode → 403.
+    """ADMIN sets landing_mode=checkout with domain active → 200.
 
-    The payload must pass schema-level validation (include custom_domain + active=True)
-    so the router role gate is the one that rejects it, not the schema validator.
+    Mirrors the superadmin test: the role gate on landing_mode was removed, so an
+    ADMIN may switch to checkout as long as the custom domain is already active
+    (custom_domain_active stays superadmin-only and is therefore unchanged here).
     """
-    # First ensure tenant_a has a valid custom_domain so schema accepts the payload
     suffix = uuid.uuid4().hex[:6]
-    domain = f"admin-gate-{suffix}.example.com"
+    domain = f"admin-checkout-{suffix}.example.com"
     tenant_a.custom_domain = domain
     tenant_a.custom_domain_active = True
     db.add(tenant_a)
@@ -90,14 +90,39 @@ def test_admin_cannot_set_landing_mode(
 
     resp = client.patch(
         f"/api/v1/tenants/{tenant_a.id}",
-        json={
-            "landing_mode": "checkout",
-            "custom_domain": domain,
-            "custom_domain_active": True,
-        },
+        json={"landing_mode": "checkout"},
         headers=_admin_headers(admin_token_tenant_a),
     )
-    assert resp.status_code == 403, resp.text
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["landing_mode"] == "checkout"
+
+
+def test_admin_rejected_checkout_when_domain_inactive(
+    client: TestClient,
+    db: Session,
+    admin_token_tenant_a: str,
+    tenant_a: Tenants,
+) -> None:
+    """ADMIN PATCH landing_mode=checkout with inactive domain → 422.
+
+    The merged-state validation still protects checkout integrity for all roles:
+    an ADMIN cannot reach checkout without an active custom domain (which only a
+    superadmin can activate).
+    """
+    suffix = uuid.uuid4().hex[:6]
+    domain = f"admin-inactive-{suffix}.example.com"
+    tenant_a.custom_domain = domain
+    tenant_a.custom_domain_active = False
+    db.add(tenant_a)
+    db.commit()
+    db.refresh(tenant_a)
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"landing_mode": "checkout"},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 422, resp.text
 
 
 def test_superadmin_can_set_landing_mode_checkout_when_domain_active(

--- a/backoffice/src/components/forms/TenantForm.landing-mode.test.tsx
+++ b/backoffice/src/components/forms/TenantForm.landing-mode.test.tsx
@@ -6,7 +6,7 @@
  * - BK-2: toggle enabled when custom_domain_active=true
  * - BK-3: warning shown when switching to checkout AND >1 active popup
  * - BK-4: no warning when switching to checkout AND <=1 active popup
- * - BK-5: ADMIN cannot see/interact with toggle (hidden for non-superadmin)
+ * - BK-5: toggle is visible to admins, hidden for roles without admin rights
  * - BK-6: PATCH payload includes landing_mode on form submit
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -32,7 +32,7 @@ vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => vi.fn(),
 }))
 
-const mockUseAuth = vi.fn(() => ({ isSuperadmin: true }))
+const mockUseAuth = vi.fn(() => ({ isSuperadmin: true, isAdmin: true }))
 
 vi.mock("@/hooks/useAuth", () => ({
   default: () => mockUseAuth(),
@@ -111,7 +111,7 @@ describe("TenantForm — landing_mode toggle", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset to superadmin for each test
-    mockUseAuth.mockReturnValue({ isSuperadmin: true })
+    mockUseAuth.mockReturnValue({ isSuperadmin: true, isAdmin: true })
     // Default: one active popup (no warning)
     mockListPopups.mockResolvedValue(
       makePopupResult(1) as Awaited<
@@ -225,9 +225,28 @@ describe("TenantForm — landing_mode toggle", () => {
     })
   })
 
-  // BK-5: ADMIN cannot see toggle
-  it("BK-5: toggle is not rendered for non-superadmin users", async () => {
-    mockUseAuth.mockReturnValue({ isSuperadmin: false })
+  // BK-5a: ADMIN can see the toggle
+  it("BK-5: toggle is rendered for admin users", async () => {
+    mockUseAuth.mockReturnValue({ isSuperadmin: false, isAdmin: true })
+
+    render(
+      <TenantForm
+        defaultValues={TENANT_WITH_ACTIVE_DOMAIN}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /landing mode|direct checkout/i }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  // BK-5b: roles without admin rights (e.g. viewer/operator) cannot see the toggle
+  it("BK-5: toggle is not rendered for users without admin rights", async () => {
+    mockUseAuth.mockReturnValue({ isSuperadmin: false, isAdmin: false })
 
     render(
       <TenantForm

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -85,7 +85,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
   const { data: popupsData } = useQuery({
     queryKey: ["popups", { tenantId: defaultValues?.id, status: "active" }],
     queryFn: () => PopupsService.listPopups({ limit: 100 }),
-    enabled: isEdit && isSuperadmin,
+    enabled: isEdit && isAdmin,
   })
   const activePopupCount = (popupsData?.results ?? []).filter(
     (p) => p.status === "active",
@@ -562,8 +562,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
               </AlertDescription>
             </Alert>
 
-            {/* Landing Mode toggle — SUPERADMIN only (ADR-4, ADR-8) */}
-            {isSuperadmin && (
+            {/* Landing Mode toggle — ADMIN and SUPERADMIN (ADR-4, ADR-8) */}
+            {isAdmin && (
               <form.Field name="landing_mode">
                 {(field) => {
                   const isDomainActive = !!defaultValues?.custom_domain_active


### PR DESCRIPTION
## Context

An **ADMIN** saving an organization in the backoffice (after only changing branding images) hit **"Only superadmin can modify landing_mode"** (HTTP 403), because `TenantForm.onSubmit` always includes `landing_mode` in the PATCH payload while the backend rejected any ADMIN sending a non-null `landing_mode`. The toggle was also superadmin-only, so the admin never saw the control causing the error.

Confirmed scope: **full edit with toggle** — ADMINs can now see and use the Landing Mode toggle just like superadmins, and the backend accepts the change. The business rule that `landing_mode=checkout` requires an active custom domain stays intact. `custom_domain_active` remains superadmin-only (out of scope).

## Changes

- **Backend** (`tenant/router.py`): removed the role gate that returned 403 for ADMINs sending `landing_mode`. The schema validator and the router's merged-state check (active + non-null custom domain for checkout) still apply to all roles.
- **Frontend** (`TenantForm.tsx`): toggle visibility changed from `isSuperadmin` to `isAdmin` (covers admin + superadmin); the multi-popup warning query is enabled for admins too. The toggle keeps `disabled={!isDomainActive}`, so an admin without an active domain sees a disabled control instead of a save error.
- **Tests**:
  - backend: `test_admin_cannot_set_landing_mode` → `test_admin_can_set_landing_mode_checkout_when_domain_active` (200); added `test_admin_rejected_checkout_when_domain_inactive` (422).
  - frontend: BK-5 split into toggle-visible-for-admin and toggle-hidden-for-non-admin; `mockUseAuth` now includes `isAdmin`.

## Verification

- `uv run pytest tests/api/tenant/test_tenant_landing_mode_integration.py` — 11 passed
- `uv run bash scripts/lint.sh` — passed
- `pnpm vitest run src/components/forms/TenantForm.landing-mode.test.tsx` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)