### PR TITLE
fix(dashboard): unify product-category source across widgets

### DIFF
--- a/backend/app/api/dashboard/router.py
+++ b/backend/app/api/dashboard/router.py
@@ -270,15 +270,18 @@ def _get_accommodation_percentage(
     if total_people == 0:
         return Decimal("0")
 
-    # Count distinct attendees with an approved housing payment product
+    # Count distinct attendees with an approved housing payment product.
+    # Filter by the live product category (consistent with the ticket widgets);
+    # the purchase-time snapshot product_category can be stale.
     housing_attendees = db.exec(
         select(func.count(func.distinct(PaymentProducts.attendee_id)))
         .join(Payments, PaymentProducts.payment_id == Payments.id)
+        .join(Products, PaymentProducts.product_id == Products.id)
         .where(
             Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
-            PaymentProducts.product_category == CATEGORY_HOUSING,
+            Products.category == CATEGORY_HOUSING,
         )
     ).one()
 
@@ -321,11 +324,16 @@ def _get_cumulative_trends(
     ticket_rows = db.exec(
         select(bucket, func.coalesce(func.sum(PaymentProducts.quantity), 0))
         .join(Payments, PaymentProducts.payment_id == Payments.id)
+        .join(Products, PaymentProducts.product_id == Products.id)
         .where(
             Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
-            PaymentProducts.product_category == CATEGORY_TICKET,
+            # Live product category (same source as the Tickets by Type widget)
+            # so the cumulative count reconciles with it. The purchase-time
+            # snapshot product_category is stale for tickets re-categorised
+            # after sale (e.g. day/week/month folded into ticket + duration).
+            Products.category == CATEGORY_TICKET,
         )
         .group_by(bucket)
         .order_by(bucket)
@@ -618,18 +626,20 @@ def _get_distribution(db: TenantSession, popup_id: uuid.UUID) -> Distribution:
         for cat, qty in attendee_type_rows
     ]
 
-    # Accommodation by product name
+    # Accommodation by product name. Live product category, consistent with the
+    # other widgets (snapshot product_category can be stale).
     housing_rows = db.exec(
         select(
             PaymentProducts.product_name,
             func.sum(PaymentProducts.quantity),
         )
         .join(Payments, PaymentProducts.payment_id == Payments.id)
+        .join(Products, PaymentProducts.product_id == Products.id)
         .where(
             Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
-            PaymentProducts.product_category == CATEGORY_HOUSING,
+            Products.category == CATEGORY_HOUSING,
         )
         .group_by(PaymentProducts.product_name)
     ).all()
@@ -688,11 +698,13 @@ def _get_attach_rate(db: TenantSession, popup_id: uuid.UUID) -> list[AttachRateI
     housing_attendee_ids = (
         select(PaymentProducts.attendee_id)
         .join(Payments, PaymentProducts.payment_id == Payments.id)
+        .join(Products, PaymentProducts.product_id == Products.id)
         .where(
             Payments.popup_id == popup_id,
             Payments.status == PaymentStatus.APPROVED.value,
             Payments.payment_type == PaymentType.PASS_PURCHASE.value,
-            PaymentProducts.product_category == CATEGORY_HOUSING,
+            # Live product category, matching the ticket leg of this metric.
+            Products.category == CATEGORY_HOUSING,
         )
     ).correlate(None)
 

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -12,7 +12,11 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.api.attendee.models import Attendees
-from app.api.dashboard.router import _get_revenue_breakdown
+from app.api.dashboard.router import (
+    _get_accommodation_percentage,
+    _get_cumulative_trends,
+    _get_revenue_breakdown,
+)
 from app.api.payment.models import PaymentProducts, Payments
 from app.api.payment.schemas import PaymentStatus, PaymentType
 from app.api.popup.models import Popups
@@ -356,3 +360,135 @@ class TestRevenueBreakdownNetReconciliation:
         # Reported under the live "ticket" category, not the stale "month".
         assert by_category == {"ticket": Decimal("500.00")}
         assert "month" not in by_category
+
+
+class TestCategorySourceConsistency:
+    """Count/percentage widgets must detect product category from the live
+    products.category (same source as Tickets by Type), so they reconcile with
+    each other even when the purchase-time snapshot category is stale.
+    """
+
+    def test_cumulative_tickets_count_live_category(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = Popups(
+            name="Cumulative Tickets Live Category",
+            slug="cumulative-tickets-live-category",
+            tenant_id=tenant_a.id,
+        )
+        db.add(popup)
+        db.flush()
+
+        ticket = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Month Pass",
+            slug="ct-live-month",
+            price=Decimal("500.00"),
+            category="ticket",
+            discountable=True,
+        )
+        db.add(ticket)
+        db.flush()
+
+        attendee = Attendees(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Buyer Cumulative",
+        )
+        db.add(attendee)
+        db.flush()
+
+        payment = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.APPROVED.value,
+            payment_type=PaymentType.PASS_PURCHASE.value,
+            amount=Decimal("500.00"),
+            insurance_amount=Decimal("0.00"),
+            contribution_amount=Decimal("0.00"),
+        )
+        db.add(payment)
+        db.flush()
+
+        db.add(
+            PaymentProducts(
+                tenant_id=tenant_a.id,
+                payment_id=payment.id,
+                product_id=ticket.id,
+                attendee_id=attendee.id,
+                quantity=2,
+                product_name=ticket.name,
+                product_price=Decimal("250.00"),
+                product_category="month",  # stale snapshot category
+            )
+        )
+        db.commit()
+
+        trends = _get_cumulative_trends(db, popup.id, "UTC")
+        total_tickets = sum(p.value for p in trends.tickets)
+
+        # Counted as a ticket (live category) despite the stale "month" snapshot.
+        assert total_tickets == 2
+
+    def test_accommodation_percentage_live_category(
+        self, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = Popups(
+            name="Accommodation Live Category",
+            slug="accommodation-live-category",
+            tenant_id=tenant_a.id,
+        )
+        db.add(popup)
+        db.flush()
+
+        cabin = Products(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Cabin",
+            slug="acc-live-cabin",
+            price=Decimal("1000.00"),
+            category="housing",
+            discountable=False,
+        )
+        db.add(cabin)
+        db.flush()
+
+        attendee = Attendees(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            name="Buyer Housing",
+        )
+        db.add(attendee)
+        db.flush()
+
+        payment = Payments(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            status=PaymentStatus.APPROVED.value,
+            payment_type=PaymentType.PASS_PURCHASE.value,
+            amount=Decimal("1000.00"),
+            insurance_amount=Decimal("0.00"),
+            contribution_amount=Decimal("0.00"),
+        )
+        db.add(payment)
+        db.flush()
+
+        db.add(
+            PaymentProducts(
+                tenant_id=tenant_a.id,
+                payment_id=payment.id,
+                product_id=cabin.id,
+                attendee_id=attendee.id,
+                quantity=1,
+                product_name=cabin.name,
+                product_price=Decimal("1000.00"),
+                product_category="other",  # stale snapshot category
+            )
+        )
+        db.commit()
+
+        # One housing attendee out of two total people -> 50%, detected via the
+        # live category despite the stale "other" snapshot.
+        pct = _get_accommodation_percentage(db, popup.id, total_people=2)
+        assert pct == Decimal("50.0")

--- a/backoffice/src/components/Dashboard/KeyMetricsCards.tsx
+++ b/backoffice/src/components/Dashboard/KeyMetricsCards.tsx
@@ -135,9 +135,10 @@ export function KeyMetricsCards({ data, isLoading }: KeyMetricsCardsProps) {
         accentClass="text-green-500"
       />
       <MetricCard
-        title="Avg Ticket Price"
+        title="Avg Order Value"
         value={formatCurrency(data.avg_ticket_price, currency)}
         icon={Receipt}
+        description="per payment"
         accentClass="text-amber-500"
       />
       <MetricCard


### PR DESCRIPTION
## Problem

Audit follow-up to #361 and #384. Several dashboard widgets detect a product's category from **two different sources**, so they disagree with each other:

- **Cumulative Tickets**, **% w/ Accommodation** (KPI), **Accommodation Mix**, and the **housing leg of the Attach Rate** filter by the purchase-time snapshot `payment_products.product_category`.
- **Tickets by Type** and **Tickets by Attendee** use the **live** `products.category`.

Tickets re-categorised after sale (day/week/month folded into `ticket` + `duration_type`) left stale snapshot categories. As a result **Cumulative Tickets undercounts and does not match Tickets by Type**, and the accommodation widgets are exposed to the same drift (they happen to agree today only because no housing product has a stale snapshot yet).

## Fix

1. Join `products` and filter on the live `products.category` in all four spots, matching the source the ticket-type/attendee widgets already use. Every count/percentage widget now reads category from a single source and reconciles with the others. No change to revenue math (handled in #361/#384); this only affects which category a line is counted under.

2. Rename the **"Avg Ticket Price"** KPI to **"Avg Order Value"** (with a "per payment" subtitle). The metric is total approved revenue divided by approved payment count, so it includes non-ticket revenue and is averaged per payment, not per ticket — the old label was misleading. Computation unchanged; label only.

## Tests

- New: cumulative ticket count includes a ticket whose live category is `ticket` but whose snapshot says `month`.
- New: accommodation percentage counts a housing product whose live category is `housing` but whose snapshot says `other`.
- Existing reconciliation/grouping tests still pass (6/6 total).

## Notes

- Stacked on #384 (base branch `fix/dashboard-revenue-by-category-live-category`); retarget to `dev` once #384 merges.
