### PR TITLE
fix(applications): grant fee credit on review acceptance and manual fee approval

### DIFF
--- a/backend/app/api/application_review/router.py
+++ b/backend/app/api/application_review/router.py
@@ -212,6 +212,17 @@ async def submit_review(
     status_before = application.status
     updated_application = approval_calculator.recalculate_status(db, application)
 
+    # If the review just accepted the application, convert the paid application
+    # fee into credit. This is the backoffice manual-accept path; without it the
+    # fee-to-credit grant never fires for popups that require manual review.
+    # Flush-only helper (idempotent no-op unless ACCEPTED with an approved fee);
+    # the commit below persists it alongside the status change.
+    from app.api.application.crud import _maybe_grant_fee_credit
+
+    _maybe_grant_fee_credit(db, updated_application)
+    db.commit()
+    db.refresh(updated_application)
+
     # Send status-change emails if the application just reached a final decision
     if updated_application.human:
         await send_application_status_email(

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -675,6 +675,19 @@ async def update_payment(
     # If status is being updated, use the special method
     old_status = payment.status
     if payment_in.status:
+        # Manual backoffice approval of an application-fee payment: route through
+        # the shared handler so the application transitions out of PENDING_FEE and
+        # credit is granted — identical to the SimpleFi webhook path.
+        if (
+            payment_in.status == PaymentStatus.APPROVED
+            and old_status != PaymentStatus.APPROVED.value
+        ):
+            from app.api.payment.schemas import PaymentType
+
+            if payment.payment_type == PaymentType.APPLICATION_FEE.value:
+                await _handle_fee_payment_approved(db, payment, source="manual")
+                return PaymentPublic.model_validate(payment)
+
         payment = payments_crud.update_status(db, payment_id, payment_in.status)
     else:
         payment = payments_crud.update(db, payment, payment_in)
@@ -1237,7 +1250,8 @@ async def _handle_fee_payment_approved(
 
     # Approve the payment record first
     payment.status = PaymentStatus.APPROVED.value
-    payment.settlement_currency = settlement_currency
+    if settlement_currency is not None:
+        payment.settlement_currency = settlement_currency
     if rate is not None:
         payment.rate = rate
     payment.source = source

--- a/backend/tests/api/application_review/test_review_grants_fee_credit.py
+++ b/backend/tests/api/application_review/test_review_grants_fee_credit.py
@@ -1,0 +1,232 @@
+"""Regression test: submit_review endpoint grants application-fee credit on acceptance.
+
+Path 7 (previously missing): a popup that requires an application fee AND uses a
+manual-review approval strategy (ANY_REVIEWER). The applicant paid the fee
+(APPROVED fee payment), the application is IN_REVIEW, and a reviewer submits a
+YES decision via POST /api/v1/applications/{id}/reviews.
+
+Before the fix, submit_review called recalculate_status (which transitioned the
+application to ACCEPTED) but never called _maybe_grant_fee_credit, so
+fee_credit_granted stayed False and credit remained 0.
+
+After the fix, _maybe_grant_fee_credit is called immediately after
+recalculate_status inside submit_review, mirroring the review_scholarship path.
+
+Why this test fails without the fix
+------------------------------------
+Without the fix, submit_review does NOT call _maybe_grant_fee_credit after
+recalculate_status. The application transitions to ACCEPTED (the status assertion
+would still pass), but:
+  - application.credit stays at Decimal("0")
+  - application.fee_credit_granted stays False
+  - No AuditLog row with action=CREDIT_GRANTED is written
+
+The assertions on credit amount, fee_credit_granted, and the audit log would each
+fail independently, making the regression unambiguous.
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.approval_strategy.models import ApprovalStrategies
+from app.api.approval_strategy.schemas import ApprovalStrategyType
+from app.api.audit_log.constants import AuditAction, AuditEntityType
+from app.api.audit_log.models import AuditLog
+from app.api.human.models import Humans
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentStatus, PaymentType
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType, UserRole
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+from app.core.security import create_access_token
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FEE_AMOUNT = Decimal("90.00")
+
+
+def _make_manual_review_fee_popup(db: Session, tenant: Tenants) -> Popups:
+    """Popup that requires an application fee AND uses ANY_REVIEWER strategy."""
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"ReviewFeePopup {uuid.uuid4().hex[:6]}",
+        slug=f"rfp-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        currency="USD",
+        requires_application_fee=True,
+        application_fee_amount=FEE_AMOUNT,
+    )
+    db.add(popup)
+    db.flush()
+
+    # ANY_REVIEWER: one YES vote is enough to accept the application
+    strategy = ApprovalStrategies(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        strategy_type=ApprovalStrategyType.ANY_REVIEWER,
+    )
+    db.add(strategy)
+    db.flush()
+
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"rfp-applicant-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Review",
+        last_name="Applicant",
+    )
+    db.add(human)
+    db.flush()
+    return human
+
+
+def _make_reviewer_user(db: Session, tenant: Tenants) -> Users:
+    user = Users(
+        email=f"rfp-reviewer-{uuid.uuid4().hex[:8]}@test.com",
+        role=UserRole.ADMIN,
+        tenant_id=tenant.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_in_review_application_with_approved_fee(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    human: Humans,
+) -> Applications:
+    """Application that has already paid its fee and is waiting for a review decision."""
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.IN_REVIEW.value,
+        credit=Decimal("0"),
+        fee_credit_granted=False,
+    )
+    db.add(application)
+    db.flush()
+
+    # Approved fee payment — prerequisite for credit grant
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        payment_type=PaymentType.APPLICATION_FEE.value,
+        status=PaymentStatus.APPROVED.value,
+        amount=FEE_AMOUNT,
+        currency="USD",
+        external_id=f"sf-rfp-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _credit_granted_entries(db: Session, human_id: uuid.UUID) -> list[AuditLog]:
+    db.expire_all()
+    return list(
+        db.exec(
+            select(AuditLog).where(
+                AuditLog.entity_type == AuditEntityType.HUMAN,
+                AuditLog.entity_id == human_id,
+                AuditLog.action == AuditAction.CREDIT_GRANTED,
+            )
+        ).all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression test
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGrantsFeeCredit:
+    """POST /applications/{id}/reviews (YES) on a fee popup must grant credit."""
+
+    def test_yes_review_on_any_reviewer_popup_grants_fee_credit(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        client: TestClient,
+    ) -> None:
+        """Regression: submit_review must call _maybe_grant_fee_credit after accepting.
+
+        Scenario:
+        - Popup: requires_application_fee=True, strategy=ANY_REVIEWER (one YES = ACCEPTED)
+        - Application: IN_REVIEW, fee_credit_granted=False, credit=0
+        - Fee payment: status=APPROVED
+        - Action: reviewer submits YES via the HTTP endpoint
+        - Expected: status=ACCEPTED, credit==FEE_AMOUNT, fee_credit_granted=True,
+                    exactly one credit.granted audit log with source=="application_fee"
+        """
+        popup = _make_manual_review_fee_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        application = _make_in_review_application_with_approved_fee(
+            db, tenant_a, popup, human
+        )
+        app_id = application.id
+
+        reviewer = _make_reviewer_user(db, tenant_a)
+        reviewer_token = create_access_token(subject=reviewer.id, token_type="user")
+
+        response = client.post(
+            f"/api/v1/applications/{app_id}/reviews",
+            headers={
+                "Authorization": f"Bearer {reviewer_token}",
+                "X-Tenant-Id": str(tenant_a.id),
+            },
+            json={"decision": "yes"},
+        )
+        assert response.status_code == 201, response.text
+
+        db.expire_all()
+        fresh_app = db.exec(
+            select(Applications).where(Applications.id == app_id)
+        ).first()
+        assert fresh_app is not None
+
+        # Status must have transitioned to ACCEPTED
+        assert fresh_app.status == ApplicationStatus.ACCEPTED.value, (
+            f"Application should be ACCEPTED after YES review, got {fresh_app.status!r}"
+        )
+
+        # Credit must equal the fee amount — FAILS without the fix (stays 0)
+        assert fresh_app.credit == FEE_AMOUNT, (
+            f"Expected credit={FEE_AMOUNT}, got {fresh_app.credit} — "
+            "_maybe_grant_fee_credit was not called from submit_review"
+        )
+
+        # Guard flag must be set — FAILS without the fix (stays False)
+        assert fresh_app.fee_credit_granted is True, (
+            "fee_credit_granted should be True after credit grant, got False — "
+            "_maybe_grant_fee_credit was not called from submit_review"
+        )
+
+        # Exactly one audit log entry with source == "application_fee" — FAILS without fix
+        entries = _credit_granted_entries(db, human.id)
+        assert len(entries) == 1, (
+            f"Expected exactly 1 credit.granted audit entry, got {len(entries)}"
+        )
+        assert entries[0].details["source"] == "application_fee", (
+            f"Expected audit source 'application_fee', got {entries[0].details.get('source')!r}"
+        )
+        assert Decimal(str(entries[0].details["amount"])) == FEE_AMOUNT, (
+            f"Expected audit amount={FEE_AMOUNT}, got {entries[0].details.get('amount')!r}"
+        )

--- a/backend/tests/api/payment/test_fee_credit_manual_approval.py
+++ b/backend/tests/api/payment/test_fee_credit_manual_approval.py
@@ -1,0 +1,211 @@
+"""Integration test: manual backoffice approval of APPLICATION_FEE payment.
+
+RED-first (TDD): before the fix, PATCH /{payment_id} with status=approved on an
+APPLICATION_FEE payment calls update_status which does NOT transition the application
+out of PENDING_FEE and does NOT grant credit.  After the fix it must:
+
+  1. Set payment.status = APPROVED.
+  2. Transition application from PENDING_FEE → ACCEPTED (AUTO_ACCEPT popup, no strategy).
+  3. Grant fee as credit: application.credit == fee_amount.
+  4. Set fee_credit_granted = True.
+  5. Write exactly one credit.granted audit log with source == "application_fee".
+  6. NOT null existing settlement_currency on the payment (non-destructive overwrite).
+
+The test is driven through the HTTP PATCH endpoint so the routing path in
+update_payment() is covered, not just _handle_fee_payment_approved() directly.
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.audit_log.constants import AuditAction, AuditEntityType
+from app.api.audit_log.models import AuditLog
+from app.api.human.models import Humans
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentStatus, PaymentType
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FEE_AMOUNT = Decimal("80.00")
+
+
+def _make_fee_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"ManualFeePopup {uuid.uuid4().hex[:6]}",
+        slug=f"mfp-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        currency="USD",
+        requires_application_fee=True,
+        application_fee_amount=FEE_AMOUNT,
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"mfa-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Manual",
+        last_name="Approval",
+    )
+    db.add(human)
+    db.flush()
+    return human
+
+
+def _make_pending_fee_application(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> Applications:
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.PENDING_FEE.value,
+        credit=Decimal("0"),
+        fee_credit_granted=False,
+    )
+    db.add(application)
+    db.flush()
+    return application
+
+
+def _make_pending_fee_payment(
+    db: Session, tenant: Tenants, popup: Popups, application: Applications
+) -> Payments:
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        payment_type=PaymentType.APPLICATION_FEE.value,
+        status=PaymentStatus.PENDING.value,
+        amount=FEE_AMOUNT,
+        currency="USD",
+        external_id=f"sf-mfa-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _credit_granted_entries(db: Session, human_id: uuid.UUID) -> list[AuditLog]:
+    db.expire_all()
+    return list(
+        db.exec(
+            select(AuditLog).where(
+                AuditLog.entity_type == AuditEntityType.HUMAN,
+                AuditLog.entity_id == human_id,
+                AuditLog.action == AuditAction.CREDIT_GRANTED,
+            )
+        ).all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestManualFeeApprovalViaEndpoint:
+    """PATCH /{payment_id} with status=approved on APPLICATION_FEE must route through
+    _handle_fee_payment_approved so application transitions and credit is granted."""
+
+    def test_manual_approval_transitions_application_and_grants_credit(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """RED: before fix — application stays PENDING_FEE, no credit granted.
+        GREEN: after fix — application transitions, credit == fee_amount, audit written."""
+        popup = _make_fee_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        application = _make_pending_fee_application(db, tenant_a, popup, human)
+        payment = _make_pending_fee_payment(db, tenant_a, popup, application)
+
+        # Approve via backoffice PATCH endpoint
+        resp = client.patch(
+            f"/api/v1/payments/{payment.id}",
+            json={"status": "approved"},
+            headers={
+                "Authorization": f"Bearer {admin_token_tenant_a}",
+                "X-Tenant-Id": str(tenant_a.id),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Payment must be APPROVED
+        db.expire_all()
+        db.refresh(payment)
+        assert payment.status == PaymentStatus.APPROVED.value
+
+        # Application must have transitioned out of PENDING_FEE
+        db.refresh(application)
+        assert application.status != ApplicationStatus.PENDING_FEE.value, (
+            f"Application is still in PENDING_FEE after manual fee approval — "
+            f"fix not applied: got {application.status!r}"
+        )
+
+        # Credit must be granted
+        assert application.credit == FEE_AMOUNT, (
+            f"Expected credit={FEE_AMOUNT}, got {application.credit} — "
+            f"_handle_fee_payment_approved was not called from update_payment"
+        )
+        assert application.fee_credit_granted is True
+
+        # Exactly one credit.granted audit log with source == "application_fee"
+        entries = _credit_granted_entries(db, human.id)
+        assert len(entries) == 1, (
+            f"Expected 1 credit.granted audit entry, got {len(entries)}"
+        )
+        assert entries[0].details["source"] == "application_fee"
+        assert Decimal(str(entries[0].details["amount"])) == FEE_AMOUNT
+
+    def test_settlement_currency_not_nulled_on_existing_value(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Non-destructive overwrite: passing settlement_currency=None must not null
+        an existing value on the payment (covers the _handle_fee_payment_approved fix)."""
+        import asyncio
+
+        from app.api.payment.router import _handle_fee_payment_approved
+
+        popup = _make_fee_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        application = _make_pending_fee_application(db, tenant_a, popup, human)
+        payment = _make_pending_fee_payment(db, tenant_a, popup, application)
+
+        # Pre-set settlement_currency (simulates a partial update already recorded)
+        payment.settlement_currency = "BTC"
+        db.add(payment)
+        db.flush()
+
+        # Call handler with settlement_currency=None (manual path)
+        asyncio.run(
+            _handle_fee_payment_approved(
+                db, payment, settlement_currency=None, source="manual"
+            )
+        )
+
+        db.expire_all()
+        db.refresh(payment)
+        assert payment.settlement_currency == "BTC", (
+            "settlement_currency was nulled out — the non-destructive guard is missing"
+        )


### PR DESCRIPTION
## What

Grants the application-fee credit on two acceptance flows that the credit-decoupling change (PR #408) missed.

## Why

Fee-to-credit conversion was wired into the six accept methods and the SimpleFi webhook, but two real flows never granted the credit:

- **Manual review acceptance** — the backoffice "Approve" button goes through `submit_review`, which transitions the application via `recalculate_status` but did not call `_maybe_grant_fee_credit`. Popups requiring manual review therefore never converted the paid fee to credit on acceptance. Fixed by granting right after `recalculate_status`, mirroring the scholarship review path.
- **Manual fee-payment approval** — approving an `application_fee` payment through the backoffice payment PATCH went through `update_status`, which does not transition the application or grant credit (only the webhook did). Fee approvals are now routed through the shared `_handle_fee_payment_approved` handler so manual and webhook approvals behave identically. The settlement overwrite in that handler is made non-destructive so the manual path does not null existing settlement data.

## Testing

- New `test_review_grants_fee_credit.py`: a YES review on a manual-review popup with an approved fee grants the fee as credit (status accepted, credit == fee, `fee_credit_granted` true, one `credit.granted` audit with `source=application_fee`).
- New `test_fee_credit_manual_approval.py`: approving a fee via the payment PATCH transitions the application and grants credit.
- Full backend suite green (pre-existing `portal:api_keys:manage` scope-registry failures unrelated to this change). Lint clean. Single alembic head.
