### PR TITLE
fix(email): deep-link accepted-email CTA to popup passes page

### DIFF
--- a/backend/app/services/email/service.py
+++ b/backend/app/services/email/service.py
@@ -117,14 +117,15 @@ def _enrich_with_popup_data(
         else None,
     }
 
-    # Build portal_url from tenant (respects active custom domain)
-    if "portal_url" not in enriched:
-        from app.api.tenant.models import Tenants
-        from app.api.tenant.utils import get_portal_url
+    # Build popup-specific URLs from tenant (respects active custom domain)
+    from app.api.tenant.models import Tenants
+    from app.api.tenant.utils import get_portal_url
 
-        tenant = db_session.get(Tenants, popup.tenant_id)
-        if tenant:
-            popup_fields["portal_url"] = get_portal_url(tenant)
+    tenant = db_session.get(Tenants, popup.tenant_id)
+    if tenant:
+        portal_base = get_portal_url(tenant).rstrip("/")
+        popup_fields["portal_url"] = portal_base
+        popup_fields["passes_url"] = f"{portal_base}/portal/{popup.slug}/passes"
 
     for key, value in popup_fields.items():
         if key not in enriched:

--- a/backend/app/services/email/templates.py
+++ b/backend/app/services/email/templates.py
@@ -59,6 +59,7 @@ class ApplicationAcceptedContext(BaseModel):
     last_name: str
     popup_name: str
     portal_url: str | None = None
+    passes_url: str | None = None
 
 
 class ApplicationRejectedContext(BaseModel):
@@ -84,6 +85,7 @@ class ApplicationAcceptedWithDiscountContext(BaseModel):
     popup_name: str
     discount_percentage: int  # e.g. 50 = "50% off", 100 = "full waiver"
     portal_url: str | None = None
+    passes_url: str | None = None
 
 
 class ApplicationAcceptedWithIncentiveContext(BaseModel):
@@ -100,6 +102,7 @@ class ApplicationAcceptedWithIncentiveContext(BaseModel):
     incentive_amount: float  # e.g. 1000.00
     incentive_currency: str  # e.g. "USD"
     portal_url: str | None = None
+    passes_url: str | None = None
 
 
 class ApplicationAcceptedScholarshipRejectedContext(BaseModel):
@@ -113,6 +116,7 @@ class ApplicationAcceptedScholarshipRejectedContext(BaseModel):
     last_name: str
     popup_name: str
     portal_url: str | None = None
+    passes_url: str | None = None
 
 
 class PaymentProductItem(BaseModel):
@@ -581,6 +585,14 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "required": False,
                 "group": "General",
             },
+            {
+                "name": "passes_url",
+                "label": "Passes URL",
+                "type": "string",
+                "description": "Deep link to this popup's passes page",
+                "required": False,
+                "group": "General",
+            },
             *_POPUP_EVENT_VARIABLES,
         ],
     },
@@ -649,6 +661,14 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "required": False,
                 "group": "General",
             },
+            {
+                "name": "passes_url",
+                "label": "Passes URL",
+                "type": "string",
+                "description": "Deep link to this popup's passes page",
+                "required": False,
+                "group": "General",
+            },
             *_POPUP_EVENT_VARIABLES,
         ],
     },
@@ -707,6 +727,14 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "required": False,
                 "group": "General",
             },
+            {
+                "name": "passes_url",
+                "label": "Passes URL",
+                "type": "string",
+                "description": "Deep link to this popup's passes page",
+                "required": False,
+                "group": "General",
+            },
             *_POPUP_EVENT_VARIABLES,
         ],
     },
@@ -738,6 +766,14 @@ POPUP_TEMPLATE_METADATA: list[dict[str, Any]] = [
                 "label": "Portal URL",
                 "type": "string",
                 "description": "Link to the attendee portal",
+                "required": False,
+                "group": "General",
+            },
+            {
+                "name": "passes_url",
+                "label": "Passes URL",
+                "type": "string",
+                "description": "Deep link to this popup's passes page",
                 "required": False,
                 "group": "General",
             },

--- a/backend/app/templates/emails/application/accepted.html
+++ b/backend/app/templates/emails/application/accepted.html
@@ -41,9 +41,9 @@
     </table>
 </div>
 
-{% if portal_url %}
+{% if passes_url or portal_url %}
 <div style="text-align: center; margin: 30px 0;">
-    <a href="{{ portal_url }}" class="button" style="background-color: #28a745;">
+    <a href="{{ passes_url or portal_url }}" class="button" style="background-color: #28a745;">
         Purchase Passes
     </a>
 </div>

--- a/backend/app/templates/emails/application/accepted_scholarship_rejected.html
+++ b/backend/app/templates/emails/application/accepted_scholarship_rejected.html
@@ -43,9 +43,9 @@
     </table>
 </div>
 
-{% if portal_url %}
+{% if passes_url or portal_url %}
 <div style="text-align: center; margin: 30px 0;">
-    <a href="{{ portal_url }}" class="button" style="background-color: #28a745;">
+    <a href="{{ passes_url or portal_url }}" class="button" style="background-color: #28a745;">
         Purchase Your Pass
     </a>
 </div>

--- a/backend/app/templates/emails/application/accepted_with_discount.html
+++ b/backend/app/templates/emails/application/accepted_with_discount.html
@@ -65,9 +65,9 @@
     </table>
 </div>
 
-{% if portal_url %}
+{% if passes_url or portal_url %}
 <div style="text-align: center; margin: 30px 0;">
-    <a href="{{ portal_url }}" class="button" style="background-color: #28a745;">
+    <a href="{{ passes_url or portal_url }}" class="button" style="background-color: #28a745;">
         Proceed to Portal
     </a>
 </div>

--- a/backend/app/templates/emails/application/accepted_with_incentive.html
+++ b/backend/app/templates/emails/application/accepted_with_incentive.html
@@ -82,9 +82,9 @@
     </table>
 </div>
 
-{% if portal_url %}
+{% if passes_url or portal_url %}
 <div style="text-align: center; margin: 30px 0;">
-    <a href="{{ portal_url }}" class="button" style="background-color: #28a745;">
+    <a href="{{ passes_url or portal_url }}" class="button" style="background-color: #28a745;">
         Proceed to Portal
     </a>
 </div>

--- a/backend/tests/test_accepted_email_passes_url.py
+++ b/backend/tests/test_accepted_email_passes_url.py
@@ -1,0 +1,93 @@
+"""Accepted-application emails must deep-link the CTA to the popup's passes page.
+
+Regression test for the "Purchase Passes" button pointing at the bare tenant
+base URL (which redirects to the first/default popup) instead of
+``/portal/{popup.slug}/passes``.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+from app.api.popup.crud import popups_crud
+from app.services.email.service import EmailService, _enrich_with_popup_data
+
+
+class _FakeDBSession:
+    """Minimal stand-in for a Session: only ``.get`` is exercised."""
+
+    def __init__(self, tenant):
+        self._tenant = tenant
+
+    def get(self, _model, _pk):
+        return self._tenant
+
+
+def _make_popup(slug: str):
+    return SimpleNamespace(
+        name="Edge Summit",
+        slug=slug,
+        tenant_id=uuid.uuid4(),
+        image_url=None,
+        icon_url=None,
+        web_url=None,
+        blog_url=None,
+        twitter_url=None,
+        start_date=None,
+        end_date=None,
+    )
+
+
+def _make_tenant(slug="acme", custom_domain=None, custom_domain_active=False):
+    return SimpleNamespace(
+        slug=slug,
+        custom_domain=custom_domain,
+        custom_domain_active=custom_domain_active,
+    )
+
+
+def test_enrich_adds_popup_specific_passes_url(monkeypatch):
+    popup = _make_popup("edge-summit")
+    monkeypatch.setattr(popups_crud, "get", lambda *a, **k: popup)
+
+    enriched = _enrich_with_popup_data(
+        {}, popup_id=uuid.uuid4(), db_session=_FakeDBSession(_make_tenant())
+    )
+
+    assert "portal_url" in enriched
+    assert "passes_url" in enriched
+    assert enriched["passes_url"] == f"{enriched['portal_url']}/portal/edge-summit/passes"
+    assert enriched["passes_url"].endswith("/portal/edge-summit/passes")
+
+
+def test_accepted_email_button_deep_links_to_passes_page(monkeypatch):
+    popup = _make_popup("edge-summit")
+    monkeypatch.setattr(popups_crud, "get", lambda *a, **k: popup)
+
+    enriched = _enrich_with_popup_data(
+        {"first_name": "Ada", "last_name": "Lovelace", "popup_name": "Edge Summit"},
+        popup_id=uuid.uuid4(),
+        db_session=_FakeDBSession(_make_tenant()),
+    )
+
+    html = EmailService().render_template("application/accepted.html", enriched)
+
+    passes_url = enriched["passes_url"]
+    portal_url = enriched["portal_url"]
+
+    # The CTA href is the popup-specific passes deep link...
+    assert f'href="{passes_url}"' in html
+    assert passes_url.endswith("/portal/edge-summit/passes")
+    # ...not the bare tenant base URL.
+    assert f'href="{portal_url}"' not in html
+
+
+def test_accepted_email_passes_url_respects_active_custom_domain(monkeypatch):
+    popup = _make_popup("edge-summit")
+    monkeypatch.setattr(popups_crud, "get", lambda *a, **k: popup)
+
+    tenant = _make_tenant(custom_domain="events.acme.com", custom_domain_active=True)
+    enriched = _enrich_with_popup_data(
+        {}, popup_id=uuid.uuid4(), db_session=_FakeDBSession(tenant)
+    )
+
+    assert enriched["passes_url"] == "https://events.acme.com/portal/edge-summit/passes"


### PR DESCRIPTION
## Context

When an application is **accepted** for a popup, the recipient gets an "application accepted" email with a CTA button ("Purchase Passes" / "Proceed to Portal" / "Purchase Your Pass"). That button linked to the **bare tenant base URL** (no popup slug, no `/passes` path), so the portal redirected the user to the first/default popup instead of the popup whose application was just accepted.

## Root cause

The acceptance context models default `portal_url=None` and emails are sent with `model_dump(exclude_none=True)`, so `portal_url` is dropped and repopulated by `_enrich_with_popup_data()` via `get_portal_url(tenant)` — which returns only the tenant base. The four acceptance templates then render `<a href="{{ portal_url }}">`, pointing at the base URL.

## Changes

- **`service.py`** — `_enrich_with_popup_data()` now always computes a popup-specific `passes_url = f"{portal_base}/portal/{popup.slug}/passes"` alongside the existing base `portal_url` (respects active custom domains via `get_portal_url`).
- **Four acceptance templates** — CTA `href` changed from `{{ portal_url }}` to `{{ passes_url or portal_url }}`, and the `{% if portal_url %}` guard to `{% if passes_url or portal_url %}` (fallback keeps custom/DB templates safe):
  - `accepted.html`, `accepted_with_discount.html`, `accepted_with_incentive.html`, `accepted_scholarship_rejected.html`
- **`templates.py`** — added `passes_url: str | None = None` to the four acceptance context models and a `passes_url` entry to each corresponding template-variable declaration list.
- **New test** `test_accepted_email_passes_url.py` — asserts the rendered accepted email's button `href` ends with `/portal/{slug}/passes` (not the bare base URL) and that the custom-domain branch is respected.

**Scope:** acceptance emails only. Check-in / payment / `received.html` buttons share the same latent `portal_url` bug but are intentionally left untouched here.

## Verification

- `uv run pytest tests/ -k "accept or email"` → 93 passed, 2 skipped
- `bash scripts/lint.sh` → `ruff check` passes; changed files formatted clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)