### PR TITLE
release: dev to main v1.32.0

### DIFF
--- a/backend/app/api/application_review/router.py
+++ b/backend/app/api/application_review/router.py
@@ -212,6 +212,17 @@ async def submit_review(
     status_before = application.status
     updated_application = approval_calculator.recalculate_status(db, application)
 
+    # If the review just accepted the application, convert the paid application
+    # fee into credit. This is the backoffice manual-accept path; without it the
+    # fee-to-credit grant never fires for popups that require manual review.
+    # Flush-only helper (idempotent no-op unless ACCEPTED with an approved fee);
+    # the commit below persists it alongside the status change.
+    from app.api.application.crud import _maybe_grant_fee_credit
+
+    _maybe_grant_fee_credit(db, updated_application)
+    db.commit()
+    db.refresh(updated_application)
+
     # Send status-change emails if the application just reached a final decision
     if updated_application.human:
         await send_application_status_email(

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -675,6 +675,19 @@ async def update_payment(
     # If status is being updated, use the special method
     old_status = payment.status
     if payment_in.status:
+        # Manual backoffice approval of an application-fee payment: route through
+        # the shared handler so the application transitions out of PENDING_FEE and
+        # credit is granted — identical to the SimpleFi webhook path.
+        if (
+            payment_in.status == PaymentStatus.APPROVED
+            and old_status != PaymentStatus.APPROVED.value
+        ):
+            from app.api.payment.schemas import PaymentType
+
+            if payment.payment_type == PaymentType.APPLICATION_FEE.value:
+                await _handle_fee_payment_approved(db, payment, source="manual")
+                return PaymentPublic.model_validate(payment)
+
         payment = payments_crud.update_status(db, payment_id, payment_in.status)
     else:
         payment = payments_crud.update(db, payment, payment_in)
@@ -1237,7 +1250,8 @@ async def _handle_fee_payment_approved(
 
     # Approve the payment record first
     payment.status = PaymentStatus.APPROVED.value
-    payment.settlement_currency = settlement_currency
+    if settlement_currency is not None:
+        payment.settlement_currency = settlement_currency
     if rate is not None:
         payment.rate = rate
     payment.source = source

--- a/backend/tests/api/application_review/test_review_grants_fee_credit.py
+++ b/backend/tests/api/application_review/test_review_grants_fee_credit.py
@@ -1,0 +1,232 @@
+"""Regression test: submit_review endpoint grants application-fee credit on acceptance.
+
+Path 7 (previously missing): a popup that requires an application fee AND uses a
+manual-review approval strategy (ANY_REVIEWER). The applicant paid the fee
+(APPROVED fee payment), the application is IN_REVIEW, and a reviewer submits a
+YES decision via POST /api/v1/applications/{id}/reviews.
+
+Before the fix, submit_review called recalculate_status (which transitioned the
+application to ACCEPTED) but never called _maybe_grant_fee_credit, so
+fee_credit_granted stayed False and credit remained 0.
+
+After the fix, _maybe_grant_fee_credit is called immediately after
+recalculate_status inside submit_review, mirroring the review_scholarship path.
+
+Why this test fails without the fix
+------------------------------------
+Without the fix, submit_review does NOT call _maybe_grant_fee_credit after
+recalculate_status. The application transitions to ACCEPTED (the status assertion
+would still pass), but:
+  - application.credit stays at Decimal("0")
+  - application.fee_credit_granted stays False
+  - No AuditLog row with action=CREDIT_GRANTED is written
+
+The assertions on credit amount, fee_credit_granted, and the audit log would each
+fail independently, making the regression unambiguous.
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.approval_strategy.models import ApprovalStrategies
+from app.api.approval_strategy.schemas import ApprovalStrategyType
+from app.api.audit_log.constants import AuditAction, AuditEntityType
+from app.api.audit_log.models import AuditLog
+from app.api.human.models import Humans
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentStatus, PaymentType
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType, UserRole
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+from app.core.security import create_access_token
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FEE_AMOUNT = Decimal("90.00")
+
+
+def _make_manual_review_fee_popup(db: Session, tenant: Tenants) -> Popups:
+    """Popup that requires an application fee AND uses ANY_REVIEWER strategy."""
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"ReviewFeePopup {uuid.uuid4().hex[:6]}",
+        slug=f"rfp-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        currency="USD",
+        requires_application_fee=True,
+        application_fee_amount=FEE_AMOUNT,
+    )
+    db.add(popup)
+    db.flush()
+
+    # ANY_REVIEWER: one YES vote is enough to accept the application
+    strategy = ApprovalStrategies(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        strategy_type=ApprovalStrategyType.ANY_REVIEWER,
+    )
+    db.add(strategy)
+    db.flush()
+
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"rfp-applicant-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Review",
+        last_name="Applicant",
+    )
+    db.add(human)
+    db.flush()
+    return human
+
+
+def _make_reviewer_user(db: Session, tenant: Tenants) -> Users:
+    user = Users(
+        email=f"rfp-reviewer-{uuid.uuid4().hex[:8]}@test.com",
+        role=UserRole.ADMIN,
+        tenant_id=tenant.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_in_review_application_with_approved_fee(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    human: Humans,
+) -> Applications:
+    """Application that has already paid its fee and is waiting for a review decision."""
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.IN_REVIEW.value,
+        credit=Decimal("0"),
+        fee_credit_granted=False,
+    )
+    db.add(application)
+    db.flush()
+
+    # Approved fee payment — prerequisite for credit grant
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        payment_type=PaymentType.APPLICATION_FEE.value,
+        status=PaymentStatus.APPROVED.value,
+        amount=FEE_AMOUNT,
+        currency="USD",
+        external_id=f"sf-rfp-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _credit_granted_entries(db: Session, human_id: uuid.UUID) -> list[AuditLog]:
+    db.expire_all()
+    return list(
+        db.exec(
+            select(AuditLog).where(
+                AuditLog.entity_type == AuditEntityType.HUMAN,
+                AuditLog.entity_id == human_id,
+                AuditLog.action == AuditAction.CREDIT_GRANTED,
+            )
+        ).all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression test
+# ---------------------------------------------------------------------------
+
+
+class TestReviewGrantsFeeCredit:
+    """POST /applications/{id}/reviews (YES) on a fee popup must grant credit."""
+
+    def test_yes_review_on_any_reviewer_popup_grants_fee_credit(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        client: TestClient,
+    ) -> None:
+        """Regression: submit_review must call _maybe_grant_fee_credit after accepting.
+
+        Scenario:
+        - Popup: requires_application_fee=True, strategy=ANY_REVIEWER (one YES = ACCEPTED)
+        - Application: IN_REVIEW, fee_credit_granted=False, credit=0
+        - Fee payment: status=APPROVED
+        - Action: reviewer submits YES via the HTTP endpoint
+        - Expected: status=ACCEPTED, credit==FEE_AMOUNT, fee_credit_granted=True,
+                    exactly one credit.granted audit log with source=="application_fee"
+        """
+        popup = _make_manual_review_fee_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        application = _make_in_review_application_with_approved_fee(
+            db, tenant_a, popup, human
+        )
+        app_id = application.id
+
+        reviewer = _make_reviewer_user(db, tenant_a)
+        reviewer_token = create_access_token(subject=reviewer.id, token_type="user")
+
+        response = client.post(
+            f"/api/v1/applications/{app_id}/reviews",
+            headers={
+                "Authorization": f"Bearer {reviewer_token}",
+                "X-Tenant-Id": str(tenant_a.id),
+            },
+            json={"decision": "yes"},
+        )
+        assert response.status_code == 201, response.text
+
+        db.expire_all()
+        fresh_app = db.exec(
+            select(Applications).where(Applications.id == app_id)
+        ).first()
+        assert fresh_app is not None
+
+        # Status must have transitioned to ACCEPTED
+        assert fresh_app.status == ApplicationStatus.ACCEPTED.value, (
+            f"Application should be ACCEPTED after YES review, got {fresh_app.status!r}"
+        )
+
+        # Credit must equal the fee amount — FAILS without the fix (stays 0)
+        assert fresh_app.credit == FEE_AMOUNT, (
+            f"Expected credit={FEE_AMOUNT}, got {fresh_app.credit} — "
+            "_maybe_grant_fee_credit was not called from submit_review"
+        )
+
+        # Guard flag must be set — FAILS without the fix (stays False)
+        assert fresh_app.fee_credit_granted is True, (
+            "fee_credit_granted should be True after credit grant, got False — "
+            "_maybe_grant_fee_credit was not called from submit_review"
+        )
+
+        # Exactly one audit log entry with source == "application_fee" — FAILS without fix
+        entries = _credit_granted_entries(db, human.id)
+        assert len(entries) == 1, (
+            f"Expected exactly 1 credit.granted audit entry, got {len(entries)}"
+        )
+        assert entries[0].details["source"] == "application_fee", (
+            f"Expected audit source 'application_fee', got {entries[0].details.get('source')!r}"
+        )
+        assert Decimal(str(entries[0].details["amount"])) == FEE_AMOUNT, (
+            f"Expected audit amount={FEE_AMOUNT}, got {entries[0].details.get('amount')!r}"
+        )

--- a/backend/tests/api/payment/test_fee_credit_manual_approval.py
+++ b/backend/tests/api/payment/test_fee_credit_manual_approval.py
@@ -1,0 +1,211 @@
+"""Integration test: manual backoffice approval of APPLICATION_FEE payment.
+
+RED-first (TDD): before the fix, PATCH /{payment_id} with status=approved on an
+APPLICATION_FEE payment calls update_status which does NOT transition the application
+out of PENDING_FEE and does NOT grant credit.  After the fix it must:
+
+  1. Set payment.status = APPROVED.
+  2. Transition application from PENDING_FEE → ACCEPTED (AUTO_ACCEPT popup, no strategy).
+  3. Grant fee as credit: application.credit == fee_amount.
+  4. Set fee_credit_granted = True.
+  5. Write exactly one credit.granted audit log with source == "application_fee".
+  6. NOT null existing settlement_currency on the payment (non-destructive overwrite).
+
+The test is driven through the HTTP PATCH endpoint so the routing path in
+update_payment() is covered, not just _handle_fee_payment_approved() directly.
+"""
+
+import uuid
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.audit_log.constants import AuditAction, AuditEntityType
+from app.api.audit_log.models import AuditLog
+from app.api.human.models import Humans
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentStatus, PaymentType
+from app.api.popup.models import Popups
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FEE_AMOUNT = Decimal("80.00")
+
+
+def _make_fee_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"ManualFeePopup {uuid.uuid4().hex[:6]}",
+        slug=f"mfp-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.application.value,
+        status="active",
+        currency="USD",
+        requires_application_fee=True,
+        application_fee_amount=FEE_AMOUNT,
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants) -> Humans:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"mfa-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Manual",
+        last_name="Approval",
+    )
+    db.add(human)
+    db.flush()
+    return human
+
+
+def _make_pending_fee_application(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> Applications:
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.PENDING_FEE.value,
+        credit=Decimal("0"),
+        fee_credit_granted=False,
+    )
+    db.add(application)
+    db.flush()
+    return application
+
+
+def _make_pending_fee_payment(
+    db: Session, tenant: Tenants, popup: Popups, application: Applications
+) -> Payments:
+    payment = Payments(
+        tenant_id=tenant.id,
+        application_id=application.id,
+        popup_id=popup.id,
+        payment_type=PaymentType.APPLICATION_FEE.value,
+        status=PaymentStatus.PENDING.value,
+        amount=FEE_AMOUNT,
+        currency="USD",
+        external_id=f"sf-mfa-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _credit_granted_entries(db: Session, human_id: uuid.UUID) -> list[AuditLog]:
+    db.expire_all()
+    return list(
+        db.exec(
+            select(AuditLog).where(
+                AuditLog.entity_type == AuditEntityType.HUMAN,
+                AuditLog.entity_id == human_id,
+                AuditLog.action == AuditAction.CREDIT_GRANTED,
+            )
+        ).all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestManualFeeApprovalViaEndpoint:
+    """PATCH /{payment_id} with status=approved on APPLICATION_FEE must route through
+    _handle_fee_payment_approved so application transitions and credit is granted."""
+
+    def test_manual_approval_transitions_application_and_grants_credit(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        client: TestClient,
+        admin_token_tenant_a: str,
+    ) -> None:
+        """RED: before fix — application stays PENDING_FEE, no credit granted.
+        GREEN: after fix — application transitions, credit == fee_amount, audit written."""
+        popup = _make_fee_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        application = _make_pending_fee_application(db, tenant_a, popup, human)
+        payment = _make_pending_fee_payment(db, tenant_a, popup, application)
+
+        # Approve via backoffice PATCH endpoint
+        resp = client.patch(
+            f"/api/v1/payments/{payment.id}",
+            json={"status": "approved"},
+            headers={
+                "Authorization": f"Bearer {admin_token_tenant_a}",
+                "X-Tenant-Id": str(tenant_a.id),
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Payment must be APPROVED
+        db.expire_all()
+        db.refresh(payment)
+        assert payment.status == PaymentStatus.APPROVED.value
+
+        # Application must have transitioned out of PENDING_FEE
+        db.refresh(application)
+        assert application.status != ApplicationStatus.PENDING_FEE.value, (
+            f"Application is still in PENDING_FEE after manual fee approval — "
+            f"fix not applied: got {application.status!r}"
+        )
+
+        # Credit must be granted
+        assert application.credit == FEE_AMOUNT, (
+            f"Expected credit={FEE_AMOUNT}, got {application.credit} — "
+            f"_handle_fee_payment_approved was not called from update_payment"
+        )
+        assert application.fee_credit_granted is True
+
+        # Exactly one credit.granted audit log with source == "application_fee"
+        entries = _credit_granted_entries(db, human.id)
+        assert len(entries) == 1, (
+            f"Expected 1 credit.granted audit entry, got {len(entries)}"
+        )
+        assert entries[0].details["source"] == "application_fee"
+        assert Decimal(str(entries[0].details["amount"])) == FEE_AMOUNT
+
+    def test_settlement_currency_not_nulled_on_existing_value(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Non-destructive overwrite: passing settlement_currency=None must not null
+        an existing value on the payment (covers the _handle_fee_payment_approved fix)."""
+        import asyncio
+
+        from app.api.payment.router import _handle_fee_payment_approved
+
+        popup = _make_fee_popup(db, tenant_a)
+        human = _make_human(db, tenant_a)
+        application = _make_pending_fee_application(db, tenant_a, popup, human)
+        payment = _make_pending_fee_payment(db, tenant_a, popup, application)
+
+        # Pre-set settlement_currency (simulates a partial update already recorded)
+        payment.settlement_currency = "BTC"
+        db.add(payment)
+        db.flush()
+
+        # Call handler with settlement_currency=None (manual path)
+        asyncio.run(
+            _handle_fee_payment_approved(
+                db, payment, settlement_currency=None, source="manual"
+            )
+        )
+
+        db.expire_all()
+        db.refresh(payment)
+        assert payment.settlement_currency == "BTC", (
+            "settlement_currency was nulled out — the non-destructive guard is missing"
+        )

--- a/portal/src/app/[popupSlug]/page.tsx
+++ b/portal/src/app/[popupSlug]/page.tsx
@@ -14,19 +14,21 @@ export default async function PopupRoutePage({ params }: PopupRoutePageProps) {
     throw new Error("NEXT_PUBLIC_API_URL is not configured")
   }
 
-  const response = await fetch(
-    `${apiBaseUrl}/api/v1/popups/portal/${popupSlug}`,
-    {
+  let response: Response
+  try {
+    response = await fetch(`${apiBaseUrl}/api/v1/popups/portal/${popupSlug}`, {
       cache: "no-store",
-    },
-  )
-
-  if (response.status === 404) {
+    })
+  } catch {
+    // Network/backend unreachable: show the 404 page instead of a raw
+    // server-side exception.
     notFound()
   }
 
+  // Any non-OK status (404 unknown slug, 401 anonymous SSR request, etc.)
+  // resolves to the not-found page rather than throwing.
   if (!response.ok) {
-    throw new Error(`Failed to resolve popup ${popupSlug}`)
+    notFound()
   }
 
   const popup = (await response.json()) as { sale_type?: string; slug: string }

--- a/portal/src/app/portal/[popupSlug]/application/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/page.tsx
@@ -65,7 +65,11 @@ export default function FormPage() {
   const application = getRelevantApplication()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const isReturnFromCheckout = searchParams.has("checkout", "success")
+  // Capture once on mount so a later URL change doesn't tear down the fee
+  // banner while it's still polling for the payment webhook.
+  const [isReturnFromCheckout] = useState(() =>
+    searchParams.has("checkout", "success"),
+  )
 
   const {
     data: schema,
@@ -86,25 +90,19 @@ export default function FormPage() {
     }
   }, [importSource, existingApp])
 
-  // Redirect if already accepted/rejected (not for pending_fee — that stays editable)
+  // Once submitted, the application is no longer accessible from the form —
+  // same behavior as a fee-less submit. draft/pending_fee stay editable so the
+  // applicant can still finish or retry the fee payment.
   useEffect(() => {
     if (
       application &&
-      (application.status === "accepted" || application.status === "rejected")
+      (application.status === "in review" ||
+        application.status === "accepted" ||
+        application.status === "rejected")
     ) {
-      router.push(`/portal/${city?.slug}`)
+      router.replace(`/portal/${city?.slug}`)
     }
   }, [application, city, router])
-
-  // Clean up ?checkout=success from the URL after the banner mounts,
-  // so stale polling doesn't re-trigger on subsequent navigations.
-  // isReturnFromCheckout is computed synchronously above, so the banner
-  // already received the initial `true` value before this replace runs.
-  useEffect(() => {
-    if (isReturnFromCheckout) {
-      router.replace(`/portal/${city?.slug}/application`, { scroll: false })
-    }
-  }, [isReturnFromCheckout, city?.slug, router])
 
   useEffect(() => {
     if (city?.sale_type === "direct") {
@@ -132,6 +130,30 @@ export default function FormPage() {
 
   if (city.sale_type === "direct") {
     return <Loader />
+  }
+
+  // Submitted or resolved applications never render the form. The effect above
+  // redirects to the portal home; show a loader meanwhile to avoid flashing it.
+  if (
+    application?.status === "in review" ||
+    application?.status === "accepted" ||
+    application?.status === "rejected"
+  ) {
+    return <Loader />
+  }
+
+  // Returning from the fee checkout: show only the confirmation banner while we
+  // poll for the payment webhook. The form must not reappear after paying.
+  if (isReturnFromCheckout) {
+    return (
+      <main className="container py-6 md:py-12 mb-8 px-8 md:px-12">
+        {application ? (
+          <FeePaymentBanner application={application} isReturnFromCheckout />
+        ) : (
+          <Loader />
+        )}
+      </main>
+    )
   }
 
   if (isError || !schema) {
@@ -165,12 +187,6 @@ export default function FormPage() {
         <FormHeader />
         <SectionSeparator />
       </div>
-      {application?.status === "pending_fee" && isReturnFromCheckout && (
-        <FeePaymentBanner
-          application={application}
-          isReturnFromCheckout={isReturnFromCheckout}
-        />
-      )}
       <FileUploadProvider value={uploadFile}>
         <DynamicApplicationForm
           key={existingApp?.id ?? importedData?.id ?? "new"}

--- a/portal/src/app/portal/[popupSlug]/events/layout.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/layout.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useEffect } from "react"
+import { Loader } from "@/components/ui/Loader"
+import { useApplicationsQuery } from "@/hooks/useGetApplications"
+import { useParticipationQuery } from "@/hooks/useParticipationQuery"
+import { useApplication } from "@/providers/applicationProvider"
+import { useCityProvider } from "@/providers/cityProvider"
+
+export default function EventsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const params = useParams()
+  const router = useRouter()
+  const { getCity } = useCityProvider()
+  const { getRelevantApplication, participation } = useApplication()
+  const city = getCity()
+  const popupId = city?.id ? String(city.id) : null
+
+  // Subscribe to the same queries the sidebar reads so this route gate matches
+  // nav visibility exactly (see useResources `canSeeAttendees`). Reusing
+  // getRelevantApplication (not the backend access ladder) also keeps this in
+  // lockstep with the popup root redirect, so the two can never disagree and
+  // bounce the user back and forth.
+  const applicationsQuery = useApplicationsQuery()
+  const participationQuery = useParticipationQuery(popupId)
+
+  const isDirectSale = city?.sale_type === "direct"
+  const isCompanion = participation?.type === "companion"
+  const application = getRelevantApplication()
+
+  // Only an accepted application (or an accepted companion) may view events,
+  // mirroring the sidebar gate. A draft/pending_fee/in-review application owns
+  // an attendee row but is not approved, so it is bounced here just as the nav
+  // hides the link. Direct-sale popups don't run the application flow, so their
+  // events access is left untouched.
+  const isEligible = isCompanion
+    ? participation?.application_status === "accepted"
+    : application?.status === "accepted"
+
+  const stillLoading =
+    !city || applicationsQuery.isLoading || participationQuery.isLoading
+
+  const blocked = !isDirectSale && !stillLoading && !isEligible
+
+  useEffect(() => {
+    if (blocked) {
+      router.replace(`/portal/${params.popupSlug}`)
+    }
+  }, [blocked, params.popupSlug, router])
+
+  if (isDirectSale) return <>{children}</>
+  if (stillLoading || !isEligible) return <Loader />
+
+  return <>{children}</>
+}

--- a/portal/src/app/portal/[popupSlug]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/page.tsx
@@ -1,13 +1,11 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { useEffect } from "react"
 import type { CompanionParticipation } from "@/client"
 import { EventCard } from "@/components/Card/EventCard"
 import type { EventStatus } from "@/components/Card/EventProgressBar"
 import { CompanionView } from "@/components/CompanionView"
 import { ScholarshipStatusBadge } from "@/components/ScholarshipStatusBadge"
-import { useHumanAttendeesQuery } from "@/hooks/useHumanAttendeesQuery"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 
@@ -18,36 +16,11 @@ export default function Home() {
   const city = getCity()
   const relevantApplication = getRelevantApplication()
 
-  // Application-flow ticket holders skip their application card and land
-  // straight on the events list. Direct-sale and companion flows keep their
-  // own landing views, and we only redirect when the events module is on.
-  const attendeesQuery = useHumanAttendeesQuery(city?.id)
-  const isDirectSale = city?.sale_type === "direct"
-  const isCompanion = participation?.type === "companion"
-  const eventsEnabled = city?.events_enabled ?? true
-  const shouldRedirectToEvents =
-    !!city &&
-    !isDirectSale &&
-    !isCompanion &&
-    eventsEnabled &&
-    (attendeesQuery.data?.length ?? 0) > 0
-
-  const slug = city?.slug
-  useEffect(() => {
-    if (shouldRedirectToEvents && slug) {
-      router.replace(`/portal/${slug}/events`)
-    }
-  }, [shouldRedirectToEvents, slug, router])
-
   if (!city) return null
 
-  // Wait for the attendees query before rendering the application card so a
-  // ticket holder never sees it flash before the redirect fires.
-  if (!isDirectSale && !isCompanion) {
-    if (attendeesQuery.isLoading || shouldRedirectToEvents) return null
-  }
+  const isDirectSale = city.sale_type === "direct"
 
-  if (!isDirectSale && isCompanion) {
+  if (!isDirectSale && participation?.type === "companion") {
     return (
       <section className="container mx-auto">
         <div className="space-y-6 max-w-5xl p-6 mx-auto">

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -99,6 +99,10 @@ export default function ScrollySectionNav({
   // overflow. The result never truncates a label and never clips an icon at
   // any width or step count. `compact` drives both the layout and whether
   // labels render.
+  // Stable full-width wrapper used as the available-width reference. The track
+  // itself swaps between w-fit (expanded) and w-full (compact), so measuring it
+  // would couple `avail` to `compact` — see the effect below.
+  const shellRef = useRef<HTMLDivElement>(null)
   const trackRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
@@ -110,10 +114,17 @@ export default function ScrollySectionNav({
 
   useIsomorphicLayoutEffect(() => {
     const recalc = () => {
-      const track = trackRef.current
       const list = listRef.current
-      if (track && list) {
-        const avail = track.clientWidth
+      // Measure available width from the stable shell, never the track. The
+      // track is w-fit while expanded and w-full while compact, so reading its
+      // width would make `avail` depend on `compact`. Since this effect also
+      // writes `compact` (and re-runs on it), that feedback flip-flops
+      // true<->false forever until React aborts with "Maximum update depth
+      // exceeded" (#185). The shell is always full-width, so the decision has a
+      // fixed basis and settles within a 1px hysteresis band.
+      const shell = shellRef.current
+      if (list && shell) {
+        const avail = shell.clientWidth
         if (!compact) {
           // Labels are showing → scrollWidth is the true expanded width.
           expandedWidthRef.current = list.scrollWidth
@@ -142,9 +153,10 @@ export default function ScrollySectionNav({
       track.scrollTo({ left: Math.max(0, target), behavior: "smooth" })
     }
 
-    if (!track) return
+    const shell = shellRef.current
+    if (!shell) return
     const ro = new ResizeObserver(recalc)
-    ro.observe(track)
+    ro.observe(shell)
     return () => ro.disconnect()
     // sections.length re-runs when tabs change; compact re-runs after a mode
     // flip so the measurement settles (pre-paint, so no visible flicker).
@@ -166,6 +178,7 @@ export default function ScrollySectionNav({
             />
           ) : null}
           <div
+            ref={shellRef}
             className={cn("flex min-w-0 flex-1", !compact && "justify-center")}
           >
             <div

--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -5,9 +5,7 @@ import Image from "next/image"
 import type { CSSProperties } from "react"
 import { useTranslation } from "react-i18next"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
-import QuantitySelector, {
-  supportsQuantitySelector,
-} from "@/components/ui/QuantitySelector"
+import QuantitySelector from "@/components/ui/QuantitySelector"
 import type {
   TicketAttendeeVM,
   TicketRowVM,
@@ -345,7 +343,7 @@ function OpenCheckoutProductRow({
   const { product, quantity, maxQuantity, selected, disabled } = row
 
   const isAdded = quantity > 0 || selected
-  const showStepper = supportsQuantitySelector(product.max_per_order)
+  const showStepper = row.usesStepper
   const max = maxQuantity
   const rowDisabled = disabled && !isAdded
   const hasDiscount =

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -915,8 +915,7 @@ function CompactAttendeeCard({
         <div className="flex flex-wrap gap-2">
           {visibleProducts.map((p) => {
             const isDayPass = p.duration_type === "day"
-            const hasStepper =
-              isDayPass || supportsQuantitySelector(p.max_per_order)
+            const hasStepper = isPassQuantityBased(p)
             const pillSaleState = deriveProductState(p)
             const pillStateBlocked = pillSaleState !== "on_sale"
 

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -41,6 +41,7 @@ import useGetPassesData from "@/hooks/useGetPassesData"
 import { useIsAuthenticated } from "@/hooks/useIsAuthenticated"
 import { buildFormZodSchema } from "@/lib/form-schema-builder"
 import { trackMetaAddToCart } from "@/lib/meta-pixel"
+import { isPassQuantityBased } from "@/strategies/passQuantityHelper"
 import type { AttendeePassState } from "@/types/Attendee"
 import type {
   CheckoutCartState,
@@ -474,7 +475,7 @@ export function CheckoutProvider({
                 : 1
               : isDayPass
                 ? (product.quantity ?? 1) - (product.original_quantity ?? 0)
-                : supportsQuantitySelector(product.max_per_order)
+                : isPassQuantityBased(product)
                   ? (product.quantity ?? 1)
                   : 1
 

--- a/portal/src/providers/passesProvider.tsx
+++ b/portal/src/providers/passesProvider.tsx
@@ -14,7 +14,6 @@ import {
   resolvePopupCheckoutPolicy,
 } from "@/checkout/popupCheckoutPolicy"
 import type { AttendeePurchases } from "@/client"
-import { supportsQuantitySelector } from "@/components/ui/QuantitySelector"
 import { useCart } from "@/hooks/useCartApi"
 import useGetPassesData from "@/hooks/useGetPassesData"
 import { usePurchasesQuery } from "@/hooks/useGetPurchases"
@@ -198,8 +197,11 @@ function applyCartSelections(
         }
       }
       // Non-day: multi-unit products restore the persisted quantity;
-      // single-unit products stay at the legacy quantity of 1.
-      const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+      // single-unit products stay at the legacy quantity of 1. Use
+      // isPassQuantityBased so full/month passes (single-select even when
+      // max_per_order is null) keep their quantity instead of adopting the
+      // saved cart quantity.
+      const isMultiUnit = isPassQuantityBased(product)
       return {
         ...product,
         selected: true,
@@ -460,8 +462,7 @@ const PassesProvider = ({
             return { ...p, selected: false, edit: false, disabled: false }
           }
           const isMultiUnit =
-            p.duration_type !== "day" &&
-            supportsQuantitySelector(p.max_per_order)
+            p.duration_type !== "day" && isPassQuantityBased(p)
           const initialQuantity =
             p.duration_type === "day"
               ? (p.original_quantity ?? 0)

--- a/portal/src/strategies/ProductStrategies.test.ts
+++ b/portal/src/strategies/ProductStrategies.test.ts
@@ -400,11 +400,12 @@ describe("WeekProductStrategy — attendeeVisibleProductIds (wide scope)", () =>
 })
 
 describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => {
-  // Reproduces: GA + VIP both exclusive, multi-unit (max_per_order=null), duration_type=full.
-  // Pre-state: GA quantity=1 selected, VIP quantity=0 not selected.
-  // Action: user clicks +1 on VIP.
-  // Expected: VIP quantity=1 selected, GA quantity=0 NOT selected.
-  it("clicking + on VIP cancels GA when both are exclusive multi-unit full passes in same section", () => {
+  // GA + VIP both exclusive full passes (max_per_order=null) in the same
+  // section. Full passes are single-select (isPassQuantityBased=false), so
+  // selecting one clears the other via `selected` — not quantity.
+  // Pre-state: GA selected, VIP not. Action: user clicks VIP's checkbox.
+  // Expected: VIP selected, GA cleared.
+  it("clicking VIP cancels GA when both are exclusive full passes in same section", () => {
     const ga = {
       ...createProduct({
         id: "ga",
@@ -423,7 +424,7 @@ describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => 
         name: "VIP Pass",
         category: "ticket",
         duration_type: "full",
-        quantity: 0,
+        quantity: 1,
         selected: false,
       }),
       max_per_order: null,
@@ -432,31 +433,29 @@ describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => 
     const attendees = [createAttendee([ga, vip])]
     const strategy = getProductStrategy(vip, false, CHECKOUT_MODE.PASS_SYSTEM)
 
-    // Simulate the stepper +1: caller passes product with quantity=1 and the section scope.
+    // Checkbox toggle: caller passes the current product with the section scope.
     const result = strategy.handleSelection(
       attendees,
       "attendee-1",
-      { ...vip, quantity: 1 },
+      vip,
       undefined,
       ["ga", "vip"],
     )
 
     const updatedGa = result[0]?.products.find((p) => p.id === "ga")
     const updatedVip = result[0]?.products.find((p) => p.id === "vip")
-    expect(updatedVip?.quantity).toBe(1)
     expect(updatedVip?.selected).toBe(true)
-    expect(updatedGa?.quantity).toBe(0)
     expect(updatedGa?.selected).toBe(false)
   })
 
-  it("clicking + on GA cancels VIP (symmetric)", () => {
+  it("clicking GA cancels VIP (symmetric)", () => {
     const ga = {
       ...createProduct({
         id: "ga",
         name: "General Admission",
         category: "ticket",
         duration_type: "full",
-        quantity: 0,
+        quantity: 1,
         selected: false,
       }),
       max_per_order: null,
@@ -479,15 +478,13 @@ describe("ExclusivityGuard — section scope (tech-summit reproduction)", () => 
     const result = strategy.handleSelection(
       attendees,
       "attendee-1",
-      { ...ga, quantity: 1 },
+      ga,
       undefined,
       ["ga", "vip"],
     )
     const updatedGa = result[0]?.products.find((p) => p.id === "ga")
     const updatedVip = result[0]?.products.find((p) => p.id === "vip")
-    expect(updatedGa?.quantity).toBe(1)
     expect(updatedGa?.selected).toBe(true)
-    expect(updatedVip?.quantity).toBe(0)
     expect(updatedVip?.selected).toBe(false)
   })
 })
@@ -687,10 +684,11 @@ describe("EditProductStrategy — month upgrade while editing", () => {
     expect(result[0]?.products.find((p) => p.id === "w1")?.edit).toBeFalsy()
   })
 
-  // Reported bug: a quantity-based full pass (max_per_order null/>1) reads its
-  // selection from quantity, so upgrading credited the week but the tile never
-  // showed selected because quantity stayed 0.
-  it("upgrading to a quantity-based full pass sets its quantity and credits the week", () => {
+  // A full pass is single-select (isPassQuantityBased=false): upgrading selects
+  // it via `selected` and credits the owned week. The tile reads its state from
+  // `selected`, not quantity, so this can never regress to "selected but
+  // quantity 0" the way a quantity-driven pass could.
+  it("upgrading to a full pass selects it and credits the week", () => {
     const fullPass = createProduct({
       id: "full",
       duration_type: "full",
@@ -704,7 +702,7 @@ describe("EditProductStrategy — month upgrade while editing", () => {
           id: "full",
           duration_type: "full",
           price: 400,
-          quantity: 0,
+          quantity: 1,
           max_per_order: 5,
           selected: false,
         }),
@@ -721,7 +719,6 @@ describe("EditProductStrategy — month upgrade while editing", () => {
     const full = result[0]?.products.find((p) => p.id === "full")
     const w1 = result[0]?.products.find((p) => p.id === "w1")
     expect(full?.selected).toBe(true)
-    expect(full?.quantity).toBeGreaterThanOrEqual(1)
     expect(w1?.edit).toBe(true)
     expect(w1?.selected).toBe(false)
   })

--- a/portal/src/strategies/ProductStrategies.ts
+++ b/portal/src/strategies/ProductStrategies.ts
@@ -73,7 +73,7 @@ class MonthProductStrategy implements ProductStrategy {
     attendeeId: string,
     product: ProductsPass,
   ): AttendeePassState[] {
-    const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+    const isMultiUnit = isPassQuantityBased(product)
     // For multi-unit products, the caller passes the NEW desired quantity in
     // `product.quantity`. The selection is active when quantity > 0.
     const willSelectMonth = isMultiUnit
@@ -191,7 +191,7 @@ class WeekProductStrategy implements ProductStrategy {
     exclusivityScopeIds?: string[],
     attendeeVisibleProductIds?: string[],
   ): AttendeePassState[] {
-    const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+    const isMultiUnit = isPassQuantityBased(product)
 
     // Promotion scope: prefer the WIDE scope (all attendee-visible products
     // across sections) so a week-in-section-A can promote a month-in-section-B
@@ -282,7 +282,7 @@ class FullProductStrategy implements ProductStrategy {
     attendeeId: string,
     product: ProductsPass,
   ): AttendeePassState[] {
-    const isMultiUnit = supportsQuantitySelector(product.max_per_order)
+    const isMultiUnit = isPassQuantityBased(product)
 
     return attendees.map((attendee) => {
       if (attendee.id !== attendeeId) return attendee
@@ -339,19 +339,14 @@ class ExclusivityGuard implements ProductStrategy {
   private isActive(product: ProductsPass): boolean {
     if (product.purchased) return true
     if (product.selected) return true
-    if (
-      product.duration_type === "day" ||
-      supportsQuantitySelector(product.max_per_order)
-    ) {
+    if (isPassQuantityBased(product)) {
       return (product.quantity ?? 0) > 0
     }
     return false
   }
 
   private clearSelection(product: ProductsPass): ProductsPass {
-    const usesQuantity =
-      product.duration_type === "day" ||
-      supportsQuantitySelector(product.max_per_order)
+    const usesQuantity = isPassQuantityBased(product)
 
     return {
       ...product,
@@ -476,7 +471,7 @@ class EditProductStrategy implements ProductStrategy {
   ): ProductsPass[] {
     return products.map((p) => {
       if (p.id === monthId) {
-        const quantity = supportsQuantitySelector(p.max_per_order)
+        const quantity = isPassQuantityBased(p)
           ? Math.max(1, p.quantity ?? 0)
           : p.quantity
         return { ...p, selected: true, quantity }


### PR DESCRIPTION
## Release v1.32.0 — dev to main

Promotes the current `dev` state to `main`.

### Changes
- fix(applications): grant fee credit on review acceptance and manual fee approval (#414)
- fix(portal): block events route for non-accepted applications (#413)
- fix(portal): remove popup-root auto-redirect to events

### Notes
- Merge commit only — do NOT squash (preserves dev↔main ancestry).
- Resolve any conflicts toward `dev`.