### PR TITLE
fix(portal): reveal SnapSection header on tall mobile sections

### DIFF
--- a/portal/src/components/checkout-flow/SnapSection.tsx
+++ b/portal/src/components/checkout-flow/SnapSection.tsx
@@ -25,7 +25,7 @@ export default function SnapSection({
     if (!el) return
     const observer = new IntersectionObserver(
       ([entry]) => setVisible(entry.isIntersecting),
-      { threshold: 0.3 },
+      { rootMargin: "-35% 0px -55% 0px", threshold: 0 },
     )
     observer.observe(el)
     return () => observer.disconnect()


### PR DESCRIPTION
## Problem

On the checkout steps (`/checkout/[popupSlug]`), the section header does not render on mobile for longer steps.

`SnapSection.tsx` gated the header's fade-in animation on an `IntersectionObserver` with `{ threshold: 0.3 }` — a fraction of the **section's own height**, not the viewport. On mobile, pathway cards stack vertically, so a section becomes much taller than the screen and 30% of it can never fit in the viewport. The observer never fires, `visible` stays `false`, and the GSAP effect leaves the title at `opacity: 0` permanently. The first section is worst-hit since it already fills the viewport on load (ratio = viewportH / sectionH < 0.3).

On desktop the cards sit side-by-side, the section is short enough that 30% fits, and the header reveals normally — which is why this only reproduces on mobile / short viewports.

## Fix

Replace the height-relative threshold with a viewport **band**, independent of section height:

```diff
-      { threshold: 0.3 },
+      { rootMargin: "-35% 0px -55% 0px", threshold: 0 },
```

`threshold: 0` + `rootMargin` creates a ~10% band in the vertical middle of the viewport. A section counts as visible when **any** part of it crosses that band, regardless of how tall it is → the header always reveals. This is the same pattern already proven in production for the nav highlight in `ScrollyCheckoutFlow.tsx`, so it's not an ad-hoc value.

- The first section overlaps the band on load → its header animates in (previously never revealed).
- While reading the lower part of a tall section, it still overlaps the band → header stays visible.
- On leaving to the next section it stops overlapping → resets to re-animate on return (existing behavior, now actually triggered).

## Why not just lower the threshold / remove the animation

Lowering to e.g. `0.1` stays fragile — an even taller section could fall below it again. Removing the animation loses the effect on desktop. The band approach fixes the root cause (dependence on section height) without either downside.

## Verification

- `pnpm --filter portal lint` (Biome) passes; no type changes (only two pre-existing warnings in unrelated files).
- The bug depends on the section-height / viewport-height ratio and does not reproduce with short local data. To reproduce: run `pnpm dev:portal`, open a checkout with a long first section, and use DevTools with a short mobile viewport (~550px) — before this change the first section's header is absent; after, it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)