### PR TITLE
fix(payment): apply contribution and defer coupon use in open checkout

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -742,9 +742,23 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 payment.coupon_id = coupon.id
                 payment.coupon_code = coupon.code
                 payment.discount_value = discount_value
-                coupons_crud.use_coupon(session, coupon.id)
+                # Consumption is deferred until the payment is persisted (the
+                # zero-amount commit or the post-SimpleFi commit below) so a
+                # provider failure never burns a single-use code. Mirrors the
+                # application flow.
 
             payment.amount = discountable_amount + non_discountable_amount
+
+            # Contribution fee (mandatory when the popup enables it — no buyer
+            # opt-in). Open checkout has no insurance, so the post-discount
+            # subtotal is the contribution base, matching the portal display.
+            # Mirrors the application flow in _apply_discounts.
+            if popup.contribution_enabled and popup.contribution_percentage:
+                contribution_amount = calculate_contribution_amount(
+                    popup, payment.amount
+                )
+                payment.contribution_amount = contribution_amount
+                payment.amount += contribution_amount
 
             # Resolve the open-checkout success redirect once, reused by the
             # zero-amount bypass (returned as redirect_url) and the paid path
@@ -778,6 +792,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             # this, the open-ticketing buyer never received tickets nor the
             # confirmation email).
             if payment.amount == Decimal("0"):
+                # A 100% coupon zeroed the cart: consume it now, alongside the
+                # auto-approval, since this branch never reaches SimpleFi.
+                if payment.coupon_id:
+                    coupons_crud.use_coupon(session, payment.coupon_id)
                 self._finalize_zero_amount_payment(
                     session,
                     payment,
@@ -881,6 +899,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 0 if simplefi_response.is_installment_plan else None
             )
             session.add(payment)
+            # Consume the coupon only now that SimpleFi accepted the payment, so
+            # a provider failure above never burns a single-use code.
+            if payment.coupon_id:
+                coupons_crud.use_coupon(session, payment.coupon_id)
             session.commit()
             session.refresh(payment)
             # Paid flow: SimpleFi performs the success redirect itself (to the

--- a/backend/tests/api/payment/test_contribution_integration.py
+++ b/backend/tests/api/payment/test_contribution_integration.py
@@ -5,12 +5,13 @@ Scenarios covered:
   - SCN-02: contribution disabled → preview has contribution_amount=0
   - SCN-04: enabled + null percentage → contribution_amount=0
   - SCN-07: insurance + contribution both enabled → parallel fees, no compounding
-  - SCN-08: direct-sale (sale_type=direct) → contribution NOT applied
+  - SCN-08: Payments.contribution_amount column defaults to 0 when not set
 
-SCN-08 note: The direct-sale flow uses create_open_ticketing_payment, which does
-NOT call _apply_discounts — it builds Payments directly with amount=0 and no
-contribution. Contribution is naturally excluded from the direct-sale path
-because it runs through a completely separate code path.
+SCN-08 note: The direct-sale / open-checkout flow uses create_open_ticketing_payment,
+a separate code path from _apply_discounts. It DOES apply contribution — covered by
+test_create_open_ticketing_payment.py::test_create_open_ticketing_payment_applies_contribution.
+The test here only guards the column server_default (0, not NULL) for payments built
+without an explicit contribution_amount.
 """
 
 import uuid
@@ -322,12 +323,13 @@ class TestContributionInApplyDiscounts:
         )
 
 
-class TestDirectSaleExclusion:
-    """SCN-08: Direct-sale flow excludes contribution (different code path).
+class TestContributionColumnDefault:
+    """SCN-08: Payments.contribution_amount defaults to 0 when not explicitly set.
 
-    The create_open_ticketing_payment path does not call _apply_discounts,
-    so contribution is naturally excluded. We verify the Payments model
-    has contribution_amount=0 default when no calculation runs.
+    Guards the column server_default so any flow that skips the contribution
+    calculation (e.g. a contribution-disabled popup) yields 0 on the row rather
+    than NULL. The open-checkout flow DOES apply contribution — see
+    test_create_open_ticketing_payment.py.
     """
 
     def test_payments_model_has_zero_contribution_amount_by_default(
@@ -337,8 +339,8 @@ class TestDirectSaleExclusion:
     ) -> None:
         """SCN-08: Payments created without contribution_amount → defaults to 0.
 
-        This validates the column default and that the direct-sale path
-        (which never calls calculate_contribution_amount) yields 0 on the row.
+        Validates the column server_default for payments built without an
+        explicit contribution_amount.
         """
         from app.api.payment.models import Payments
         from app.api.payment.schemas import PaymentStatus
@@ -351,8 +353,8 @@ class TestDirectSaleExclusion:
             sale_type=SaleType.direct,
         )
 
-        # Simulate what create_open_ticketing_payment does: build Payments
-        # WITHOUT passing contribution_amount — the server_default kicks in.
+        # Build Payments WITHOUT passing contribution_amount — the
+        # server_default kicks in and the row lands at 0, not NULL.
         payment = Payments(
             tenant_id=tenant_a.id,
             popup_id=popup.id,

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -29,7 +29,14 @@ from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
 
 
-def _make_popup(db: Session, tenant: Tenants, *, slug_prefix: str = "ot") -> Popups:
+def _make_popup(
+    db: Session,
+    tenant: Tenants,
+    *,
+    slug_prefix: str = "ot",
+    contribution_enabled: bool = False,
+    contribution_percentage: str | None = None,
+) -> Popups:
     popup = Popups(
         id=uuid.uuid4(),
         tenant_id=tenant.id,
@@ -39,6 +46,10 @@ def _make_popup(db: Session, tenant: Tenants, *, slug_prefix: str = "ot") -> Pop
         status="active",
         simplefi_api_key="simplefi_test_key",
         currency="USD",
+        contribution_enabled=contribution_enabled,
+        contribution_percentage=Decimal(contribution_percentage)
+        if contribution_percentage
+        else None,
     )
     db.add(popup)
     db.flush()
@@ -432,6 +443,43 @@ def test_create_open_ticketing_payment_rolls_back_payment_artifacts_on_provider_
     assert attendee_products == []
 
 
+def test_create_open_ticketing_payment_does_not_consume_coupon_on_provider_failure(
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """A coupon is consumed only after SimpleFI accepts the payment. A provider
+    failure must NOT burn a single-use code. Regression: the open-checkout path
+    used to consume the coupon before the SimpleFI call, creating false uses."""
+    popup = _make_popup(db, tenant_a, slug_prefix="coupon-rollback")
+    product = _make_product(db, popup, name="GA", price="100.00")
+    coupon = _make_coupon(db, popup, code="SAFE10", discount_value=10)
+    db.commit()
+
+    obj = _purchase_create(
+        email="buyer@test.com",
+        first_name="Matias",
+        last_name="Walter",
+        products=[(product, 2)],
+        form_data={},
+        coupon_code="SAFE10",
+    )
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.side_effect = RuntimeError("boom")
+
+        with pytest.raises(HTTPException):
+            payments_crud.create_open_ticketing_payment(
+                db,
+                obj=obj,
+                popup=popup,
+                tenant=tenant_a,
+            )
+
+    db.expire(coupon)
+    db.refresh(coupon)
+    assert coupon.current_uses == 0
+
+
 def test_create_open_ticketing_payment_applies_coupon_discount(
     db: Session,
     tenant_a: Tenants,
@@ -474,6 +522,57 @@ def test_create_open_ticketing_payment_applies_coupon_discount(
     db.expire(coupon)
     db.refresh(coupon)
     assert coupon.current_uses == 1
+
+
+def test_create_open_ticketing_payment_applies_contribution(
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Popup-level contribution fee is added to the open-checkout total, persisted
+    on the payment, and sent to SimpleFI. Regression: the festival popup showed the
+    contribution in checkout but never charged it (separate code path from
+    _apply_discounts)."""
+    popup = _make_popup(
+        db,
+        tenant_a,
+        slug_prefix="contribution",
+        contribution_enabled=True,
+        contribution_percentage="10.00",
+    )
+    product = _make_product(db, popup, name="GA", price="100.00")
+    db.commit()
+
+    obj = _purchase_create(
+        email="buyer@test.com",
+        first_name="Matias",
+        last_name="Walter",
+        products=[(product, 2)],
+        form_data={},
+    )
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_open_ticketing_contribution",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/contribution",
+            is_installment_plan=False,
+        )
+
+        payment, _, _ = payments_crud.create_open_ticketing_payment(
+            db,
+            obj=obj,
+            popup=popup,
+            tenant=tenant_a,
+        )
+
+        sent_amount = mock_get_client.return_value.create_payment.call_args.kwargs[
+            "amount"
+        ]
+
+    # 2 × $100 = $200 base, + 10% contribution = $20 → $220 grand total
+    assert payment.contribution_amount == Decimal("20.00")
+    assert payment.amount == Decimal("220.00")
+    assert sent_amount == Decimal("220.00")
 
 
 def test_create_open_ticketing_payment_100_percent_coupon_auto_approves(


### PR DESCRIPTION
## Problem

Open checkout (`create_open_ticketing_payment`, `sale_type=direct` / festival popups) runs in a code path separate from the application flow and diverged from it in two ways. Both were observed in production on a festival popup.

### 1. Contribution fee not charged
The popup-level contribution fee was rendered in the portal checkout and added to the displayed cart total, but the backend open-checkout path never computed it. As a result it was neither added to the payment record nor sent to SimpleFi, so buyers were charged less than what the portal showed.

### 2. Coupon consumed before payment confirmation
The coupon was consumed (`use_coupon`) before the SimpleFi call. A provider failure rolled back the local payment but the coupon use was already committed, burning a single-use code for an order that never completed.

## Fix

- **Contribution**: compute it on the post-discount subtotal (open checkout has no insurance), matching the application flow in `_apply_discounts` and the portal display. Persist `contribution_amount` and include it in the amount sent to SimpleFi.
- **Coupon**: defer consumption until the payment is persisted — the zero-amount commit (100% coupon) or the post-SimpleFi commit. Validation and discount still happen early since the amount depends on them; only consumption moves. Concurrency safety is unchanged: `use_coupon`'s conditional `UPDATE (current_uses < max_uses)` still serializes simultaneous redemptions.

## Tests

- `test_create_open_ticketing_payment_applies_contribution` — contribution included in the charged amount and the amount sent to SimpleFi.
- `test_create_open_ticketing_payment_does_not_consume_coupon_on_provider_failure` — coupon not consumed when the provider fails.
- Updated the SCN-08 narrative in `test_contribution_integration.py`, which previously documented the buggy "open checkout excludes contribution" behavior as expected.

All open-ticketing and contribution tests pass; ruff check + format clean.