### PR TITLE
fix(portal): guard localStorage in SDK interceptor for SSR

### DIFF
--- a/portal/src/lib/api-client.ts
+++ b/portal/src/lib/api-client.ts
@@ -14,6 +14,12 @@ OpenAPI.TOKEN = async () => {
 }
 
 OpenAPI.interceptors.request.use((config) => {
+  // `localStorage` only exists in the browser. During SSR (e.g. checkout
+  // `generateMetadata`) this interceptor still runs, so guard the access or it
+  // throws `ReferenceError` and the caller silently falls back to null.
+  if (typeof window === "undefined") {
+    return config
+  }
   const tenantId = localStorage.getItem("portal_tenant_id")
   if (tenantId) {
     config.headers = { ...config.headers, "X-Tenant-Id": tenantId }


### PR DESCRIPTION
## Problem

Shared checkout links (e.g. `https://entradas.dev.edgeos.world/checkout/amanita`) render the **generic portal** OpenGraph metadata and browser tab title (\"Amanita Portal\") instead of the checkout/event context added in #409. The event name, tagline and cover image never show in social previews.

## Root cause

Not #409's OG logic — that is correct. The bug is pre-existing and latent.

The generated OpenAPI client (`portal/src/client/core/request.ts`) runs **all request interceptors on every call, including SSR**. The interceptor in `portal/src/lib/api-client.ts` read `localStorage` (`portal_tenant_id`, `portal_language`) with no `typeof window` guard. During `generateMetadata` (server-side) this throws `ReferenceError: localStorage is not defined`; `fetchCheckoutShareMeta`'s `try/catch` swallows it and returns `null`, so the checkout `generateMetadata` returns `{}` and the root layout's generic portal metadata wins.

The root layout was unaffected only because it resolves the tenant via native `fetch` (`fetchTenantBySlug`), not the SDK. **Every** server-side SDK call in the portal was silently failing the same way.

## Fix

Guard the interceptor with `if (typeof window === \"undefined\") return config`, matching the existing `OpenAPI.TOKEN` pattern. Server-side callers pass `X-Tenant-Id` explicitly via the SDK method args, so skipping the localStorage step off the browser is safe.

## Verification

- Backend `GET /api/v1/checkout/amanita/share` with `X-Tenant-Id` returns 200 with the correct data (Amanita Festival 2026, tagline, cover image).
- `pnpm --filter portal build` passes.
- Real crawler preview needs the dev deploy to confirm end-to-end.