### PR TITLE
feat(checkout): responsive card grid, centered step nav, image ratios

### DIFF
--- a/backoffice/src/components/ticketing-step-builder/template-configs/TicketCardConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/TicketCardConfig.tsx
@@ -66,8 +66,10 @@ const TICKET_CARD_SURFACES = [
 ] as const
 
 const ASPECTS = [
-  { value: "16:9", label: "16:9" },
-  { value: "3:2", label: "3:2" },
+  { value: "16:9", label: "Banner", hint: "16:9" },
+  { value: "3:2", label: "Classic", hint: "3:2" },
+  { value: "1:1", label: "Square", hint: "1:1" },
+  { value: "4:5", label: "Portrait", hint: "4:5" },
 ] as const
 
 export function TicketCardConfig({
@@ -250,10 +252,10 @@ export function TicketCardConfig({
           Section image aspect ratio
         </Label>
         <p className="text-xs text-muted-foreground">
-          Applied to every section's hero image. 16:9 keeps cards short; 3:2
-          gives the image more presence.
+          Applied to every section's hero image. Banner keeps cards short;
+          Square and Portrait give the image more presence.
         </p>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           {ASPECTS.map((a) => {
             const isActive = imageAspect === a.value
             return (
@@ -267,13 +269,16 @@ export function TicketCardConfig({
                   })
                 }
                 className={cn(
-                  "rounded-md border-2 px-3 py-1.5 text-xs font-medium transition-all",
+                  "flex flex-col items-center gap-0.5 rounded-md border-2 px-3 py-1.5 text-xs font-medium transition-all",
                   isActive
                     ? "border-primary bg-primary/5 text-primary"
                     : "border-border hover:bg-accent/50",
                 )}
               >
-                {a.label}
+                <span>{a.label}</span>
+                <span className="text-[10px] text-muted-foreground">
+                  {a.hint}
+                </span>
               </button>
             )
           })}

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -457,11 +457,21 @@ function ScrollyCheckoutFlowInner({
       <CheckoutToast onChipClick={scrollToStep} />
       {allSections.map((section) => {
         const { config } = section
+        // The ticket-card "stacked" layout renders a responsive grid of cards,
+        // which needs more width than the default centred column. Other steps
+        // (and the tabs/compact ticket-card variants) keep the narrow column.
+        const templateConfig = config?.template_config as
+          | Record<string, unknown>
+          | undefined
+        const isStackedCards =
+          config?.template === "ticket-card" &&
+          (templateConfig?.variant ?? "stacked") === "stacked"
         return (
           <SnapSection
             key={section.id}
             id={section.id}
             bottomPadding={section.id === lastSectionId ? "4rem" : "50vh"}
+            widthClass={isStackedCards ? "max-w-6xl" : "max-w-2xl"}
           >
             <SectionHeader
               title={config?.title ?? section.label}

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -473,24 +473,33 @@ function ScrollyCheckoutFlowInner({
             bottomPadding={section.id === lastSectionId ? "4rem" : "50vh"}
             widthClass={isStackedCards ? "max-w-6xl" : "max-w-2xl"}
           >
-            <SectionHeader
-              title={config?.title ?? section.label}
-              subtitle={config?.description ?? undefined}
-              variant="snap"
-              watermark={config?.watermark ?? section.label}
-              watermarkStyle={watermarkStyle}
-              showTitle={config?.show_title ?? true}
-              showWatermark={config?.show_watermark ?? true}
-            />
+            {/* Header and footer stay in the narrow column even when the step
+                is widened for a card grid, so the section title/watermark keep
+                the same size and rhythm as every other step. Only the step
+                content (the grid) uses the wider width. The max-w-2xl wrapper
+                is a no-op on non-widened steps. */}
+            <div className="mx-auto w-full max-w-2xl">
+              <SectionHeader
+                title={config?.title ?? section.label}
+                subtitle={config?.description ?? undefined}
+                variant="snap"
+                watermark={config?.watermark ?? section.label}
+                watermarkStyle={watermarkStyle}
+                showTitle={config?.show_title ?? true}
+                showWatermark={config?.show_watermark ?? true}
+              />
+            </div>
             {renderSectionContent(section)}
             {(() => {
               const ft = (
                 config?.template_config as Record<string, unknown> | undefined
               )?.footer_text
               return typeof ft === "string" && ft ? (
-                <p className="text-xs text-gray-400 leading-relaxed px-1 pt-4 text-center">
-                  {ft}
-                </p>
+                <div className="mx-auto w-full max-w-2xl">
+                  <p className="text-xs text-gray-400 leading-relaxed px-1 pt-4 text-center">
+                    {ft}
+                  </p>
+                </div>
               ) : null
             })()}
           </SnapSection>

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -166,95 +166,107 @@ export default function ScrollySectionNav({
             />
           ) : null}
           <div
-            ref={trackRef}
-            className="relative flex-1 overflow-x-auto rounded-xl border border-white/10 bg-checkout-badge-bg-disabled/60 p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            className={cn("flex min-w-0 flex-1", !compact && "justify-center")}
           >
             <div
-              ref={listRef}
+              ref={trackRef}
               className={cn(
-                "relative flex",
-                // Expanded: content-width tabs spread across the bar.
-                // Compact: equal-width tabs that fill and shrink to fit.
-                compact ? "w-full" : "w-max min-w-full justify-between",
+                "relative overflow-x-auto rounded-xl border border-white/10 bg-checkout-badge-bg-disabled/60 p-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+                // Expanded: the bar hugs the centred tab group, so the sides
+                // show the page background instead of an empty track. Compact:
+                // fill the row so equal-width icon tabs distribute.
+                compact ? "w-full" : "w-fit max-w-full",
               )}
             >
-              {pill && (
-                <div
-                  aria-hidden
-                  className="pointer-events-none absolute inset-y-0 left-0 rounded-lg bg-checkout-badge-bg shadow-sm transition-[transform,width] duration-300 ease-out"
-                  style={{
-                    width: `${pill.width}px`,
-                    transform: `translateX(${pill.left}px)`,
-                  }}
-                />
-              )}
-              {sections.map((section, index) => {
-                const Icon = resolveIcon(section)
-                const isActive = section.id === activeSection
-                const isComplete =
-                  !isActive && isStepComplete(section.id as CheckoutStep)
-                const isIncomplete = !isActive && isStepIncomplete(section.id)
-                const emoji = section.emoji?.trim()
-                // Two ways a tenant can specify the nav icon: a slug into
-                // the curated Lucide registry ("user", "mushroom", …)
-                // which renders a stroke SVG, OR a literal emoji
-                // character. If neither is set, the step-type/template
-                // default applies via resolveIcon. The literal-emoji
-                // branch picks up the optional monochrome filter so
-                // colorful glyphs can be forced to a single tone.
-                const RegistryIcon = getRegistryIcon(emoji)
-                return (
-                  <button
-                    key={section.id}
-                    ref={(el) => {
-                      buttonRefs.current[index] = el
+              <div
+                ref={listRef}
+                className={cn(
+                  "relative flex",
+                  // Expanded: content-width tabs sit adjacent so the pill slides
+                  // between them (segmented-control feel). Compact: equal-width.
+                  compact ? "w-full" : "w-max",
+                )}
+              >
+                {pill && (
+                  <div
+                    aria-hidden
+                    className="pointer-events-none absolute inset-y-0 left-0 rounded-lg bg-checkout-badge-bg shadow-sm transition-[transform,width] duration-300 ease-out"
+                    style={{
+                      width: `${pill.width}px`,
+                      transform: `translateX(${pill.left}px)`,
                     }}
-                    type="button"
-                    onClick={() => onSectionClick(section.id)}
-                    aria-current={isActive ? "step" : undefined}
-                    aria-invalid={isIncomplete || undefined}
-                    className={cn(
-                      "relative z-10 flex h-7 items-center justify-center text-xs font-semibold transition-[color,opacity] duration-200",
-                      // Compact equal-width icons vs. expanded content-width
-                      // labelled tabs.
-                      compact
-                        ? "min-w-0 flex-1 gap-1 px-1"
-                        : "shrink-0 gap-1.5 px-3",
-                      isActive
-                        ? "text-checkout-badge-title"
-                        : isIncomplete
-                          ? // Muted amber tint — "needs your attention"
-                            // without the red-alarm rage of a destructive
-                            // colour. Matches the toast/banner palette.
-                            "text-amber-400 hover:text-amber-300"
-                          : "text-checkout-badge-title-disabled hover:opacity-70",
-                    )}
-                  >
-                    {RegistryIcon ? (
-                      <RegistryIcon className="size-3.5 shrink-0" />
-                    ) : emoji ? (
-                      <span
-                        aria-hidden
-                        style={{
-                          filter:
-                            "var(--checkout-nav-emoji-filter, none)" as string,
-                        }}
-                        className="text-sm leading-none shrink-0"
-                      >
-                        {emoji}
-                      </span>
-                    ) : (
-                      <Icon className="size-3.5 shrink-0" />
-                    )}
-                    {!compact && (
-                      <span className="whitespace-nowrap">{section.label}</span>
-                    )}
-                    {isComplete && (
-                      <Check className="size-2.5 text-emerald-400" />
-                    )}
-                  </button>
-                )
-              })}
+                  />
+                )}
+                {sections.map((section, index) => {
+                  const Icon = resolveIcon(section)
+                  const isActive = section.id === activeSection
+                  const isComplete =
+                    !isActive && isStepComplete(section.id as CheckoutStep)
+                  const isIncomplete = !isActive && isStepIncomplete(section.id)
+                  const emoji = section.emoji?.trim()
+                  // Two ways a tenant can specify the nav icon: a slug into
+                  // the curated Lucide registry ("user", "mushroom", …)
+                  // which renders a stroke SVG, OR a literal emoji
+                  // character. If neither is set, the step-type/template
+                  // default applies via resolveIcon. The literal-emoji
+                  // branch picks up the optional monochrome filter so
+                  // colorful glyphs can be forced to a single tone.
+                  const RegistryIcon = getRegistryIcon(emoji)
+                  return (
+                    <button
+                      key={section.id}
+                      ref={(el) => {
+                        buttonRefs.current[index] = el
+                      }}
+                      type="button"
+                      onClick={() => onSectionClick(section.id)}
+                      aria-current={isActive ? "step" : undefined}
+                      aria-invalid={isIncomplete || undefined}
+                      className={cn(
+                        "relative z-10 flex h-7 items-center justify-center text-xs font-semibold transition-[color,opacity] duration-200",
+                        // Compact equal-width icons vs. expanded content-width
+                        // labelled tabs.
+                        compact
+                          ? "min-w-0 flex-1 gap-1 px-1"
+                          : "shrink-0 gap-1.5 px-3",
+                        isActive
+                          ? "text-checkout-badge-title"
+                          : isIncomplete
+                            ? // Muted amber tint — "needs your attention"
+                              // without the red-alarm rage of a destructive
+                              // colour. Matches the toast/banner palette.
+                              "text-amber-400 hover:text-amber-300"
+                            : "text-checkout-badge-title-disabled hover:opacity-70",
+                      )}
+                    >
+                      {RegistryIcon ? (
+                        <RegistryIcon className="size-3.5 shrink-0" />
+                      ) : emoji ? (
+                        <span
+                          aria-hidden
+                          style={{
+                            filter:
+                              "var(--checkout-nav-emoji-filter, none)" as string,
+                          }}
+                          className="text-sm leading-none shrink-0"
+                        >
+                          {emoji}
+                        </span>
+                      ) : (
+                        <Icon className="size-3.5 shrink-0" />
+                      )}
+                      {!compact && (
+                        <span className="whitespace-nowrap">
+                          {section.label}
+                        </span>
+                      )}
+                      {isComplete && (
+                        <Check className="size-2.5 text-emerald-400" />
+                      )}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
           </div>
           {extraContent ? <div className="shrink-0">{extraContent}</div> : null}

--- a/portal/src/components/checkout-flow/SnapSection.tsx
+++ b/portal/src/components/checkout-flow/SnapSection.tsx
@@ -7,10 +7,15 @@ export default function SnapSection({
   id,
   children,
   bottomPadding = "50vh",
+  // Most steps read as a centred column; card-grid steps pass a wider class so
+  // their cards have room to sit side by side. Both literals live here and at
+  // the call site so Tailwind keeps them.
+  widthClass = "max-w-2xl",
 }: {
   id: string
   children: React.ReactNode
   bottomPadding?: string
+  widthClass?: string
 }) {
   const ref = useRef<HTMLElement>(null)
   const [visible, setVisible] = useState(false)
@@ -88,7 +93,7 @@ export default function SnapSection({
     <section
       id={id}
       ref={ref}
-      className="flex flex-col justify-start px-4 max-w-2xl mx-auto"
+      className={`flex flex-col justify-start px-4 ${widthClass} mx-auto`}
       style={{
         minHeight: "var(--snap-section-h, 100vh)",
         paddingTop: "calc(var(--snap-nav-h, 48px) + 1.5rem)",

--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -24,8 +24,10 @@ import type { VariantProps } from "../registries/variantRegistry"
  *  the menu on purpose — anything more extreme than 3:2 ate the cards in
  *  the design pass. */
 const ASPECT_CLASSES = {
-  "16:9": "aspect-[16/9]",
-  "3:2": "aspect-[3/2]",
+  "16:9": "aspect-[16/9]", // Banner — panoramic, short cards
+  "3:2": "aspect-[3/2]", // Classic — standard photo
+  "1:1": "aspect-[1/1]", // Square — strong presence, CTA still visible
+  "4:5": "aspect-[4/5]", // Portrait — image-forward, poster feel
 } as const
 type SectionImageAspect = keyof typeof ASPECT_CLASSES
 
@@ -116,7 +118,9 @@ function parseImageAspect(
   templateConfig: VariantProps["templateConfig"],
 ): SectionImageAspect | undefined {
   const a = templateConfig?.image_aspect
-  return a === "16:9" || a === "3:2" ? a : undefined
+  return typeof a === "string" && a in ASPECT_CLASSES
+    ? (a as SectionImageAspect)
+    : undefined
 }
 
 function resolveAspectClass(aspect?: SectionImageAspect): string {
@@ -217,7 +221,7 @@ function ProductRow({
     >
       <div className="flex items-center gap-3">
         <div className="flex-1 min-w-0">
-          <h4 className="font-medium text-foreground text-sm">
+          <h4 className="font-medium text-foreground text-sm line-clamp-2">
             {product.name}
           </h4>
         </div>

--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -409,17 +409,22 @@ function StackedLayout({
   surface,
   imageAspect,
 }: LayoutProps) {
+  // Cards sit side by side at a fixed width and wrap, centred. Flex-wrap (not
+  // a fractional grid) keeps every card the same size regardless of how many
+  // sections exist, so a lone card doesn't stretch to fill the row. The parent
+  // step is widened (max-w-6xl) so up to three cards fit per row on desktop.
   return (
-    <div className="space-y-4">
+    <div className="flex flex-wrap items-start justify-center gap-4">
       {groups.map(({ section, products }) => (
-        <SectionCard
-          key={section.key}
-          section={section}
-          products={products}
-          stepType={stepType}
-          surface={surface}
-          imageAspect={imageAspect}
-        />
+        <div key={section.key} className="w-full sm:w-[340px]">
+          <SectionCard
+            section={section}
+            products={products}
+            stepType={stepType}
+            surface={surface}
+            imageAspect={imageAspect}
+          />
+        </div>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary

- Checkout step nav: centered, hugging segmented control that adapts to width (no truncation, no clipping, no horizontal scroll).
- Ticket-card sections render as a responsive grid of cards instead of full-width stacked.
- Section image aspect ratio gains Square (1:1) and Portrait (4:5) options so the toggle visibly changes image presence.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**Step nav (`ScrollySectionNav.tsx`)**
- Centered, content-hugging segmented control: tabs sit adjacent and the active pill slides between them; the sides show the page background instead of an empty bar.
- Adaptive density (measured with hysteresis): full labels while the row fits, collapse to equal-width icon-only tabs when it would overflow. Never truncates a label, clips an icon, or needs horizontal scroll at any width or step count.

**Ticket-card grid (`VariantTicketCard.tsx`, `ScrollyCheckoutFlow.tsx`, `SnapSection.tsx`)**
- Stacked variant now lays section cards out as a centered, wrapping row of fixed-width cards (full width on mobile, ~340px from sm up, up to three per row on desktop). Flex-wrap keeps every card the same size regardless of section count.
- Only the grid content widens (max-w-6xl); the section title, watermark and footer stay in the narrow column so their size and rhythm match every other step. Other steps and the tabs/compact variants are unaffected.
- Long product names clamp to two lines so they don't wrap messily in the narrower cards.

**Image aspect ratio (`VariantTicketCard.tsx`, backoffice `TicketCardConfig.tsx`)**
- Added Square (1:1) and Portrait (4:5) alongside Banner (16:9) and Classic (3:2). The two original ratios were too close to read as different; the new ones make the "image presence" toggle actually visible. Backoffice toggle relabeled (Banner / Classic / Square / Portrait) with the ratio shown as a hint.

## Changes Table

| File | Change |
|------|--------|
| `portal/.../ScrollySectionNav.tsx` | Centered adaptive segmented step nav |
| `portal/.../variants/VariantTicketCard.tsx` | Responsive card grid, new aspect ratios, name clamp |
| `portal/.../ScrollyCheckoutFlow.tsx` | Widen only the card-grid step; keep header/footer narrow |
| `portal/.../SnapSection.tsx` | Configurable step width |
| `backoffice/.../TicketCardConfig.tsx` | Four named aspect-ratio options |

## Testing

- [x] Portal builds and lints (`pnpm --filter portal run build` / `lint`)
- [x] Backoffice builds and lints (`pnpm --filter backoffice run build` / `lint`)
- [x] Verified layout across viewport widths and section counts via a standalone preview (no truncation, no clipping, no horizontal scroll; cards reflow 1-3 per row)
- [ ] Pending manual verification on a real popup in a running environment
