### PR TITLE
chore(alembic): merge tenant-smtp + telegram-links heads (single head)

### DIFF
--- a/backend/app/alembic/versions/e7a1c93f2b6d_merge_smtp_and_telegram_links_heads.py
+++ b/backend/app/alembic/versions/e7a1c93f2b6d_merge_smtp_and_telegram_links_heads.py
@@ -1,0 +1,34 @@
+"""merge tenant-smtp and human-telegram-links heads
+
+Two independent feature branches each advanced the migration graph from a shared
+ancestor and were never collapsed, leaving the tree with two heads:
+
+  - ``d9e6f4b2a1c3`` (tenant SMTP settings)
+  - ``d3a91f7c5e82`` (human_telegram_links) -> b8d2f3a47c19 (rich profiles)
+
+``backend/scripts/prestart.sh`` runs ``alembic upgrade head`` (singular) with
+``set -e`` on every boot, which errors out ("Multiple head revisions are present")
+whenever more than one head exists — so this no-op merge restores a single head and
+keeps deploys (dev and prod) able to upgrade cleanly. The work itself was applied by
+the two parent migrations; there is nothing to do here.
+
+Revision ID: e7a1c93f2b6d
+Revises: d9e6f4b2a1c3, d3a91f7c5e82
+Create Date: 2026-06-26
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "e7a1c93f2b6d"
+down_revision: str | Sequence[str] | None = ("d9e6f4b2a1c3", "d3a91f7c5e82")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
dev currently has **two alembic heads** — `d9e6f4b2a1c3` (tenant SMTP) and `d3a91f7c5e82` (human_telegram_links, ← rich profiles). `backend/scripts/prestart.sh` runs `alembic upgrade head` (singular) under `set -e`, which errors with "Multiple head revisions are present" whenever there's more than one head — so the backend would fail to boot on deploy.

This adds a **no-op merge migration** collapsing the two heads into one (`e7a1c93f2b6d`). Standard pattern in this repo (cf. `baa61e35a1e5`, `0d62c955bfdf`, …).

Effect on prod when dev→main releases: prod (at `d9e6`) upgrades to the merge head by applying `d3a91` (idempotent — the table already exists, so it no-ops) + this no-op merge. Clean.

Makes `dev` single-head and release-ready, so a `dev→main` PR can be merged by anyone without hitting the multi-head error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)