### PR TITLE
feat(checkout): align thank-you redirect payload with Amanita field spec

### DIFF
--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -142,6 +142,9 @@ class OpenTicketingPurchaseCreate(BaseModel):
     insurance: bool = False
     fbc: str | None = Field(default=None, max_length=512)
     fbp: str | None = Field(default=None, max_length=512)
+    # Active checkout language (from the entry URL ?lang=), used to build the
+    # locale-aware success redirect. Falls back to the popup default when absent.
+    locale: str | None = Field(default=None, max_length=8)
 
 
 class OpenTicketingPurchaseResponse(BaseModel):

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -136,8 +136,9 @@ def _build_purchase_thank_you_payload(
     choices (installment count / payment method are chosen later on SimpleFi)."""
     items = [
         {
-            "name": products_map[line.product_id].name,
-            "quantity": line.quantity,
+            "title": products_map[line.product_id].name,
+            "qty": line.quantity,
+            "price": float(products_map[line.product_id].price),
         }
         for line in obj.products
     ]
@@ -146,7 +147,7 @@ def _build_purchase_thank_you_payload(
         first_name=obj.buyer.first_name,
         email=obj.buyer.email,
         items=items,
-        amount_total=str(payment.amount),
+        amount_total=float(payment.amount),
         currency=popup.currency,
         issued_at=issued_at,
         exp=exp,
@@ -154,18 +155,21 @@ def _build_purchase_thank_you_payload(
 
 
 def _resolve_open_checkout_success_url(
-    popup: "Popups", internal_thank_you_url: str, payload: dict
+    popup: "Popups", internal_thank_you_url: str, payload: dict, *, locale: str
 ) -> str:
     """Resolve where a successful open-checkout buyer lands.
 
     A custom popup success URL overrides the portal thank-you: signed with the
     order payload when a signing secret is set (external page verifies it),
-    plain otherwise. With no custom URL, the buyer stays on the portal
-    thank-you, which carries the order data unsigned so it can render the
-    summary (our own page — no HMAC needed).
+    plain otherwise. A ``{locale}`` placeholder in the custom URL is replaced
+    with the checkout language (e.g. ``.../{locale}/gracias`` → ``.../es/gracias``).
+    With no custom URL, the buyer stays on the portal thank-you, which carries
+    the order data unsigned so it can render the summary (our own page — no HMAC
+    needed).
     """
     custom = popup.open_checkout_success_url
     if custom:
+        custom = custom.replace("{locale}", locale)
         secret = popup.open_checkout_signing_secret
         return build_signed_redirect_url(custom, payload, secret) if secret else custom
     return build_unsigned_redirect_url(internal_thank_you_url, payload)
@@ -912,6 +916,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     portal_base, landing_is_checkout, popup, payment
                 ),
                 thank_you_payload,
+                locale=obj.locale or popup.default_language or "en",
             )
 
             # Zero-amount short-circuit: a 100% coupon zeroed the cart, so

--- a/backend/app/utils/checkout_signing.py
+++ b/backend/app/utils/checkout_signing.py
@@ -43,6 +43,19 @@ def hash_email(email: str) -> str:
     return hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
 
 
+def mask_email(email: str) -> str:
+    """Masked email for display, e.g. ``ab****@gmail.com``.
+
+    Shows the first two characters of the local part and its domain; everything
+    in between is hidden. Best-effort for malformed input (no ``@`` → returned
+    trimmed as-is).
+    """
+    local, at, domain = email.strip().partition("@")
+    if not at:
+        return local
+    return f"{local[:2]}****@{domain}"
+
+
 def _b64url_nopad(raw: bytes) -> str:
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
@@ -100,7 +113,7 @@ def build_thank_you_payload(
     first_name: str,
     email: str,
     items: list[dict[str, Any]],
-    amount_total: str,
+    amount_total: float,
     currency: str,
     issued_at: str,
     exp: int,
@@ -108,12 +121,15 @@ def build_thank_you_payload(
     """Assemble the order snapshot sent to the thank-you page.
 
     Field names form the contract with the external page; keep them stable.
-    ``exp`` is an epoch-seconds expiry (anti-replay) covered by the signature.
+    ``items`` are ``{title, qty, price}`` and ``amount_total`` is a number (no
+    thousands separators). ``exp`` is an epoch-seconds expiry (anti-replay)
+    covered by the signature.
     """
     return {
         "order_id": order_id,
         "first_name": first_name,
         "email_hash": hash_email(email),
+        "email_masked": mask_email(email),
         "items": items,
         "amount_total": amount_total,
         "currency": currency,

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -628,10 +628,58 @@ def test_paid_purchase_signs_order_payload_into_simplefi_success_url(
     assert success_url.startswith("https://brand.example.com/thank-you")
     payload = _verify_signed_redirect(success_url, secret)
     assert payload["first_name"] == "Matias"
-    assert payload["amount_total"] == "240.00"
+    assert payload["amount_total"] == 240.0
     assert payload["currency"] == "USD"
-    assert payload["items"] == [{"name": product.name, "quantity": 2}]
+    assert payload["items"] == [{"title": product.name, "qty": 2, "price": 120.0}]
     assert payload["email_hash"] == hashlib.sha256(b"buyer@test.com").hexdigest()
+    assert payload["email_masked"] == "bu****@test.com"
+
+
+def test_signed_redirect_substitutes_locale_placeholder(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """A {locale} placeholder in the custom success URL is replaced with the
+    popup language before signing (e.g. .../{locale}/gracias → .../es/gracias)."""
+    secret = "amanita-secret"
+    popup = _make_popup(db, tenant_a, slug_prefix="locale-signed")
+    popup.open_checkout_success_url = "https://amanita.example.com/{locale}/gracias"
+    popup.open_checkout_signing_secret = secret
+    popup.default_language = "es"  # fallback; the request locale must win
+    db.add(popup)
+    product = _make_product(db, popup, price="120.00")
+    db.commit()
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_locale_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/locale",
+            is_installment_plan=False,
+        )
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Ana",
+                    "last_name": "Diaz",
+                    "form_data": {},
+                },
+                "locale": "en",  # from the entry URL ?lang=en
+            },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
+        )
+
+    assert response.status_code == 200, response.text
+    success_url = mock_get_client.return_value.create_payment.call_args.kwargs[
+        "success_path"
+    ]
+    # Request locale ("en") wins over the popup default ("es").
+    assert success_url.startswith("https://amanita.example.com/en/gracias")
+    assert "{locale}" not in success_url
 
 
 def test_zero_amount_purchase_signs_order_payload_into_redirect_url(
@@ -671,8 +719,8 @@ def test_zero_amount_purchase_signs_order_payload_into_redirect_url(
     assert body["status"] == "approved"
     assert body["checkout_url"] == ""
     payload = _verify_signed_redirect(body["redirect_url"], secret)
-    assert payload["amount_total"] == "0.00"
-    assert payload["items"] == [{"name": product.name, "quantity": 1}]
+    assert payload["amount_total"] == 0.0
+    assert payload["items"] == [{"title": product.name, "qty": 1, "price": 75.0}]
     mock_get_client.assert_not_called()
 
 
@@ -723,8 +771,8 @@ def test_paid_purchase_injects_order_data_into_portal_thank_you(
     assert "sig=" not in success_url  # portal page is ours — no signature
     payload = _decode_data_param(success_url)
     assert payload["first_name"] == "Matias"
-    assert payload["amount_total"] == "240.00"
-    assert payload["items"] == [{"name": product.name, "quantity": 2}]
+    assert payload["amount_total"] == 240.0
+    assert payload["items"] == [{"title": product.name, "qty": 2, "price": 120.0}]
 
 
 def test_zero_amount_purchase_injects_order_data_into_portal_thank_you(
@@ -761,8 +809,8 @@ def test_zero_amount_purchase_injects_order_data_into_portal_thank_you(
     redirect_url = body["redirect_url"]
     assert f"/checkout/{popup.slug}/thank-you" in redirect_url
     payload = _decode_data_param(redirect_url)
-    assert payload["amount_total"] == "0.00"
-    assert payload["items"] == [{"name": product.name, "quantity": 1}]
+    assert payload["amount_total"] == 0.0
+    assert payload["items"] == [{"title": product.name, "qty": 1, "price": 75.0}]
     mock_get_client.assert_not_called()
 
 

--- a/backend/tests/core/test_checkout_signing.py
+++ b/backend/tests/core/test_checkout_signing.py
@@ -17,6 +17,7 @@ from app.utils.checkout_signing import (
     build_signed_redirect_url,
     build_thank_you_payload,
     hash_email,
+    mask_email,
 )
 
 SECRET = "amanita-shared-secret"
@@ -42,8 +43,8 @@ def _payload() -> dict:
         order_id="order-1",
         first_name="Matias",
         email="Buyer@Test.com",
-        items=[{"name": "GA", "quantity": 2}],
-        amount_total="150.00",
+        items=[{"title": "GA", "qty": 2, "price": 75.0}],
+        amount_total=150.0,
         currency="USD",
         issued_at="2026-06-19T12:00:00+00:00",
         exp=1_781_000_000,
@@ -55,6 +56,13 @@ def test_hash_email_is_normalized_sha256() -> None:
     assert hash_email("buyer@test.com") == hashlib.sha256(b"buyer@test.com").hexdigest()
 
 
+def test_mask_email_shows_prefix_and_domain() -> None:
+    assert mask_email("Buyer@Test.com") == "Bu****@Test.com"
+    assert mask_email("a@x.io") == "a****@x.io"
+    # Malformed input (no @) is returned trimmed, not exploded.
+    assert mask_email(" no-at-sign ") == "no-at-sign"
+
+
 def test_signed_url_verifies_and_recovers_payload() -> None:
     url = build_signed_redirect_url(
         "https://brand.example.com/thank-you", _payload(), SECRET
@@ -62,13 +70,14 @@ def test_signed_url_verifies_and_recovers_payload() -> None:
     recovered = _verify_like_external_page(url, SECRET)
     assert recovered["order_id"] == "order-1"
     assert recovered["first_name"] == "Matias"
-    assert recovered["items"] == [{"name": "GA", "quantity": 2}]
-    assert recovered["amount_total"] == "150.00"
+    assert recovered["items"] == [{"title": "GA", "qty": 2, "price": 75.0}]
+    assert recovered["amount_total"] == 150.0
     assert recovered["currency"] == "USD"
     # Anti-replay expiry travels inside the signed payload.
     assert recovered["exp"] == 1_781_000_000
-    # Raw email is never present; only its hash travels.
+    # Raw email is never present; only its hash and masked form travel.
     assert recovered["email_hash"] == hash_email("buyer@test.com")
+    assert recovered["email_masked"] == "Bu****@Test.com"
     assert "buyer@test.com" not in url
 
 
@@ -80,8 +89,8 @@ def test_tampering_with_payload_breaks_signature() -> None:
         order_id="order-1",
         first_name="Matias",
         email="buyer@test.com",
-        items=[{"name": "GA", "quantity": 2}],
-        amount_total="0.01",  # spoofed total
+        items=[{"title": "GA", "qty": 2, "price": 75.0}],
+        amount_total=0.01,  # spoofed total
         currency="USD",
         issued_at="2026-06-19T12:00:00+00:00",
         exp=1_781_000_000,

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -11747,6 +11747,18 @@ export const OpenTicketingPurchaseCreateSchema = {
                 }
             ],
             title: 'Fbp'
+        },
+        locale: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 8
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Locale'
         }
     },
     type: 'object',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2557,6 +2557,7 @@ export type OpenTicketingPurchaseCreate = {
     insurance?: boolean;
     fbc?: (string | null);
     fbp?: (string | null);
+    locale?: (string | null);
 };
 
 /**

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -11747,6 +11747,18 @@ export const OpenTicketingPurchaseCreateSchema = {
                 }
             ],
             title: 'Fbp'
+        },
+        locale: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 8
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Locale'
         }
     },
     type: 'object',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2557,6 +2557,7 @@ export type OpenTicketingPurchaseCreate = {
     insurance?: boolean;
     fbc?: (string | null);
     fbp?: (string | null);
+    locale?: (string | null);
 };
 
 /**

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -89,7 +89,7 @@ export function usePaymentSubmit({
   editPassesEnabled,
   popupName,
 }: UsePaymentSubmitParams) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const queryClient = useQueryClient()
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -173,6 +173,7 @@ export function usePaymentSubmit({
               slug: popupSlug!,
               requestBody: {
                 ...getMetaAttribution(),
+                locale: i18n.language,
                 products: Object.values(
                   productsToSend.reduce<
                     Record<string, { product_id: string; quantity: number }>
@@ -370,6 +371,7 @@ export function usePaymentSubmit({
     editPassesEnabled,
     isSubmitting,
     t,
+    i18n.language,
   ])
 
   return { submitPayment, isSubmitting }


### PR DESCRIPTION
## What

Slice 1 of the Amanita integration: finalizes the external thank-you **redirect** payload (section 5.2 of their spec) on top of the already-merged signed contract (#420).

### Payload changes (`build_thank_you_payload`)
- `items` now carry `{title, qty, price}` (was `{name, quantity}`) with the line **unit price**.
- `amount_total` and item `price` are JSON **numbers** instead of strings.
- Adds `email_masked` (e.g. `bu****@test.com`) next to `email_hash`.

### Locale-aware success URL
- A `{locale}` placeholder in the popup `open_checkout_success_url` is substituted with the active checkout language, so a configured `.../{locale}/gracias` resolves to `.../es/gracias` or `.../en/gracias`.
- The locale source is the **entry URL `?lang=`**: the portal now sends the resolved language (`i18n.language`) in the open-ticketing purchase request. Backend falls back to the popup `default_language` when absent.

## Intentionally omitted
`installments` and `payment_method` (both optional in the spec) are **not** sent: the buyer picks them later on SimpleFi, so they do not exist at payment-creation time.

## Pending confirmation with Amanita (non-blocking)
- **`amount`/`price` as JSON number**: implemented per their examples (`255000`). Trivial to switch back to string if they prefer.
- **`order_id`** stays `str(payment.id)` (uuid), identical between redirect and the upcoming webhook.

## Scope note
This does **not** include the outbound purchase webhook (section 6), the attribution passthrough (utm/fbclid/anonymous_id), or the funnel events (section 7) — those are separate slices with their own dependencies.

## Tests
- `tests/core/test_checkout_signing.py` — new item shape, numeric amounts, `email_masked`, `mask_email` unit test.
- `tests/api/checkout/test_purchase.py` — locale substitution (request locale wins over popup default), updated signed + portal payload assertions.
- Backend `lint.sh` + Biome (both frontends) clean; portal `build` passes; targeted tests green.