### PR TITLE
fix(portal): keep full popup window in events list view

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/lib/listWindow.test.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/listWindow.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import { eventListWindowForPopup } from "./listWindow"
 
 describe("eventListWindowForPopup", () => {
-  it("starts at popup-timezone today when the popup is in progress", () => {
+  it("spans the full popup window even while the popup is in progress", () => {
     const window = eventListWindowForPopup(
       "2026-05-30",
       "2026-06-02",
@@ -10,9 +10,10 @@ describe("eventListWindowForPopup", () => {
       new Date("2026-06-01T01:00:00.000Z"),
     )
 
-    // 2026-06-01T01:00Z is still May 31 in Los Angeles. Same-day morning
-    // events stay visible, but May 30 events are no longer in the default list.
-    expect(window.startAfter).toBe("2026-05-31T07:00:00.000Z")
+    // The window is no longer clamped to "today": events from earlier popup
+    // days (May 30/31) stay in the list instead of silently dropping out once
+    // the local date rolls past them — matching the calendar and day views.
+    expect(window.startAfter).toBe("2026-05-30T07:00:00.000Z")
     expect(window.startBefore).toBe("2026-06-03T07:00:00.000Z")
   })
 

--- a/portal/src/app/portal/[popupSlug]/events/lib/listWindow.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/listWindow.ts
@@ -5,17 +5,6 @@ function dayStr(s: string | null | undefined) {
   return m ? m[0] : null
 }
 
-function dayKeyInTz(date: Date, timezone: string) {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(date)
-  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ""
-  return `${get("year")}-${get("month")}-${get("day")}`
-}
-
 export function eventListWindowForPopup(
   popupStartDate: string | null | undefined,
   popupEndDate: string | null | undefined,
@@ -25,13 +14,18 @@ export function eventListWindowForPopup(
   const startDay = dayStr(popupStartDate)
   const endDay = dayStr(popupEndDate)
   if (startDay && endDay) {
-    const today = dayKeyInTz(now, timezone)
-    const queryStartDay =
-      startDay <= today && today <= endDay ? today : startDay
-
+    // Anchor the window to the popup's full booking range — same as the
+    // calendar and day views. We deliberately do NOT clamp the start to
+    // "today": an event earlier in the popup (e.g. yesterday, or earlier
+    // today once the local date rolls over) is still a valid published event
+    // and stays visible everywhere else, so clamping silently dropped it from
+    // the list only. The list's ``autoScrollToUpcoming`` already scrolls past
+    // events out of the initial viewport, so the "starts at today" feel is
+    // preserved without hiding anything.
+    //
     // dayBoundsInTz returns [dayStart, dayEnd): the end of ``endDay`` is
     // midnight of the following local day, which keeps the last day's events in.
-    const { start } = dayBoundsInTz(queryStartDay, timezone)
+    const { start } = dayBoundsInTz(startDay, timezone)
     const { end } = dayBoundsInTz(endDay, timezone)
     return {
       startAfter: start.toISOString(),


### PR DESCRIPTION
## Problema

Un usuario reportó en producción que un evento (Jue 18 Jun, 5–6 PM) **no aparecía en la list view** del portal, pero **sí se veía** en day view, calendar view y en el backoffice. El evento estaba dentro del rango del popup (start `2026-05-30`, end `2026-06-28`).

## Causa raíz

`eventListWindowForPopup` (`portal/.../events/lib/listWindow.ts`) movía el `startAfter` de la list a **la medianoche de "hoy" en la timezone del popup** mientras el popup estaba en curso:

```js
const queryStartDay = startDay <= today && today <= endDay ? today : startDay
```

Esto descartaba de la list cualquier evento anterior al día local actual, aunque siguiera siendo un evento publicado válido dentro del popup. La **list view es la única** que recortaba así:

- **Calendar** (`CalendarBody.tsx`) consulta por el mes navegado.
- **Day** (`DayBody.tsx`) consulta ±1 día alrededor del día seleccionado.
- **Backoffice** no recorta por fecha.

Por eso el evento seguía visible en esas vistas. El bug **depende de la fecha actual** (en tz del popup): el día del evento todavía se ve en la list, pero una vez que el día rueda al siguiente, el evento se cae solo de la list — lo que explica por qué no se podía reproducir el mismo día del evento.

## Fix

Anclar la ventana de la list al rango completo de fechas del popup (igual que calendar/day), sin recortar a "hoy". La list ya hace `autoScrollToUpcoming`, así que la sensación de "arranca en hoy" se mantiene sin ocultar eventos pasados.

## Tests

- Actualizado `listWindow.test.ts`: el caso "in progress" ahora verifica que la ventana abarca el popup completo en lugar de recortar a hoy.
- `npx vitest run listWindow.test.ts` → 4/4 passed.
- `npx biome check` sobre los archivos modificados → sin issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
