### PR TITLE
fix(portal): checkout step-nav crash, pass single-select, fee flow, and unknown-slug page

### DIFF
--- a/portal/src/app/[popupSlug]/page.tsx
+++ b/portal/src/app/[popupSlug]/page.tsx
@@ -14,19 +14,21 @@ export default async function PopupRoutePage({ params }: PopupRoutePageProps) {
     throw new Error("NEXT_PUBLIC_API_URL is not configured")
   }
 
-  const response = await fetch(
-    `${apiBaseUrl}/api/v1/popups/portal/${popupSlug}`,
-    {
+  let response: Response
+  try {
+    response = await fetch(`${apiBaseUrl}/api/v1/popups/portal/${popupSlug}`, {
       cache: "no-store",
-    },
-  )
-
-  if (response.status === 404) {
+    })
+  } catch {
+    // Network/backend unreachable: show the 404 page instead of a raw
+    // server-side exception.
     notFound()
   }
 
+  // Any non-OK status (404 unknown slug, 401 anonymous SSR request, etc.)
+  // resolves to the not-found page rather than throwing.
   if (!response.ok) {
-    throw new Error(`Failed to resolve popup ${popupSlug}`)
+    notFound()
   }
 
   const popup = (await response.json()) as { sale_type?: string; slug: string }

--- a/portal/src/app/portal/[popupSlug]/application/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/page.tsx
@@ -65,7 +65,11 @@ export default function FormPage() {
   const application = getRelevantApplication()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const isReturnFromCheckout = searchParams.has("checkout", "success")
+  // Capture once on mount so a later URL change doesn't tear down the fee
+  // banner while it's still polling for the payment webhook.
+  const [isReturnFromCheckout] = useState(() =>
+    searchParams.has("checkout", "success"),
+  )
 
   const {
     data: schema,
@@ -86,25 +90,19 @@ export default function FormPage() {
     }
   }, [importSource, existingApp])
 
-  // Redirect if already accepted/rejected (not for pending_fee — that stays editable)
+  // Once submitted, the application is no longer accessible from the form —
+  // same behavior as a fee-less submit. draft/pending_fee stay editable so the
+  // applicant can still finish or retry the fee payment.
   useEffect(() => {
     if (
       application &&
-      (application.status === "accepted" || application.status === "rejected")
+      (application.status === "in review" ||
+        application.status === "accepted" ||
+        application.status === "rejected")
     ) {
-      router.push(`/portal/${city?.slug}`)
+      router.replace(`/portal/${city?.slug}`)
     }
   }, [application, city, router])
-
-  // Clean up ?checkout=success from the URL after the banner mounts,
-  // so stale polling doesn't re-trigger on subsequent navigations.
-  // isReturnFromCheckout is computed synchronously above, so the banner
-  // already received the initial `true` value before this replace runs.
-  useEffect(() => {
-    if (isReturnFromCheckout) {
-      router.replace(`/portal/${city?.slug}/application`, { scroll: false })
-    }
-  }, [isReturnFromCheckout, city?.slug, router])
 
   useEffect(() => {
     if (city?.sale_type === "direct") {
@@ -132,6 +130,30 @@ export default function FormPage() {
 
   if (city.sale_type === "direct") {
     return <Loader />
+  }
+
+  // Submitted or resolved applications never render the form. The effect above
+  // redirects to the portal home; show a loader meanwhile to avoid flashing it.
+  if (
+    application?.status === "in review" ||
+    application?.status === "accepted" ||
+    application?.status === "rejected"
+  ) {
+    return <Loader />
+  }
+
+  // Returning from the fee checkout: show only the confirmation banner while we
+  // poll for the payment webhook. The form must not reappear after paying.
+  if (isReturnFromCheckout) {
+    return (
+      <main className="container py-6 md:py-12 mb-8 px-8 md:px-12">
+        {application ? (
+          <FeePaymentBanner application={application} isReturnFromCheckout />
+        ) : (
+          <Loader />
+        )}
+      </main>
+    )
   }
 
   if (isError || !schema) {
@@ -165,12 +187,6 @@ export default function FormPage() {
         <FormHeader />
         <SectionSeparator />
       </div>
-      {application?.status === "pending_fee" && isReturnFromCheckout && (
-        <FeePaymentBanner
-          application={application}
-          isReturnFromCheckout={isReturnFromCheckout}
-        />
-      )}
       <FileUploadProvider value={uploadFile}>
         <DynamicApplicationForm
           key={existingApp?.id ?? importedData?.id ?? "new"}

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -99,6 +99,10 @@ export default function ScrollySectionNav({
   // overflow. The result never truncates a label and never clips an icon at
   // any width or step count. `compact` drives both the layout and whether
   // labels render.
+  // Stable full-width wrapper used as the available-width reference. The track
+  // itself swaps between w-fit (expanded) and w-full (compact), so measuring it
+  // would couple `avail` to `compact` — see the effect below.
+  const shellRef = useRef<HTMLDivElement>(null)
   const trackRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
@@ -110,10 +114,17 @@ export default function ScrollySectionNav({
 
   useIsomorphicLayoutEffect(() => {
     const recalc = () => {
-      const track = trackRef.current
       const list = listRef.current
-      if (track && list) {
-        const avail = track.clientWidth
+      // Measure available width from the stable shell, never the track. The
+      // track is w-fit while expanded and w-full while compact, so reading its
+      // width would make `avail` depend on `compact`. Since this effect also
+      // writes `compact` (and re-runs on it), that feedback flip-flops
+      // true<->false forever until React aborts with "Maximum update depth
+      // exceeded" (#185). The shell is always full-width, so the decision has a
+      // fixed basis and settles within a 1px hysteresis band.
+      const shell = shellRef.current
+      if (list && shell) {
+        const avail = shell.clientWidth
         if (!compact) {
           // Labels are showing → scrollWidth is the true expanded width.
           expandedWidthRef.current = list.scrollWidth
@@ -142,9 +153,10 @@ export default function ScrollySectionNav({
       track.scrollTo({ left: Math.max(0, target), behavior: "smooth" })
     }
 
-    if (!track) return
+    const shell = shellRef.current
+    if (!shell) return
     const ro = new ResizeObserver(recalc)
-    ro.observe(track)
+    ro.observe(shell)
     return () => ro.disconnect()
     // sections.length re-runs when tabs change; compact re-runs after a mode
     // flip so the measurement settles (pre-paint, so no visible flicker).
@@ -166,6 +178,7 @@ export default function ScrollySectionNav({
             />
           ) : null}
           <div
+            ref={shellRef}
             className={cn("flex min-w-0 flex-1", !compact && "justify-center")}
           >
             <div

--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -5,9 +5,7 @@ import Image from "next/image"
 import type { CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
-import QuantitySelector, {
-  supportsQuantitySelector,
-} from "@/components/ui/QuantitySelector"
+import QuantitySelector from "@/components/ui/QuantitySelector"
 import type {
   TicketAttendeeVM,
   TicketRowVM,
@@ -345,7 +343,7 @@ function OpenCheckoutProductRow({
   const { product, quantity, maxQuantity, selected, disabled } = row
 
   const isAdded = quantity > 0 || selected
-  const showStepper = supportsQuantitySelector(product.max_per_order)
+  const showStepper = row.usesStepper
   const max = maxQuantity
   const rowDisabled = disabled && !isAdded
   const hasDiscount =

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -915,8 +915,7 @@ function CompactAttendeeCard({
         <div className="flex flex-wrap gap-2">
           {visibleProducts.map((p) => {
             const isDayPass = p.duration_type === "day"
-            const hasStepper =
-              isDayPass || supportsQuantitySelector(p.max_per_order)
+            const hasStepper = isPassQuantityBased(p)
             const pillSaleState = deriveProductState(p)
             const pillStateBlocked = pillSaleState !== "on_sale"
 

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -41,6 +41,7 @@ import useGetPassesData from "@/hooks/useGetPassesData"
 import { useIsAuthenticated } from "@/hooks/useIsAuthenticated"
 import { buildFormZodSchema } from "@/lib/form-schema-builder"
 import { trackMetaAddToCart } from "@/lib/meta-pixel"
+import { isPassQuantityBased } from "@/strategies/passQuantityHelper"
 import type { AttendeePassState } from "@/types/Attendee"
 import type {
   CheckoutCartState,
@@ -474,7 +475,7 @@ export function CheckoutProvider({
                 : 1
               : isDayPass
                 ? (product.quantity ?? 1) - (product.original_quantity ?? 0)
-                : supportsQuantitySelector(product.max_per_order)
+                : isPassQuantityBased(product)
                   ? (product.quantity ?? 1)
                   : 1
 

--- a/portal/src/providers/passesProvider.tsx
+++ b/portal/src/providers/passesProvider.tsx
@@ -14,7 +14,6 @@ import {
   resolvePopupCheckoutPolicy,
 } from "@/checkout/popupCheckoutPolicy"
 import type { AttendeePurchases } from "@/client"
-import { supportsQuantitySelector } from "@/components/ui/QuantitySelector"
 import { useCart } from "@/hooks/useCartApi"
 import useGetPassesData from "@/hooks/useGetPassesData"
 import { usePurchasesQuery } from "@/hooks/useGetPurchases"
@@ -198,8 +197,11 @@ function applyCartSelections(
         }
       }
       // Non-day: multi-unit products restore the persisted quantity;
-      // single-unit products stay at the legacy quantity of 1.
-      const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+      // single-unit products stay at the legacy quantity of 1. Use
+      // isPassQuantityBased so full/month passes (single-select even when
+      // max_per_order is null) keep their quantity instead of adopting the
+      // saved cart quantity.
+      const isMultiUnit = isPassQuantityBased(product)
       return {
         ...product,
         selected: true,
@@ -460,8 +462,7 @@ const PassesProvider = ({
             return { ...p, selected: false, edit: false, disabled: false }
           }
           const isMultiUnit =
-            p.duration_type !== "day" &&
-            supportsQuantitySelector(p.max_per_order)
+            p.duration_type !== "day" && isPassQuantityBased(p)
           const initialQuantity =
             p.duration_type === "day"
               ? (p.original_quantity ?? 0)

--- a/portal/src/strategies/ProductStrategies.test.ts
+++ b/portal/src/strategies/ProductStrategies.test.ts
@@ -400,11 +400,12 @@ describe("WeekProductStrategy — attendeeVisibleProductIds (wide scope)", () =>
 })
 
 describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => {
-  // Reproduces: GA + VIP both exclusive, multi-unit (max_per_order=null), duration_type=full.
-  // Pre-state: GA quantity=1 selected, VIP quantity=0 not selected.
-  // Action: user clicks +1 on VIP.
-  // Expected: VIP quantity=1 selected, GA quantity=0 NOT selected.
-  it("clicking + on VIP cancels GA when both are exclusive multi-unit full passes in same section", () => {
+  // GA + VIP both exclusive full passes (max_per_order=null) in the same
+  // section. Full passes are single-select (isPassQuantityBased=false), so
+  // selecting one clears the other via `selected` — not quantity.
+  // Pre-state: GA selected, VIP not. Action: user clicks VIP's checkbox.
+  // Expected: VIP selected, GA cleared.
+  it("clicking VIP cancels GA when both are exclusive full passes in same section", () => {
     const ga = {
       ...createProduct({
         id: "ga",
@@ -423,7 +424,7 @@ describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => 
         name: "VIP Pass",
         category: "ticket",
         duration_type: "full",
-        quantity: 0,
+        quantity: 1,
         selected: false,
       }),
       max_per_order: null,
@@ -432,31 +433,29 @@ describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => 
     const attendees = [createAttendee([ga, vip])]
     const strategy = getProductStrategy(vip, false, CHECKOUT_MODE.PASS_SYSTEM)
 
-    // Simulate the stepper +1: caller passes product with quantity=1 and the section scope.
+    // Checkbox toggle: caller passes the current product with the section scope.
     const result = strategy.handleSelection(
       attendees,
       "attendee-1",
-      { ...vip, quantity: 1 },
+      vip,
       undefined,
       ["ga", "vip"],
     )
 
     const updatedGa = result[0]?.products.find((p) => p.id === "ga")
     const updatedVip = result[0]?.products.find((p) => p.id === "vip")
-    expect(updatedVip?.quantity).toBe(1)
     expect(updatedVip?.selected).toBe(true)
-    expect(updatedGa?.quantity).toBe(0)
     expect(updatedGa?.selected).toBe(false)
   })
 
-  it("clicking + on GA cancels VIP (symmetric)", () => {
+  it("clicking GA cancels VIP (symmetric)", () => {
     const ga = {
       ...createProduct({
         id: "ga",
         name: "General Admission",
         category: "ticket",
         duration_type: "full",
-        quantity: 0,
+        quantity: 1,
         selected: false,
       }),
       max_per_order: null,
@@ -479,15 +478,13 @@ describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => 
     const result = strategy.handleSelection(
       attendees,
       "attendee-1",
-      { ...ga, quantity: 1 },
+      ga,
       undefined,
       ["ga", "vip"],
     )
     const updatedGa = result[0]?.products.find((p) => p.id === "ga")
     const updatedVip = result[0]?.products.find((p) => p.id === "vip")
-    expect(updatedGa?.quantity).toBe(1)
     expect(updatedGa?.selected).toBe(true)
-    expect(updatedVip?.quantity).toBe(0)
     expect(updatedVip?.selected).toBe(false)
   })
 })
@@ -687,10 +684,11 @@ describe("EditProductStrategy — month upgrade while editing", () => {
     expect(result[0]?.products.find((p) => p.id === "w1")?.edit).toBeFalsy()
   })
 
-  // Reported bug: a quantity-based full pass (max_per_order null/>1) reads its
-  // selection from quantity, so upgrading credited the week but the tile never
-  // showed selected because quantity stayed 0.
-  it("upgrading to a quantity-based full pass sets its quantity and credits the week", () => {
+  // A full pass is single-select (isPassQuantityBased=false): upgrading selects
+  // it via `selected` and credits the owned week. The tile reads its state from
+  // `selected`, not quantity, so this can never regress to "selected but
+  // quantity 0" the way a quantity-driven pass could.
+  it("upgrading to a full pass selects it and credits the week", () => {
     const fullPass = createProduct({
       id: "full",
       duration_type: "full",
@@ -704,7 +702,7 @@ describe("EditProductStrategy — month upgrade while editing", () => {
           id: "full",
           duration_type: "full",
           price: 400,
-          quantity: 0,
+          quantity: 1,
           max_per_order: 5,
           selected: false,
         }),
@@ -721,7 +719,6 @@ describe("EditProductStrategy — month upgrade while editing", () => {
     const full = result[0]?.products.find((p) => p.id === "full")
     const w1 = result[0]?.products.find((p) => p.id === "w1")
     expect(full?.selected).toBe(true)
-    expect(full?.quantity).toBeGreaterThanOrEqual(1)
     expect(w1?.edit).toBe(true)
     expect(w1?.selected).toBe(false)
   })

--- a/portal/src/strategies/ProductStrategies.ts
+++ b/portal/src/strategies/ProductStrategies.ts
@@ -73,7 +73,7 @@ class MonthProductStrategy implements ProductStrategy {
     attendeeId: string,
     product: ProductsPass,
   ): AttendeePassState[] {
-    const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+    const isMultiUnit = isPassQuantityBased(product)
     // For multi-unit products, the caller passes the NEW desired quantity in
     // `product.quantity`. The selection is active when quantity > 0.
     const willSelectMonth = isMultiUnit
@@ -191,7 +191,7 @@ class WeekProductStrategy implements ProductStrategy {
     exclusivityScopeIds?: string[],
     attendeeVisibleProductIds?: string[],
   ): AttendeePassState[] {
-    const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+    const isMultiUnit = isPassQuantityBased(product)
 
     // Promotion scope: prefer the WIDE scope (all attendee-visible products
     // across sections) so a week-in-section-A can promote a month-in-section-B
@@ -282,7 +282,7 @@ class FullProductStrategy implements ProductStrategy {
     attendeeId: string,
     product: ProductsPass,
   ): AttendeePassState[] {
-    const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+    const isMultiUnit = isPassQuantityBased(product)
 
     return attendees.map((attendee) => {
       if (attendee.id !== attendeeId) return attendee
@@ -339,19 +339,14 @@ class ExclusivityGuard implements ProductStrategy {
   private isActive(product: ProductsPass): boolean {
     if (product.purchased) return true
     if (product.selected) return true
-    if (
-      product.duration_type === "day" ||
-      supportsQuantitySelector(product.max_per_order)
-    ) {
+    if (isPassQuantityBased(product)) {
       return (product.quantity ?? 0) > 0
     }
     return false
   }
 
   private clearSelection(product: ProductsPass): ProductsPass {
-    const usesQuantity =
-      product.duration_type === "day" ||
-      supportsQuantitySelector(product.max_per_order)
+    const usesQuantity = isPassQuantityBased(product)
 
     return {
       ...product,
@@ -476,7 +471,7 @@ class EditProductStrategy implements ProductStrategy {
   ): ProductsPass[] {
     return products.map((p) => {
       if (p.id === monthId) {
-        const quantity = supportsQuantitySelector(p.max_per_order)
+        const quantity = isPassQuantityBased(p)
           ? Math.max(1, p.quantity ?? 0)
           : p.quantity
         return { ...p, selected: true, quantity }


### PR DESCRIPTION
## Summary

Four portal checkout/application bug fixes found during QA:

- Unknown popup slugs (e.g. `/wrong-path`) now render the 404 page instead of a server exception.
- After paying an application fee, a submitted application no longer re-shows the editable form.
- Full/month passes are now correctly single-select in the checkout (checkbox toggle works both ways).
- The checkout step nav no longer crashes with a "Maximum update depth exceeded" (React #185) infinite loop.

## Related Issue

N/A — bugs surfaced during checkout QA.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Unknown-slug page** (`[popupSlug]/page.tsx`): the SSR resolver hit an auth-gated backend endpoint and got 401 for every slug, but only handled 404 — any non-OK now degrades to `notFound()`, so unknown paths show the 404 page instead of a raw server exception.
- **Application fee flow** (`application/page.tsx`): once an application is submitted (`in review`), it redirects to the portal home instead of re-rendering the editable form; the fee-success banner is captured once so URL cleanup no longer tears it down mid-poll.
- **Pass selection** (`ProductStrategies.ts` + tests, `passesProvider.tsx`, `checkoutProvider.tsx`, `VariantTicketCard.tsx`, `VariantTicketSelect.tsx`): the pass_system state layer now decides "quantity-driven vs single-select" with `isPassQuantityBased` instead of `supportsQuantitySelector`, so full/month passes with `max_per_order = null` (rendered as checkboxes) can be deselected and re-selected. Fixes the stuck checkbox + empty cart PUT.
- **Step nav crash** (`ScrollySectionNav.tsx`): the adaptive-density layout effect measured available width from the track, whose width class swaps with `compact` — coupling the measurement to the state it writes and looping forever. Now measures from a stable full-width shell.

## Testing

- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [x] Portal linting passes (`pnpm --filter portal run lint`)
- [x] Type check passes (`tsc --noEmit`)
- [x] Strategy/provider unit tests pass (`vitest run src/strategies src/providers/passesProvider.test.ts src/hooks/checkout/useTicketsStep.test.ts`)
- [x] Manual testing: unknown-slug 404, fee-payment return, pass toggle, and step-nav navigation reproduced and verified

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [ ] No backend API change (OpenAPI client regeneration not needed)
- [ ] No schema change (no migration needed)
