### PR TITLE
fix(checkout): section header vertical spacing (clears nav, separates from content)

### DIFF
--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -478,7 +478,7 @@ function ScrollyCheckoutFlowInner({
                 the same size and rhythm as every other step. Only the step
                 content (the grid) uses the wider width. The max-w-2xl wrapper
                 is a no-op on non-widened steps. */}
-            <div className="mx-auto w-full max-w-2xl">
+            <div className="mx-auto mb-8 w-full max-w-2xl sm:mb-12 lg:mb-16">
               <SectionHeader
                 title={config?.title ?? section.label}
                 subtitle={config?.description ?? undefined}

--- a/portal/src/components/checkout-flow/SnapSection.tsx
+++ b/portal/src/components/checkout-flow/SnapSection.tsx
@@ -96,7 +96,7 @@ export default function SnapSection({
       className={`flex flex-col justify-start px-4 ${widthClass} mx-auto`}
       style={{
         minHeight: "var(--snap-section-h, 100vh)",
-        paddingTop: "calc(var(--snap-nav-h, 48px) + 1.5rem)",
+        paddingTop: "calc(var(--snap-nav-h, 48px) + 4rem)",
         paddingBottom: bottomPadding,
       }}
     >


### PR DESCRIPTION
## Summary

- Follow-up to #377 (these two commits were pushed after that PR merged, so they never landed in dev).
- Adds vertical breathing room around the checkout section header.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Top margin per section** (`SnapSection.tsx`): the section header (and its upward-offset watermark) sat flush against the sticky nav. Increased the section top padding so every step clears the navbar.
- **Header-to-content gap** (`ScrollyCheckoutFlow.tsx`): added a responsive bottom margin below the section header (2rem mobile, up to 4rem on large screens) so cards no longer sit flush against the subtitle, using the space available above the cart footer without breaking small screens.

## Changes Table

| File | Change |
|------|--------|
| `portal/.../SnapSection.tsx` | Larger top padding so the header clears the sticky nav |
| `portal/.../ScrollyCheckoutFlow.tsx` | Responsive bottom margin separating header from content |

## Testing

- [x] Portal builds and lints (`pnpm --filter portal run build` / `lint`)
- [ ] Pending manual verification on a real popup in a running environment
