### PR TITLE
fix(portal): restore application landing and gate events route

### DIFF
--- a/portal/src/app/portal/[popupSlug]/events/layout.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/layout.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useEffect } from "react"
+import { Loader } from "@/components/ui/Loader"
+import { useApplicationsQuery } from "@/hooks/useGetApplications"
+import { useParticipationQuery } from "@/hooks/useParticipationQuery"
+import { useApplication } from "@/providers/applicationProvider"
+import { useCityProvider } from "@/providers/cityProvider"
+
+export default function EventsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const params = useParams()
+  const router = useRouter()
+  const { getCity } = useCityProvider()
+  const { getRelevantApplication, participation } = useApplication()
+  const city = getCity()
+  const popupId = city?.id ? String(city.id) : null
+
+  // Subscribe to the same queries the sidebar reads so this route gate matches
+  // nav visibility exactly (see useResources `canSeeAttendees`). Reusing
+  // getRelevantApplication (not the backend access ladder) also keeps this in
+  // lockstep with the popup root redirect, so the two can never disagree and
+  // bounce the user back and forth.
+  const applicationsQuery = useApplicationsQuery()
+  const participationQuery = useParticipationQuery(popupId)
+
+  const isDirectSale = city?.sale_type === "direct"
+  const isCompanion = participation?.type === "companion"
+  const application = getRelevantApplication()
+
+  // Only an accepted application (or an accepted companion) may view events,
+  // mirroring the sidebar gate. A draft/pending_fee/in-review application owns
+  // an attendee row but is not approved, so it is bounced here just as the nav
+  // hides the link. Direct-sale popups don't run the application flow, so their
+  // events access is left untouched.
+  const isEligible = isCompanion
+    ? participation?.application_status === "accepted"
+    : application?.status === "accepted"
+
+  const stillLoading =
+    !city || applicationsQuery.isLoading || participationQuery.isLoading
+
+  const blocked = !isDirectSale && !stillLoading && !isEligible
+
+  useEffect(() => {
+    if (blocked) {
+      router.replace(`/portal/${params.popupSlug}`)
+    }
+  }, [blocked, params.popupSlug, router])
+
+  if (isDirectSale) return <>{children}</>
+  if (stillLoading || !isEligible) return <Loader />
+
+  return <>{children}</>
+}

--- a/portal/src/app/portal/[popupSlug]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/page.tsx
@@ -1,13 +1,11 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import type { CompanionParticipation } from "@/client"
 import { EventCard } from "@/components/Card/EventCard"
 import type { EventStatus } from "@/components/Card/EventProgressBar"
 import { CompanionView } from "@/components/CompanionView"
 import { ScholarshipStatusBadge } from "@/components/ScholarshipStatusBadge"
-import { useHumanAttendeesQuery } from "@/hooks/useHumanAttendeesQuery"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 
@@ -18,36 +16,11 @@ export default function Home() {
   const city = getCity()
   const relevantApplication = getRelevantApplication()
 
-  // Application-flow ticket holders skip their application card and land
-  // straight on the events list. Direct-sale and companion flows keep their
-  // own landing views, and we only redirect when the events module is on.
-  const attendeesQuery = useHumanAttendeesQuery(city?.id)
-  const isDirectSale = city?.sale_type === "direct"
-  const isCompanion = participation?.type === "companion"
-  const eventsEnabled = city?.events_enabled ?? true
-  const shouldRedirectToEvents =
-    !!city &&
-    !isDirectSale &&
-    !isCompanion &&
-    eventsEnabled &&
-    (attendeesQuery.data?.length ?? 0) > 0
-
-  const slug = city?.slug
-  useEffect(() => {
-    if (shouldRedirectToEvents && slug) {
-      router.replace(`/portal/${slug}/events`)
-    }
-  }, [shouldRedirectToEvents, slug, router])
-
   if (!city) return null
 
-  // Wait for the attendees query before rendering the application card so a
-  // ticket holder never sees it flash before the redirect fires.
-  if (!isDirectSale && !isCompanion) {
-    if (attendeesQuery.isLoading || shouldRedirectToEvents) return null
-  }
+  const isDirectSale = city.sale_type === "direct"
 
-  if (!isDirectSale && isCompanion) {
+  if (!isDirectSale && participation?.type === "companion") {
     return (
       <section className="container mx-auto">
         <div className="space-y-6 max-w-5xl p-6 mx-auto">


### PR DESCRIPTION
## What

Two related portal fixes around the popup landing and the events route.

### 1. Remove the popup-root auto-redirect to events
The popup root (`/portal/[popupSlug]`) redirected to the events list whenever the human had **any** attendee record. An attendee row exists even for `draft` and `pending_fee` applications, so this locked users out of completing or paying their application, and made the "Application" sidebar link bounce straight to events. This restores the original pre-redirect behavior: the application detail card is always reachable.

### 2. Gate the events route by acceptance
The sidebar hides the events link unless the application is `accepted` (`canSeeAttendees`), but the route itself had no guard, so anyone could open `/portal/[popupSlug]/events` (and its subroutes) directly by URL. A new `events/layout.tsx` mirrors the nav gate: non-accepted humans (and non-accepted companions) are redirected to the popup root. Direct-sale flows are left untouched.

## Notes

- This front guard closes the **UX** gap only. The backend events read endpoints still return event data to any authenticated human of the tenant regardless of application status. The real access-control gate (reusing `applications_crud.resolve_popup_access` as a dependency across the events read endpoints) is deferred to a dedicated backend PR.
- Portal lint and build pass locally.

## Test plan

- [ ] `draft` / `pending_fee` user lands on the popup root and sees their application card (no bounce to events).
- [ ] "Application" sidebar link opens the application card.
- [ ] Non-accepted user typing `/portal/[popupSlug]/events` is redirected to the popup root.
- [ ] Accepted user (and accepted companion) can open events normally.
- [ ] Direct-sale popup events behavior is unchanged.
