### PR TITLE
fix(humans): English rating labels + flag/star emojis

### DIFF
--- a/backoffice/src/components/Common/StatusBadge.tsx
+++ b/backoffice/src/components/Common/StatusBadge.tsx
@@ -25,21 +25,21 @@ const statusMap: Record<
   flagged: { variant: "destructive" },
   deleted: { variant: "destructive" },
   // Human rating levels
-  sin_calificar: { variant: "outline", label: "Sin calificar" },
-  red_flag: { variant: "destructive", label: "Red Flag" },
+  sin_calificar: { variant: "outline", label: "No rating" },
+  red_flag: { variant: "destructive", label: "🔴 Red Flag" },
   orange_flag: {
     variant: "outline",
-    label: "Orange Flag",
+    label: "🟠 Orange Flag",
     className: "border-orange-300 bg-orange-100 text-orange-800",
   },
   green_flag: {
     variant: "outline",
-    label: "Green Flag",
+    label: "🟢 Green Flag",
     className: "border-green-300 bg-green-100 text-green-800",
   },
   star: {
     variant: "outline",
-    label: "Star",
+    label: "⭐ Star",
     className: "border-yellow-400 bg-yellow-100 text-yellow-800",
   },
   ambassador: { variant: "default" },

--- a/backoffice/src/components/forms/HumanForm.tsx
+++ b/backoffice/src/components/forms/HumanForm.tsx
@@ -57,31 +57,31 @@ const RATING_OPTIONS: {
 }[] = [
   {
     value: "sin_calificar",
-    label: "Sin calificar",
+    label: "No rating",
     description: "No assessment yet",
     badge: "secondary",
   },
   {
     value: "red_flag",
-    label: "Red Flag",
+    label: "🔴 Red Flag",
     description: "Should not be admitted to gatherings (blocks the user)",
     badge: "destructive",
   },
   {
     value: "orange_flag",
-    label: "Orange Flag",
+    label: "🟠 Orange Flag",
     description: "Reasons against, still open to discussion",
     badge: "outline",
   },
   {
     value: "green_flag",
-    label: "Green Flag",
+    label: "🟢 Green Flag",
     description: "A great attendee who adds value",
     badge: "default",
   },
   {
     value: "star",
-    label: "Star",
+    label: "⭐ Star",
     description: "Excellent — their presence enriches everyone's experience",
     badge: "default",
   },

--- a/backoffice/src/routes/_layout/humans/index.tsx
+++ b/backoffice/src/routes/_layout/humans/index.tsx
@@ -74,11 +74,11 @@ function countActiveFieldFilters(filters: HumanFieldFilters): number {
 const RATING_FILTER_ALL = "all"
 
 const HUMAN_RATING_OPTIONS: { value: HumanRating; label: string }[] = [
-  { value: "sin_calificar", label: "Sin calificar" },
-  { value: "red_flag", label: "Red Flag" },
-  { value: "orange_flag", label: "Orange Flag" },
-  { value: "green_flag", label: "Green Flag" },
-  { value: "star", label: "Star" },
+  { value: "sin_calificar", label: "No rating" },
+  { value: "red_flag", label: "🔴 Red Flag" },
+  { value: "orange_flag", label: "🟠 Orange Flag" },
+  { value: "green_flag", label: "🟢 Green Flag" },
+  { value: "star", label: "⭐ Star" },
 ]
 
 /** Snapshot a value behind a debounce so typing doesn't fire a query per key. */


### PR DESCRIPTION
## Qué cambia

Saca el texto en español de la feature de **ratings de humanos** y le agrega emojis a cada nivel (dropdown de filtro, dropdown del form de edición y badge de la tabla).

- `"Sin calificar"` → `"No rating"` (inglés) en los 3 lugares visibles.
- Emojis consistentes en badge + dropdowns:
  - 🔴 Red Flag · 🟠 Orange Flag · 🟢 Green Flag · ⭐ Star
  - `No rating` queda sin emoji (ausencia de calificación).

El único `sin_calificar` que queda es el **valor del enum** (coincide con la DB/backend), no es texto visible.

## Por qué

El merge de #382 dejó el label en español (`"Sin calificar"`) visible en la página; nunca debería haber texto en español en la UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
