### PR TITLE
feat(theme): expose checkout footer, card and nav-text color overrides

### DIFF
--- a/backoffice/src/components/forms/ThemeConfigForm.tsx
+++ b/backoffice/src/components/forms/ThemeConfigForm.tsx
@@ -406,6 +406,86 @@ export function ThemeConfigForm({
               isHighlighted={highlightedKeys.has("checkout_subtitle_color")}
               disabled={readOnly}
             />
+            <ColorField
+              colorKey="checkout_nav_text_color"
+              label="Checkout nav text"
+              description="Optional color for the checkout step-nav labels and icons (Tickets, Your Information, Review). Leave empty to derive from your primary text color."
+              value={colors.checkout_nav_text_color ?? ""}
+              defaultValue=""
+              onChange={(v) => handleColorChange("checkout_nav_text_color", v)}
+              onReset={() => handleResetColor("checkout_nav_text_color")}
+              onHover={handleHover}
+              isHighlighted={highlightedKeys.has("checkout_nav_text_color")}
+              disabled={readOnly}
+            />
+            <ColorField
+              colorKey="checkout_bottom_bar_bg_color"
+              label="Checkout footer bar"
+              description="Optional background for the floating total/continue bar at the bottom of the checkout. Leave empty to use the default bar color."
+              value={colors.checkout_bottom_bar_bg_color ?? ""}
+              defaultValue=""
+              onChange={(v) =>
+                handleColorChange("checkout_bottom_bar_bg_color", v)
+              }
+              onReset={() => handleResetColor("checkout_bottom_bar_bg_color")}
+              onHover={handleHover}
+              isHighlighted={highlightedKeys.has(
+                "checkout_bottom_bar_bg_color",
+              )}
+              disabled={readOnly}
+            />
+            <ColorField
+              colorKey="checkout_bottom_bar_text_color"
+              label="Checkout footer text"
+              description="Optional text/total color for the floating bottom bar. Leave empty to use the default."
+              value={colors.checkout_bottom_bar_text_color ?? ""}
+              defaultValue=""
+              onChange={(v) =>
+                handleColorChange("checkout_bottom_bar_text_color", v)
+              }
+              onReset={() => handleResetColor("checkout_bottom_bar_text_color")}
+              onHover={handleHover}
+              isHighlighted={highlightedKeys.has(
+                "checkout_bottom_bar_text_color",
+              )}
+              disabled={readOnly}
+            />
+            <ColorField
+              colorKey="card_background_color"
+              label="Checkout card background"
+              description="Optional background for cards in the checkout (ticket cards, summary, insurance). Leave empty to use the mode's card surface."
+              value={colors.card_background_color ?? ""}
+              defaultValue=""
+              onChange={(v) => handleColorChange("card_background_color", v)}
+              onReset={() => handleResetColor("card_background_color")}
+              onHover={handleHover}
+              isHighlighted={highlightedKeys.has("card_background_color")}
+              disabled={readOnly}
+            />
+            <ColorField
+              colorKey="card_foreground_color"
+              label="Checkout card text"
+              description="Optional text color inside checkout cards. Leave empty to derive from the mode for readable contrast."
+              value={colors.card_foreground_color ?? ""}
+              defaultValue=""
+              onChange={(v) => handleColorChange("card_foreground_color", v)}
+              onReset={() => handleResetColor("card_foreground_color")}
+              onHover={handleHover}
+              isHighlighted={highlightedKeys.has("card_foreground_color")}
+              disabled={readOnly}
+            />
+            <ColorField
+              colorKey="checkout_watermark_color"
+              label="Checkout watermark"
+              description="Optional color for the giant section-name text behind the checkout content. Leave empty to derive a subtle tint from the mode."
+              value={colors.checkout_watermark_color ?? ""}
+              defaultValue=""
+              onChange={(v) => handleColorChange("checkout_watermark_color", v)}
+              onReset={() => handleResetColor("checkout_watermark_color")}
+              onHover={handleHover}
+              isHighlighted={highlightedKeys.has("checkout_watermark_color")}
+              disabled={readOnly}
+            />
           </div>
 
           {/* Typography */}

--- a/backoffice/src/components/forms/ThemePreview/tabs/CheckoutView.tsx
+++ b/backoffice/src/components/forms/ThemePreview/tabs/CheckoutView.tsx
@@ -5,12 +5,6 @@ import { PreviewCheckoutTopBar } from "../parts/PreviewCheckoutTopBar"
 import { useDisplayEvent, usePreview } from "../parts/PreviewContext"
 import { makeIsHl, ringIf } from "../parts/ring"
 
-// Gradient fallback cuando el popup no tiene express_checkout_background —
-// mantiene el cosmic look del checkout real aunque el usuario no haya subido
-// imagen todavía.
-const FALLBACK_BG =
-  "radial-gradient(ellipse at 30% 20%, #4c3a8a 0%, #1b1540 50%, #080618 100%)"
-
 // Replica del flujo de Pases del checkout real: background image fullscreen,
 // navbar sticky con pills de steps, una sola card con el header del tenant y
 // la sección "Experiencias" con un producto, y bottom bar flotante.
@@ -24,15 +18,23 @@ export function CheckoutView() {
   const backgroundImage =
     checkoutEnabled && event.express_checkout_background
       ? `url(${event.express_checkout_background})`
-      : FALLBACK_BG
+      : undefined
 
   return (
     <div
       className="relative flex h-full flex-col"
       style={{
-        backgroundImage,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
+        // No image (or context off) → solid theme background, matching the real
+        // checkout, where getCheckoutBackground returns `bg-background` for the
+        // no-image case instead of an invented gradient.
+        backgroundColor: "var(--background)",
+        ...(backgroundImage
+          ? {
+              backgroundImage,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
+            }
+          : {}),
       }}
     >
       <PreviewCheckoutTopBar />

--- a/backoffice/src/components/forms/ThemePreview/themeExpand.ts
+++ b/backoffice/src/components/forms/ThemePreview/themeExpand.ts
@@ -14,6 +14,12 @@ export interface ThemeColors {
   accent_color?: string
   checkout_navbar_bg?: string
   checkout_subtitle_color?: string
+  checkout_nav_text_color?: string
+  checkout_watermark_color?: string
+  checkout_bottom_bar_bg_color?: string
+  checkout_bottom_bar_text_color?: string
+  card_background_color?: string
+  card_foreground_color?: string
 }
 
 // Editable keys shown in the backoffice form. Anything else in
@@ -27,6 +33,12 @@ export const NEW_THEME_KEYS = [
   "accent_color",
   "checkout_navbar_bg",
   "checkout_subtitle_color",
+  "checkout_nav_text_color",
+  "checkout_watermark_color",
+  "checkout_bottom_bar_bg_color",
+  "checkout_bottom_bar_text_color",
+  "card_background_color",
+  "card_foreground_color",
 ] as const
 
 export type NewThemeKey = (typeof NEW_THEME_KEYS)[number]
@@ -39,6 +51,12 @@ export const NEW_KEY_DEFAULTS: Record<NewThemeKey, string> = {
   accent_color: "",
   checkout_navbar_bg: "",
   checkout_subtitle_color: "",
+  checkout_nav_text_color: "",
+  checkout_watermark_color: "",
+  checkout_bottom_bar_bg_color: "",
+  checkout_bottom_bar_text_color: "",
+  card_background_color: "",
+  card_foreground_color: "",
 }
 
 const LIGHT = {
@@ -121,15 +139,19 @@ export function computeThemeVars(
     "--checkout-title": palette.foreground,
     "--checkout-subtitle":
       colors.checkout_subtitle_color || palette.foregroundSecondary,
-    "--checkout-watermark": mix(palette.background, palette.foreground, 92),
+    "--checkout-watermark":
+      colors.checkout_watermark_color ||
+      mix(palette.background, palette.foreground, 92),
     "--checkout-navbar-bg":
       colors.checkout_navbar_bg || mix(palette.background, "transparent", 85),
     "--checkout-nav-bg":
       colors.checkout_navbar_bg || mix(palette.background, "transparent", 85),
     "--checkout-footer-bg": mix(palette.background, "transparent", 85),
     "--checkout-card-bg": palette.card,
-    "--checkout-bottom-bar-bg": palette.sidebar,
-    "--checkout-bottom-bar-text": palette.foreground,
+    "--checkout-bottom-bar-bg":
+      colors.checkout_bottom_bar_bg_color || palette.sidebar,
+    "--checkout-bottom-bar-text":
+      colors.checkout_bottom_bar_text_color || palette.foreground,
   }
 
   if (primary) {
@@ -154,6 +176,22 @@ export function computeThemeVars(
     vars["--checkout-nav-text"] = primaryFg
     vars["--checkout-button"] = primary
     vars["--checkout-button-title"] = primaryFg
+  }
+
+  // Explicit per-surface overrides win over anything derived above. Mirrors
+  // the portal runtime (themeProvider.tsx): the checkout nav text/icons and
+  // the step-card surface stay on the palette unless the admin sets them.
+  if (colors.checkout_nav_text_color) {
+    vars["--checkout-badge-title"] = colors.checkout_nav_text_color
+    vars["--checkout-nav-text"] = colors.checkout_nav_text_color
+    vars["--checkout-badge-title-disabled"] =
+      `color-mix(in srgb, ${colors.checkout_nav_text_color} 70%, transparent)`
+  }
+  if (colors.card_background_color) {
+    vars["--step-card-bg"] = colors.card_background_color
+  }
+  if (colors.card_foreground_color) {
+    vars["--step-card-fg"] = colors.card_foreground_color
   }
 
   return vars
@@ -208,15 +246,17 @@ export const LEGACY_HIGHLIGHT_FROM_NEW: Record<string, string[]> = {
   checkout_title: ["mode"],
   checkout_subtitle: ["checkout_subtitle_color", "mode"],
   checkout_subtitle_color: ["checkout_subtitle_color", "mode"],
-  checkout_watermark: ["mode"],
+  checkout_watermark: ["checkout_watermark_color", "mode"],
   checkout_navbar_bg: ["checkout_navbar_bg", "mode"],
   checkout_nav_bg: ["checkout_navbar_bg", "mode"],
-  checkout_nav_text: ["primary_foreground_color"],
+  checkout_nav_text: ["checkout_nav_text_color", "primary_foreground_color"],
   checkout_badge_bg: ["primary_color"],
-  checkout_badge_title: ["primary_foreground_color"],
-  checkout_card_bg: ["mode"],
-  checkout_bottom_bar_bg: ["mode"],
-  checkout_bottom_bar_text: ["mode"],
+  checkout_badge_title: ["checkout_nav_text_color", "primary_foreground_color"],
+  checkout_card_bg: ["card_background_color", "mode"],
+  step_card_bg: ["card_background_color", "mode"],
+  step_card_fg: ["card_foreground_color", "mode"],
+  checkout_bottom_bar_bg: ["checkout_bottom_bar_bg_color", "mode"],
+  checkout_bottom_bar_text: ["checkout_bottom_bar_text_color", "mode"],
   checkout_button: ["primary_color"],
   checkout_button_title: ["primary_foreground_color"],
 }


### PR DESCRIPTION
## Summary

- The portal already reads `checkout_nav_text_color`, `checkout_bottom_bar_bg_color`, `checkout_bottom_bar_text_color`, `card_background_color`, `card_foreground_color` and `checkout_watermark_color` as optional per-surface theme overrides, but the backoffice **theme editor had no inputs** for them.
- So popups configured only through the editor were missing those keys and fell back to the `globals.css` defaults (navy footer bar / white Continue button), rendering inconsistently vs popups that had the keys hand-authored.
- This adds editable inputs for the six keys and wires them into the live preview.

## Related Issue

N/A — follow-up from a theming inconsistency found while testing open checkout.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

| File | Change |
|------|--------|
| `backoffice/.../ThemeConfigForm.tsx` | Add 6 `ColorField` inputs: Checkout nav text, footer bar bg, footer text, card background, card text, watermark |
| `backoffice/.../ThemePreview/themeExpand.ts` | Register the 6 keys (`ThemeColors`, `NEW_THEME_KEYS`, `NEW_KEY_DEFAULTS`), read them in the preview `computeThemeVars` (override wins over derived), and update the hover-highlight map |

## Why no portal change

The portal runtime (`themeProvider.tsx`) already consumes these keys verbatim. Deriving them from the palette instead would **break existing hand-authored popups** that set them explicitly, so they stay as editable overrides. The editor's `colors` state is initialized from and saved back as `theme_config.colors` raw, so existing values surface in the new inputs and remain editable.

## Note

The backoffice preview and the portal runtime were out of sync for the footer (`--checkout-bottom-bar-bg`): the preview derived it from `palette.sidebar` while the portal left it on the globals default. With the explicit override now read in both, they match when the color is set.

## Testing

- [x] Backoffice builds successfully (`pnpm --filter backoffice run build`)
- [x] Backoffice linting passes (biome)
- [ ] Manual testing performed (set each override in the editor, confirm preview + portal reflect it)