### PR TITLE
fix(analytics): use raw order id as Purchase event_id for cross-partner dedup

### DIFF
--- a/backend/app/services/meta_capi.py
+++ b/backend/app/services/meta_capi.py
@@ -392,7 +392,9 @@ def _safe_object_id(obj: Any) -> str:
 
 
 def _purchase_event_id(payment: Any) -> str:
-    return f"EVT_PURCHASE_{getattr(payment, 'id', '')}"
+    # Raw order id (== payment.id) so a partner that also fires its own Purchase
+    # to the same pixel with event_id=order_id deduplicates against ours in Meta.
+    return str(getattr(payment, "id", ""))
 
 
 def _initiate_checkout_event_id(payment: Any) -> str:

--- a/backend/tests/test_meta_capi.py
+++ b/backend/tests/test_meta_capi.py
@@ -79,7 +79,8 @@ def test_prepare_purchase_event_includes_popup_purchase_metadata() -> None:
     event = prepare_purchase_event(tenant, payment, popup)
 
     assert event is not None
-    assert event.event_id == f"EVT_PURCHASE_{payment_id}"
+    # event_id is the raw order id (payment.id) for cross-partner Meta dedup.
+    assert event.event_id == str(payment_id)
     payload_event = event.payload["data"][0]
     assert payload_event["event_name"] == "Purchase"
     assert payload_event["action_source"] == "website"

--- a/portal/src/lib/meta-pixel.ts
+++ b/portal/src/lib/meta-pixel.ts
@@ -159,6 +159,8 @@ export function trackMetaPurchase(params: {
       order_id: params.paymentId,
       value: Number(params.amount),
     },
-    `EVT_PURCHASE_${params.paymentId}`,
+    // Raw order id so a partner firing its own Purchase (event_id=order_id) to
+    // the same pixel deduplicates against ours in Meta.
+    String(params.paymentId),
   )
 }


### PR DESCRIPTION
## What

The Purchase `event_id` was `EVT_PURCHASE_{payment.id}` on both the browser Pixel (`meta-pixel.ts`) and the server CAPI (`meta_capi.py`).

A partner (e.g. Amanita) that fires **its own** Purchase to the same pixel with `event_id = order_id` would **not** deduplicate against ours — Meta would double-count the conversion.

## Change

Use the **raw order id (`payment.id`)** as the Purchase `event_id` in both places. Any partner keying on `order_id` now dedups with EdgeOS, and browser/server stay in sync with each other.

We keep firing Purchase (rather than dropping it) so tenants without their own Meta setup still get conversion tracking — a partner that also fires just dedups on top.

`InitiateCheckout` keeps its prefixed id — it is EdgeOS-internal with no partner pairing.

## Why now

Decision from the Amanita integration: `order_id = payment.id`, and EdgeOS adapts its event_id rather than stop firing Purchase.

## Tests

- `backend/tests/test_meta_capi.py` — asserts `event_id == str(payment_id)`.
- Backend `lint.sh` + Biome (portal) clean; portal `build` passes.