### PR TITLE
Update refundable application fee copy

### DIFF
--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -744,7 +744,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
               <InlineRow
                 icon={<DollarSign className="h-4 w-4 text-muted-foreground" />}
                 label="Require Application Fee"
-                description="Applicants must pay a fee before their application is reviewed"
+                description="Applicants must pay a refundable fee before their application is reviewed"
               >
                 <Switch
                   id="requires_application_fee"

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -142,7 +142,7 @@
     "pay_and_submit": "Pay & Submit ({{amount}})",
     "fee": {
       "required_title": "Application fee required",
-      "required_description": "A non-refundable fee of ${{amount}} USD is required to submit your application. You will be redirected to a secure payment page.",
+      "required_description": "A refundable fee of ${{amount}} USD is required to submit your application. You will be redirected to a secure payment page.",
       "processing_title": "Processing payment...",
       "processing_description": "We are confirming your payment. This may take a few moments.",
       "confirmed_title": "Payment confirmed!",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -142,7 +142,7 @@
     "pay_and_submit": "Pagar y enviar ({{amount}})",
     "fee": {
       "required_title": "Se requiere tarifa de aplicación",
-      "required_description": "Se requiere una tarifa no reembolsable de ${{amount}} USD para enviar tu aplicación. Serás redirigido a una página de pago segura.",
+      "required_description": "Se requiere una tarifa reembolsable de ${{amount}} USD para enviar tu aplicación. Serás redirigido a una página de pago segura.",
       "processing_title": "Procesando pago...",
       "processing_description": "Estamos confirmando tu pago. Esto puede tardar unos momentos.",
       "confirmed_title": "¡Pago confirmado!",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -128,7 +128,7 @@
     "pay_and_submit": "Greiða og senda ({{amount}})",
     "fee": {
       "required_title": "Umsóknargjald krafist",
-      "required_description": "Óafturkræft gjald upp á ${{amount}} USD er krafist til að senda umsóknina. Þér verður vísað á örugga greiðslusíðu.",
+      "required_description": "Endurgreiðanlegt gjald upp á ${{amount}} USD er krafist til að senda umsóknina. Þér verður vísað á örugga greiðslusíðu.",
       "processing_title": "Vinn úr greiðslu...",
       "processing_description": "Við erum að staðfesta greiðsluna þína. Þetta getur tekið nokkur augnablik.",
       "confirmed_title": "Greiðsla staðfest!",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -128,7 +128,7 @@
     "pay_and_submit": "支付并提交 ({{amount}})",
     "fee": {
       "required_title": "需要申请费",
-      "required_description": "提交申请需支付 ${{amount}} USD 的不可退还费用。您将被重定向到安全支付页面。",
+      "required_description": "提交申请需支付 ${{amount}} USD 的可退还费用。您将被重定向到安全支付页面。",
       "processing_title": "正在处理付款...",
       "processing_description": "我们正在确认您的付款。这可能需要一些时间。",
       "confirmed_title": "付款已确认！",


### PR DESCRIPTION
## Summary
- Update portal application fee translations to say the fee is refundable.
- Align backoffice application fee setting description with refundable wording.

## Testing
- git diff --check
- Searched portal/backoffice source for remaining non-refundable application fee wording.