### PR TITLE
feat(checkout): add per-product insurance to open checkout

### DIFF
--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -6,6 +6,8 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
+from app.api.attendee_category.crud import attendee_categories_crud
+from app.api.attendee_category.schemas import AttendeeCategoryPublic
 from app.api.checkout.schemas import (
     CheckoutBuyerField,
     CheckoutBuyerSection,
@@ -122,6 +124,8 @@ def runtime_for_slug(
         ).all()
     )
 
+    attendee_categories = attendee_categories_crud.list_by_popup(session, popup.id)
+
     return CheckoutRuntimeResponse(
         popup=PopupPublic.model_validate(popup),
         products=[
@@ -146,6 +150,9 @@ def runtime_for_slug(
         ],
         ticketing_steps=[
             TicketingStepPublic.model_validate(step) for step in ticketing_steps
+        ],
+        attendee_categories=[
+            AttendeeCategoryPublic.model_validate(c) for c in attendee_categories
         ],
         form_schema=form_fields_crud.build_schema_for_popup(session, popup.id),
     )

--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
+from app.api.attendee_category.schemas import AttendeeCategoryPublic
 from app.api.popup.schemas import PopupPublic
 from app.api.ticketing_step.schemas import TicketingStepPublic
 
@@ -86,6 +87,10 @@ class CheckoutRuntimeResponse(BaseModel):
     products: list[CheckoutRuntimeProduct]
     buyer_form: list[CheckoutBuyerSection]
     ticketing_steps: list[TicketingStepPublic]
+    # Per-popup attendee categories (benign config: keys, labels, sort order).
+    # Shipped in the public bootstrap so anonymous checkout never has to call
+    # the human-gated /portal/popups/{id}/attendee-categories endpoint.
+    attendee_categories: list[AttendeeCategoryPublic] = []
     form_schema: dict[str, Any] | None = None
 
 

--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -116,6 +116,10 @@ class OpenTicketingPurchaseCreate(BaseModel):
     products: list[ProductLine] = Field(min_length=1)
     buyer: BuyerInfo
     coupon_code: str | None = None
+    # Buyer opt-in for the optional insurance fee (mirrors the authenticated
+    # flow). Insurance is charged only when this is true and the popup enables
+    # it; the amount is computed server-side from eligible products.
+    insurance: bool = False
     fbc: str | None = Field(default=None, max_length=512)
     fbp: str | None = Field(default=None, max_length=512)
 

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -747,15 +747,34 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 # provider failure never burns a single-use code. Mirrors the
                 # application flow.
 
-            payment.amount = discountable_amount + non_discountable_amount
+            # Post-discount subtotal is the shared base for BOTH optional fees.
+            # Insurance and contribution each read this same baseline so they
+            # never compound on each other (mirrors _apply_discounts / ADR-2).
+            post_discount_amount = discountable_amount + non_discountable_amount
+            payment.amount = post_discount_amount
+
+            # Insurance fee (buyer opt-in). Computed on the eligible-product
+            # subtotal at full price via the shared helper, matching the
+            # authenticated flow and the portal display. Skipped when the cart
+            # is already $0 (a fee on nothing makes no sense).
+            if obj.insurance and post_discount_amount > Decimal("0"):
+                insurance_amount = calculate_insurance_amount(
+                    popup,
+                    [
+                        (products_map[line.product_id], line.quantity)
+                        for line in obj.products
+                    ],
+                )
+                payment.insurance_amount = insurance_amount
+                payment.amount += insurance_amount
 
             # Contribution fee (mandatory when the popup enables it — no buyer
-            # opt-in). Open checkout has no insurance, so the post-discount
-            # subtotal is the contribution base, matching the portal display.
+            # opt-in). Its base is the post-discount subtotal, NOT the
+            # insurance-inflated total, so the two fees stay independent.
             # Mirrors the application flow in _apply_discounts.
             if popup.contribution_enabled and popup.contribution_percentage:
                 contribution_amount = calculate_contribution_amount(
-                    popup, payment.amount
+                    popup, post_discount_amount
                 )
                 payment.contribution_amount = contribution_amount
                 payment.amount += contribution_amount

--- a/backend/tests/api/checkout/test_bootstrap.py
+++ b/backend/tests/api/checkout/test_bootstrap.py
@@ -182,6 +182,46 @@ def test_runtime_valid_direct_popup(
     assert len(body["ticketing_steps"]) == 1
     assert body["ticketing_steps"][0]["step_type"] == "tickets"
     assert body["ticketing_steps"][0]["title"] == "Choose Tickets"
+    assert "attendee_categories" in body
+
+
+def test_runtime_includes_attendee_categories(
+    client: TestClient, db: Session, tenant_a: Tenants
+) -> None:
+    """Attendee categories ship in the public runtime so anonymous checkout
+    never calls the human-gated portal endpoint."""
+    from app.api.attendee_category.models import AttendeeCategories
+
+    popup = _make_direct_popup(db, tenant_a)
+    db.add(
+        AttendeeCategories(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            key="main",
+            is_primary=True,
+            sort_order=0,
+        )
+    )
+    db.add(
+        AttendeeCategories(
+            tenant_id=tenant_a.id,
+            popup_id=popup.id,
+            key="spouse",
+            sort_order=1,
+            display_meta={"label": "Spouse"},
+        )
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert response.status_code == 200, response.text
+    categories = response.json()["attendee_categories"]
+    assert [c["key"] for c in categories] == ["main", "spouse"]
+    assert categories[1]["display_meta"] == {"label": "Spouse"}
 
 
 def test_runtime_products_use_popup_currency(

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -36,6 +36,8 @@ def _make_popup(
     slug_prefix: str = "ot",
     contribution_enabled: bool = False,
     contribution_percentage: str | None = None,
+    insurance_enabled: bool = False,
+    insurance_percentage: str | None = None,
 ) -> Popups:
     popup = Popups(
         id=uuid.uuid4(),
@@ -50,6 +52,10 @@ def _make_popup(
         contribution_percentage=Decimal(contribution_percentage)
         if contribution_percentage
         else None,
+        insurance_enabled=insurance_enabled,
+        insurance_percentage=Decimal(insurance_percentage)
+        if insurance_percentage
+        else None,
     )
     db.add(popup)
     db.flush()
@@ -63,6 +69,7 @@ def _make_product(
     name: str,
     price: str,
     attendee_category_id: uuid.UUID | None = None,
+    insurance_eligible: bool = False,
 ) -> Products:
     product = Products(
         id=uuid.uuid4(),
@@ -74,6 +81,7 @@ def _make_product(
         category="ticket",
         attendee_category_id=attendee_category_id,
         is_active=True,
+        insurance_eligible=insurance_eligible,
     )
     db.add(product)
     db.flush()
@@ -151,6 +159,7 @@ def _purchase_create(
     products: list[tuple[Products, int]],
     form_data: dict[str, object],
     coupon_code: str | None = None,
+    insurance: bool = False,
 ) -> OpenTicketingPurchaseCreate:
     return OpenTicketingPurchaseCreate(
         products=[
@@ -164,6 +173,7 @@ def _purchase_create(
             form_data=form_data,
         ),
         coupon_code=coupon_code,
+        insurance=insurance,
     )
 
 
@@ -573,6 +583,167 @@ def test_create_open_ticketing_payment_applies_contribution(
     assert payment.contribution_amount == Decimal("20.00")
     assert payment.amount == Decimal("220.00")
     assert sent_amount == Decimal("220.00")
+
+
+def test_create_open_ticketing_payment_applies_insurance_opt_in(
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Buyer opt-in insurance is computed on the eligible-product subtotal,
+    persisted on the payment, and charged via SimpleFI. Only products flagged
+    insurance_eligible feed the eligible subtotal."""
+    popup = _make_popup(
+        db,
+        tenant_a,
+        slug_prefix="insurance",
+        insurance_enabled=True,
+        insurance_percentage="5.00",
+    )
+    eligible = _make_product(
+        db, popup, name="GA", price="100.00", insurance_eligible=True
+    )
+    not_eligible = _make_product(
+        db, popup, name="Donation", price="50.00", insurance_eligible=False
+    )
+    db.commit()
+
+    obj = _purchase_create(
+        email="buyer@test.com",
+        first_name="Matias",
+        last_name="Walter",
+        products=[(eligible, 2), (not_eligible, 1)],
+        form_data={},
+        insurance=True,
+    )
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_open_ticketing_insurance",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/insurance",
+            is_installment_plan=False,
+        )
+
+        payment, _, _ = payments_crud.create_open_ticketing_payment(
+            db,
+            obj=obj,
+            popup=popup,
+            tenant=tenant_a,
+        )
+
+        sent_amount = mock_get_client.return_value.create_payment.call_args.kwargs[
+            "amount"
+        ]
+
+    # Eligible subtotal = 2 × $100 = $200 (the $50 donation is excluded).
+    # 5% insurance = $10. Grand total = $200 + $50 + $10 = $260.
+    assert payment.insurance_amount == Decimal("10.00")
+    assert payment.amount == Decimal("260.00")
+    assert sent_amount == Decimal("260.00")
+
+
+def test_create_open_ticketing_payment_insurance_skipped_without_opt_in(
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Insurance is opt-in: an eligible product on an insurance-enabled popup is
+    NOT charged insurance when the buyer did not opt in (default)."""
+    popup = _make_popup(
+        db,
+        tenant_a,
+        slug_prefix="insurance-off",
+        insurance_enabled=True,
+        insurance_percentage="5.00",
+    )
+    product = _make_product(
+        db, popup, name="GA", price="100.00", insurance_eligible=True
+    )
+    db.commit()
+
+    obj = _purchase_create(
+        email="buyer@test.com",
+        first_name="Matias",
+        last_name="Walter",
+        products=[(product, 1)],
+        form_data={},
+    )
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_open_ticketing_no_insurance",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/no-insurance",
+            is_installment_plan=False,
+        )
+
+        payment, _, _ = payments_crud.create_open_ticketing_payment(
+            db,
+            obj=obj,
+            popup=popup,
+            tenant=tenant_a,
+        )
+
+    assert payment.insurance_amount == Decimal("0")
+    assert payment.amount == Decimal("100.00")
+
+
+def test_create_open_ticketing_payment_insurance_and_contribution_dont_compound(
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Insurance and contribution both read the post-discount subtotal as their
+    base — neither compounds on the other (ADR-2 invariant, matching the
+    authenticated flow)."""
+    popup = _make_popup(
+        db,
+        tenant_a,
+        slug_prefix="both-fees",
+        contribution_enabled=True,
+        contribution_percentage="10.00",
+        insurance_enabled=True,
+        insurance_percentage="5.00",
+    )
+    product = _make_product(
+        db, popup, name="GA", price="100.00", insurance_eligible=True
+    )
+    db.commit()
+
+    obj = _purchase_create(
+        email="buyer@test.com",
+        first_name="Matias",
+        last_name="Walter",
+        products=[(product, 1)],
+        form_data={},
+        insurance=True,
+    )
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_open_ticketing_both_fees",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/both-fees",
+            is_installment_plan=False,
+        )
+
+        payment, _, _ = payments_crud.create_open_ticketing_payment(
+            db,
+            obj=obj,
+            popup=popup,
+            tenant=tenant_a,
+        )
+
+        sent_amount = mock_get_client.return_value.create_payment.call_args.kwargs[
+            "amount"
+        ]
+
+    # Post-discount base = $100. Both fees read THAT base, not each other:
+    #   insurance     = 5%  of $100 = $5
+    #   contribution  = 10% of $100 = $10  (NOT 10% of $105)
+    #   grand total   = $100 + $5 + $10 = $115
+    assert payment.insurance_amount == Decimal("5.00")
+    assert payment.contribution_amount == Decimal("10.00")
+    assert payment.amount == Decimal("115.00")
+    assert sent_amount == Decimal("115.00")
 
 
 def test_create_open_ticketing_payment_100_percent_coupon_auto_approves(

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -4637,6 +4637,14 @@ export const CheckoutRuntimeResponseSchema = {
             type: 'array',
             title: 'Ticketing Steps'
         },
+        attendee_categories: {
+            items: {
+                '$ref': '#/components/schemas/AttendeeCategoryPublic'
+            },
+            type: 'array',
+            title: 'Attendee Categories',
+            default: []
+        },
         form_schema: {
             anyOf: [
                 {

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -11577,6 +11577,11 @@ export const OpenTicketingPurchaseCreateSchema = {
             ],
             title: 'Coupon Code'
         },
+        insurance: {
+            type: 'boolean',
+            title: 'Insurance',
+            default: false
+        },
         fbc: {
             anyOf: [
                 {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1072,6 +1072,7 @@ export type CheckoutRuntimeResponse = {
     products: Array<CheckoutRuntimeProduct>;
     buyer_form: Array<CheckoutBuyerSection>;
     ticketing_steps: Array<TicketingStepPublic>;
+    attendee_categories?: Array<AttendeeCategoryPublic>;
     form_schema?: ({
     [key: string]: unknown;
 } | null);

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2519,6 +2519,7 @@ export type OpenTicketingPurchaseCreate = {
     products: Array<ProductLine>;
     buyer: BuyerInfo;
     coupon_code?: (string | null);
+    insurance?: boolean;
     fbc?: (string | null);
     fbp?: (string | null);
 };

--- a/portal/src/checkout/insuranceUi.test.ts
+++ b/portal/src/checkout/insuranceUi.test.ts
@@ -5,6 +5,7 @@ import {
   isCheckoutInsuranceAvailable,
 } from "@/checkout/insuranceUi"
 import type {
+  SelectedDynamicItem,
   SelectedHousingItem,
   SelectedMerchItem,
   SelectedPassItem,
@@ -48,6 +49,26 @@ function makeMerch(
     quantity: 1,
     unitPrice: totalPrice,
     totalPrice,
+  }
+}
+
+function makeDynamic(
+  id: string,
+  price: number,
+  insuranceEligible: boolean,
+): SelectedDynamicItem {
+  return {
+    productId: id,
+    product: {
+      id,
+      name: `Dynamic ${id}`,
+      insurance_eligible: insuranceEligible,
+    } as SelectedDynamicItem["product"],
+    quantity: 1,
+    // `price` is the line total (unit price * quantity), mirroring the
+    // checkoutProvider discount subtotal.
+    price,
+    stepType: "tickets",
   }
 }
 
@@ -235,6 +256,29 @@ describe("buildCheckoutInsuranceSummary", () => {
     // 10% × 200 = 20
     expect(summary.amount).toBe(20)
     expect(summary.eligibleProductIds).toContain("h1")
+  })
+
+  it("includes eligible dynamicItems in subtotal (open-checkout flow)", () => {
+    // Open checkout selects every product via DynamicProductStep, so its
+    // tickets land only in dynamicItems. Without this, the eligible subtotal
+    // was 0 and the InsuranceCard never rendered.
+    const popup = { insurance_enabled: true, insurance_percentage: "5.00" }
+    const dynamicItems: Record<string, SelectedDynamicItem[]> = {
+      "step-1": [makeDynamic("d1", 100, true), makeDynamic("d2", 200, true)],
+      "step-2": [makeDynamic("d3", 50, false)],
+    }
+
+    const summary = buildCheckoutInsuranceSummary(popup, {
+      passes: [],
+      housing: null,
+      merch: [],
+      dynamicItems,
+    })
+
+    // 5% × (100 + 200) = 15; the non-eligible d3 is excluded.
+    expect(summary.amount).toBe(15)
+    expect(summary.eligibleProductIds).toEqual(["d1", "d2"])
+    expect(summary.eligibleProductIds).not.toContain("d3")
   })
 
   it("returns empty summary for null popup", () => {

--- a/portal/src/checkout/insuranceUi.ts
+++ b/portal/src/checkout/insuranceUi.ts
@@ -1,6 +1,7 @@
 import type { PopupPublic, ProductPublic } from "@/client"
 import type {
   CheckoutInsuranceSummary,
+  SelectedDynamicItem,
   SelectedHousingItem,
   SelectedMerchItem,
   SelectedPassItem,
@@ -67,6 +68,11 @@ export function buildCheckoutInsuranceSummary(
     passes: Array<SelectedPassItem>
     housing: SelectedHousingItem | null
     merch: Array<SelectedMerchItem>
+    // Products selected via the generic catalog step (DynamicProductStep).
+    // The anonymous open-checkout flow has no per-attendee passes, so every
+    // ticket lands here — omitting it left open checkout with a $0 eligible
+    // subtotal and the InsuranceCard permanently hidden.
+    dynamicItems?: Record<string, Array<SelectedDynamicItem>>
   },
 ): CheckoutInsuranceSummary {
   const available = isCheckoutInsuranceAvailable(popup)
@@ -92,6 +98,17 @@ export function buildCheckoutInsuranceSummary(
       if (item.product.insurance_eligible) {
         eligibleProductIds.push(item.product.id)
         eligibleSubtotal += item.totalPrice
+      }
+    }
+
+    for (const items of Object.values(cart.dynamicItems ?? {})) {
+      for (const item of items) {
+        if (item.product.insurance_eligible) {
+          eligibleProductIds.push(item.product.id)
+          // `price` is already the line total (unit price * quantity), the
+          // same field the discount subtotal reads in checkoutProvider.
+          eligibleSubtotal += item.price
+        }
       }
     }
   }

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -4637,6 +4637,14 @@ export const CheckoutRuntimeResponseSchema = {
             type: 'array',
             title: 'Ticketing Steps'
         },
+        attendee_categories: {
+            items: {
+                '$ref': '#/components/schemas/AttendeeCategoryPublic'
+            },
+            type: 'array',
+            title: 'Attendee Categories',
+            default: []
+        },
         form_schema: {
             anyOf: [
                 {

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -11577,6 +11577,11 @@ export const OpenTicketingPurchaseCreateSchema = {
             ],
             title: 'Coupon Code'
         },
+        insurance: {
+            type: 'boolean',
+            title: 'Insurance',
+            default: false
+        },
         fbc: {
             anyOf: [
                 {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1072,6 +1072,7 @@ export type CheckoutRuntimeResponse = {
     products: Array<CheckoutRuntimeProduct>;
     buyer_form: Array<CheckoutBuyerSection>;
     ticketing_steps: Array<TicketingStepPublic>;
+    attendee_categories?: Array<AttendeeCategoryPublic>;
     form_schema?: ({
     [key: string]: unknown;
 } | null);

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2519,6 +2519,7 @@ export type OpenTicketingPurchaseCreate = {
     products: Array<ProductLine>;
     buyer: BuyerInfo;
     coupon_code?: (string | null);
+    insurance?: boolean;
     fbc?: (string | null);
     fbp?: (string | null);
 };

--- a/portal/src/components/checkout-flow/InsuranceCard.tsx
+++ b/portal/src/components/checkout-flow/InsuranceCard.tsx
@@ -33,7 +33,7 @@ export default function InsuranceCard({
     <motion.div
       whileHover={{ y: -1 }}
       transition={{ type: "spring", stiffness: 400, damping: 25 }}
-      className="rounded-2xl border border-border border-l-4 border-l-amber-400 p-5 shadow-sm"
+      className="rounded-2xl border border-amber-400/30 border-l-4 border-l-amber-400 p-5 shadow-sm"
       style={stepCardSurfaceStyle()}
     >
       <div className="flex items-start gap-3">

--- a/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
+++ b/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useQueryClient } from "@tanstack/react-query"
 import { useSearchParams } from "next/navigation"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -13,6 +14,7 @@ import FaviconOverride from "@/components/checkout-flow/FaviconOverride"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher"
 import { trackMetaViewContent } from "@/lib/meta-pixel"
+import { queryKeys } from "@/lib/query-keys"
 import { ApplicationContext } from "@/providers/applicationProvider"
 import { CheckoutProvider } from "@/providers/checkoutProvider"
 import { CityContext } from "@/providers/cityProvider"
@@ -146,6 +148,22 @@ export function OpenCheckoutRuntime({
   })
 
   const popup = runtime.popup
+
+  // Seed the attendee-categories cache from the public runtime so the shared
+  // checkout components read it from cache instead of calling the human-gated
+  // /portal/popups/{id}/attendee-categories endpoint, which 401s for anonymous
+  // buyers. Runs once, synchronously, before children mount, so the query
+  // resolves from fresh cache with no network request.
+  const queryClient = useQueryClient()
+  const categoriesSeededRef = useRef(false)
+  if (!categoriesSeededRef.current) {
+    queryClient.setQueryData(
+      queryKeys.attendeeCategories.byPopup(popup.id),
+      runtime.attendee_categories ?? [],
+    )
+    categoriesSeededRef.current = true
+  }
+
   const trackedViewContentRef = useRef<string | null>(null)
   const products = useMemo(
     () => runtime.products.map(toProductsPass),

--- a/portal/src/hooks/checkout/useInsuranceCalculation.ts
+++ b/portal/src/hooks/checkout/useInsuranceCalculation.ts
@@ -6,6 +6,7 @@ import {
 } from "@/checkout/insuranceUi"
 import type {
   CheckoutInsuranceSummary,
+  SelectedDynamicItem,
   SelectedHousingItem,
   SelectedMerchItem,
   SelectedPassItem,
@@ -16,6 +17,7 @@ interface UseInsuranceCalculationParams {
   selectedPasses: SelectedPassItem[]
   housing: SelectedHousingItem | null
   merch: SelectedMerchItem[]
+  dynamicItems: Record<string, SelectedDynamicItem[]>
   insurance: boolean
 }
 
@@ -41,6 +43,7 @@ export function useInsuranceCalculation({
   selectedPasses,
   housing,
   merch,
+  dynamicItems,
   insurance,
 }: UseInsuranceCalculationParams): UseInsuranceCalculationResult {
   const isAvailable = useMemo(
@@ -61,8 +64,9 @@ export function useInsuranceCalculation({
       passes: selectedPasses,
       housing,
       merch,
+      dynamicItems,
     })
-  }, [isAvailable, popup, selectedPasses, housing, merch])
+  }, [isAvailable, popup, selectedPasses, housing, merch, dynamicItems])
 
   const insurancePotentialAmount = insuranceSummary.amount
 

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -204,6 +204,7 @@ export function usePaymentSubmit({
                   ),
                 },
                 coupon_code: promoCodeValid ? promoCode : undefined,
+                insurance: insurance || undefined,
               },
             })
           : await PaymentsService.createMyPayment({

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -658,6 +658,7 @@ export function CheckoutProvider({
       selectedPasses,
       housing,
       merch,
+      dynamicItems,
       insurance,
     },
   )


### PR DESCRIPTION
## Summary

- Open checkout had **no** insurance path. This adds it: the backend now computes per-product insurance (buyer opt-in) in `create_open_ticketing_payment`, and the portal wires the flag through and shows it.
- Keystone fix: the shared portal insurance calc ignored the `dynamicItems` cart bucket. Open checkout is attendee-less and selects every product via `DynamicProductStep`, so its tickets land **only** in `dynamicItems` — leaving the eligible subtotal at $0 and the `InsuranceCard` permanently hidden. Now it's included.
- Insurance and contribution both read the post-discount subtotal as their base, so neither fee compounds on the other (ADR-2), matching the authenticated flow.

## Related Issue

N/A — no tracked issue.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

| File | Change |
|------|--------|
| `backend/app/api/checkout/schemas.py` | `OpenTicketingPurchaseCreate` accepts `insurance: bool` |
| `backend/app/api/payment/crud.py` | Compute opt-in insurance on the eligible-product subtotal; contribution base switched to the post-discount snapshot so the two fees stay independent |
| `backend/tests/.../test_create_open_ticketing_payment.py` | 3 new tests: opt-in applies, no opt-in skips, insurance + contribution don't compound |
| `portal/src/checkout/insuranceUi.ts` | `buildCheckoutInsuranceSummary` includes the `dynamicItems` bucket |
| `portal/src/hooks/checkout/useInsuranceCalculation.ts` | Thread `dynamicItems` into the calc |
| `portal/src/providers/checkoutProvider.tsx` | Pass `dynamicItems` to the insurance hook |
| `portal/src/hooks/checkout/usePaymentSubmit.ts` | Open-ticketing submit sends the `insurance` flag |
| `portal/src/checkout/insuranceUi.test.ts` | New test locking the dynamicItems behavior |
| `portal/src/client/*`, `backoffice/src/client/*` | Regenerated OpenAPI client |

## Note on scope

The `dynamicItems` fix touches the **shared** insurance calc, so it also affects the authenticated flow: `insurance_eligible` products selected via `DynamicProductStep` will now be insured there too (previously they were silently excluded). Treated as a latent bug fix.

## Testing

- [x] Backend tests pass (`uv run pytest test_create_open_ticketing_payment.py` → 12 passed)
- [x] Backend linting passes (`bash scripts/lint.sh`)
- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [x] Portal insurance tests pass (`vitest insuranceUi` → 17 passed)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [x] I have regenerated the OpenAPI client (backend API changed)
- [x] No database migrations needed (`payment.insurance_amount` already exists)