### PR TITLE
feat(humans): Declared panel, two-column profile layout, fix Sources 404 + telegram-links table

### DIFF
--- a/backend/app/alembic/versions/d3a91f7c5e82_human_telegram_links.py
+++ b/backend/app/alembic/versions/d3a91f7c5e82_human_telegram_links.py
@@ -1,0 +1,119 @@
+"""human_telegram_links — derived Telegram-id ↔ human binding (separate from humans.telegram).
+
+Rich Profiles follow-up. Telegram chat exports (and the live Bot API) identify a
+message author only by a stable numeric id (the export's ``from_id`` minus the
+"user" prefix; the Bot API's ``message.from.id``) — the *export never carries the
+@handle*. To attribute a downloaded conversation (or a new bot message) to an
+EdgeOS human deterministically by id instead of fuzzy-matching display names on
+every re-run, we persist the id↔human binding once.
+
+This is an INTERNAL identity index, deliberately NOT ``humans.telegram``: that
+field is user-owned and user-visible, so a handle we *derived* (e.g. resolved via
+a one-time Telethon participants dump) must never be written back into it. Weak
+(display-name-only) links stay ``verified = false`` until confirmed by hand.
+
+Like ``human_enrichment_facts`` / ``human_comments`` this is a global table reached
+only through the privileged main engine (authorization at the API layer): NO
+tenant RLS policy and NO grants to the tenant DB roles. A single ``tg_user_id`` may
+bind to more than one human (same person, several tenants), so uniqueness is on
+the (human_id, tg_user_id) pair — not on ``tg_user_id`` alone.
+
+Schema:
+  human_telegram_links (
+    id uuid PK,
+    human_id uuid NOT NULL FK -> humans(id) ON DELETE CASCADE,
+    tg_user_id varchar(32) NOT NULL,     -- numeric Telegram id as text
+    tg_username varchar(255) NULL,       -- observed @handle (evidence only)
+    tg_display_name varchar(255) NULL,   -- observed display name (evidence only)
+    match_method varchar(20) NOT NULL,   -- handle_resolved|handle_exact|name_fuzzy|manual
+    confidence numeric NULL,             -- 0..1
+    verified boolean NOT NULL DEFAULT false,
+    source_groups jsonb NULL,            -- which export group(s) the evidence came from
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (human_id, tg_user_id)
+  )
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic
+revision = "d3a91f7c5e82"
+# Chained onto the Rich Profiles migration (same feature family) to keep this
+# work on a single linear head.
+down_revision = "b8d2f3a47c19"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent: the table is created out-of-band in prod ahead of the dev→prod
+    # pipeline (the Rich Profiles mapping landed via direct SQL while prod's
+    # alembic head was still the sibling SMTP migration). Skip if it already
+    # exists so a later pipeline run no-ops and simply advances the version.
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table("human_telegram_links"):
+        return
+
+    op.create_table(
+        "human_telegram_links",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("human_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("tg_user_id", sa.String(32), nullable=False),
+        sa.Column("tg_username", sa.String(255), nullable=True),
+        sa.Column("tg_display_name", sa.String(255), nullable=True),
+        sa.Column("match_method", sa.String(20), nullable=False),
+        sa.Column("confidence", sa.Numeric(), nullable=True),
+        sa.Column(
+            "verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("source_groups", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["human_id"],
+            ["humans.id"],
+            name="fk_human_telegram_links_human_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_human_telegram_links"),
+        sa.UniqueConstraint(
+            "human_id", "tg_user_id", name="uq_human_telegram_link_human_tg"
+        ),
+    )
+    op.create_index(
+        "ix_human_telegram_links_human_id",
+        "human_telegram_links",
+        ["human_id"],
+    )
+    # The bot's hot path: given a Telegram id from a new message, find the human.
+    op.create_index(
+        "ix_human_telegram_links_tg_user_id",
+        "human_telegram_links",
+        ["tg_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_human_telegram_links_tg_user_id", table_name="human_telegram_links"
+    )
+    op.drop_index(
+        "ix_human_telegram_links_human_id", table_name="human_telegram_links"
+    )
+    op.drop_table("human_telegram_links")

--- a/backend/app/api/human/models.py
+++ b/backend/app/api/human/models.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Numeric, String, Text, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, Numeric, String, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlmodel import Column, Field, Relationship, SQLModel
 
@@ -165,5 +165,91 @@ class HumanEnrichmentFact(SQLModel, table=True):
         default_factory=lambda: datetime.now(UTC),
         sa_column=Column(
             DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
+    )
+
+
+class HumanTelegramLink(SQLModel, table=True):
+    """Derived binding between a Telegram account and an EdgeOS human.
+
+    Telegram chat exports (and the live Bot API) identify an author by a stable
+    numeric ``tg_user_id`` — the *export never contains the @handle*. This table
+    is the durable join key that lets us attribute a downloaded conversation (or
+    a new bot message) to a human deterministically by id, instead of guessing by
+    display name on every re-run.
+
+    IMPORTANT — this is an INTERNAL identity index, deliberately separate from
+    ``humans.telegram``: that field is user-owned and user-visible, so we never
+    write a handle we derived into it. The binding here may be high-confidence
+    (a resolved/exact handle match) or weak (display-name only), in which case it
+    stays ``verified = False`` until a human confirms it in the backoffice.
+
+    Like ``human_enrichment_facts`` / ``human_comments`` it is reached only through
+    the privileged main engine (authorization at the API layer), so it carries NO
+    tenant RLS policy and NO grants to the tenant DB roles. A single ``tg_user_id``
+    may bind to more than one human (the same person can be a human under several
+    tenants), so uniqueness is on the (human, tg) pair, not on ``tg_user_id``.
+    """
+
+    __tablename__ = "human_telegram_links"
+    __table_args__ = (
+        UniqueConstraint(
+            "human_id", "tg_user_id", name="uq_human_telegram_link_human_tg"
+        ),
+    )
+
+    id: uuid.UUID = Field(
+        default_factory=uuid.uuid4,
+        sa_column=Column(UUID(as_uuid=True), primary_key=True),
+    )
+
+    human_id: uuid.UUID = Field(foreign_key="humans.id", index=True)
+
+    # Numeric Telegram user id as text (e.g. "7027773675"). This equals the chat
+    # export's ``from_id`` with the "user" prefix stripped, and the Bot API's
+    # ``message.from.id`` — the same id space across all three. Indexed for the
+    # bot's lookup-by-id path.
+    tg_user_id: str = Field(sa_column=Column(String(32), nullable=False, index=True))
+
+    # Handle observed for this account (without "@"), when known. Evidence only —
+    # NOT authoritative and NOT mirrored to humans.telegram.
+    tg_username: str | None = Field(
+        default=None, sa_column=Column(String(255), nullable=True)
+    )
+    # Display name observed in the group/export (changes over time; evidence only).
+    tg_display_name: str | None = Field(
+        default=None, sa_column=Column(String(255), nullable=True)
+    )
+
+    # See TelegramLinkMethod (handle_resolved|handle_exact|name_fuzzy|manual).
+    match_method: str = Field(sa_column=Column(String(20), nullable=False))
+    # 0..1 score of how sure we are this id is this human.
+    confidence: float | None = Field(
+        default=None, sa_column=Column(Numeric, nullable=True)
+    )
+    # Trust gate: only verified (or deterministic) links auto-attribute messages.
+    verified: bool = Field(
+        default=False,
+        sa_column=Column(Boolean, nullable=False, server_default="false"),
+    )
+
+    # Which exported group(s)/source(s) this link's evidence came from.
+    source_groups: dict | None = Field(
+        default=None, sa_column=Column(JSONB, nullable=True)
+    )
+
+    created_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True), server_default=func.now(), nullable=False
+        ),
+    )
+    updated_at: datetime = Field(
+        default_factory=lambda: datetime.now(UTC),
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
         ),
     )

--- a/backend/app/api/shared/enums.py
+++ b/backend/app/api/shared/enums.py
@@ -44,6 +44,29 @@ class EnrichmentSource(StrEnum):
     MANUAL = "manual"  # entered/edited by a human in the backoffice
 
 
+class TelegramLinkMethod(StrEnum):
+    """How a ``human_telegram_links`` row binding a Telegram account to a human
+    was established. Drives trust: only high-confidence, ``verified`` links are
+    used to auto-attribute downloaded chat messages / new bot messages to a human.
+
+    Note: this is an INTERNAL, derived identity link. It is never written back to
+    the user-owned ``humans.telegram`` field — a human who never typed their own
+    handle must not see one we inferred.
+    """
+
+    # Telethon resolved a human's own ``humans.telegram`` handle to the numeric id
+    # and it matched a group participant / export author. Deterministic.
+    HANDLE_RESOLVED = "handle_resolved"
+    # A current group participant's @username equals a human's ``telegram`` handle
+    # (exact, normalized, unique). Deterministic.
+    HANDLE_EXACT = "handle_exact"
+    # Only the display name matched a human's full name (unique). Weak — stays
+    # ``verified = false`` until a human confirms it in the backoffice.
+    NAME_FUZZY = "name_fuzzy"
+    # Confirmed/created by hand in the backoffice.
+    MANUAL = "manual"
+
+
 class LandingMode(StrEnum):
     """Per-tenant landing mode for custom domains.
 

--- a/backoffice/src/components/Humans/DeclaredFieldsCard.tsx
+++ b/backoffice/src/components/Humans/DeclaredFieldsCard.tsx
@@ -1,0 +1,191 @@
+import { useQuery } from "@tanstack/react-query"
+
+import {
+  ApplicationsService,
+  FormFieldsService,
+  type HumanPublic,
+} from "@/client"
+
+/**
+ * "Declared" panel — the answers a person typed into the application form,
+ * shown read-only and tidied at display time. We deliberately do NOT copy this
+ * into the curated `enriched_profile`: it is user-owned and user-editable, so
+ * the only honest place to surface it is its source, rendered against the live
+ * form schema (label, type, order, section) rather than the raw slug/value.
+ */
+
+interface FieldSchema {
+  type: string
+  label: string
+  position?: number
+  section_id?: string | null
+  options?: string[]
+}
+interface SectionSchema {
+  id: string
+  label: string
+  order: number
+}
+interface AppSchema {
+  custom_fields: Record<string, FieldSchema>
+  sections: SectionSchema[]
+}
+
+function fieldLabel(schema: AppSchema | undefined, key: string): string {
+  const label = schema?.custom_fields?.[key]?.label
+  if (label) return label
+  return key
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ")
+}
+
+function formatValue(
+  schema: AppSchema | undefined,
+  key: string,
+  value: unknown,
+): string {
+  if (value === null || value === undefined || value === "") return "—"
+  const type = schema?.custom_fields?.[key]?.type
+  if (type === "boolean") return value ? "Yes" : "No"
+  if (type === "multiselect" && Array.isArray(value)) return value.join(", ")
+  if (type === "date" && typeof value === "string") {
+    const d = new Date(value)
+    return Number.isNaN(d.getTime()) ? value : d.toLocaleDateString()
+  }
+  if (Array.isArray(value)) return value.join(", ")
+  if (typeof value === "object") return JSON.stringify(value)
+  return String(value)
+}
+
+/** Skip empty answers and structural/sensitive keys that aren't worth showing. */
+function isMeaningful(value: unknown): boolean {
+  if (value === null || value === undefined || value === "") return false
+  if (Array.isArray(value) && value.length === 0) return false
+  if (typeof value === "object" && !Array.isArray(value)) {
+    // signature-like or empty objects — not useful in a read-only summary
+    return Object.values(value as Record<string, unknown>).some(Boolean)
+  }
+  return true
+}
+
+function FieldRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-muted-foreground break-words">{label}</p>
+      <p className="text-sm break-words whitespace-pre-wrap">{value}</p>
+    </div>
+  )
+}
+
+export function DeclaredFieldsCard({ human }: { human: HumanPublic }) {
+  // A human row is tenant-scoped, so this is normally 0-1 application; if the
+  // person applied to several popups we surface the richest (most-answered) one.
+  const { data: appsData, isPending } = useQuery({
+    queryKey: ["human-applications", human.id],
+    queryFn: () =>
+      ApplicationsService.listApplications({ humanId: human.id, limit: 100 }),
+  })
+
+  const applications = appsData?.results ?? []
+  const application = [...applications].sort(
+    (a, b) =>
+      Object.keys(b.custom_fields ?? {}).length -
+      Object.keys(a.custom_fields ?? {}).length,
+  )[0]
+
+  const { data: schema } = useQuery({
+    queryKey: ["form-fields-schema", application?.popup_id],
+    queryFn: async () =>
+      (await FormFieldsService.getApplicationSchema({
+        popupId: application!.popup_id,
+      })) as unknown as AppSchema,
+    enabled: !!application?.popup_id,
+  })
+
+  // Structured human attributes the person also declared (live on the human row,
+  // editable above) — handy to see alongside the form answers.
+  const profileBasics: [string, string | null | undefined][] = [
+    ["Telegram", human.telegram],
+    ["Residence", human.residence],
+    ["Gender", human.gender],
+    ["Age", human.age],
+  ]
+  const basics = profileBasics.filter(([, v]) => v)
+
+  const entries = Object.entries(application?.custom_fields ?? {}).filter(
+    ([, v]) => isMeaningful(v),
+  )
+  entries.sort(([a], [b]) => {
+    const pa = schema?.custom_fields?.[a]?.position ?? 999
+    const pb = schema?.custom_fields?.[b]?.position ?? 999
+    return pa - pb
+  })
+
+  // Group by section, preserving section order from the schema.
+  const sectionOrder = new Map(
+    (schema?.sections ?? []).map((s) => [s.id, s] as const),
+  )
+  const grouped = new Map<string | null, [string, unknown][]>()
+  for (const [key, value] of entries) {
+    const sid = schema?.custom_fields?.[key]?.section_id ?? null
+    if (!grouped.has(sid)) grouped.set(sid, [])
+    grouped.get(sid)!.push([key, value])
+  }
+  const groups = [...grouped.entries()].sort((a, b) => {
+    const oa = a[0] ? (sectionOrder.get(a[0])?.order ?? 999) : 1000
+    const ob = b[0] ? (sectionOrder.get(b[0])?.order ?? 999) : 1000
+    return oa - ob
+  })
+
+  if (isPending) {
+    return (
+      <p className="text-sm text-muted-foreground">Loading declared data…</p>
+    )
+  }
+
+  if (basics.length === 0 && entries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        This person hasn't declared any profile information yet.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      {basics.length > 0 && (
+        <div className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+          {basics.map(([label, value]) => (
+            <FieldRow key={label} label={label} value={value as string} />
+          ))}
+        </div>
+      )}
+
+      {groups.map(([sid, fields]) => (
+        <div key={sid ?? "_"} className="space-y-3">
+          {sid && sectionOrder.get(sid)?.label && (
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {sectionOrder.get(sid)!.label}
+            </p>
+          )}
+          <div className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
+            {fields.map(([key, value]) => (
+              <FieldRow
+                key={key}
+                label={fieldLabel(schema, key)}
+                value={formatValue(schema, key, value)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {applications.length > 1 && (
+        <p className="text-xs text-muted-foreground">
+          Showing the most complete of {applications.length} applications.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/backoffice/src/components/Humans/EnrichedProfileCard.tsx
+++ b/backoffice/src/components/Humans/EnrichedProfileCard.tsx
@@ -78,6 +78,53 @@ function linkLabel(url: string): string {
   }
 }
 
+/** The two Telegram groups we enriched from — for a human-readable source label. */
+const TELEGRAM_GROUPS: Record<string, string> = {
+  "2944565963": "Edge City Patagonia 2025",
+  "3980048315": "Edge Esmeralda 2026",
+}
+
+/**
+ * Provenance facts were written by two passes with different `evidence` shapes:
+ * a proper `https://t.me/c/<chat>/<msg>` deep link, and a bare `<chat>:<msg>`
+ * (which the browser resolves as a relative path → 404). Normalize both to a
+ * valid Telegram deep link, preferring the structured `raw` payload when present.
+ */
+function factEvidence(f: {
+  evidence?: string | null
+  raw?: { [key: string]: unknown } | null
+}): { href: string; label: string } | null {
+  let chat: string | undefined
+  let msg: string | undefined
+
+  const raw = f.raw
+  if (raw && typeof raw === "object") {
+    if (raw.chat_id != null) chat = String(raw.chat_id)
+    if (raw.message_id != null) msg = String(raw.message_id)
+  }
+
+  const ev = f.evidence?.trim()
+  if (ev) {
+    if (/^https?:\/\//i.test(ev)) {
+      const m = ev.match(/t\.me\/c\/(\d+)\/(\d+)/)
+      const label =
+        m && TELEGRAM_GROUPS[m[1]] ? TELEGRAM_GROUPS[m[1]] : "Telegram"
+      return { href: ev, label }
+    }
+    const m = ev.match(/^(\d+):(\d+)$/)
+    if (m) {
+      chat = chat ?? m[1]
+      msg = msg ?? m[2]
+    }
+  }
+
+  if (chat && msg) {
+    const label = TELEGRAM_GROUPS[chat] ?? "Telegram"
+    return { href: `https://t.me/c/${chat}/${msg}`, label }
+  }
+  return null
+}
+
 function BadgeRow({ label, values }: { label: string; values: string[] }) {
   if (values.length === 0) return null
   return (
@@ -136,17 +183,20 @@ function EnrichmentFacts({ humanId }: { humanId: string }) {
                 </Badge>
               </div>
               <p className="mt-1 text-foreground/80">{f.value}</p>
-              {f.evidence && (
-                <a
-                  href={f.evidence}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-1 inline-flex items-center gap-1 text-primary underline"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                  evidence
-                </a>
-              )}
+              {(() => {
+                const ev = factEvidence(f)
+                return ev ? (
+                  <a
+                    href={ev.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-1 inline-flex items-center gap-1 text-primary underline"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    {ev.label}
+                  </a>
+                ) : null
+              })()}
             </div>
           ))
         )}
@@ -167,8 +217,7 @@ export function EnrichedProfileCard({ human }: { human: HumanPublic }) {
     <div className="space-y-3">
       {!profile || isEmptyProfile(profile) ? (
         <p className="text-sm text-muted-foreground">
-          This person hasn't been enriched yet. The enrichment agent fills this
-          in from Telegram, applications, events and an org deep-dive.
+          There is no additional information for this profile.
         </p>
       ) : (
         <div className="space-y-4">
@@ -195,31 +244,33 @@ export function EnrichedProfileCard({ human }: { human: HumanPublic }) {
 
           {(profile.tags.length > 0 ||
             profile.interests.length > 0 ||
-            profile.topics.length > 0) && (
-            <div className="space-y-2">
+            profile.topics.length > 0 ||
+            profile.links.length > 0) && (
+            <div className="grid grid-cols-1 gap-x-6 gap-y-4 sm:grid-cols-2">
               <BadgeRow label="Tags" values={profile.tags} />
               <BadgeRow label="Interests" values={profile.interests} />
               <BadgeRow label="Topics" values={profile.topics} />
-            </div>
-          )}
-
-          {profile.links.length > 0 && (
-            <div className="space-y-1">
-              <p className="text-xs font-medium text-muted-foreground">Links</p>
-              <div className="flex flex-col gap-1">
-                {profile.links.map((url) => (
-                  <a
-                    key={url}
-                    href={url.includes("://") ? url : `https://${url}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-sm text-primary underline"
-                  >
-                    <ExternalLink className="h-3 w-3 shrink-0" />
-                    {linkLabel(url)}
-                  </a>
-                ))}
-              </div>
+              {profile.links.length > 0 && (
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Links
+                  </p>
+                  <div className="flex flex-col gap-1">
+                    {profile.links.map((url) => (
+                      <a
+                        key={url}
+                        href={url.includes("://") ? url : `https://${url}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-sm text-primary underline"
+                      >
+                        <ExternalLink className="h-3 w-3 shrink-0" />
+                        {linkLabel(url)}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/backoffice/src/routes/_layout/humans/$id.edit.tsx
+++ b/backoffice/src/routes/_layout/humans/$id.edit.tsx
@@ -11,10 +11,17 @@ import { DangerZone } from "@/components/Common/DangerZone"
 import { FormPageLayout } from "@/components/Common/FormPageLayout"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
 import { HumanForm } from "@/components/forms/HumanForm"
+import { DeclaredFieldsCard } from "@/components/Humans/DeclaredFieldsCard"
 import { EnrichedProfileCard } from "@/components/Humans/EnrichedProfileCard"
 import { HumanActivity } from "@/components/Humans/HumanActivity"
 import { HumanCommentThread } from "@/components/Humans/HumanCommentThread"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import useAuth from "@/hooks/useAuth"
@@ -73,26 +80,38 @@ function EditHumanContent({ humanId }: { humanId: string }) {
       <TabsContent value="details">
         <div className="space-y-8">
           <HumanForm defaultValues={human} onSuccess={goBack} />
-          <div className="mx-auto max-w-2xl">
+          <div className="grid grid-cols-1 items-start gap-6 lg:grid-cols-2">
             <Card>
               <CardHeader>
                 <CardTitle>Rich profile</CardTitle>
+                <CardDescription>
+                  Curated from non-declared signals (Telegram activity, events).
+                </CardDescription>
               </CardHeader>
               <CardContent>
                 <EnrichedProfileCard human={human} />
               </CardContent>
             </Card>
-          </div>
-          <div className="mx-auto max-w-2xl">
             <Card>
               <CardHeader>
-                <CardTitle>Comments</CardTitle>
+                <CardTitle>Declared</CardTitle>
+                <CardDescription>
+                  What this person typed into their application form.
+                </CardDescription>
               </CardHeader>
               <CardContent>
-                <HumanCommentThread humanId={humanId} />
+                <DeclaredFieldsCard human={human} />
               </CardContent>
             </Card>
           </div>
+          <Card>
+            <CardHeader>
+              <CardTitle>Comments</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <HumanCommentThread humanId={humanId} />
+            </CardContent>
+          </Card>
           {isAdmin && (
             <div className="mx-auto max-w-2xl">
               <DangerZone

--- a/backoffice/src/routes/_layout/humans/index.tsx
+++ b/backoffice/src/routes/_layout/humans/index.tsx
@@ -70,14 +70,6 @@ const HUMAN_FIELD_FILTER_DEFS: {
   },
 ]
 
-type EnrichedFilter = "all" | "enriched" | "not_enriched"
-
-const ENRICHED_FILTER_OPTIONS: { value: EnrichedFilter; label: string }[] = [
-  { value: "all", label: "All profiles" },
-  { value: "enriched", label: "✨ Has rich profile" },
-  { value: "not_enriched", label: "No rich profile" },
-]
-
 function countActiveFieldFilters(filters: HumanFieldFilters): number {
   return HUMAN_FIELD_FILTER_DEFS.filter(
     (d) => (filters[d.key] ?? "").trim() !== "",
@@ -113,15 +105,8 @@ function getHumansQueryOptions(
   applicationFilter: HumansApplicationFilter = HUMAN_APPLICATION_FILTER.ALL,
   fieldFilters: HumanFieldFilters = {},
   rating: HumanRating | null = null,
-  enrichedFilter: EnrichedFilter = "all",
 ) {
   const isIncomplete = applicationFilter === HUMAN_APPLICATION_FILTER.INCOMPLETE
-  const hasEnrichedProfile =
-    enrichedFilter === "enriched"
-      ? true
-      : enrichedFilter === "not_enriched"
-        ? false
-        : undefined
   return {
     queryFn: () =>
       HumansService.listHumans({
@@ -138,7 +123,6 @@ function getHumansQueryOptions(
         age: fieldFilters.age?.trim() || undefined,
         residence: fieldFilters.residence?.trim() || undefined,
         rating: rating ?? undefined,
-        hasEnrichedProfile,
         enrichmentQuery: fieldFilters.enrichment?.trim() || undefined,
       }),
     queryKey: [
@@ -151,7 +135,6 @@ function getHumansQueryOptions(
         applicationFilter,
         fieldFilters,
         rating,
-        enrichedFilter,
       },
     ],
   }
@@ -221,32 +204,6 @@ function HumansRatingFilterSelect({
       <SelectContent>
         <SelectItem value={RATING_FILTER_ALL}>All ratings</SelectItem>
         {HUMAN_RATING_OPTIONS.map((opt) => (
-          <SelectItem key={opt.value} value={opt.value}>
-            {opt.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  )
-}
-
-function HumansEnrichedFilterSelect({
-  value,
-  onValueChange,
-}: {
-  value: EnrichedFilter
-  onValueChange: (value: EnrichedFilter) => void
-}) {
-  return (
-    <Select
-      value={value}
-      onValueChange={(next) => onValueChange(next as EnrichedFilter)}
-    >
-      <SelectTrigger className="w-[180px]">
-        <SelectValue placeholder="Rich profile" />
-      </SelectTrigger>
-      <SelectContent>
-        {ENRICHED_FILTER_OPTIONS.map((opt) => (
           <SelectItem key={opt.value} value={opt.value}>
             {opt.label}
           </SelectItem>
@@ -376,15 +333,6 @@ function HumansTableContent() {
     }
   }
 
-  const [enrichedFilter, setEnrichedFilter] = useState<EnrichedFilter>("all")
-  const handleEnrichedFilterChange = (next: EnrichedFilter) => {
-    setEnrichedFilter(next)
-    // New filter criteria → back to the first page.
-    if (pagination.pageIndex !== 0) {
-      setPagination({ pageIndex: 0, pageSize: pagination.pageSize })
-    }
-  }
-
   const setApplicationFilter = (value: HumansApplicationFilter) => {
     navigate({
       to: "/humans",
@@ -406,7 +354,6 @@ function HumansTableContent() {
       applicationFilter,
       debouncedFieldFilters,
       ratingFilter,
-      enrichedFilter,
     ),
     enabled: !requiresPopupForFilter,
     placeholderData: keepPreviousData,
@@ -442,10 +389,6 @@ function HumansTableContent() {
           <HumansRatingFilterSelect
             value={ratingFilter}
             onValueChange={handleRatingFilterChange}
-          />
-          <HumansEnrichedFilterSelect
-            value={enrichedFilter}
-            onValueChange={handleEnrichedFilterChange}
           />
           <HumansFieldFilters
             value={fieldFilters}


### PR DESCRIPTION
Follow-ups on the Rich Profiles backoffice feature (PR #388), rebuilt cleanly on top of current \`dev\`.

## Frontend (backoffice — Human detail view)
- **Declared panel** (`DeclaredFieldsCard`): read-time tidy render of an application's `custom_fields` against the live form schema (label / type / order / section). Declared data is shown in its source, never copied into `enriched_profile`, so it never goes stale if the user edits it.
- **Two-column layout** (`$id.edit.tsx`, Details tab): `Rich profile | Declared` side by side (full width), `Comments` below. Activity tab unchanged.
- **Fix Sources 404** (`EnrichedProfileCard`): provenance facts stored evidence two ways — a valid `https://t.me/c/<chat>/<msg>` link and a bare `chat_id:message_id` that the browser resolved as a relative path → 404. Both are now normalized to a valid Telegram deep link, labelled by group.
- Drop the buggy "Has rich profile" list filter (it filtered on `enriched_profile IS NOT NULL`, counting empty profiles as "has").

## Backend (mapping table)
- `human_telegram_links`: internal identity index binding a numeric Telegram id to a human, kept **separate** from the user-owned `humans.telegram` (a derived handle is never written back). Model + `TelegramLinkMethod` enum + migration.
- The migration is **idempotent** (skips creation if the table already exists): prod received this table out-of-band ahead of the dev→prod pipeline, so a later pipeline run no-ops on it and just advances the alembic version.

## Notes
- `tsc` + `biome` clean on touched files; backend compiles.
- The enrichment **data** (profiles, facts, 783 telegram links) is already applied directly in prod; this PR is the **code/schema** only.
- Heads-up for the eventual dev→prod deploy of this feature family: prod's rich-profiles schema isn't recorded in prod's alembic history, and the `rich_profiles` (b8d2…) / `tenant-smtp` (d9e6…) migrations are siblings that will need a merge migration when both reach the integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)