### PR TITLE
fix(events): prevent duplicate + RSVP loss when detaching a recurring occurrence

### DIFF
--- a/backend/app/api/event/crud.py
+++ b/backend/app/api/event/crud.py
@@ -23,6 +23,28 @@ class EventsCRUD(BaseCRUD[Events, EventCreate, EventUpdate]):
     def __init__(self) -> None:
         super().__init__(Events)
 
+    def get_detached_child(
+        self,
+        session: Session,
+        master_id: uuid.UUID,
+        occ_start: datetime,
+    ) -> Events | None:
+        """Return the already-materialized override for a given occurrence.
+
+        A detached override is a child row with ``recurrence_master_id ==
+        master_id`` whose ``start_time`` equals the occurrence. Matching uses
+        ``_strip_tz`` so it mirrors how the series expander keys overrides
+        (see ``_expand_rows_with_occurrences``), making detach idempotent: a
+        retry of the same occurrence finds the existing child instead of
+        creating a duplicate. Returns ``None`` when no override exists yet.
+        """
+        target = _strip_tz(occ_start)
+        statement = select(Events).where(Events.recurrence_master_id == master_id)
+        for child in session.exec(statement).all():
+            if _strip_tz(child.start_time) == target:
+                return child
+        return None
+
     def find_by_popup(
         self,
         session: Session,

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -1577,6 +1577,15 @@ async def detach_occurrence(
     occ_start = payload.occurrence_start
     occ_end = occ_start + duration
 
+    # Idempotency: if this occurrence was already detached (e.g. a network
+    # retry or a stale-cache re-trigger of "Edit only this event"), return the
+    # existing override instead of creating a second standalone row. Skips the
+    # exdate append and iTIP re-send so retries neither duplicate the event nor
+    # double-send calendar invites.
+    existing_child = crud.events_crud.get_detached_child(db, master.id, occ_start)
+    if existing_child is not None:
+        return _to_public(existing_child)
+
     exdate_iso = occ_start.isoformat()
     existing = list(master.recurrence_exdates or [])
     if exdate_iso not in existing:
@@ -1597,10 +1606,16 @@ async def detach_occurrence(
         max_participant=master.max_participant,
         tags=list(master.tags or []),
         venue_id=master.venue_id,
+        custom_location_name=master.custom_location_name,
+        custom_location_url=master.custom_location_url,
         track_id=master.track_id,
         visibility=master.visibility,
         require_approval=master.require_approval,
         kind=master.kind,
+        host_id=master.host_id,
+        host_display_name=master.host_display_name,
+        collaborator_ids=list(master.collaborator_ids or []),
+        highlighted=master.highlighted,
         status=master.status,
         rrule=None,
         recurrence_master_id=master.id,
@@ -1641,6 +1656,20 @@ async def detach_occurrence(
             child.id,
             exc,
         )
+
+    # Re-point the occurrence's RSVPs onto the standalone child so the detached
+    # event owns its attendee list instead of leaving them orphaned on the
+    # master (keyed by occurrence_start). Done AFTER the iTIP dispatch above,
+    # which gathers recipients from the master occurrence — moving the rows
+    # first would leave those emails with no recipients.
+    from app.api.event_participant.crud import event_participants_crud
+
+    event_participants_crud.repoint_occurrence_to_event(
+        db, master.id, occ_start, child.id
+    )
+    db.commit()
+    db.refresh(child)
+
     detach_snapshot = build_event_snapshot(db, master)
     detach_snapshot["occurrence_start"] = occ_start.isoformat()
     detach_snapshot["detached_child_id"] = str(child.id)

--- a/backend/app/api/event_participant/crud.py
+++ b/backend/app/api/event_participant/crud.py
@@ -167,6 +167,38 @@ class EventParticipantsCRUD(
             session.commit()
         return len(rows)
 
+    def repoint_occurrence_to_event(
+        self,
+        session: Session,
+        src_event_id: uuid.UUID,
+        occurrence_start: datetime,
+        dst_event_id: uuid.UUID,
+    ) -> int:
+        """Move RSVPs of one occurrence onto a standalone event.
+
+        Re-points every participant row matching ``(src_event_id,
+        occurrence_start)`` to ``(dst_event_id, occurrence_start=NULL)``. Used
+        when a recurring occurrence is detached into its own row so the RSVPs
+        that targeted that occurrence follow the new event instead of being
+        orphaned on the master. All statuses are moved (cancelled rows
+        included) to preserve history.
+
+        Safe against the partial unique indexes: ``dst_event_id`` is a freshly
+        created child, so ``(dst_event_id, profile_id)`` with a NULL
+        ``occurrence_start`` cannot collide with an existing one-off row.
+        Returns the number of rows moved. Does not commit.
+        """
+        statement = select(EventParticipants).where(
+            EventParticipants.event_id == src_event_id,
+            EventParticipants.occurrence_start == occurrence_start,
+        )
+        rows = list(session.exec(statement).all())
+        for row in rows:
+            row.event_id = dst_event_id
+            row.occurrence_start = None
+            session.add(row)
+        return len(rows)
+
     def find_by_profile(
         self,
         session: Session,

--- a/backend/tests/test_detach_occurrence.py
+++ b/backend/tests/test_detach_occurrence.py
@@ -1,0 +1,235 @@
+"""Tests for POST /events/{event_id}/detach-occurrence.
+
+Detaching a single occurrence of a recurring series materializes it as its
+own standalone row. These tests pin the three fixes for the duplicate /
+empty-RSVP bug:
+
+- idempotency: re-detaching the same occurrence returns the existing child
+  instead of creating a second duplicate row;
+- RSVP re-pointing: the occurrence's participants follow the new child row
+  instead of being orphaned on the master;
+- field copy: custom location / host / collaborators / highlighted are
+  carried over to the child.
+
+Email delivery is mocked at the ``send_event_itip`` boundary so no SMTP is
+attempted.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.event.models import Events
+from app.api.event.schemas import EventStatus, EventVisibility
+from app.api.event_participant.crud import event_participants_crud
+from app.api.event_participant.models import EventParticipants
+from app.api.event_participant.schemas import ParticipantStatus
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def _mute_itip() -> Generator[None, None, None]:
+    """Stub out iTIP email dispatch so detach makes no SMTP calls."""
+    with (
+        patch("app.services.event_itip.send_event_itip", new=AsyncMock()),
+        patch("app.api.event.router._send_event_itip", new=AsyncMock()),
+    ):
+        yield
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        name=f"Detach Test {uuid.uuid4().hex[:6]}",
+        slug=f"detach-{uuid.uuid4().hex[:10]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_master(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    start: datetime,
+    **extra: object,
+) -> Events:
+    ev = Events(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        owner_id=uuid.uuid4(),
+        title="Series master",
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+        timezone="UTC",
+        visibility=EventVisibility.PUBLIC,
+        status=EventStatus.PUBLISHED,
+        rrule="FREQ=WEEKLY;INTERVAL=1;COUNT=4",
+        **extra,
+    )
+    db.add(ev)
+    db.commit()
+    db.refresh(ev)
+    return ev
+
+
+def _add_participant(
+    db: Session,
+    tenant: Tenants,
+    event_id: uuid.UUID,
+    occurrence_start: datetime | None,
+) -> EventParticipants:
+    row = EventParticipants(
+        tenant_id=tenant.id,
+        event_id=event_id,
+        profile_id=uuid.uuid4(),
+        status=ParticipantStatus.REGISTERED,
+        occurrence_start=occurrence_start,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+class TestDetachIdempotency:
+    def test_redetaching_same_occurrence_returns_existing_child(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        master = _make_master(
+            db, tenant_a, popup, start=datetime(2026, 6, 5, 14, 0, tzinfo=UTC)
+        )
+        occ = "2026-06-12T14:00:00+00:00"
+
+        first = client.post(
+            f"/api/v1/events/{master.id}/detach-occurrence",
+            headers=_auth(admin_token_tenant_a),
+            json={"occurrence_start": occ},
+        )
+        assert first.status_code == 200, first.text
+        second = client.post(
+            f"/api/v1/events/{master.id}/detach-occurrence",
+            headers=_auth(admin_token_tenant_a),
+            json={"occurrence_start": occ},
+        )
+        assert second.status_code == 200, second.text
+
+        # Same child returned, and only ONE override exists.
+        assert first.json()["id"] == second.json()["id"]
+        overrides = client.get(
+            f"/api/v1/events/{master.id}/overrides",
+            headers=_auth(admin_token_tenant_a),
+        )
+        assert overrides.status_code == 200, overrides.text
+        assert len(overrides.json()) == 1
+
+
+class TestDetachRepointsRsvps:
+    def test_occurrence_rsvps_follow_the_child(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        master = _make_master(
+            db, tenant_a, popup, start=datetime(2026, 6, 5, 14, 0, tzinfo=UTC)
+        )
+        target_occ = datetime(2026, 6, 12, 14, 0, tzinfo=UTC)
+        other_occ = datetime(2026, 6, 19, 14, 0, tzinfo=UTC)
+        # Two RSVPs on the occurrence we detach, one on a different occurrence.
+        _add_participant(db, tenant_a, master.id, target_occ)
+        _add_participant(db, tenant_a, master.id, target_occ)
+        _add_participant(db, tenant_a, master.id, other_occ)
+
+        resp = client.post(
+            f"/api/v1/events/{master.id}/detach-occurrence",
+            headers=_auth(admin_token_tenant_a),
+            json={"occurrence_start": target_occ.isoformat()},
+        )
+        assert resp.status_code == 200, resp.text
+        child_id = uuid.UUID(resp.json()["id"])
+
+        db.expire_all()
+        # The two target-occurrence RSVPs moved onto the child as one-off rows.
+        child_rows, child_total = event_participants_crud.find_by_event(
+            db, event_id=child_id
+        )
+        assert child_total == 2
+        assert all(r.occurrence_start is None for r in child_rows)
+        # The other occurrence's RSVP stays on the master, untouched.
+        assert (
+            event_participants_crud.count_active_for_event(
+                db, master.id, occurrence_start=target_occ
+            )
+            == 0
+        )
+        assert (
+            event_participants_crud.count_active_for_event(
+                db, master.id, occurrence_start=other_occ
+            )
+            == 1
+        )
+
+
+class TestDetachCopiesFields:
+    def test_child_inherits_custom_location_and_metadata(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        host_id = uuid.uuid4()
+        collaborator_ids = [uuid.uuid4(), uuid.uuid4()]
+        master = _make_master(
+            db,
+            tenant_a,
+            popup,
+            start=datetime(2026, 6, 5, 14, 0, tzinfo=UTC),
+            custom_location_name="Barbieri Park",
+            custom_location_url="https://maps.example/park",
+            host_id=host_id,
+            host_display_name="Women's Health Summit",
+            collaborator_ids=collaborator_ids,
+            highlighted=True,
+        )
+
+        resp = client.post(
+            f"/api/v1/events/{master.id}/detach-occurrence",
+            headers=_auth(admin_token_tenant_a),
+            json={"occurrence_start": "2026-06-12T14:00:00+00:00"},
+        )
+        assert resp.status_code == 200, resp.text
+        child = resp.json()
+        assert child["custom_location_name"] == "Barbieri Park"
+        assert child["custom_location_url"] == "https://maps.example/park"
+        assert child["host_id"] == str(host_id)
+        assert child["host_display_name"] == "Women's Health Summit"
+        assert set(child["collaborator_ids"]) == {str(c) for c in collaborator_ids}
+        assert child["highlighted"] is True
+        # And it's a standalone override of the master.
+        assert child["recurrence_master_id"] == str(master.id)
+        assert child["rrule"] is None


### PR DESCRIPTION
## Contexto

Un usuario de Edge City editó la ubicación de una ocurrencia del evento recurrente "Women's Sharing Circle" y reportó que **se borró la lista de RSVP y apareció un evento duplicado**. La investigación contra producción (audit log + conteo de participantes) confirmó que el bug está en el flujo de **desprender una sola ocurrencia** (`detach_occurrence`), no en el update simple de eventos.

La misma ocurrencia (2026-06-20) se desprendió **dos veces** (~75s aparte, mismo usuario) creando dos filas standalone, y ambas nacieron con **0 RSVP** mientras los 9 RSVP reales seguían en el master (keyed por `occurrence_start`).

## Defectos corregidos

1. **Sin idempotencia** → un reintento de red / re-disparo sobre caché stale de "Edit only this event" creaba un segundo evento duplicado.
2. **RSVP huérfanos** → el detach copiaba campos del master pero nunca re-apuntaba las filas `EventParticipants`, así que el evento desprendido mostraba lista vacía.
3. **Campos no copiados** → `custom_location_name/url`, `host_id`, `host_display_name`, `collaborator_ids`, `highlighted` se perdían al desprender (por eso desapareció la ubicación custom).

## Cambios

- **`EventsCRUD.get_detached_child()`** — busca un override existente por `(recurrence_master_id, start_time)` usando `_strip_tz` (mismo criterio que el expander). `detach_occurrence` lo devuelve en vez de crear un duplicado (idempotente: omite el append de exdate y el reenvío de iTIP).
- **`EventParticipantsCRUD.repoint_occurrence_to_event()`** — mueve las RSVP de la ocurrencia al evento standalone. Se ejecuta **después** del envío iTIP (que recolecta destinatarios del master por `occurrence_start`), para que los correos CANCEL/REQUEST sigan llegando a los asistentes.
- **Copia de campos faltantes** al child en `detach_occurrence`.

## Tests

Nuevo `backend/tests/test_detach_occurrence.py`:
- Idempotencia: doble detach → un solo child, mismo `id`.
- Re-apuntado de RSVP: los participantes siguen al child; las RSVP de otras ocurrencias quedan intactas en el master.
- Copia de campos: el child hereda ubicación custom / host / colaboradores / highlighted.

Verificado localmente (imagen del backend + postgres en Docker): **3/3 tests nuevos** + **36/36** de `test_event_overrides_endpoint.py` y `test_event_itip.py` (sin regresiones). `ruff check app` y format limpios.

## Alcance / notas

- **No** incluye migración de datos ni limpieza de los 2 eventos ya en producción (los 9 RSVP siguen vivos en el master). Esto solo cambia el comportamiento a futuro.
- **No** se añade índice único en BD sobre `(recurrence_master_id, start_time)`: esa migración fallaría porque prod ya contiene el par duplicado. El guard es a nivel de aplicación y cubre el caso real (secuencial, no concurrente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
