### PR TITLE
fix(checkout): cap expanded card description so it doesn't tower or hide CTAs

### DIFF
--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -374,6 +374,9 @@ function SectionCard({
           <ExpandableDescription
             text={section.description}
             clamp={3}
+            // Bound the expanded text so a long description can't make one card
+            // tower over the others or push its product rows under the footer.
+            expandedClassName="max-h-56 overflow-y-auto pr-1 overscroll-contain"
             className="text-sm text-muted-foreground whitespace-pre-line"
             // Branded toggle: uppercase micro-caps + chevron glyph in the
             // theme accent colour. Falls back to currentColor when the

--- a/portal/src/components/ui/ExpandableDescription.tsx
+++ b/portal/src/components/ui/ExpandableDescription.tsx
@@ -18,6 +18,10 @@ interface ExpandableDescriptionProps {
   buttonClassName?: string
   moreLabel?: string
   lessLabel?: string
+  /** Classes applied to the text only while expanded. Use to bound the height
+   *  (e.g. "max-h-56 overflow-y-auto") so a long description can't make a grid
+   *  card tower over its neighbours. The toggle button stays outside this box. */
+  expandedClassName?: string
 }
 
 const ExpandableDescription = ({
@@ -27,6 +31,7 @@ const ExpandableDescription = ({
   buttonClassName,
   moreLabel,
   lessLabel,
+  expandedClassName,
 }: ExpandableDescriptionProps) => {
   const { t } = useTranslation()
   const resolvedMoreLabel = moreLabel ?? t("common.see_more")
@@ -95,7 +100,11 @@ const ExpandableDescription = ({
 
   return (
     <div className="w-full">
-      <p ref={paragraphRef} className={cn(className)} style={collapsedStyle}>
+      <p
+        ref={paragraphRef}
+        className={cn(className, isExpanded && expandedClassName)}
+        style={collapsedStyle}
+      >
         {text}
       </p>
       {isOverflowing && (


### PR DESCRIPTION
## Summary

- Expanding a long section description no longer makes one grid card tower over the others or push its product rows under the cart footer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

In the ticket-card grid, a section with a long description expanded inline to its full height, which:
- made that card much taller than its neighbours (unbalanced row),
- pushed its product rows (prices + add buttons) down under the floating cart footer.

`ExpandableDescription` now accepts an optional `expandedClassName` applied to the text only while expanded. `SectionCard` uses it to bound the expanded description (`max-h-56 overflow-y-auto`), so the text scrolls internally past that height while the card stays in proportion and the "see less" toggle and product rows remain in place. One root fix covers all three symptoms (height balance, footer overlap, overly long description).

## Changes Table

| File | Change |
|------|--------|
| `portal/.../ui/ExpandableDescription.tsx` | Optional `expandedClassName` to bound expanded text |
| `portal/.../variants/VariantTicketCard.tsx` | Cap expanded section description (max height + internal scroll) |

## Testing

- [x] Portal builds and lints (`pnpm --filter portal run build` / `lint`)
- [ ] Pending manual verification on a real popup with a long section description
