### PR TITLE
fix(dashboard): group Revenue by Category by live product category

### DIFF
--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -421,7 +421,14 @@ def _get_revenue_breakdown(db: TenantSession, popup_id: uuid.UUID) -> RevenueBre
         select(
             PaymentProducts.product_id.label("product_id"),
             PaymentProducts.product_name.label("product_name"),
-            PaymentProducts.product_category.label("product_category"),
+            # Group by the live product category, not the purchase-time snapshot:
+            # products re-categorised after a sale (e.g. day/week/month folded
+            # into "ticket" + duration_type) left stale snapshot categories that
+            # scattered tickets into ghost categories and disagreed with the
+            # other widgets. Fall back to the snapshot for deleted products.
+            func.coalesce(Products.category, PaymentProducts.product_category).label(
+                "product_category"
+            ),
             PaymentProducts.quantity.label("quantity"),
             line_nominal.label("nominal"),
             is_discountable.label("is_discountable"),

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -287,3 +287,72 @@ class TestRevenueBreakdownNetReconciliation:
         # Category total equals the money actually collected (130 + 0), not the
         # 250 list total the old reconstruction would have reported.
         assert sum(by_category.values()) == Decimal("130.00")
+
+    def test_breakdown_groups_by_live_category_not_snapshot(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        # A ticket re-categorised after sale: the live product is category
+        # "ticket" but the purchase-time snapshot still says "month". The
+        # breakdown must report it under the live "ticket" category so it agrees
+        # with the ticket-type / product widgets, not a ghost "month" category.
+        popup = Popups(
+            name="Revenue Breakdown Live Category",
+            slug="revenue-breakdown-live-category",
+            tenant_id=tenant_a.id,
+        )
+        db.add(popup)
+        db.flush()
+
+        ticket = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Month Pass",
+            slug="rb-live-month",
+            price=Decimal("500.00"),
+            category="ticket",
+            discountable=True,
+        )
+        db.add(ticket)
+        db.flush()
+
+        attendee = Attendees(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Buyer Three",
+        )
+        db.add(attendee)
+        db.flush()
+
+        payment = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.APPROVED.value,
+            payment_type=PaymentType.PASS_PURCHASE.value,
+            amount=Decimal("500.00"),
+            insurance_amount=Decimal("0.00"),
+            contribution_amount=Decimal("0.00"),
+            discount_value=None,
+        )
+        db.add(payment)
+        db.flush()
+
+        db.add(
+            PaymentProducts(
+                tenant_id=tenant_a.id,
+                payment_id=payment.id,
+                product_id=ticket.id,
+                attendee_id=attendee.id,
+                quantity=1,
+                product_name=ticket.name,
+                product_price=Decimal("500.00"),
+                product_category="month",  # stale snapshot category
+            )
+        )
+        db.commit()
+
+        breakdown = _get_revenue_breakdown(db, popup.id)
+        by_category = {c.category: c.revenue for c in breakdown.by_category}
+
+        # Reported under the live "ticket" category, not the stale "month".
+        assert by_category == {"ticket": Decimal("500.00")}
+        assert "month" not in by_category


### PR DESCRIPTION
## Problem

Follow-up to #361 (revenue reconciliation, already in production). With totals now reconciling, a second inconsistency is visible: **Revenue by Category disagrees with Revenue by Product and Tickets by Type**.

"Revenue by Category" groups by `payment_products.product_category` (the purchase-time **snapshot**). Some ticket products were re-categorised after sale — their live `products.category` is now `ticket` (+ a `duration_type`), but old payment snapshots still carry `month`/`week`/`day`. The result:

- Tickets scatter into ghost "Week"/"Month"/"Day" categories alongside "Tickets".
- The ticket count and revenue disagree with "Tickets by Type", which uses the live `products.category` + `duration_type`.

## Fix

Group the breakdown by `COALESCE(products.category, payment_products.product_category)` — the **live** category (same source the other widgets use), falling back to the snapshot only for hard-deleted products. The `products` LEFT JOIN was already present for the `discountable` flag, so no extra cost.

Reconciliation and per-line allocation are unchanged; only the category bucket label changes. After the fix, the ticket category count matches "Tickets by Type" and the totals still reconcile with Total Revenue.

## Tests

New regression test: a ticket whose live category is `ticket` but whose snapshot says `month` is reported under `ticket`, not a ghost `month` category. Existing reconciliation tests still pass.
