### PR TITLE
feat(checkout): capture entry-URL attribution and persist on the payment

### DIFF
--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -130,6 +130,24 @@ class BuyerInfo(BaseModel):
     form_data: dict[str, Any] = {}
 
 
+class Attribution(BaseModel):
+    """Marketing attribution captured from the checkout entry URL.
+
+    Generic (not partner-specific): any tenant running paid ads can use these.
+    Persisted on the payment so an outbound purchase webhook can return them,
+    which is how a partner ties the purchase back to its web session
+    (``anonymous_id``). All fields optional; absent ones are dropped.
+    """
+
+    utm_source: str | None = Field(default=None, max_length=256)
+    utm_medium: str | None = Field(default=None, max_length=256)
+    utm_campaign: str | None = Field(default=None, max_length=256)
+    utm_content: str | None = Field(default=None, max_length=256)
+    fbclid: str | None = Field(default=None, max_length=512)
+    landing_segment: str | None = Field(default=None, max_length=256)
+    anonymous_id: str | None = Field(default=None, max_length=128)
+
+
 class OpenTicketingPurchaseCreate(BaseModel):
     """Request schema for POST /checkout/{slug}/purchase."""
 
@@ -145,6 +163,7 @@ class OpenTicketingPurchaseCreate(BaseModel):
     # Active checkout language (from the entry URL ?lang=), used to build the
     # locale-aware success redirect. Falls back to the popup default when absent.
     locale: str | None = Field(default=None, max_length=8)
+    attribution: Attribution | None = None
 
 
 class OpenTicketingPurchaseResponse(BaseModel):

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -607,8 +607,14 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         self,
         popup: "Popups",
         form_data: dict[str, Any],
+        attribution: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Build immutable buyer snapshot JSONB for open ticketing payments."""
+        """Build immutable buyer snapshot JSONB for open ticketing payments.
+
+        ``attribution`` carries the marketing params captured from the checkout
+        entry URL (utm_*, fbclid, landing_segment, anonymous_id). Stored under a
+        namespaced key so an outbound purchase webhook can read it back later.
+        """
         sections_snapshot: list[dict[str, Any]] = []
 
         ordered_sections = sorted(
@@ -641,11 +647,14 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 }
             )
 
-        return {
+        snapshot: dict[str, Any] = {
             "schema_version": 1,
             "submitted_at": datetime.now(UTC).isoformat(),
             "sections": sections_snapshot,
         }
+        if attribution:
+            snapshot["attribution"] = attribution
+        return snapshot
 
     def _finalize_zero_amount_payment(
         self,
@@ -766,7 +775,15 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         # Atomically decrement total-stock counters (409 if sold out).
         self._decrement_total_stocks(session, fabricated_requests, valid_products)
 
-        buyer_snapshot = self._build_buyer_snapshot(popup, obj.buyer.form_data)
+        buyer_snapshot = self._build_buyer_snapshot(
+            popup,
+            obj.buyer.form_data,
+            attribution=(
+                obj.attribution.model_dump(exclude_none=True)
+                if obj.attribution
+                else None
+            ),
+        )
         buyer_name = (
             f"{obj.buyer.first_name} {obj.buyer.last_name}".strip() or obj.buyer.email
         )

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -191,6 +191,91 @@ def test_purchase_happy_path_creates_payment_and_attendees(
     assert len(attendees) == 1
 
 
+def test_purchase_persists_attribution_in_buyer_snapshot(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Marketing attribution from the entry URL is stored under
+    buyer_snapshot["attribution"] so a later webhook can return it. Absent
+    params are dropped (only the sent keys persist)."""
+    popup = _make_popup(db, tenant_a, slug_prefix="attribution")
+    product = _make_product(db, popup, price="100.00")
+    db.commit()
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_attr_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/attr",
+            is_installment_plan=False,
+        )
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Ana",
+                    "last_name": "Diaz",
+                    "form_data": {},
+                },
+                "attribution": {
+                    "utm_source": "meta",
+                    "utm_campaign": "amanita-launch",
+                    "anonymous_id": "f48a026b-cb27-4249-920a-281cbc5b73c4",
+                },
+            },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
+        )
+
+    assert response.status_code == 200, response.text
+    payment = db.exec(select(Payments).where(Payments.popup_id == popup.id)).first()
+    assert payment is not None
+    assert payment.buyer_snapshot["attribution"] == {
+        "utm_source": "meta",
+        "utm_campaign": "amanita-launch",
+        "anonymous_id": "f48a026b-cb27-4249-920a-281cbc5b73c4",
+    }
+
+
+def test_purchase_without_attribution_omits_the_key(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """No attribution sent → no attribution key in the snapshot (not an empty dict)."""
+    popup = _make_popup(db, tenant_a, slug_prefix="no-attribution")
+    product = _make_product(db, popup, price="100.00")
+    db.commit()
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_noattr_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/noattr",
+            is_installment_plan=False,
+        )
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Ana",
+                    "last_name": "Diaz",
+                    "form_data": {},
+                },
+            },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
+        )
+
+    assert response.status_code == 200, response.text
+    payment = db.exec(select(Payments).where(Payments.popup_id == popup.id)).first()
+    assert payment is not None
+    assert "attribution" not in payment.buyer_snapshot
+
+
 def test_purchase_pending_open_checkout_sends_initiate_checkout_capi(
     client: TestClient,
     db: Session,

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -3191,6 +3191,103 @@ The directory is attendee-centric: one entry per ticket-holding attendee
 (any category), sourced from that attendee's own human record.`
 } as const;
 
+export const AttributionSchema = {
+    properties: {
+        utm_source: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Source'
+        },
+        utm_medium: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Medium'
+        },
+        utm_campaign: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Campaign'
+        },
+        utm_content: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Content'
+        },
+        fbclid: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 512
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Fbclid'
+        },
+        landing_segment: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Landing Segment'
+        },
+        anonymous_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 128
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Anonymous Id'
+        }
+    },
+    type: 'object',
+    title: 'Attribution',
+    description: `Marketing attribution captured from the checkout entry URL.
+
+Generic (not partner-specific): any tenant running paid ads can use these.
+Persisted on the payment so an outbound purchase webhook can return them,
+which is how a partner ties the purchase back to its web session
+(\`\`anonymous_id\`\`). All fields optional; absent ones are dropped.`
+} as const;
+
 export const AuditLogPublicSchema = {
     properties: {
         id: {
@@ -11759,6 +11856,16 @@ export const OpenTicketingPurchaseCreateSchema = {
                 }
             ],
             title: 'Locale'
+        },
+        attribution: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/Attribution'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -730,6 +730,24 @@ export type AttendeeWithTickets = {
 };
 
 /**
+ * Marketing attribution captured from the checkout entry URL.
+ *
+ * Generic (not partner-specific): any tenant running paid ads can use these.
+ * Persisted on the payment so an outbound purchase webhook can return them,
+ * which is how a partner ties the purchase back to its web session
+ * (``anonymous_id``). All fields optional; absent ones are dropped.
+ */
+export type Attribution = {
+    utm_source?: (string | null);
+    utm_medium?: (string | null);
+    utm_campaign?: (string | null);
+    utm_content?: (string | null);
+    fbclid?: (string | null);
+    landing_segment?: (string | null);
+    anonymous_id?: (string | null);
+};
+
+/**
  * A single audit log entry returned to the backoffice.
  */
 export type AuditLogPublic = {
@@ -2558,6 +2576,7 @@ export type OpenTicketingPurchaseCreate = {
     fbc?: (string | null);
     fbp?: (string | null);
     locale?: (string | null);
+    attribution?: (Attribution | null);
 };
 
 /**

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -3191,6 +3191,103 @@ The directory is attendee-centric: one entry per ticket-holding attendee
 (any category), sourced from that attendee's own human record.`
 } as const;
 
+export const AttributionSchema = {
+    properties: {
+        utm_source: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Source'
+        },
+        utm_medium: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Medium'
+        },
+        utm_campaign: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Campaign'
+        },
+        utm_content: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Utm Content'
+        },
+        fbclid: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 512
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Fbclid'
+        },
+        landing_segment: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 256
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Landing Segment'
+        },
+        anonymous_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 128
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Anonymous Id'
+        }
+    },
+    type: 'object',
+    title: 'Attribution',
+    description: `Marketing attribution captured from the checkout entry URL.
+
+Generic (not partner-specific): any tenant running paid ads can use these.
+Persisted on the payment so an outbound purchase webhook can return them,
+which is how a partner ties the purchase back to its web session
+(\`\`anonymous_id\`\`). All fields optional; absent ones are dropped.`
+} as const;
+
 export const AuditLogPublicSchema = {
     properties: {
         id: {
@@ -11759,6 +11856,16 @@ export const OpenTicketingPurchaseCreateSchema = {
                 }
             ],
             title: 'Locale'
+        },
+        attribution: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/Attribution'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         }
     },
     type: 'object',

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -730,6 +730,24 @@ export type AttendeeWithTickets = {
 };
 
 /**
+ * Marketing attribution captured from the checkout entry URL.
+ *
+ * Generic (not partner-specific): any tenant running paid ads can use these.
+ * Persisted on the payment so an outbound purchase webhook can return them,
+ * which is how a partner ties the purchase back to its web session
+ * (``anonymous_id``). All fields optional; absent ones are dropped.
+ */
+export type Attribution = {
+    utm_source?: (string | null);
+    utm_medium?: (string | null);
+    utm_campaign?: (string | null);
+    utm_content?: (string | null);
+    fbclid?: (string | null);
+    landing_segment?: (string | null);
+    anonymous_id?: (string | null);
+};
+
+/**
  * A single audit log entry returned to the backoffice.
  */
 export type AuditLogPublic = {
@@ -2558,6 +2576,7 @@ export type OpenTicketingPurchaseCreate = {
     fbc?: (string | null);
     fbp?: (string | null);
     locale?: (string | null);
+    attribution?: (Attribution | null);
 };
 
 /**

--- a/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
+++ b/portal/src/components/checkout-flow/OpenCheckoutRuntime.tsx
@@ -13,6 +13,7 @@ import {
 import FaviconOverride from "@/components/checkout-flow/FaviconOverride"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
 import { LanguageSwitcher } from "@/components/common/LanguageSwitcher"
+import { captureAttribution } from "@/lib/attribution"
 import { trackGAViewItem } from "@/lib/google-analytics"
 import { trackMetaViewContent } from "@/lib/meta-pixel"
 import { queryKeys } from "@/lib/query-keys"
@@ -141,6 +142,12 @@ export function OpenCheckoutRuntime({
   const searchParams = useSearchParams()
   const cartCid = searchParams.get("cid")
   const cartSig = searchParams.get("sig")
+
+  // Persist marketing attribution from the entry URL before it is lost across
+  // checkout steps; read back at purchase time and forwarded to the webhook.
+  useEffect(() => {
+    captureAttribution(searchParams)
+  }, [searchParams])
   const [discountApplied, setDiscountApplied] = useState<DiscountProps>({
     discount_value: 0,
     discount_type: "percentage",

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import type { CheckoutMode } from "@/checkout/popupCheckoutPolicy"
 import { ApiError, CheckoutService, PaymentsService } from "@/client"
+import { getAttribution } from "@/lib/attribution"
 import { trackGAPurchase } from "@/lib/google-analytics"
 import { getMetaAttribution, trackMetaPurchase } from "@/lib/meta-pixel"
 import { queryKeys } from "@/lib/query-keys"
@@ -174,6 +175,9 @@ export function usePaymentSubmit({
               requestBody: {
                 ...getMetaAttribution(),
                 locale: i18n.language,
+                ...(Object.keys(getAttribution()).length
+                  ? { attribution: getAttribution() }
+                  : {}),
                 products: Object.values(
                   productsToSend.reduce<
                     Record<string, { product_id: string; quantity: number }>

--- a/portal/src/lib/attribution.ts
+++ b/portal/src/lib/attribution.ts
@@ -1,0 +1,67 @@
+"use client"
+
+/**
+ * Marketing attribution captured from the checkout entry URL.
+ *
+ * The params (utm_*, fbclid, landing_segment, anonymous_id) arrive on the entry
+ * URL but the URL is lost as the buyer moves through checkout steps, so we
+ * persist them in localStorage on entry and read them back at purchase time.
+ * Generic capability — not partner-specific. `anonymous_id` is what a partner
+ * uses to tie the purchase back to its web session.
+ */
+
+const STORAGE_KEY = "edgeos_attribution_v1"
+
+const ATTRIBUTION_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "fbclid",
+  "landing_segment",
+  "anonymous_id",
+] as const
+
+type AttributionKey = (typeof ATTRIBUTION_KEYS)[number]
+export type Attribution = Partial<Record<AttributionKey, string>>
+
+interface ReadableParams {
+  get(key: string): string | null
+}
+
+/**
+ * Merge any attribution params present in the URL into the stored blob.
+ * Non-empty values win; missing params never clear previously captured ones.
+ */
+export function captureAttribution(params: ReadableParams): void {
+  if (typeof window === "undefined") return
+
+  const stored = getAttribution()
+  let changed = false
+  for (const key of ATTRIBUTION_KEYS) {
+    const value = params.get(key)
+    if (value && stored[key] !== value) {
+      stored[key] = value
+      changed = true
+    }
+  }
+
+  if (changed) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stored))
+    } catch {
+      // localStorage unavailable (private mode / SSR) — attribution is best-effort.
+    }
+  }
+}
+
+/** Read the captured attribution blob (empty object when none/unavailable). */
+export function getAttribution(): Attribution {
+  if (typeof window === "undefined") return {}
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Attribution) : {}
+  } catch {
+    return {}
+  }
+}


### PR DESCRIPTION
## What

Slice 2 (foundation) of the Amanita integration: capture marketing attribution from the checkout entry URL and persist it on the payment, so the upcoming outbound purchase webhook (Slice 3) can return it.

### Portal
- New `lib/attribution.ts`: captures `utm_source/medium/campaign/content`, `fbclid`, `landing_segment`, `anonymous_id` from the entry URL into `localStorage` (survives step navigation), and reads them back at purchase time.
- `OpenCheckoutRuntime` calls `captureAttribution(searchParams)` on entry.
- `usePaymentSubmit` sends the captured `attribution` in the open-ticketing purchase request (only when non-empty).

### Backend
- New `Attribution` schema on `OpenTicketingPurchaseCreate` (all fields optional).
- `_build_buyer_snapshot` stores it under a namespaced `buyer_snapshot["attribution"]` key — **no new table columns, no migration**. Absent params are dropped; nothing is stored when none is sent.

## Why buyer_snapshot JSON (not columns)
The webhook fires on payment **approval**, later than creation, in a context that only has the `Payment` row. The params only exist at creation, so they must be persisted — but they don't warrant schema columns. The existing `buyer_snapshot` JSONB is the natural home. `anonymous_id` is what ties the purchase back to the partner's web session.

## Not partner-specific
This is a generic marketing-attribution capability. Amanita is the first consumer; any tenant running paid ads can use it.

## Scope
Does **not** include the outbound webhook (Slice 3) that reads this back, nor the funnel events (Slice 4).

## Tests
- `tests/api/checkout/test_purchase.py` — attribution persisted under the namespaced key (sent params only); no key when none sent.
- Backend `lint.sh` + Biome (both frontends) clean; portal `build` passes.