### PR TITLE
feat(portal): gate event RSVP on ticket ownership and application status

### DIFF
--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -321,6 +321,9 @@ async def register_for_event(
     body: RegisterRequest | None = None,
 ) -> EventParticipantPublic:
     """Register current human for an event (portal)."""
+    from app.api.application.crud import applications_crud
+    from app.api.application.schemas import ApplicationStatus
+    from app.api.attendee.crud import attendees_crud
     from app.api.event.crud import events_crud
     from app.api.event.schemas import EventStatus
     from app.api.event_participant.models import EventParticipants
@@ -333,6 +336,34 @@ async def register_for_event(
     if event.status != EventStatus.PUBLISHED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Event is not published"
+        )
+
+    # Eligibility gate: a human may only RSVP to a popup's events if they have a
+    # purchased ticket for that popup AND their application (if any) was not
+    # rejected. Mirrors the portal UI gate; enforced here so the rule can't be
+    # bypassed via the API directly.
+    application = applications_crud.get_by_human_popup(
+        db, current_human.id, event.popup_id
+    )
+    if application and application.status == ApplicationStatus.REJECTED.value:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your application was not accepted, so you can't RSVP to events.",
+        )
+
+    # Same ticket source as `list_my_tickets` (find_by_human) so "has a ticket"
+    # matches exactly what the portal shows, including companion/spouse tickets.
+    owned_attendees, _ = attendees_crud.find_by_human(
+        db, human_id=current_human.id, limit=1000
+    )
+    has_ticket = any(
+        a.popup_id == event.popup_id and len(a.attendee_products) > 0
+        for a in owned_attendees
+    )
+    if not has_ticket:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You need a purchased ticket for this popup to RSVP.",
         )
 
     occ_start = _resolve_occurrence_start(

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,12 +10,14 @@ from sqlmodel import Session, select
 
 from app.api.api_key import crud as api_key_crud
 from app.api.api_key.models import ApiKeys
+from app.api.attendee.models import AttendeeProducts, Attendees
 from app.api.event.models import EventInvitations, Events
 from app.api.event.schemas import EventStatus, EventVisibility
 from app.api.event_settings.models import EventSettings
 from app.api.event_settings.schemas import PublishPermission
 from app.api.human.models import Humans
 from app.api.popup.models import Popups
+from app.api.product.models import Products
 from app.api.shared.enums import HumanRating
 from app.api.tenant.models import Tenants
 
@@ -40,6 +43,48 @@ def _make_popup(db: Session, tenant: Tenants) -> Popups:
     db.commit()
     db.refresh(popup)
     return popup
+
+
+def _give_ticket(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> Attendees:
+    """Seed a purchased ticket for ``human`` in ``popup``.
+
+    Portal RSVP registration requires the human to hold a ticket for the
+    event's popup, so the success-path register test must seed one.
+    """
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Ticket {uuid.uuid4().hex[:6]}",
+        slug=f"ticket-{uuid.uuid4().hex[:10]}",
+        price=Decimal("100.00"),
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        name="PAT Ticket Holder",
+        email=human.email,
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+
+    db.add(
+        AttendeeProducts(
+            tenant_id=tenant.id,
+            attendee_id=attendee.id,
+            product_id=product.id,
+            check_in_code=uuid.uuid4().hex[:10],
+        )
+    )
+    db.commit()
+    return attendee
 
 
 def _set_event_settings(
@@ -262,6 +307,7 @@ class TestApiKeyPolicy:
         db.refresh(event)
 
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
         raw_key = _make_pat(db, tenant_a, human, scopes=["rsvp:write"])
 
         resp = client.post(

--- a/backend/tests/test_event_participants.py
+++ b/backend/tests/test_event_participants.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -29,12 +30,14 @@ from sqlmodel import Session, select
 
 from app.api.application.models import Applications
 from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import AttendeeProducts, Attendees
 from app.api.event.models import Events
 from app.api.event.schemas import EventStatus, EventVisibility
 from app.api.event_participant.models import EventParticipants
 from app.api.event_participant.schemas import ParticipantRole, ParticipantStatus
 from app.api.human.models import Humans
 from app.api.popup.models import Popups
+from app.api.product.models import Products
 from app.api.tenant.models import Tenants
 from app.core.security import create_access_token
 
@@ -94,6 +97,54 @@ def _make_human(db: Session, tenant: Tenants, *, email: str | None = None) -> Hu
     db.commit()
     db.refresh(human)
     return human
+
+
+def _give_ticket(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    human: Humans,
+) -> Attendees:
+    """Give ``human`` a purchased ticket for ``popup``.
+
+    Portal RSVP registration requires the human to hold at least one ticket
+    (an attendee row with products) for the event's popup, so success-path
+    register/cancel/check-in tests must seed one. Mirrors the real shape:
+    a Product (ticket) + an Attendees row keyed by human_id/popup_id + one
+    AttendeeProducts (ticket) row linking them.
+    """
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Ticket {uuid.uuid4().hex[:6]}",
+        slug=f"ticket-{uuid.uuid4().hex[:10]}",
+        price=Decimal("100.00"),
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+
+    attendee = Attendees(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        name=f"{human.first_name} {human.last_name}".strip(),
+        email=human.email,
+    )
+    db.add(attendee)
+    db.commit()
+    db.refresh(attendee)
+
+    db.add(
+        AttendeeProducts(
+            tenant_id=tenant.id,
+            attendee_id=attendee.id,
+            product_id=product.id,
+            check_in_code=uuid.uuid4().hex[:10],
+        )
+    )
+    db.commit()
+    return attendee
 
 
 def _human_headers(human: Humans) -> dict[str, str]:
@@ -308,6 +359,7 @@ class TestPortalRegister:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)) as itip_mock:
             resp = client.post(
@@ -381,6 +433,7 @@ class TestPortalRegister:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             first = client.post(
@@ -405,6 +458,10 @@ class TestPortalRegister:
         event = _make_event(db, tenant_a, popup, max_participant=1)
         first_human = _make_human(db, tenant_a)
         second_human = _make_human(db, tenant_a)
+        # Both hold tickets so the capacity guard — not the ticket gate — is
+        # what blocks the second registration.
+        _give_ticket(db, tenant_a, popup, first_human)
+        _give_ticket(db, tenant_a, popup, second_human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             first = client.post(
@@ -431,6 +488,7 @@ class TestPortalRegister:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             client.post(
@@ -465,6 +523,121 @@ class TestPortalRegister:
 
 
 # ---------------------------------------------------------------------------
+# Portal: register eligibility gate (ticket required, not rejected)
+# ---------------------------------------------------------------------------
+
+
+class TestPortalRegisterEligibility:
+    """A human may only RSVP if they hold a ticket for the popup and their
+    application (if any) isn't rejected. Mirrors the portal UI gate."""
+
+    def test_register_without_ticket_forbidden(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        human = _make_human(db, tenant_a)  # no ticket for this popup
+
+        with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)) as itip_mock:
+            resp = client.post(
+                f"/api/v1/event-participants/portal/register/{event.id}",
+                headers=_human_headers(human),
+            )
+
+        assert resp.status_code == 403, resp.text
+        assert "ticket" in resp.json()["detail"].lower()
+        assert itip_mock.await_count == 0
+        assert _fetch_participant(db, event.id, human.id) is None
+
+    def test_register_with_ticket_for_other_popup_forbidden(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        other_popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        human = _make_human(db, tenant_a)
+        # Ticket belongs to a different popup, so it doesn't grant access here.
+        _give_ticket(db, tenant_a, other_popup, human)
+
+        with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
+            resp = client.post(
+                f"/api/v1/event-participants/portal/register/{event.id}",
+                headers=_human_headers(human),
+            )
+
+        assert resp.status_code == 403, resp.text
+        assert _fetch_participant(db, event.id, human.id) is None
+
+    def test_register_with_rejected_application_forbidden(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        human = _make_human(db, tenant_a)
+        # Even with a ticket, a rejected application blocks RSVP.
+        _give_ticket(db, tenant_a, popup, human)
+        db.add(
+            Applications(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a.id,
+                popup_id=popup.id,
+                human_id=human.id,
+                status=ApplicationStatus.REJECTED.value,
+            )
+        )
+        db.commit()
+
+        with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)) as itip_mock:
+            resp = client.post(
+                f"/api/v1/event-participants/portal/register/{event.id}",
+                headers=_human_headers(human),
+            )
+
+        assert resp.status_code == 403, resp.text
+        assert itip_mock.await_count == 0
+        assert _fetch_participant(db, event.id, human.id) is None
+
+    def test_register_with_ticket_and_accepted_application_succeeds(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        event = _make_event(db, tenant_a, popup)
+        human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
+        db.add(
+            Applications(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a.id,
+                popup_id=popup.id,
+                human_id=human.id,
+                status=ApplicationStatus.ACCEPTED.value,
+            )
+        )
+        db.commit()
+
+        with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
+            resp = client.post(
+                f"/api/v1/event-participants/portal/register/{event.id}",
+                headers=_human_headers(human),
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == ParticipantStatus.REGISTERED.value
+
+
+# ---------------------------------------------------------------------------
 # Portal: cancel
 # ---------------------------------------------------------------------------
 
@@ -481,6 +654,7 @@ class TestPortalCancelRegistration:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             client.post(
@@ -528,6 +702,7 @@ class TestPortalCancelRegistration:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         # Register with the iTIP send fully stubbed so only the cancel below
         # exercises the real template-routing path.
@@ -590,6 +765,7 @@ class TestPortalCancelRegistration:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             client.post(
@@ -627,6 +803,7 @@ class TestPortalCheckIn:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             client.post(
@@ -678,6 +855,7 @@ class TestPortalCheckIn:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             client.post(
@@ -705,6 +883,7 @@ class TestPortalCheckIn:
         popup = _make_popup(db, tenant_a)
         event = _make_event(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
+        _give_ticket(db, tenant_a, popup, human)
 
         with patch(_ITIP_TARGET, new=AsyncMock(return_value=None)):
             client.post(

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -69,10 +69,10 @@ import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
 import { AddToCalendarModal } from "../lib/AddToCalendarModal"
 import { CoverImage } from "../lib/CoverImage"
-import { useCanRsvp } from "../lib/useCanRsvp"
 import { canManageEvent } from "../lib/eventPermissions"
 import { summarizeRrule } from "../lib/summarizeRrule"
 import { useCalendarAddedFlag } from "../lib/useCalendarAddedFlag"
+import { useCanRsvp } from "../lib/useCanRsvp"
 import {
   useEventTimezone,
   usePortalEventSettings,

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -69,6 +69,7 @@ import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
 import { AddToCalendarModal } from "../lib/AddToCalendarModal"
 import { CoverImage } from "../lib/CoverImage"
+import { useCanRsvp } from "../lib/useCanRsvp"
 import { canManageEvent } from "../lib/eventPermissions"
 import { summarizeRrule } from "../lib/summarizeRrule"
 import { useCalendarAddedFlag } from "../lib/useCalendarAddedFlag"
@@ -243,6 +244,16 @@ export default function EventDetailPage() {
   const goingCount = event?.attendee_count ?? activeParticipants.length
   const isFull =
     event?.max_participant != null && goingCount >= event.max_participant
+
+  // Gate the RSVP (register) action: only humans holding a ticket for this
+  // popup and without a rejected application may register. Cancel stays open.
+  const { canRsvp, reason: rsvpBlockReason } = useCanRsvp()
+  const rsvpDisabledReason =
+    rsvpBlockReason === "rejected"
+      ? (t("events.rsvp.application_rejected") as string)
+      : rsvpBlockReason === "no_tickets"
+        ? (t("events.rsvp.requires_ticket") as string)
+        : undefined
 
   // Recurring events require occurrence_start so the RSVP targets a single
   // instance; one-off events must not send it (the backend rejects mixing
@@ -731,6 +742,25 @@ export default function EventDetailPage() {
                   <Users className="h-4 w-4" />
                   {t("events.rsvp.full")}
                 </Button>
+              ) : !canRsvp ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    {/* span wrapper so the tooltip still fires on the
+                        disabled button (disabled elements emit no events) */}
+                    <span className="inline-flex">
+                      <Button
+                        disabled
+                        className="inline-flex items-center gap-2"
+                      >
+                        <UserPlus className="h-4 w-4" />
+                        {t("events.rsvp.rsvp")}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>{rsvpDisabledReason}</p>
+                  </TooltipContent>
+                </Tooltip>
               ) : (
                 <Button
                   onClick={() => registerMutation.mutate()}

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -91,6 +91,14 @@ interface CalendarBodyProps {
   timezoneOverride?: string
   /** Popup-scoped fallback image when an event has no cover/venue image. */
   placeholderUrl?: string | null
+  /**
+   * When false, the RSVP (register) button is disabled — the human lacks a
+   * ticket for this popup or has a rejected application. Cancel is never gated.
+   * Defaults to true.
+   */
+  canRsvp?: boolean
+  /** Tooltip text shown on the disabled RSVP button explaining why. */
+  rsvpDisabledReason?: string
 }
 
 /**
@@ -114,6 +122,8 @@ export function CalendarBody({
   onEventClick,
   timezoneOverride,
   placeholderUrl,
+  canRsvp = true,
+  rsvpDisabledReason,
 }: CalendarBodyProps) {
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
@@ -606,7 +616,10 @@ export function CalendarBody({
                               ) : (
                                 <button
                                   type="button"
-                                  disabled={isRsvpPending}
+                                  disabled={isRsvpPending || !canRsvp}
+                                  title={
+                                    !canRsvp ? rsvpDisabledReason : undefined
+                                  }
                                   onClick={() => rsvpMutation.mutate(event)}
                                   className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-xs font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                                 >

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -92,6 +92,14 @@ interface DayBodyProps {
    */
   isFullscreen?: boolean
   onToggleFullscreen?: () => void
+  /**
+   * When false, the RSVP (register) button is disabled — the human lacks a
+   * ticket for this popup or has a rejected application. Cancel is never gated.
+   * Defaults to true.
+   */
+  canRsvp?: boolean
+  /** Tooltip text shown on the disabled RSVP button explaining why. */
+  rsvpDisabledReason?: string
 }
 
 const HOUR_PX = 56
@@ -155,6 +163,8 @@ export function DayBody({
   venuesOverride,
   onEventClick,
   timezoneOverride,
+  canRsvp = true,
+  rsvpDisabledReason,
 }: DayBodyProps) {
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
@@ -819,7 +829,12 @@ export function DayBody({
                                     ) : (
                                       <button
                                         type="button"
-                                        disabled={isRsvpPending}
+                                        disabled={isRsvpPending || !canRsvp}
+                                        title={
+                                          !canRsvp
+                                            ? rsvpDisabledReason
+                                            : undefined
+                                        }
                                         onClick={(e) => {
                                           e.preventDefault()
                                           e.stopPropagation()

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -110,6 +110,14 @@ interface ListBodyProps {
    * spinner and is disabled until the request settles.
    */
   pendingRsvpKey?: string | null
+  /**
+   * When false, the RSVP (register) button is disabled — the human lacks a
+   * ticket for this popup or has a rejected application. The "Going"/cancel
+   * button is never gated. Defaults to true.
+   */
+  canRsvp?: boolean
+  /** Tooltip text shown on the disabled RSVP button explaining why. */
+  rsvpDisabledReason?: string
   onHide?: (eventId: string) => void
   onUnhide?: (eventId: string) => void
   /** Popup-scoped fallback image when an event has no cover/venue image. */
@@ -150,6 +158,8 @@ export function ListBody({
   onRsvp,
   onCancelRsvp,
   pendingRsvpKey,
+  canRsvp = true,
+  rsvpDisabledReason,
   onHide,
   onUnhide,
   placeholderUrl,
@@ -525,7 +535,10 @@ export function ListBody({
                                 ) : (
                                   <button
                                     type="button"
-                                    disabled={isRsvpPending}
+                                    disabled={isRsvpPending || !canRsvp}
+                                    title={
+                                      !canRsvp ? rsvpDisabledReason : undefined
+                                    }
                                     onClick={(e) => {
                                       e.preventDefault()
                                       e.stopPropagation()

--- a/portal/src/app/portal/[popupSlug]/events/lib/useCanRsvp.ts
+++ b/portal/src/app/portal/[popupSlug]/events/lib/useCanRsvp.ts
@@ -1,0 +1,58 @@
+"use client"
+
+import { useMyTicketsQuery } from "@/hooks/useMyTicketsQuery"
+import { useApplication } from "@/providers/applicationProvider"
+import { useCityProvider } from "@/providers/cityProvider"
+
+/**
+ * Reason an attendee is blocked from RSVPing, or null when they can.
+ * - `rejected`    — their application for this popup is in "rejected" status.
+ * - `no_tickets`  — they hold no purchased ticket for this popup.
+ */
+export type RsvpBlockReason = "rejected" | "no_tickets" | null
+
+/**
+ * Resolves whether the current human may RSVP to events in the active popup.
+ *
+ * Rule (mirrors the backend gate in event_participant/register):
+ *   canRsvp = has a purchased ticket for this popup AND application not rejected
+ *
+ * "Has a ticket" uses `listMyTickets` (the same source the portal's tickets/
+ * passes views read), so companion/spouse tickets count too — matching the
+ * "any ticket of the popup" definition.
+ *
+ * While the tickets query is loading, returns `canRsvp: true` (optimistic) to
+ * avoid a flash of a disabled button; the backend is the real guard. Must be
+ * called within ApplicationProvider + CityProvider (i.e. inside the portal).
+ */
+export function useCanRsvp(): {
+  canRsvp: boolean
+  reason: RsvpBlockReason
+  isLoading: boolean
+} {
+  const { getCity } = useCityProvider()
+  const { getRelevantApplication } = useApplication()
+  const { data: tickets, isLoading } = useMyTicketsQuery()
+
+  const city = getCity()
+  const isRejected = getRelevantApplication()?.status === "rejected"
+
+  const hasTickets = (tickets ?? []).some(
+    (t) => t.popup_id === city?.id && (t.products?.length ?? 0) > 0,
+  )
+
+  // Rejected always blocks. Otherwise gate on tickets — but stay optimistic
+  // while the tickets query is still in flight so the button doesn't flicker.
+  if (isRejected) {
+    return { canRsvp: false, reason: "rejected", isLoading }
+  }
+  if (isLoading) {
+    return { canRsvp: true, reason: null, isLoading }
+  }
+  if (!hasTickets) {
+    return { canRsvp: false, reason: "no_tickets", isLoading }
+  }
+  return { canRsvp: true, reason: null, isLoading }
+}
+
+export default useCanRsvp

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -31,6 +31,7 @@ import { fetchAllPortalEvents } from "./lib/fetchAllPortalEvents"
 import { ListBody } from "./lib/ListBody"
 import { eventListWindowForPopup } from "./lib/listWindow"
 import { SubscribeCalendarButton } from "./lib/SubscribeCalendarButton"
+import { useCanRsvp } from "./lib/useCanRsvp"
 import { useEventRsvp } from "./lib/useEventRsvp"
 import {
   useEventTimezone,
@@ -519,6 +520,17 @@ export default function EventsPage() {
     "portal-events",
   ])
 
+  // Gate the RSVP (register) action: a human can only RSVP if they hold a
+  // ticket for this popup and their application isn't rejected. Shared across
+  // all three views; the button renders disabled with an explanatory tooltip.
+  const { canRsvp, reason: rsvpBlockReason } = useCanRsvp()
+  const rsvpDisabledReason =
+    rsvpBlockReason === "rejected"
+      ? (t("events.rsvp.application_rejected") as string)
+      : rsvpBlockReason === "no_tickets"
+        ? (t("events.rsvp.requires_ticket") as string)
+        : undefined
+
   const hideMutation = useMutation({
     mutationFn: (eventId: string) => EventsService.hidePortalEvent({ eventId }),
     onSuccess: () => {
@@ -792,6 +804,8 @@ export default function EventsPage() {
             defaultDate={selectedDate}
             onEventLinkClick={handleEventLinkClick}
             placeholderUrl={eventSettings?.placeholder_url}
+            canRsvp={canRsvp}
+            rsvpDisabledReason={rsvpDisabledReason}
           />
         ) : view === "day" ? (
           isDayFullscreen ? null : (
@@ -810,6 +824,8 @@ export default function EventsPage() {
               onEventLinkClick={handleEventLinkClick}
               isFullscreen={false}
               onToggleFullscreen={toggleDayFullscreen}
+              canRsvp={canRsvp}
+              rsvpDisabledReason={rsvpDisabledReason}
             />
           )
         ) : (
@@ -826,6 +842,8 @@ export default function EventsPage() {
             onRsvp={(e) => rsvpMutation.mutate(e)}
             onCancelRsvp={(e) => cancelRsvpMutation.mutate(e)}
             pendingRsvpKey={pendingRsvpKey}
+            canRsvp={canRsvp}
+            rsvpDisabledReason={rsvpDisabledReason}
             onHide={(id) => hideMutation.mutate(id)}
             onUnhide={(id) => unhideMutation.mutate(id)}
             placeholderUrl={eventSettings?.placeholder_url}
@@ -883,6 +901,8 @@ export default function EventsPage() {
               onEventLinkClick={handleEventLinkClick}
               isFullscreen={true}
               onToggleFullscreen={toggleDayFullscreen}
+              canRsvp={canRsvp}
+              rsvpDisabledReason={rsvpDisabledReason}
             />
           </div>,
           document.body,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -601,7 +601,9 @@
       "check_in_opens_at_start": "Check-in opens at start time",
       "registered": "Registered",
       "checked_in": "Checked in",
-      "action_error": "Couldn't update your RSVP. Please try again."
+      "action_error": "Couldn't update your RSVP. Please try again.",
+      "requires_ticket": "You need a ticket for this popup to RSVP.",
+      "application_rejected": "Your application wasn't accepted, so you can't RSVP."
     },
     "recurrence": {
       "daily_one": "Repeats daily",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -598,7 +598,9 @@
       "check_in_opens_at_start": "El check-in se habilita al comenzar el evento",
       "registered": "Anotado",
       "checked_in": "Check-in realizado",
-      "action_error": "No pudimos actualizar tu RSVP. Por favor intentá de nuevo."
+      "action_error": "No pudimos actualizar tu RSVP. Por favor intentá de nuevo.",
+      "requires_ticket": "Necesitás un ticket de este evento para registrarte.",
+      "application_rejected": "Tu aplicación no fue aceptada, no podés registrarte."
     },
     "recurrence": {
       "daily_one": "Se repite diariamente",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -574,7 +574,9 @@
       "check_in_opens_at_start": "Innritun opnar á upphafstíma",
       "registered": "Skráður",
       "checked_in": "Innritaður",
-      "action_error": "Ekki tókst að uppfæra RSVP. Vinsamlegast reyndu aftur."
+      "action_error": "Ekki tókst að uppfæra RSVP. Vinsamlegast reyndu aftur.",
+      "requires_ticket": "Þú þarft miða fyrir þennan viðburð til að skrá þig.",
+      "application_rejected": "Umsókn þín var ekki samþykkt, svo þú getur ekki skráð þig."
     },
     "login_required": {
       "title": "Skráðu þig inn til að sjá þennan viðburð",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -584,7 +584,9 @@
       "check_in_opens_at_start": "签到将在活动开始时开放",
       "registered": "已登记",
       "checked_in": "已签到",
-      "action_error": "无法更新你的报名，请稍后重试。"
+      "action_error": "无法更新你的报名，请稍后重试。",
+      "requires_ticket": "你需要持有该活动的票才能报名。",
+      "application_rejected": "你的申请未获通过，无法报名。"
     },
     "login_required": {
       "title": "登录以查看此活动",


### PR DESCRIPTION
## Qué hace

En el **portal**, bloquea el RSVP a eventos del calendario cuando el attendee:

1. **No tiene tickets comprados** para ese popup (incluye tickets de acompañante/spouse), o
2. Su **aplicación está en status `rejected`** para ese popup.

Solo se gatea la acción de **registrarse** (botón "RSVP"); cancelar un RSVP existente sigue permitido.

## Cómo

### Frontend (portal)
- **Nuevo hook** `events/lib/useCanRsvp.ts`: combina `useMyTicketsQuery` (tickets del popup) + `useApplication().getRelevantApplication()` (estado de la aplicación) → `{ canRsvp, reason }`. Optimista mientras cargan los tickets.
- `events/page.tsx` pasa `canRsvp` + `rsvpDisabledReason` (traducido) a `ListBody`, `CalendarBody` y `DayBody` (props opcionales, default `true`).
- En cada vista el botón **"RSVP"** queda `disabled` + tooltip con el motivo; el botón "Going"/cancelar no se toca.
- La página de detalle `[eventId]/page.tsx` envuelve el botón en un `Tooltip`.
- **i18n**: `events.rsvp.requires_ticket` y `events.rsvp.application_rejected` en los 4 locales (en/es/is/zh).

### Backend
- `register_for_event` aplica la misma regla y devuelve **403** si no hay ticket o la aplicación está rechazada, para que no se pueda saltar vía API.
- "Tener ticket" reutiliza `attendees_crud.find_by_human` — **la misma fuente que `list_my_tickets`** — para garantizar paridad exacta con lo que muestra el portal (incluye acompañantes).

## Tests
- Nueva clase `TestPortalRegisterEligibility` (sin ticket → 403, ticket de otro popup → 403, rechazado → 403, ticket+aceptado → 200).
- Helper `_give_ticket` agregado y aplicado a los tests de éxito existentes de register/cancel/check-in, y al test de API-key RSVP.

## Verificación
- TypeScript: 0 errores en los archivos del portal modificados.
- Ruff lint + format: OK.
- `pytest tests/test_event_participants.py`: 25 passed, 1 skipped.
- `pytest tests/test_api_key_policy.py`: 17 passed, 3 skipped.

No requiere regenerar el cliente OpenAPI (no cambian firmas; solo se agregan respuestas 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
