### PR TITLE
feat(checkout): align external thank-you redirect with signed contract

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -130,6 +130,7 @@ def _build_purchase_thank_you_payload(
     products_map: "dict[uuid.UUID, Products]",
     *,
     issued_at: str,
+    exp: int,
 ) -> dict:
     """Order snapshot at creation time — quoted total and items, no provider
     choices (installment count / payment method are chosen later on SimpleFi)."""
@@ -148,6 +149,7 @@ def _build_purchase_thank_you_payload(
         amount_total=str(payment.amount),
         currency=popup.currency,
         issued_at=issued_at,
+        exp=exp,
     )
 
 
@@ -895,12 +897,14 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
 
             portal_base = get_portal_url(tenant)
             landing_is_checkout = tenant.landing_mode == LandingMode.checkout
+            now = datetime.now(UTC)
             thank_you_payload = _build_purchase_thank_you_payload(
                 popup,
                 payment,
                 obj,
                 products_map,
-                issued_at=datetime.now(UTC).isoformat(),
+                issued_at=now.isoformat(),
+                exp=int(now.timestamp()) + 30 * 60,
             )
             success_redirect = _resolve_open_checkout_success_url(
                 popup,

--- a/backend/app/utils/checkout_signing.py
+++ b/backend/app/utils/checkout_signing.py
@@ -7,18 +7,22 @@ track the purchase without trusting the raw query string (anti-spoof).
 
 Verification contract — the external page MUST mirror this to validate:
 
-    data = base64url_nopad(utf8(json(payload, sorted keys, compact)))
-    sig  = base64url_nopad(HMAC_SHA256(secret, data))
-    url  = success_url + "?data=<data>&sig=<sig>"
+    d   = base64url_nopad(utf8(json(payload, sorted keys, compact)))
+    sig = hex(HMAC_SHA256(secret, d))
+    url = success_url + "?d=<d>&sig=<sig>"
 
-To verify: recompute ``sig`` over the received ``data`` string with the shared
-secret, compare in constant time, then base64url-decode ``data`` to recover the
-JSON payload. The signature covers the exact transmitted ``data`` bytes, so the
+To verify: recompute ``sig`` over the received ``d`` string with the shared
+secret, compare in constant time, then base64url-decode ``d`` to recover the
+JSON payload. The signature covers the exact transmitted ``d`` bytes, so the
 verifier never has to reproduce the JSON canonicalization.
 
-The payload snapshot is taken at payment creation, so it reflects the quoted
-order (total, items) — not provider-side choices made afterwards such as the
+The payload carries an ``exp`` (epoch seconds) so the page can reject stale
+links (anti-replay); it also snapshots the quoted order (total, items) at
+payment creation — not provider-side choices made afterwards such as the
 installment count or payment method.
+
+The portal's own thank-you page uses a separate, unsigned contract (the ``data``
+query param) — see :func:`build_unsigned_redirect_url`.
 """
 
 import base64
@@ -52,11 +56,25 @@ def encode_payload(payload: Mapping[str, Any]) -> str:
 
 
 def sign_data(data: str, secret: str) -> str:
-    """HMAC-SHA256 of the encoded data string, base64url-nopad encoded."""
+    """HMAC-SHA256 of the encoded data string, base64url-nopad encoded.
+
+    Used for cart-restore tokens. The thank-you redirect uses
+    :func:`sign_data_hex` instead (its external contract expects hex).
+    """
     digest = hmac.new(
         secret.encode("utf-8"), data.encode("ascii"), hashlib.sha256
     ).digest()
     return _b64url_nopad(digest)
+
+
+def sign_data_hex(data: str, secret: str) -> str:
+    """HMAC-SHA256 of the encoded data string, hex encoded.
+
+    Matches the external thank-you page contract: sig = hex(HMAC_SHA256(secret, d)).
+    """
+    return hmac.new(
+        secret.encode("utf-8"), data.encode("ascii"), hashlib.sha256
+    ).hexdigest()
 
 
 def build_cart_restore_token(cart_id: str, secret: str) -> str:
@@ -85,10 +103,12 @@ def build_thank_you_payload(
     amount_total: str,
     currency: str,
     issued_at: str,
+    exp: int,
 ) -> dict[str, Any]:
     """Assemble the order snapshot sent to the thank-you page.
 
     Field names form the contract with the external page; keep them stable.
+    ``exp`` is an epoch-seconds expiry (anti-replay) covered by the signature.
     """
     return {
         "order_id": order_id,
@@ -98,6 +118,7 @@ def build_thank_you_payload(
         "amount_total": amount_total,
         "currency": currency,
         "issued_at": issued_at,
+        "exp": exp,
     }
 
 
@@ -111,14 +132,14 @@ def _append_query(base_url: str, extra: list[tuple[str, str]]) -> str:
 def build_signed_redirect_url(
     base_url: str, payload: Mapping[str, Any], secret: str
 ) -> str:
-    """Append the signed ``data`` and ``sig`` query params to ``base_url``.
+    """Append the signed ``d`` and ``sig`` query params to ``base_url``.
 
     Existing query params on ``base_url`` are preserved. Use for external
     thank-you pages that must verify the payload.
     """
-    data = encode_payload(payload)
-    sig = sign_data(data, secret)
-    return _append_query(base_url, [("data", data), ("sig", sig)])
+    d = encode_payload(payload)
+    sig = sign_data_hex(d, secret)
+    return _append_query(base_url, [("d", d), ("sig", sig)])
 
 
 def build_unsigned_redirect_url(base_url: str, payload: Mapping[str, Any]) -> str:

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -576,18 +576,12 @@ def _verify_signed_redirect(url: str, secret: str) -> dict:
     """Verify a signed thank-you URL the way an external page would, returning
     the recovered payload. Raises AssertionError on a bad signature."""
     query = parse_qs(urlparse(url).query)
-    data = query["data"][0]
+    d = query["d"][0]
     sig = query["sig"][0]
-    expected = (
-        base64.urlsafe_b64encode(
-            hmac.new(secret.encode(), data.encode("ascii"), hashlib.sha256).digest()
-        )
-        .rstrip(b"=")
-        .decode("ascii")
-    )
+    expected = hmac.new(secret.encode(), d.encode("ascii"), hashlib.sha256).hexdigest()
     assert hmac.compare_digest(sig, expected), "signature mismatch"
-    padding = "=" * (-len(data) % 4)
-    return json.loads(base64.urlsafe_b64decode(data + padding))
+    padding = "=" * (-len(d) % 4)
+    return json.loads(base64.urlsafe_b64decode(d + padding))
 
 
 def test_paid_purchase_signs_order_payload_into_simplefi_success_url(

--- a/backend/tests/core/test_checkout_signing.py
+++ b/backend/tests/core/test_checkout_signing.py
@@ -1,8 +1,8 @@
 """Unit tests for the open-checkout thank-you signing contract.
 
 These assert the exact wire format an external thank-you page must mirror to
-verify the signed order payload: data = base64url_nopad(json(sorted, compact)),
-sig = base64url_nopad(HMAC_SHA256(secret, data)).
+verify the signed order payload: d = base64url_nopad(json(sorted, compact)),
+sig = hex(HMAC_SHA256(secret, d)).
 """
 
 from __future__ import annotations
@@ -30,17 +30,11 @@ def _b64url_decode_nopad(value: str) -> bytes:
 def _verify_like_external_page(url: str, secret: str) -> dict:
     """Reproduce the verifier an external thank-you page would implement."""
     query = parse_qs(urlparse(url).query)
-    data = query["data"][0]
+    d = query["d"][0]
     sig = query["sig"][0]
-    expected = (
-        base64.urlsafe_b64encode(
-            hmac.new(secret.encode(), data.encode("ascii"), hashlib.sha256).digest()
-        )
-        .rstrip(b"=")
-        .decode("ascii")
-    )
+    expected = hmac.new(secret.encode(), d.encode("ascii"), hashlib.sha256).hexdigest()
     assert hmac.compare_digest(sig, expected), "signature mismatch"
-    return json.loads(_b64url_decode_nopad(data))
+    return json.loads(_b64url_decode_nopad(d))
 
 
 def _payload() -> dict:
@@ -52,6 +46,7 @@ def _payload() -> dict:
         amount_total="150.00",
         currency="USD",
         issued_at="2026-06-19T12:00:00+00:00",
+        exp=1_781_000_000,
     )
 
 
@@ -70,6 +65,8 @@ def test_signed_url_verifies_and_recovers_payload() -> None:
     assert recovered["items"] == [{"name": "GA", "quantity": 2}]
     assert recovered["amount_total"] == "150.00"
     assert recovered["currency"] == "USD"
+    # Anti-replay expiry travels inside the signed payload.
+    assert recovered["exp"] == 1_781_000_000
     # Raw email is never present; only its hash travels.
     assert recovered["email_hash"] == hash_email("buyer@test.com")
     assert "buyer@test.com" not in url
@@ -87,6 +84,7 @@ def test_tampering_with_payload_breaks_signature() -> None:
         amount_total="0.01",  # spoofed total
         currency="USD",
         issued_at="2026-06-19T12:00:00+00:00",
+        exp=1_781_000_000,
     )
     forged_data = (
         base64.urlsafe_b64encode(
@@ -95,11 +93,9 @@ def test_tampering_with_payload_breaks_signature() -> None:
         .rstrip(b"=")
         .decode("ascii")
     )
-    # Swap the data param for the forged one, keep the original signature.
+    # Swap the d param for the forged one, keep the original signature.
     original_sig = parse_qs(urlparse(url).query)["sig"][0]
-    tampered = (
-        f"https://brand.example.com/thank-you?data={forged_data}&sig={original_sig}"
-    )
+    tampered = f"https://brand.example.com/thank-you?d={forged_data}&sig={original_sig}"
     try:
         _verify_like_external_page(tampered, SECRET)
     except AssertionError:
@@ -124,4 +120,4 @@ def test_existing_query_params_are_preserved() -> None:
     )
     query = parse_qs(urlparse(url).query)
     assert query["ref"][0] == "abc"
-    assert "data" in query and "sig" in query
+    assert "d" in query and "sig" in query


### PR DESCRIPTION
## What

Aligns the signed open-checkout success redirect with the external thank-you page contract.

Three changes to the **signed external** URL only (`build_signed_redirect_url`):

| | Before | After |
|---|---|---|
| Payload query param | `data` | `d` |
| `sig` encoding | base64url (no pad) | **hex** |
| Payload | no expiry | adds `exp` (epoch seconds, +30 min) |

The new wire format is `?d=<base64url(json)>&sig=<hex(HMAC_SHA256(secret, d))>`. The signature still covers the exact base64url `d` string (not the JSON), so the external verifier never has to reproduce the JSON canonicalization. The `exp` lives inside `d`, so the signature protects it too (anti-replay).

## What is intentionally left untouched

- **Cart-restore tokens** (`sign_data` / `verify_cart_restore_token`) keep their base64url HMAC — separate feature, separate contract. A new `sign_data_hex` was added rather than changing the existing signer.
- **Portal's own thank-you page** keeps its unsigned `data` query param (the data is cosmetic, our page, no HMAC needed). `exp` rides along in that payload too but the portal ignores it.

## Verifier reference (external page)

```js
const expected = crypto.createHmac("sha256", EDGEOS_REDIRECT_SECRET)
  .update(d, "utf8").digest("hex")
// constant-time compare expected vs received sig, then base64url-decode d, then reject if exp < now
```

## Tests

- `tests/core/test_checkout_signing.py` — updated wire-format contract (`d`, hex sig, `exp` assertion).
- `tests/api/checkout/test_purchase.py` — updated the external-page verifier helper for the signed flow; portal unsigned path unchanged.
- Backend `lint.sh` clean; targeted signing + purchase tests pass locally.