### PR TITLE
fix(payments): handle partial installment charges

### DIFF
--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -1521,6 +1521,8 @@ async def _handle_installment_plan_activated(
 
     installment_plan = payload.data.installment_plan
     new_total = installment_plan.number_of_installments
+    new_paid = installment_plan.paid_installments_count
+    plan_source = _plan_payment_source(installment_plan)
 
     # Idempotent. The fingerprint above catches the redis-cached case, but if
     # SimpleFi re-delivers after a cache eviction we should still no-op
@@ -1529,6 +1531,16 @@ async def _handle_installment_plan_activated(
     # silently overwriting, since downstream installment-counting depends on it.
     if payment.installments_total is not None:
         if payment.installments_total == new_total:
+            changed = False
+            if getattr(payment, "installments_paid", new_paid) != new_paid:
+                payment.installments_paid = new_paid
+                changed = True
+            if plan_source is not None and getattr(payment, "source", None) != plan_source:
+                payment.source = plan_source
+                changed = True
+            if changed:
+                db.commit()
+                return {"message": "Installment plan activation synced"}
             logger.info(
                 "Payment {}: installments_total already set to {}; skipping",
                 payment.id,
@@ -1543,6 +1555,7 @@ async def _handle_installment_plan_activated(
         )
 
     payment.installments_total = new_total
+    payment.installments_paid = new_paid
 
     # SimpleFi creates a "plan" even when the buyer picks pay-in-full
     # (number_of_installments = 1). Normalize the flag so data consumers
@@ -1557,7 +1570,6 @@ async def _handle_installment_plan_activated(
     # Activation is the only webhook that exposes the plan's rail/provider,
     # so record it here. Settlement must not downgrade it later (see
     # _handle_installment_payment).
-    plan_source = _plan_payment_source(installment_plan)
     if plan_source is not None:
         payment.source = plan_source
 

--- a/backend/app/api/payment/schemas.py
+++ b/backend/app/api/payment/schemas.py
@@ -394,7 +394,7 @@ class SimpleFIWebhookPayload(BaseModel):
 class SimpleFIInstallmentPlan(BaseModel):
     """Installment plan details from SimpleFI."""
 
-    id: str
+    id: str | None = None
     status: str
     paid_installments_count: int
     number_of_installments: int

--- a/backend/tests/test_installment_webhooks.py
+++ b/backend/tests/test_installment_webhooks.py
@@ -346,6 +346,76 @@ def test_activated_idempotent_when_total_already_matches(monkeypatch) -> None:
     assert db.committed == 0
 
 
+def test_activated_redelivery_syncs_paid_count_and_source(monkeypatch) -> None:
+    """If an earlier activation set the total but missed provider/paid fields,
+    a richer redelivery must complete the payment state instead of returning
+    early as a no-op."""
+    plan_id = "plan-act-sync"
+    payment = SimpleNamespace(
+        id="payment-act-sync",
+        external_id=plan_id,
+        installments_total=5,
+        installments_paid=None,
+        source="SimpleFI",
+    )
+
+    class FakePaymentsCRUD:
+        def get_by_external_id(self, _db, _ext_id):
+            return payment
+
+    monkeypatch.setattr(payment_router_module, "payments_crud", FakePaymentsCRUD())
+
+    db = FakeDBSession()
+    result = asyncio.run(
+        _handle_installment_plan_activated(
+            _make_activated_payload(
+                plan_id,
+                5,
+                payment_method="CARD",
+                stripe_subscription_id="sub_123",
+            ),
+            db,
+            FakeWebhookCache(),
+        )
+    )
+
+    assert result == {"message": "Installment plan activation synced"}
+    assert payment.installments_paid == 0
+    assert payment.source == "Stripe"
+    assert db.committed == 1
+
+
+def test_activated_payload_without_plain_plan_id_is_accepted(monkeypatch) -> None:
+    """SimpleFi plan documents may expose Mongo-style _id in the plan body;
+    routing uses the wrapper entity_id, so the nested id must not be required."""
+    plan_id = "plan-act-no-plain-id"
+    payload = _make_activated_payload(plan_id, 5)
+    plan = payload["data"]["installment_plan"]
+    del plan["id"]
+    plan["_id"] = {"$oid": plan_id}
+
+    payment = SimpleNamespace(
+        id="payment-act-no-plain-id",
+        external_id=plan_id,
+        installments_total=None,
+    )
+
+    class FakePaymentsCRUD:
+        def get_by_external_id(self, _db, _ext_id):
+            return payment
+
+    monkeypatch.setattr(payment_router_module, "payments_crud", FakePaymentsCRUD())
+
+    db = FakeDBSession()
+    asyncio.run(
+        _handle_installment_plan_activated(payload, db, FakeWebhookCache())
+    )
+
+    assert payment.installments_total == 5
+    assert payment.installments_paid == 0
+    assert db.committed == 1
+
+
 def test_activated_logs_warning_on_divergent_total(monkeypatch) -> None:
     """If the new total differs from the stored one, we overwrite (so future
     counting stays correct) but emit a warning — silently letting them drift

--- a/backoffice/src/routes/_layout/payments.helpers.test.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildPaymentsQueryConfig,
   buildPaymentsTableState,
+  getRailAdjustment,
   resolveLineUnitPrice,
 } from "./payments.helpers"
 
@@ -107,6 +108,48 @@ describe("payments.helpers", () => {
     expect(state.serverPagination).toEqual({
       total: 60,
       pagination: { pageIndex: 1, pageSize: 25 },
+    })
+  })
+
+  it("derives a final charged adjustment without inferring a reason", () => {
+    const adjustment = getRailAdjustment({
+      id: "payment-final-adjustment",
+      tenant_id: "tenant-1",
+      popup_id: "popup-1",
+      amount: "100.00",
+      amount_charged: "95.00",
+      currency: "USD",
+      source: "SimpleFI",
+      is_installment_plan: false,
+      installments_total: 1,
+      installments_paid: 1,
+    })
+
+    expect(adjustment).toMatchObject({
+      pct: "5",
+      isDiscount: true,
+      final: true,
+    })
+  })
+
+  it("treats a first installment as collected so far, not a final discount", () => {
+    const adjustment = getRailAdjustment({
+      id: "payment-installment-partial",
+      tenant_id: "tenant-1",
+      popup_id: "popup-1",
+      amount: "500.00",
+      amount_charged: "100.00",
+      currency: "USD",
+      source: "Stripe",
+      is_installment_plan: true,
+      installments_total: 5,
+      installments_paid: 1,
+    })
+
+    expect(adjustment).toMatchObject({
+      pct: "80",
+      isDiscount: true,
+      final: false,
     })
   })
 })

--- a/backoffice/src/routes/_layout/payments.helpers.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.ts
@@ -1,4 +1,4 @@
-import type { PaymentProductResponse, PaymentStatus } from "@/client"
+import type { PaymentProductResponse, PaymentPublic, PaymentStatus } from "@/client"
 
 interface PaymentsQueryInput {
   popupId: string | null
@@ -89,4 +89,31 @@ export function buildPaymentsTableState<TPayment>({
       pagination,
     },
   }
+}
+
+// SimpleFi can adjust the final charged total. We can derive the percentage
+// from the quoted amount and the charged amount only once the charged amount is
+// final; in-flight installment plans expose a running collected total instead.
+export function getRailAdjustment(payment: PaymentPublic): {
+  pct: string
+  isDiscount: boolean
+  delta: number
+  final: boolean
+} | null {
+  const amount = Number(payment.amount)
+  if (payment.amount_charged == null || amount <= 0) return null
+  const total = payment.installments_total
+  const isPlan =
+    payment.is_installment_plan === true && total != null && total >= 2
+  const final = !isPlan || (payment.installments_paid ?? 0) >= (total ?? 0)
+  const delta = Number(payment.amount_charged) - amount
+  const rawPct = (delta / amount) * 100
+  const rounded = Math.round(rawPct)
+  // Installment cycles round per charge, so a completed plan lands within a
+  // few cents of the exact rail percentage — snap to the integer when close.
+  const pct =
+    Math.abs(rawPct - rounded) < 0.1
+      ? String(Math.abs(rounded))
+      : Math.abs(rawPct).toFixed(1)
+  return { pct, isDiscount: delta < 0, delta, final }
 }

--- a/backoffice/src/routes/_layout/payments.helpers.ts
+++ b/backoffice/src/routes/_layout/payments.helpers.ts
@@ -1,4 +1,8 @@
-import type { PaymentProductResponse, PaymentPublic, PaymentStatus } from "@/client"
+import type {
+  PaymentProductResponse,
+  PaymentPublic,
+  PaymentStatus,
+} from "@/client"
 
 interface PaymentsQueryInput {
   popupId: string | null

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -46,6 +46,7 @@ import { exportToCsv, fetchAllPages } from "@/lib/export"
 import {
   buildPaymentsQueryConfig,
   buildPaymentsTableState,
+  getRailAdjustment,
   resolveLineUnitPrice,
 } from "./payments.helpers"
 
@@ -319,8 +320,7 @@ function getColumns(hasInvoice: boolean): ColumnDef<PaymentPublic>[] {
               <span
                 className={`text-xs ${adj.isDiscount ? "text-green-600" : "text-amber-600"}`}
               >
-                {adj.railLabel} {adj.isDiscount ? "discount" : "surcharge"}{" "}
-                {adj.isDiscount ? "−" : "+"}
+                adjustment {adj.isDiscount ? "−" : "+"}
                 {adj.pct}%
               </span>
             ) : null}
@@ -467,49 +467,6 @@ const categoryLabels: Record<string, string> = {
   housing: "Housing",
   merch: "Merch",
   patreon: "Patron",
-}
-
-// SimpleFi merchants may configure a signed per-rail (card/crypto) price
-// adjustment, so the settled total can differ from the quoted amount. EdgeOS
-// only stores the outcome (amount vs amount_charged); the percentage is
-// derived and the rail read from `source`: provider names (Stripe, ...) mean
-// card, "Crypto" is written at plan activation, and one-shot settlements
-// keep the residual "SimpleFI" only for crypto checkouts. A *plan* whose
-// source is still "SimpleFI" predates the activation-source logic — its rail
-// is unknown, so it gets a generic label rather than a guess. `final` is
-// false while a plan is still collecting, where amount_charged is a running
-// partial and the percentage can't be derived.
-function getRailAdjustment(payment: PaymentPublic): {
-  railLabel: "card" | "crypto" | "payment method"
-  pct: string
-  isDiscount: boolean
-  delta: number
-  final: boolean
-} | null {
-  const amount = Number(payment.amount)
-  if (payment.amount_charged == null || amount <= 0) return null
-  const total = payment.installments_total
-  const isPlan =
-    payment.is_installment_plan === true && total != null && total >= 2
-  const final = !isPlan || (payment.installments_paid ?? 0) >= (total ?? 0)
-  const delta = Number(payment.amount_charged) - amount
-  const rawPct = (delta / amount) * 100
-  const rounded = Math.round(rawPct)
-  // Installment cycles round per charge, so a completed plan lands within a
-  // few cents of the exact rail percentage — snap to the integer when close.
-  const pct =
-    Math.abs(rawPct - rounded) < 0.1
-      ? String(Math.abs(rounded))
-      : Math.abs(rawPct).toFixed(1)
-  let railLabel: "card" | "crypto" | "payment method"
-  if (payment.source === "Crypto") {
-    railLabel = "crypto"
-  } else if (payment.source !== "SimpleFI") {
-    railLabel = "card"
-  } else {
-    railLabel = isPlan ? "payment method" : "crypto"
-  }
-  return { railLabel, pct, isDiscount: delta < 0, delta, final }
 }
 
 function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
@@ -669,9 +626,7 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
                   colSpan={5}
                   className="py-0.5 text-right text-muted-foreground"
                 >
-                  {railAdj.railLabel.charAt(0).toUpperCase() +
-                    railAdj.railLabel.slice(1)}{" "}
-                  {railAdj.isDiscount ? "discount" : "surcharge"} (
+                  Adjustment (
                   {railAdj.isDiscount ? "−" : "+"}
                   {railAdj.pct}%)
                 </td>

--- a/backoffice/src/routes/_layout/payments.tsx
+++ b/backoffice/src/routes/_layout/payments.tsx
@@ -626,8 +626,7 @@ function PaymentSubRow({ row }: { row: Row<PaymentPublic> }) {
                   colSpan={5}
                   className="py-0.5 text-right text-muted-foreground"
                 >
-                  Adjustment (
-                  {railAdj.isDiscount ? "−" : "+"}
+                  Adjustment ({railAdj.isDiscount ? "−" : "+"}
                   {railAdj.pct}%)
                 </td>
                 <td


### PR DESCRIPTION
## Summary
- sync installment activation redeliveries when paid count or source was missing
- accept SimpleFi installment plan activation payloads without a nested plain id
- show neutral payment adjustments in backoffice and avoid treating partial installments as final discounts

## Validation
- pnpm exec vitest run src/routes/_layout/payments.helpers.test.ts
- pnpm exec tsc -p tsconfig.build.json --noEmit
- uv run pytest tests/test_installment_webhooks.py tests/test_payment_amount_charged.py -q
- uv run ruff check app tests/test_installment_webhooks.py tests/test_payment_amount_charged.py
- visual check with agent-browser against local backoffice/API and local backoffice/prod API