### PR TITLE
feat(backend): restrict Sentry to production with loguru integration and tracing

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
 
     PROJECT_NAME: str = Field(...)
     SENTRY_DSN: HttpUrl | None = None
+    SENTRY_TRACES_SAMPLE_RATE: float = 0.1
     POSTGRES_SERVER: str = Field(...)
     POSTGRES_PORT: int = 5432
     POSTGRES_USER: str = Field(...)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from loguru import logger
 from pydantic import ValidationError
+from sentry_sdk.integrations.loguru import LoggingLevels, LoguruIntegration
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.cors import CORSMiddleware
@@ -24,8 +25,21 @@ def custom_generate_unique_id(route: APIRoute) -> str:
     return f"{route.tags[0]}-{route.name}"
 
 
-if settings.SENTRY_DSN and settings.ENVIRONMENT != Environment.DEV:
-    sentry_sdk.init(dsn=str(settings.SENTRY_DSN), enable_tracing=True)
+if settings.SENTRY_DSN and settings.ENVIRONMENT == Environment.PRODUCTION:
+    sentry_sdk.init(
+        dsn=str(settings.SENTRY_DSN),
+        environment=settings.ENVIRONMENT.value,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        enable_logs=True,
+        send_default_pii=False,
+        integrations=[
+            LoguruIntegration(
+                sentry_logs_level=LoggingLevels.INFO.value,
+                level=LoggingLevels.INFO.value,
+                event_level=LoggingLevels.ERROR.value,
+            ),
+        ],
+    )
 
 application = FastAPI(
     title=settings.PROJECT_NAME,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # Pin bcrypt until passlib supports the latest
     "bcrypt==4.3.0",
     "pydantic-settings<3.0.0,>=2.2.1",
-    "sentry-sdk[fastapi]<2.0.0,>=1.40.6",
+    "sentry-sdk[fastapi]>=2.35.0",
     "pyjwt<3.0.0,>=2.8.0",
     "cryptography>=46.0.3",
     "loguru>=0.7.3",

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ requires-dist = [
     { name = "redis", specifier = ">=7.1.0" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "segno", specifier = ">=1.6.6" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=1.40.6,<2.0.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.35.0" },
     { name = "sqlmodel", specifier = ">=0.0.21,<1.0.0" },
     { name = "tenacity", specifier = ">=8.2.3,<9.0.0" },
 ]
@@ -1633,15 +1633,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "1.45.1"
+version = "2.64.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/28/02c0cd9184f9108e3c52519f9628b215077a3854240e0b17ae845e664855/sentry_sdk-1.45.1.tar.gz", hash = "sha256:a16c997c0f4e3df63c0fc5e4207ccb1ab37900433e0f72fef88315d317829a26", size = 244774, upload-time = "2024-07-26T13:48:32.375Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/31/b7341f156a5f6f36f0b4845d6f1c28a2ae4799171dba7007f3a1e9b234b4/sentry_sdk-2.64.0.tar.gz", hash = "sha256:68be2c29e14ae310f8a39e1a79916b6d85c6cb41dcce789d14ff05fe293e4c55", size = 921020, upload-time = "2026-06-30T08:13:47.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/9f/105366a122efa93f0cb1914f841747d160788e4d022d0488d2d44c2ba26c/sentry_sdk-1.45.1-py2.py3-none-any.whl", hash = "sha256:608887855ccfe39032bfd03936e3a1c4f4fc99b3a4ac49ced54a4220de61c9c1", size = 267163, upload-time = "2024-07-26T13:48:29.38Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl", hash = "sha256:715ea91ca860a819e8d8a50a7bde3a80d0df3b4ed7b6660a20fb9a2d084188f1", size = 498901, upload-time = "2026-06-30T08:13:45.566Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
Tightens Sentry configuration in the backend and upgrades the SDK to v2.

- Init Sentry **only in `PRODUCTION`** (previously any non-`DEV` environment, so staging was also reporting)
- Add `LoguruIntegration` so loguru logs bridge into Sentry: `INFO` as breadcrumbs/logs, `ERROR` as events
- Add configurable `SENTRY_TRACES_SAMPLE_RATE` (default `0.1`)
- Tag the Sentry `environment` and disable default PII (`send_default_pii=False`)
- Bump `sentry-sdk[fastapi]` to `>=2.35.0`

## Files
- `backend/app/core/config.py`
- `backend/app/main.py`
- `backend/pyproject.toml`
- `uv.lock`