### PR TITLE
feat(analytics): tenant-scoped Google Analytics 4 tracking

### DIFF
--- a/backend/app/alembic/versions/c58bb16def73_tenant_ga_tracking.py
+++ b/backend/app/alembic/versions/c58bb16def73_tenant_ga_tracking.py
@@ -1,0 +1,35 @@
+"""Add GA tracking config to tenants.
+
+Revision ID: c58bb16def73
+Revises: 70b397330323
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c58bb16def73"
+down_revision: str | Sequence[str] | None = "70b397330323"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "ga_tracking_enabled",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "tenants", sa.Column("ga_measurement_id", sa.String(length=64), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenants", "ga_measurement_id")
+    op.drop_column("tenants", "ga_tracking_enabled")

--- a/backend/app/api/tenant/schemas.py
+++ b/backend/app/api/tenant/schemas.py
@@ -52,6 +52,8 @@ class TenantBase(SQLModel):
     landing_mode: LandingMode = LandingMode.portal
     meta_tracking_enabled: bool = False
     meta_pixel_id: str | None = Field(default=None, max_length=64)
+    ga_tracking_enabled: bool = False
+    ga_measurement_id: str | None = Field(default=None, max_length=64)
 
 
 class TenantCreate(SQLModel):
@@ -64,6 +66,8 @@ class TenantCreate(SQLModel):
     logo_url: str | None = None
     meta_tracking_enabled: bool = False
     meta_pixel_id: str | None = Field(default=None, max_length=64)
+    ga_tracking_enabled: bool = False
+    ga_measurement_id: str | None = Field(default=None, max_length=64)
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: int | None = 587
     smtp_user: str | None = Field(default=None, max_length=255)
@@ -108,6 +112,8 @@ class TenantUpdate(SQLModel):
     meta_tracking_enabled: bool | None = None
     meta_pixel_id: str | None = Field(default=None, max_length=64)
     meta_capi_access_token: str | None = Field(default=None, exclude=True)
+    ga_tracking_enabled: bool | None = None
+    ga_measurement_id: str | None = Field(default=None, max_length=64)
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: int | None = None
     smtp_user: str | None = Field(default=None, max_length=255)

--- a/backend/tests/core/dependencies/test_tenants.py
+++ b/backend/tests/core/dependencies/test_tenants.py
@@ -51,6 +51,8 @@ def _make_tenant(tenant_id: uuid.UUID = _TENANT_A_ID) -> MagicMock:
     t.landing_mode = LandingMode.portal
     t.meta_tracking_enabled = False
     t.meta_pixel_id = None
+    t.ga_tracking_enabled = False
+    t.ga_measurement_id = None
     t.active_popup_slug = None  # computed projection — not a DB column
     t.third_party_key_prefix = None  # third-party OTP display fragment
     return t
@@ -64,7 +66,8 @@ def _make_tenant_public_json(tenant_id: uuid.UUID = _TENANT_A_ID) -> str:
         f'"image_url":null,"icon_url":null,"logo_url":null,'
         f'"custom_domain":null,"custom_domain_active":false,'
         f'"landing_mode":"portal","meta_tracking_enabled":false,'
-        f'"meta_pixel_id":null,"active_popup_slug":null}}'
+        f'"meta_pixel_id":null,"ga_tracking_enabled":false,'
+        f'"ga_measurement_id":null,"active_popup_slug":null}}'
     )
 
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -17685,6 +17685,23 @@ export const TenantAnonymousPublicSchema = {
             ],
             title: 'Meta Pixel Id'
         },
+        ga_tracking_enabled: {
+            type: 'boolean',
+            title: 'Ga Tracking Enabled',
+            default: false
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -17791,6 +17808,23 @@ export const TenantCreateSchema = {
                 }
             ],
             title: 'Meta Pixel Id'
+        },
+        ga_tracking_enabled: {
+            type: 'boolean',
+            title: 'Ga Tracking Enabled',
+            default: false
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
         },
         smtp_host: {
             anyOf: [
@@ -18007,6 +18041,23 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Meta Pixel Id'
+        },
+        ga_tracking_enabled: {
+            type: 'boolean',
+            title: 'Ga Tracking Enabled',
+            default: false
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
         },
         id: {
             type: 'string',
@@ -18265,6 +18316,29 @@ export const TenantUpdateSchema = {
                 }
             ],
             title: 'Meta Capi Access Token'
+        },
+        ga_tracking_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Tracking Enabled'
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
         },
         smtp_host: {
             anyOf: [

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -3600,6 +3600,8 @@ export type TenantAnonymousPublic = {
     landing_mode?: LandingMode;
     meta_tracking_enabled?: boolean;
     meta_pixel_id?: (string | null);
+    ga_tracking_enabled?: boolean;
+    ga_measurement_id?: (string | null);
     id: string;
     active_popup_slug?: (string | null);
 };
@@ -3614,6 +3616,8 @@ export type TenantCreate = {
     logo_url?: (string | null);
     meta_tracking_enabled?: boolean;
     meta_pixel_id?: (string | null);
+    ga_tracking_enabled?: boolean;
+    ga_measurement_id?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);
@@ -3643,6 +3647,8 @@ export type TenantPublic = {
     landing_mode?: LandingMode;
     meta_tracking_enabled?: boolean;
     meta_pixel_id?: (string | null);
+    ga_tracking_enabled?: boolean;
+    ga_measurement_id?: (string | null);
     id: string;
     meta_capi_configured?: boolean;
     smtp_host?: (string | null);
@@ -3676,6 +3682,8 @@ export type TenantUpdate = {
     meta_tracking_enabled?: (boolean | null);
     meta_pixel_id?: (string | null);
     meta_capi_access_token?: (string | null);
+    ga_tracking_enabled?: (boolean | null);
+    ga_measurement_id?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -172,6 +172,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
       meta_tracking_enabled: defaultValues?.meta_tracking_enabled ?? false,
       meta_pixel_id: defaultValues?.meta_pixel_id ?? "",
       meta_capi_access_token: "",
+      ga_tracking_enabled: defaultValues?.ga_tracking_enabled ?? false,
+      ga_measurement_id: defaultValues?.ga_measurement_id ?? "",
       smtp_host: defaultValues?.smtp_host ?? "",
       smtp_port: defaultValues?.smtp_port ?? 587,
       smtp_user: defaultValues?.smtp_user ?? "",
@@ -195,6 +197,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           custom_domain: value.custom_domain || null,
           meta_tracking_enabled: value.meta_tracking_enabled,
           meta_pixel_id: value.meta_pixel_id || null,
+          ga_tracking_enabled: value.ga_tracking_enabled,
+          ga_measurement_id: value.ga_measurement_id || null,
           smtp_host: smtpHost || null,
           smtp_port: value.smtp_port || null,
           smtp_user: smtpUser || null,
@@ -227,6 +231,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           logo_url: value.logo_url || undefined,
           meta_tracking_enabled: value.meta_tracking_enabled,
           meta_pixel_id: value.meta_pixel_id || undefined,
+          ga_tracking_enabled: value.ga_tracking_enabled,
+          ga_measurement_id: value.ga_measurement_id || undefined,
           smtp_host: smtpHost || undefined,
           smtp_port: value.smtp_port || undefined,
           smtp_user: smtpUser || undefined,
@@ -438,6 +444,58 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
               )}
             </form.Field>
           )}
+
+          <form.Field name="ga_tracking_enabled">
+            {(field) => (
+              <InlineRow
+                icon={<Megaphone className="h-4 w-4 text-muted-foreground" />}
+                label="Google Analytics"
+                description="Load the tenant's Google Analytics on the portal and checkout."
+              >
+                <Switch
+                  id="ga_tracking_enabled"
+                  aria-label="Google Analytics"
+                  checked={field.state.value}
+                  onCheckedChange={field.handleChange}
+                />
+              </InlineRow>
+            )}
+          </form.Field>
+
+          <form.Field
+            name="ga_measurement_id"
+            validators={{
+              onBlur: ({ value, fieldApi }) => {
+                const enabled = fieldApi.form.getFieldValue(
+                  "ga_tracking_enabled",
+                )
+                if (enabled && !value)
+                  return "Measurement ID is required when tracking is enabled"
+                if (value && !/^G-[A-Z0-9]+$/i.test(value))
+                  return "Enter a valid Google Analytics measurement ID (e.g. G-XXXXXXXXXX)"
+                return undefined
+              },
+            }}
+          >
+            {(field) => (
+              <div>
+                <InlineRow
+                  icon={<Megaphone className="h-4 w-4 text-muted-foreground" />}
+                  label="Measurement ID"
+                  description="Shared by all popups in this organization."
+                >
+                  <Input
+                    placeholder="G-XXXXXXXXXX"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    className="max-w-xs text-sm"
+                  />
+                </InlineRow>
+                <FieldError errors={field.state.meta.errors} />
+              </div>
+            )}
+          </form.Field>
         </InlineSection>
 
         <Separator />

--- a/portal/src/app/layout.tsx
+++ b/portal/src/app/layout.tsx
@@ -75,7 +75,6 @@ export default async function RootLayout({
         className={`${GeistSans.variable} ${GeistSans.className} ${GeistMono.variable} antialiased`}
         suppressHydrationWarning
       >
-        <GoogleAnalytics />
         <QueryProvider>
           <TenantProvider
             initialTenantId={middlewareTenantId}
@@ -83,6 +82,7 @@ export default async function RootLayout({
             initialLandingMode={middlewareLandingMode}
             initialActivePopupSlug={middlewareActivePopupSlug}
           >
+            <GoogleAnalytics />
             <MetaPixel />
             <div className="w-full">{children}</div>
           </TenantProvider>

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -17685,6 +17685,23 @@ export const TenantAnonymousPublicSchema = {
             ],
             title: 'Meta Pixel Id'
         },
+        ga_tracking_enabled: {
+            type: 'boolean',
+            title: 'Ga Tracking Enabled',
+            default: false
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -17791,6 +17808,23 @@ export const TenantCreateSchema = {
                 }
             ],
             title: 'Meta Pixel Id'
+        },
+        ga_tracking_enabled: {
+            type: 'boolean',
+            title: 'Ga Tracking Enabled',
+            default: false
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
         },
         smtp_host: {
             anyOf: [
@@ -18007,6 +18041,23 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Meta Pixel Id'
+        },
+        ga_tracking_enabled: {
+            type: 'boolean',
+            title: 'Ga Tracking Enabled',
+            default: false
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
         },
         id: {
             type: 'string',
@@ -18265,6 +18316,29 @@ export const TenantUpdateSchema = {
                 }
             ],
             title: 'Meta Capi Access Token'
+        },
+        ga_tracking_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Tracking Enabled'
+        },
+        ga_measurement_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 64
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Ga Measurement Id'
         },
         smtp_host: {
             anyOf: [

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -3600,6 +3600,8 @@ export type TenantAnonymousPublic = {
     landing_mode?: LandingMode;
     meta_tracking_enabled?: boolean;
     meta_pixel_id?: (string | null);
+    ga_tracking_enabled?: boolean;
+    ga_measurement_id?: (string | null);
     id: string;
     active_popup_slug?: (string | null);
 };
@@ -3614,6 +3616,8 @@ export type TenantCreate = {
     logo_url?: (string | null);
     meta_tracking_enabled?: boolean;
     meta_pixel_id?: (string | null);
+    ga_tracking_enabled?: boolean;
+    ga_measurement_id?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);
@@ -3643,6 +3647,8 @@ export type TenantPublic = {
     landing_mode?: LandingMode;
     meta_tracking_enabled?: boolean;
     meta_pixel_id?: (string | null);
+    ga_tracking_enabled?: boolean;
+    ga_measurement_id?: (string | null);
     id: string;
     meta_capi_configured?: boolean;
     smtp_host?: (string | null);
@@ -3676,6 +3682,8 @@ export type TenantUpdate = {
     meta_tracking_enabled?: (boolean | null);
     meta_pixel_id?: (string | null);
     meta_capi_access_token?: (string | null);
+    ga_tracking_enabled?: (boolean | null);
+    ga_measurement_id?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);

--- a/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
+++ b/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
@@ -13,6 +13,7 @@ import {
 import FaviconOverride from "@/components/checkout-flow/FaviconOverride"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher"
+import { trackGAViewItem } from "@/lib/google-analytics"
 import { trackMetaViewContent } from "@/lib/meta-pixel"
 import { queryKeys } from "@/lib/query-keys"
 import { ApplicationContext } from "@/providers/applicationProvider"
@@ -184,6 +185,7 @@ export function OpenCheckoutRuntime({
     if (trackedViewContentRef.current === popup.id) return
 
     trackMetaViewContent({ popup, products: runtime.products })
+    trackGAViewItem({ popup, products: runtime.products })
     trackedViewContentRef.current = popup.id
   }, [popup, runtime.products])
 

--- a/portal/src/components/utils/GoogleAnalytics.tsx
+++ b/portal/src/components/utils/GoogleAnalytics.tsx
@@ -1,23 +1,104 @@
 "use client"
 
-import Script from "next/script"
+import { usePathname } from "next/navigation"
+import { useEffect, useRef } from "react"
+import { useTenant } from "@/providers/tenantProvider"
+
+type Gtag = (...args: unknown[]) => void
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[]
+    gtag?: Gtag
+  }
+}
+
+const GA4_MEASUREMENT_ID_PATTERN = /^G-[A-Z0-9]+$/i
+
+function ensureGtag(measurementId: string) {
+  if (typeof window === "undefined") return
+
+  window.dataLayer = window.dataLayer || []
+  if (!window.gtag) {
+    window.gtag = (...args: unknown[]) => {
+      window.dataLayer?.push(args)
+    }
+    window.gtag("js", new Date())
+  }
+
+  const scriptSrc = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+  if (!document.querySelector(`script[src="${scriptSrc}"]`)) {
+    const script = document.createElement("script")
+    script.async = true
+    script.src = scriptSrc
+    const firstScript = document.getElementsByTagName("script")[0]
+    if (firstScript?.parentNode) {
+      firstScript.parentNode.insertBefore(script, firstScript)
+    } else {
+      document.head.appendChild(script)
+    }
+  }
+}
+
+function resolvePopupSlug(pathname: string, activePopupSlug?: string | null) {
+  const segments = pathname.split("/").filter(Boolean)
+  const [first, second] = segments
+
+  if (first === "checkout" || first === "portal") return second ?? null
+  if (
+    !first ||
+    first === "auth" ||
+    first === "coming-soon" ||
+    first === "groups"
+  ) {
+    return activePopupSlug ?? null
+  }
+  return first
+}
 
 export default function GoogleAnalytics() {
-  return (
-    <>
-      <Script
-        src="https://www.googletagmanager.com/gtag/js?id=G-F19RHMD80N"
-        strategy="afterInteractive"
-      />
-      <Script id="google-analytics" strategy="afterInteractive">
-        {`
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
+  const pathname = usePathname()
+  const { tenant } = useTenant()
+  const initializedMeasurementId = useRef<string | null>(null)
+  const previousPathname = useRef<string | null>(null)
 
-          gtag('config', 'G-F19RHMD80N');
-        `}
-      </Script>
-    </>
-  )
+  const rawMeasurementId = tenant?.ga_tracking_enabled
+    ? tenant.ga_measurement_id?.trim()
+    : null
+  const measurementId =
+    rawMeasurementId && GA4_MEASUREMENT_ID_PATTERN.test(rawMeasurementId)
+      ? rawMeasurementId
+      : null
+  const popupSlug = resolvePopupSlug(pathname, tenant?.active_popup_slug)
+  const tenantSlug = tenant?.slug
+
+  useEffect(() => {
+    if (!measurementId || initializedMeasurementId.current === measurementId) {
+      return
+    }
+
+    ensureGtag(measurementId)
+    window.gtag?.("config", measurementId, { send_page_view: false })
+    window.gtag?.("event", "page_view", {
+      ...(tenantSlug && { tenant_slug: tenantSlug }),
+      ...(popupSlug && { popup_slug: popupSlug }),
+    })
+    initializedMeasurementId.current = measurementId
+    previousPathname.current = pathname
+  }, [pathname, measurementId, popupSlug, tenantSlug])
+
+  useEffect(() => {
+    if (!measurementId || initializedMeasurementId.current !== measurementId) {
+      return
+    }
+    if (previousPathname.current === pathname) return
+
+    previousPathname.current = pathname
+    window.gtag?.("event", "page_view", {
+      ...(tenantSlug && { tenant_slug: tenantSlug }),
+      ...(popupSlug && { popup_slug: popupSlug }),
+    })
+  }, [pathname, measurementId, popupSlug, tenantSlug])
+
+  return null
 }

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import type { CheckoutMode } from "@/checkout/popupCheckoutPolicy"
 import { ApiError, CheckoutService, PaymentsService } from "@/client"
+import { trackGAPurchase } from "@/lib/google-analytics"
 import { getMetaAttribution, trackMetaPurchase } from "@/lib/meta-pixel"
 import { queryKeys } from "@/lib/query-keys"
 import type { AttendeePassState } from "@/types/Attendee"
@@ -240,7 +241,7 @@ export function usePaymentSubmit({
           popupSlug &&
           paymentId
         ) {
-          trackMetaPurchase({
+          const purchasePayload = {
             paymentId,
             popup: {
               id: popupId,
@@ -250,7 +251,9 @@ export function usePaymentSubmit({
             amount: data.amount ?? 0,
             currency: data.currency ?? "USD",
             products: productsToSend,
-          })
+          }
+          trackMetaPurchase(purchasePayload)
+          trackGAPurchase(purchasePayload)
         }
         toast.success(
           isEditing

--- a/portal/src/lib/google-analytics.test.ts
+++ b/portal/src/lib/google-analytics.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { trackGAPurchase } from "./google-analytics"
+
+describe("trackGAPurchase", () => {
+  afterEach(() => {
+    // biome-ignore lint/performance/noDelete: reset global gtag between tests
+    delete (window as Window & { gtag?: unknown }).gtag
+    vi.restoreAllMocks()
+  })
+
+  it("maps payment data into a GA4 purchase event", () => {
+    const gtag = vi.fn()
+    ;(window as Window & { gtag?: unknown }).gtag = gtag
+
+    trackGAPurchase({
+      paymentId: "pay_123",
+      popup: { id: "popup_1", slug: "edge-city", name: "Edge City" },
+      amount: "150.5",
+      currency: "USD",
+      products: [
+        { product_id: "prod_a", quantity: 2 },
+        { product_id: "prod_b" },
+      ],
+    })
+
+    expect(gtag).toHaveBeenCalledTimes(1)
+    expect(gtag).toHaveBeenCalledWith("event", "purchase", {
+      popup_id: "popup_1",
+      popup_slug: "edge-city",
+      popup_name: "Edge City",
+      transaction_id: "pay_123",
+      currency: "USD",
+      value: 150.5,
+      items: [
+        { item_id: "prod_a", quantity: 2, price: 0 },
+        { item_id: "prod_b", quantity: 1, price: 0 },
+      ],
+    })
+  })
+
+  it("does nothing when gtag is unavailable", () => {
+    expect(() =>
+      trackGAPurchase({
+        paymentId: "pay_123",
+        popup: { id: "popup_1", slug: "edge-city", name: "Edge City" },
+        amount: 0,
+        currency: "USD",
+        products: [],
+      }),
+    ).not.toThrow()
+  })
+})

--- a/portal/src/lib/google-analytics.ts
+++ b/portal/src/lib/google-analytics.ts
@@ -1,0 +1,120 @@
+"use client"
+
+import type { CheckoutRuntimeProduct, PopupPublic } from "@/client"
+
+type GtagWindow = Window & { gtag?: (...args: unknown[]) => void }
+
+type GAProduct = {
+  id: string
+  name?: string | null
+  price: number | string
+  currency?: string | null
+  category?: string | null
+}
+
+type GAPopup = {
+  id: string
+  slug: string
+  name?: string | null
+  currency?: string | null
+}
+
+type GAItem = {
+  item_id: string
+  item_name?: string | null
+  item_category?: string | null
+  quantity: number
+  price: number
+}
+
+function getPopupParams(popup: GAPopup) {
+  return {
+    popup_id: popup.id,
+    popup_slug: popup.slug,
+    popup_name: popup.name,
+  }
+}
+
+function getProductItems(products: CheckoutRuntimeProduct[]): GAItem[] {
+  return products
+    .filter((product) => product.is_active !== false)
+    .map((product) => ({
+      item_id: product.id,
+      item_name: product.name,
+      quantity: 1,
+      price: Number(product.price),
+    }))
+}
+
+export function trackGAEvent(
+  eventName: string,
+  params: Record<string, unknown>,
+) {
+  if (typeof window === "undefined") return
+  const gtag = (window as GtagWindow).gtag
+  if (typeof gtag !== "function") return
+
+  gtag("event", eventName, params)
+}
+
+export function trackGAViewItem(params: {
+  popup: PopupPublic
+  products: CheckoutRuntimeProduct[]
+}) {
+  const items = getProductItems(params.products)
+  const value = items.reduce((total, item) => total + item.price, 0)
+
+  trackGAEvent("view_item", {
+    ...getPopupParams(params.popup),
+    currency: params.popup.currency,
+    value,
+    items,
+  })
+}
+
+export function trackGAAddToCart(params: {
+  popup: GAPopup
+  product: GAProduct
+  quantity: number
+}) {
+  if (params.quantity <= 0) return
+
+  const unitPrice = Number(params.product.price)
+
+  trackGAEvent("add_to_cart", {
+    ...getPopupParams(params.popup),
+    currency: params.product.currency ?? params.popup.currency,
+    value: unitPrice * params.quantity,
+    items: [
+      {
+        item_id: params.product.id,
+        item_name: params.product.name,
+        item_category: params.product.category,
+        quantity: params.quantity,
+        price: unitPrice,
+      },
+    ],
+  })
+}
+
+export function trackGAPurchase(params: {
+  paymentId: string
+  popup: GAPopup
+  amount: number | string
+  currency: string
+  products: Array<{ product_id: string; quantity?: number }>
+}) {
+  const items: GAItem[] = params.products.map((product) => ({
+    item_id: product.product_id,
+    quantity: product.quantity ?? 1,
+    price: 0,
+  }))
+
+  trackGAEvent("purchase", {
+    ...getPopupParams(params.popup),
+    transaction_id: params.paymentId,
+    currency: params.currency,
+    value: Number(params.amount),
+    items,
+  })
+}

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -40,6 +40,7 @@ import { useStepProductResolver } from "@/hooks/checkout/useStepProductResolver"
 import useGetPassesData from "@/hooks/useGetPassesData"
 import { useIsAuthenticated } from "@/hooks/useIsAuthenticated"
 import { buildFormZodSchema } from "@/lib/form-schema-builder"
+import { trackGAAddToCart } from "@/lib/google-analytics"
 import { trackMetaAddToCart } from "@/lib/meta-pixel"
 import { isPassQuantityBased } from "@/strategies/passQuantityHelper"
 import type { AttendeePassState } from "@/types/Attendee"
@@ -975,6 +976,11 @@ export function CheckoutProvider({
             product: item.product,
             quantity: item.quantity - previousQuantity,
           })
+          trackGAAddToCart({
+            popup: city,
+            product: item.product,
+            quantity: item.quantity - previousQuantity,
+          })
         }
         if (idx >= 0) {
           const updated = [...existing]
@@ -1010,6 +1016,11 @@ export function CheckoutProvider({
         const item = existing.find((i) => i.productId === productId)
         if (item && qty > item.quantity && city) {
           trackMetaAddToCart({
+            popup: city,
+            product: item.product,
+            quantity: qty - item.quantity,
+          })
+          trackGAAddToCart({
             popup: city,
             product: item.product,
             quantity: qty - item.quantity,
@@ -1060,6 +1071,11 @@ export function CheckoutProvider({
         const nextQuantity = quantityOverride ?? (currentQuantity > 0 ? 0 : 1)
         if (nextQuantity > currentQuantity && city) {
           trackMetaAddToCart({
+            popup: city,
+            product,
+            quantity: nextQuantity - currentQuantity,
+          })
+          trackGAAddToCart({
             popup: city,
             product,
             quantity: nextQuantity - currentQuantity,


### PR DESCRIPTION
## What

Adds browser-only, tenant-scoped Google Analytics 4 (gtag), mirroring the existing Meta Pixel browser integration. GA config lives on the **Tenant** (like Meta), not per popup.

## Changes

- **Backend**: `ga_tracking_enabled` + `ga_measurement_id` on the Tenant (schemas + migration `c58bb16def73`). No server-side / encrypted token (GA here is browser-only, unlike Meta CAPI).
- **Backoffice**: "Google Analytics" field in the Marketing Tracking section of the tenant form, validated as `G-XXXXXXXXXX`.
- **Portal**: `GoogleAnalytics` component is now 100% tenant-driven (fires `page_view` on SPA route change); new `lib/google-analytics.ts` helpers; `view_item` / `add_to_cart` / `purchase` events wired into the same checkout sites as Meta.

## Heads up

- **Replaces the hardcoded global GA id** (`G-F19RHMD80N`). The portal no longer tracks under Muvinai's own global property. To keep it, configure Muvinai as a tenant with its measurement ID.
- Migration `c58bb16def73` is parented to `70b397330323` (current `dev` head). A local seed migration was intentionally left out of this PR.
- After merge / locally: run `alembic upgrade head`.

## Scope

Browser-only by decision. No GA4 Measurement Protocol (server-side) equivalent to Meta's CAPI.