### PR TITLE
feat(portal): serve images through the next/image optimizer

### DIFF
--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import type { NextConfig } from "next"
+import { OPTIMIZED_IMAGE_HOSTS } from "./src/lib/image-optimization"
 
 const nextConfig: NextConfig = {
   output: "standalone",
@@ -10,12 +11,13 @@ const nextConfig: NextConfig = {
       process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000",
   },
   images: {
-    remotePatterns: [
-      {
-        hostname: "simplefi.s3.us-east-2.amazonaws.com",
-      },
-    ],
-    unoptimized: true,
+    remotePatterns: OPTIMIZED_IMAGE_HOSTS.map((hostname) => ({
+      protocol: "https" as const,
+      hostname,
+    })),
+    // AVIF first (best compression for the photographic tenant imagery),
+    // WebP fallback for browsers without AVIF support.
+    formats: ["image/avif", "image/webp"],
   },
 }
 

--- a/portal/src/app/auth/AuthForm.tsx
+++ b/portal/src/app/auth/AuthForm.tsx
@@ -10,6 +10,7 @@ import { z } from "zod/v4"
 import { ApiError, AuthService } from "@/client"
 import { ButtonAnimated } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { imageOptimization } from "@/lib/image-optimization"
 import { queryKeys } from "@/lib/query-keys"
 import { getSafeReturnTo } from "@/lib/safe-return-to"
 import { useTenant } from "@/providers/tenantProvider"
@@ -183,6 +184,7 @@ export default function AuthForm() {
               className="size-full rounded-lg object-cover"
               fill
               sizes="180px"
+              {...imageOptimization(tenant.logo_url)}
             />
           ) : (
             <div className="size-full rounded-lg bg-muted flex items-center justify-center">

--- a/portal/src/app/auth/Quote.tsx
+++ b/portal/src/app/auth/Quote.tsx
@@ -1,25 +1,25 @@
 "use client"
 
 import Image from "next/image"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useTenant } from "@/providers/tenantProvider"
 
 export default function Quote() {
   const { tenant } = useTenant()
 
   return (
-    <div
-      className="hidden md:flex md:w-1/2 relative p-8 items-center justify-center bg-muted"
-      style={
-        tenant?.image_url
-          ? {
-              backgroundImage: `url(${tenant.image_url})`,
-              backgroundSize: "cover",
-              backgroundPosition: "center",
-              backgroundRepeat: "no-repeat",
-            }
-          : undefined
-      }
-    >
+    <div className="hidden md:flex md:w-1/2 relative p-8 items-center justify-center bg-muted overflow-hidden">
+      {tenant?.image_url && (
+        <Image
+          src={tenant.image_url}
+          alt=""
+          fill
+          priority
+          sizes="50vw"
+          className="object-cover"
+          {...imageOptimization(tenant.image_url)}
+        />
+      )}
       <div className="absolute top-8 left-8">
         {tenant?.icon_url ? (
           <Image
@@ -28,6 +28,7 @@ export default function Quote() {
             width={100}
             height={40}
             priority
+            {...imageOptimization(tenant.icon_url)}
           />
         ) : (
           <div className="w-[100px] h-[40px] rounded bg-muted/50 flex items-center justify-center">

--- a/portal/src/app/checkout/[popupSlug]/components/PopupHero.tsx
+++ b/portal/src/app/checkout/[popupSlug]/components/PopupHero.tsx
@@ -1,4 +1,6 @@
+import Image from "next/image"
 import type { PopupPublic } from "@/client"
+import { imageOptimization } from "@/lib/image-optimization"
 
 interface PopupHeroProps {
   popup: PopupPublic
@@ -8,10 +10,16 @@ export function PopupHero({ popup }: PopupHeroProps) {
   return (
     <section className="overflow-hidden rounded-2xl border bg-card text-card-foreground shadow-sm">
       {popup.image_url ? (
-        <div
-          className="h-56 w-full bg-cover bg-center"
-          style={{ backgroundImage: `url(${popup.image_url})` }}
-        />
+        <div className="relative h-56 w-full">
+          <Image
+            src={popup.image_url}
+            alt={popup.name}
+            fill
+            sizes="100vw"
+            className="object-cover"
+            {...imageOptimization(popup.image_url)}
+          />
+        </div>
       ) : null}
       <div className="space-y-3 p-6">
         <div>

--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from "next/navigation"
 import { useTranslation } from "react-i18next"
+import { CheckoutBackgroundImage } from "@/components/CheckoutBackgroundImage"
 import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import { OpenCheckoutRuntime } from "@/components/checkout-flow/OpenCheckoutRuntime"
 import { SidebarProvider } from "@/components/Sidebar/SidebarComponents"
@@ -64,8 +65,10 @@ export default function OpenTicketingCheckoutPage() {
     >
       <main
         className={`h-svh overflow-y-auto no-scrollbar ${background.type === "none" ? "bg-background" : ""}`.trim()}
-        style={background.type === "image" ? background.style : undefined}
       >
+        {background.type === "image" && (
+          <CheckoutBackgroundImage url={background.url} />
+        )}
         {background.type === "video" && (
           <CheckoutBackgroundVideo url={background.url} />
         )}

--- a/portal/src/app/checkout/[popupSlug]/thank-you/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/thank-you/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
 import { CheckCircle, Home } from "lucide-react"
+import Image from "next/image"
 import { useParams, useRouter, useSearchParams } from "next/navigation"
 import { type CSSProperties, Suspense, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import FaviconOverride from "@/components/checkout-flow/FaviconOverride"
 import { Button } from "@/components/ui/button"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useTenant } from "@/providers/tenantProvider"
 import { useCheckoutRuntime } from "../hooks/useCheckoutRuntime"
 import { decodeOrderData, interpolate, type ThankYouTheme } from "./orderData"
@@ -46,13 +48,8 @@ function ThankYouContent() {
     : t("openCheckout.thank_you_description")
 
   const background = theme?.background
-  const outerStyle: CSSProperties = background?.image_url
-    ? {
-        backgroundImage: `url(${background.image_url})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-      }
-    : background?.color
+  const outerStyle: CSSProperties =
+    !background?.image_url && background?.color
       ? { backgroundColor: background.color }
       : {}
 
@@ -84,12 +81,23 @@ function ThankYouContent() {
 
   return (
     <div
-      className="flex min-h-screen items-center justify-center bg-background px-6 py-12"
+      className="relative flex min-h-screen items-center justify-center bg-background px-6 py-12"
       style={outerStyle}
     >
+      {background?.image_url && (
+        <Image
+          src={background.image_url}
+          alt=""
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover"
+          {...imageOptimization(background.image_url)}
+        />
+      )}
       <FaviconOverride url={popup?.favicon_url ?? null} />
       <div
-        className="w-full max-w-xl rounded-2xl border bg-card p-8 text-center shadow-sm"
+        className="relative w-full max-w-xl rounded-2xl border bg-card p-8 text-center shadow-sm"
         style={cardStyle}
       >
         {iconShow && (

--- a/portal/src/app/coming-soon/page.tsx
+++ b/portal/src/app/coming-soon/page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image"
 import { useTranslation } from "react-i18next"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useTenant } from "@/providers/tenantProvider"
 
 export default function ComingSoonPage() {
@@ -19,6 +20,7 @@ export default function ComingSoonPage() {
               className="object-contain"
               fill
               sizes="192px"
+              {...imageOptimization(tenant.logo_url)}
             />
           </div>
         )}

--- a/portal/src/app/groups/[groupSlug]/page.tsx
+++ b/portal/src/app/groups/[groupSlug]/page.tsx
@@ -3,6 +3,7 @@
 import { useParams } from "next/navigation"
 import { useEffect } from "react"
 import { PopupCheckoutContent } from "@/app/checkout/components/PopupCheckoutContent"
+import { CheckoutBackgroundImage } from "@/components/CheckoutBackgroundImage"
 import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import useGetPublicGroup from "@/hooks/useGetPublicGroup"
 import { getCheckoutBackground } from "@/lib/background-image"
@@ -89,13 +90,15 @@ const GroupCheckoutPage = () => {
   }
 
   const background = getCheckoutBackground(popup, "groups")
-  const contentBackground =
-    background.type === "image"
-      ? { className: "", style: background.style }
-      : { className: background.type === "none" ? "bg-background" : "" }
+  const contentBackground = {
+    className: background.type === "none" ? "bg-background" : "",
+  }
 
   return (
     <>
+      {background.type === "image" && (
+        <CheckoutBackgroundImage url={background.url} />
+      )}
       {background.type === "video" && (
         <CheckoutBackgroundVideo url={background.url} />
       )}

--- a/portal/src/app/portal/[popupSlug]/application/components/form-header.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/components/form-header.tsx
@@ -3,6 +3,7 @@
 import { CalendarDays, MapPin } from "lucide-react"
 import Image from "next/image"
 import { formatDate } from "@/helpers/dates"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useCityProvider } from "@/providers/cityProvider"
 
 const POPUP_DATE_FORMAT: Intl.DateTimeFormatOptions = {
@@ -30,6 +31,7 @@ export function FormHeader() {
             className="object-cover dark:invert rounded-2xl"
             fill
             sizes="(max-width: 768px) 100vw, 20vw"
+            {...imageOptimization(city.image_url)}
           />
         </div>
       ) : (

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/CoverImageField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/CoverImageField.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Loader2, Upload, X } from "lucide-react"
+import Image from "next/image"
 import { useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
@@ -8,6 +9,7 @@ import { toast } from "sonner"
 import { CoverImageCropper } from "@/components/CoverImageCropper"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useFileUpload } from "../../../lib/useFileUpload"
 
 interface CoverImageFieldProps {
@@ -68,12 +70,14 @@ export function CoverImageField({ coverUrl, onChange }: CoverImageFieldProps) {
         }}
       />
       {coverUrl ? (
-        <div className="relative w-full overflow-hidden rounded-lg border">
-          {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-          <img
+        <div className="relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+          <Image
             src={coverUrl}
             alt={t("events.form.event_cover_alt")}
-            className="aspect-[16/9] w-full object-cover"
+            fill
+            sizes="(max-width: 768px) 100vw, 672px"
+            className="object-cover"
+            {...imageOptimization(coverUrl)}
           />
           <div className="absolute top-2 right-2 flex gap-2">
             <Button

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/VenueSection.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/sections/VenueSection.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { AlertTriangle, Images } from "lucide-react"
+import Image from "next/image"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -15,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { VenueHoursSummary } from "@/components/VenueHoursSummary"
+import { imageOptimization } from "@/lib/image-optimization"
 import { VenueSelect } from "../../../components/VenueSelect"
 
 interface VenueSectionProps {
@@ -185,13 +187,15 @@ export function VenueSection({
               {pictures.map((photo) => (
                 <div
                   key={photo.id}
-                  className="overflow-hidden rounded-lg border"
+                  className="relative aspect-[4/3] overflow-hidden rounded-lg border"
                 >
-                  {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-                  <img
+                  <Image
                     src={photo.url}
                     alt=""
-                    className="aspect-[4/3] w-full object-cover"
+                    fill
+                    sizes="(max-width: 640px) 100vw, 250px"
+                    className="object-cover"
+                    {...imageOptimization(photo.url)}
                   />
                 </div>
               ))}

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -623,6 +623,7 @@ export default function EventDetailPage() {
               src={coverUrl}
               alt={event.title}
               className="w-full h-full object-cover"
+              sizes="(max-width: 768px) 100vw, 640px"
               fallback={
                 <CalendarDays className="h-10 w-10 text-muted-foreground/40" />
               }

--- a/portal/src/app/portal/[popupSlug]/events/components/CollaboratorsField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/CollaboratorsField.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query"
 import { UserPlus, X } from "lucide-react"
+import Image from "next/image"
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
@@ -17,6 +18,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { imageOptimization } from "@/lib/image-optimization"
 
 interface CollaboratorsFieldProps {
   /** Selected collaborator human ids — the form's source of truth. */
@@ -119,11 +121,13 @@ export function CollaboratorsField({
                 className="inline-flex items-center gap-1.5 rounded-full border bg-muted/40 py-1 pl-1 pr-2 text-xs"
               >
                 {h.picture_url ? (
-                  // biome-ignore lint/performance/noImgElement: user-uploaded S3 avatar
-                  <img
+                  <Image
                     src={h.picture_url}
                     alt=""
+                    width={20}
+                    height={20}
                     className="h-5 w-5 rounded-full object-cover"
+                    {...imageOptimization(h.picture_url)}
                   />
                 ) : (
                   <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground">
@@ -190,11 +194,13 @@ export function CollaboratorsField({
                     onClick={() => add(h)}
                   >
                     {h.picture_url ? (
-                      // biome-ignore lint/performance/noImgElement: user-uploaded S3 avatar
-                      <img
+                      <Image
                         src={h.picture_url}
                         alt=""
+                        width={24}
+                        height={24}
                         className="h-6 w-6 rounded-full object-cover"
+                        {...imageOptimization(h.picture_url)}
                       />
                     ) : (
                       <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">

--- a/portal/src/app/portal/[popupSlug]/events/components/EventVenueField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/EventVenueField.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { AlertTriangle, Images } from "lucide-react"
+import Image from "next/image"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { EventVenuePublic } from "@/client"
@@ -14,6 +15,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { VenueHoursSummary } from "@/components/VenueHoursSummary"
+import { imageOptimization } from "@/lib/image-optimization"
 import { VenueSelect } from "./VenueSelect"
 
 interface EventVenueFieldProps {
@@ -187,13 +189,15 @@ export function EventVenueField({
               {pictures.map((photo) => (
                 <div
                   key={photo.id}
-                  className="overflow-hidden rounded-lg border"
+                  className="relative aspect-[4/3] overflow-hidden rounded-lg border"
                 >
-                  {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-                  <img
+                  <Image
                     src={photo.url}
                     alt=""
-                    className="aspect-[4/3] w-full object-cover"
+                    fill
+                    sizes="(max-width: 640px) 100vw, 250px"
+                    className="object-cover"
+                    {...imageOptimization(photo.url)}
                   />
                 </div>
               ))}

--- a/portal/src/app/portal/[popupSlug]/events/components/HostDisplayField.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/components/HostDisplayField.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query"
 import { UserSearch } from "lucide-react"
+import Image from "next/image"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { type HumanPortalPublic, HumansService } from "@/client"
@@ -13,6 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { imageOptimization } from "@/lib/image-optimization"
 
 interface HostDisplayFieldProps {
   value: string
@@ -159,11 +161,13 @@ export function HostDisplayField({
                       }}
                     >
                       {h.picture_url ? (
-                        // biome-ignore lint/performance/noImgElement: user-uploaded S3 avatar
-                        <img
+                        <Image
                           src={h.picture_url}
                           alt=""
+                          width={24}
+                          height={24}
                           className="h-6 w-6 rounded-full object-cover"
+                          {...imageOptimization(h.picture_url)}
                         />
                       ) : (
                         <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -507,6 +507,7 @@ export function CalendarBody({
                                   src={thumbUrl}
                                   alt={event.venue_title ?? ""}
                                   className="h-full w-full object-cover"
+                                  sizes="48px"
                                   fallback={
                                     <MapPin className="h-5 w-5 text-muted-foreground/40" />
                                   }

--- a/portal/src/app/portal/[popupSlug]/events/lib/CoverImage.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CoverImage.tsx
@@ -1,11 +1,19 @@
 "use client"
 
+import Image from "next/image"
 import { useRef, useState } from "react"
+import { imageOptimization } from "@/lib/image-optimization"
 
 interface CoverImageProps {
   src: string | null | undefined
   alt: string
   className?: string
+  /**
+   * Rendered width hint for the optimizer. Callers size the image purely
+   * via CSS classes, so pass the slot's real width (e.g. "64px" for list
+   * thumbnails) to avoid over-fetching.
+   */
+  sizes?: string
   fallback: React.ReactNode
 }
 
@@ -15,7 +23,13 @@ interface CoverImageProps {
  * background with whatever node the caller passes (typically a lucide
  * icon sized for the slot).
  */
-export function CoverImage({ src, alt, className, fallback }: CoverImageProps) {
+export function CoverImage({
+  src,
+  alt,
+  className,
+  sizes = "100vw",
+  fallback,
+}: CoverImageProps) {
   const [errored, setErrored] = useState(false)
   // Reset the error flag during render when src changes — preferred over
   // useEffect per the React docs ("Adjusting state when a prop changes"),
@@ -39,12 +53,17 @@ export function CoverImage({ src, alt, className, fallback }: CoverImageProps) {
   }
 
   return (
-    // biome-ignore lint/performance/noImgElement: portal uses plain imgs for cover photos uploaded to S3
-    <img
+    // Callers control the rendered size through `className`, so width and
+    // height are zeroed out and only feed the optimizer via `sizes`.
+    <Image
       src={src}
       alt={alt}
+      width={0}
+      height={0}
+      sizes={sizes}
       className={className}
       onError={() => setErrored(true)}
+      {...imageOptimization(src)}
     />
   )
 }

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -427,6 +427,7 @@ export function ListBody({
                                 src={thumbUrl}
                                 alt={event.title}
                                 className="w-full h-full object-cover"
+                                sizes="64px"
                                 fallback={
                                   <CalendarDays className="h-5 w-5 text-muted-foreground/40" />
                                 }

--- a/portal/src/app/portal/[popupSlug]/events/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/new/page.tsx
@@ -12,6 +12,7 @@ import {
   Upload,
   X,
 } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
@@ -37,6 +38,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useCityProvider } from "@/providers/cityProvider"
 import { CollaboratorsField } from "../components/CollaboratorsField"
 import { EventScheduleFields } from "../components/EventScheduleFields"
@@ -531,12 +533,14 @@ function NewPortalEventForm({
             }}
           />
           {coverUrl ? (
-            <div className="relative w-full overflow-hidden rounded-lg border">
-              {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-              <img
+            <div className="relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+              <Image
                 src={coverUrl}
                 alt={t("events.form.event_cover_alt")}
-                className="aspect-[16/9] w-full object-cover"
+                fill
+                sizes="(max-width: 768px) 100vw, 672px"
+                className="object-cover"
+                {...imageOptimization(coverUrl)}
               />
               <div className="absolute top-2 right-2 flex gap-2">
                 <Button

--- a/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/edit/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/edit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ArrowLeft, CircleAlert, Loader2, Upload, X } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 import { useParams, useRouter } from "next/navigation"
 import { useEffect, useRef, useState } from "react"
@@ -28,6 +29,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useCityProvider } from "@/providers/cityProvider"
 import { useFileUpload } from "../../../lib/useFileUpload"
 
@@ -265,12 +267,14 @@ export default function EditPortalVenuePage() {
             }}
           />
           {imageUrl ? (
-            <div className="relative w-full overflow-hidden rounded-lg border">
-              {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-              <img
+            <div className="relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+              <Image
                 src={imageUrl}
                 alt={t("events.venues.new.venue_cover_alt")}
-                className="aspect-[16/9] w-full object-cover"
+                fill
+                sizes="(max-width: 768px) 100vw, 672px"
+                className="object-cover"
+                {...imageOptimization(imageUrl)}
               />
               <div className="absolute top-2 right-2 flex gap-2">
                 <Button

--- a/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/page.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   Users,
 } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 import { useParams, useSearchParams } from "next/navigation"
 import { useTranslation } from "react-i18next"
@@ -22,6 +23,7 @@ import {
 import { LucideIcon } from "@/components/LucideIcon"
 import { Pill } from "@/components/ui/pill"
 import { VenueHoursPreview } from "@/components/VenueHoursPreview"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useCityProvider } from "@/providers/cityProvider"
 import { CoverImage } from "../../lib/CoverImage"
 
@@ -146,6 +148,7 @@ export default function PortalVenueDetailPage() {
             src={venue.image_url}
             alt={venue.title}
             className="aspect-[21/9] w-full object-cover"
+            sizes="(max-width: 896px) 100vw, 864px"
             fallback={<MapPin className="h-10 w-10 text-muted-foreground/40" />}
           />
         </div>
@@ -260,12 +263,17 @@ export default function PortalVenueDetailPage() {
           </h2>
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
             {gallery.map((photo) => (
-              <div key={photo.id} className="overflow-hidden rounded-lg border">
-                {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-                <img
+              <div
+                key={photo.id}
+                className="relative aspect-square overflow-hidden rounded-lg border"
+              >
+                <Image
                   src={photo.image_url}
                   alt=""
-                  className="aspect-square w-full object-cover"
+                  fill
+                  sizes="(max-width: 640px) 50vw, 296px"
+                  className="object-cover"
+                  {...imageOptimization(photo.image_url)}
                 />
               </div>
             ))}

--- a/portal/src/app/portal/[popupSlug]/events/venues/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/new/page.tsx
@@ -10,6 +10,7 @@ import {
   Upload,
   X,
 } from "lucide-react"
+import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useRef, useState } from "react"
@@ -34,6 +35,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
+import { imageOptimization } from "@/lib/image-optimization"
 import { useCityProvider } from "@/providers/cityProvider"
 import { usePortalEventSettings } from "../../lib/useEventTimezone"
 import { useFileUpload } from "../../lib/useFileUpload"
@@ -264,12 +266,14 @@ export default function NewPortalVenuePage() {
             }}
           />
           {imageUrl ? (
-            <div className="relative w-full overflow-hidden rounded-lg border">
-              {/* biome-ignore lint/performance/noImgElement: user-uploaded S3 image */}
-              <img
+            <div className="relative aspect-[16/9] w-full overflow-hidden rounded-lg border">
+              <Image
                 src={imageUrl}
                 alt={t("events.venues.new.venue_cover_alt")}
-                className="aspect-[16/9] w-full object-cover"
+                fill
+                sizes="(max-width: 768px) 100vw, 672px"
+                className="object-cover"
+                {...imageOptimization(imageUrl)}
               />
               <div className="absolute top-2 right-2 flex gap-2">
                 <Button

--- a/portal/src/app/portal/[popupSlug]/events/venues/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/page.tsx
@@ -83,6 +83,7 @@ export default function PortalVenuesPage() {
                 src={venue.image_url}
                 alt={venue.title}
                 className="aspect-[16/9] w-full object-cover"
+                sizes="(max-width: 640px) 100vw, 440px"
                 fallback={
                   <MapPin className="h-8 w-8 text-muted-foreground/40" />
                 }

--- a/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/buy/components/BuyPassesContent.tsx
@@ -2,6 +2,7 @@
 
 import { useParams, useRouter } from "next/navigation"
 import { useEffect } from "react"
+import { CheckoutBackgroundImage } from "@/components/CheckoutBackgroundImage"
 import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import ScrollyCheckoutFlow from "@/components/checkout-flow/ScrollyCheckoutFlow"
 import { Loader } from "@/components/ui/Loader"
@@ -38,12 +39,14 @@ export default function BuyPassesContent() {
   return (
     <PassesProvider attendees={attendees} restoreFromCart>
       <CheckoutProvider initialStep="passes">
+        {background.type === "image" && (
+          <CheckoutBackgroundImage url={background.url} />
+        )}
         {background.type === "video" && (
           <CheckoutBackgroundVideo url={background.url} />
         )}
         <div
           className={`min-h-full w-full ${background.type === "none" ? "bg-background" : ""}`.trim()}
-          style={background.type === "image" ? background.style : undefined}
         >
           <ScrollyCheckoutFlow
             onBack={handleBack}

--- a/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
+++ b/portal/src/app/portal/[popupSlug]/passes/components/common/AttendeeTicket.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { ChevronRight, Pencil, QrCode, User } from "lucide-react"
+import Image from "next/image"
 import React, { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { TICKET_CATEGORY } from "@/checkout/popupCheckoutPolicy"
@@ -15,6 +16,7 @@ import {
 } from "@/components/ui/collapsible"
 import { Separator } from "@/components/ui/separator"
 import useAttendee from "@/hooks/useAttendee"
+import { imageOptimization } from "@/lib/image-optimization"
 import { deriveProductState } from "@/lib/product-state"
 import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
@@ -203,14 +205,26 @@ const AttendeeTicket = ({
         <div className="w-full rounded-3xl border border-border h-full lg:grid lg:grid-cols-[1fr_2px_2fr] bg-card">
           {/* Left panel - City & Attendee info */}
           <div className="relative flex flex-col p-6 overflow-hidden h-full min-h-[160px]">
-            <div
-              className="absolute inset-0 z-0 rounded-t-3xl lg:rounded-l-3xl lg:rounded-tr-none"
-              style={{
-                background: city?.image_url
-                  ? `linear-gradient(0deg, transparent, rgba(255, 255, 255, 0.8) 20%, rgb(255, 255, 255) 90%) center top / cover, url(${city.image_url}) center top / cover`
-                  : "linear-gradient(0deg, transparent, rgba(255, 255, 255, 0.8) 20%, rgb(255, 255, 255) 90%)",
-              }}
-            />
+            <div className="absolute inset-0 z-0 overflow-hidden rounded-t-3xl lg:rounded-l-3xl lg:rounded-tr-none">
+              {city?.image_url && (
+                <Image
+                  src={city.image_url}
+                  alt=""
+                  fill
+                  sizes="(max-width: 1024px) 100vw, 33vw"
+                  className="object-cover object-top"
+                  {...imageOptimization(city.image_url)}
+                />
+              )}
+              {/* White fade over the photo, same gradient as before. */}
+              <div
+                className="absolute inset-0"
+                style={{
+                  background:
+                    "linear-gradient(0deg, transparent, rgba(255, 255, 255, 0.8) 20%, rgb(255, 255, 255) 90%)",
+                }}
+              />
+            </div>
             <div className="relative z-10 h-full flex flex-col justify-between">
               <div className="flex justify-between items-start">
                 <div>

--- a/portal/src/components/Card/EventCard.tsx
+++ b/portal/src/components/Card/EventCard.tsx
@@ -8,6 +8,7 @@ import type { PopupPublic } from "@/client"
 import { ButtonAnimated } from "@/components/ui/button"
 import { CardAnimation, CardContent } from "@/components/ui/card"
 import { formatDate } from "@/helpers/dates"
+import { imageOptimization } from "@/lib/image-optimization"
 import { EventProgressBar, type EventStatus } from "./EventProgressBar"
 
 const CTA_KEYS: Record<EventStatus, string> = {
@@ -68,7 +69,9 @@ function Image() {
           src={popup.image_url}
           alt={popup.name}
           fill
+          sizes="(max-width: 1024px) 100vw, 33vw"
           className="object-cover w-full h-full"
+          {...imageOptimization(popup.image_url)}
         />
       ) : (
         <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-neutral-200 to-neutral-300">

--- a/portal/src/components/CheckoutBackgroundImage.tsx
+++ b/portal/src/components/CheckoutBackgroundImage.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import Image from "next/image"
+import { imageOptimization } from "@/lib/image-optimization"
+
+// Full-bleed image rendered behind the checkout, mirroring the fixed
+// positioning of CheckoutBackgroundVideo. The fixed wrapper reproduces the
+// old CSS `background-attachment: fixed` look while the photo itself loads
+// through next/image.
+export function CheckoutBackgroundImage({ url }: { url: string }) {
+  return (
+    <div aria-hidden className="fixed inset-0 -z-10">
+      <Image
+        src={url}
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover"
+        {...imageOptimization(url)}
+      />
+    </div>
+  )
+}

--- a/portal/src/components/MobilePopupSwitcher.tsx
+++ b/portal/src/components/MobilePopupSwitcher.tsx
@@ -10,6 +10,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
+import { imageOptimization } from "@/lib/image-optimization"
 import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
 
@@ -48,6 +49,7 @@ export function MobilePopupSwitcher() {
               width={20}
               height={20}
               className="rounded"
+              {...imageOptimization(city.icon_url)}
             />
           ) : null}
           <span className="max-w-[6rem] truncate">{city.name}</span>

--- a/portal/src/components/Sidebar/PopupsMenu.tsx
+++ b/portal/src/components/Sidebar/PopupsMenu.tsx
@@ -10,6 +10,7 @@ import Image from "next/image"
 import { useRouter } from "next/navigation"
 import { useCallback } from "react"
 import type { PopupPublic } from "@/client"
+import { imageOptimization } from "@/lib/image-optimization"
 import { cn } from "@/lib/utils"
 import { useCityProvider } from "@/providers/cityProvider"
 import { DropdownMenuContent, DropdownMenuItem } from "./DropdownMenu"
@@ -81,7 +82,9 @@ const PopupsMenu = () => {
                           src={city.icon_url}
                           alt={city.name ?? "Popup icon"}
                           fill
+                          sizes="48px"
                           className="rounded-lg object-cover"
+                          {...imageOptimization(city.icon_url)}
                         />
                       ) : (
                         <div

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Check } from "lucide-react"
+import Image from "next/image"
 import {
   type ReactNode,
   useEffect,
@@ -9,6 +10,7 @@ import {
   useState,
 } from "react"
 import { getRegistryIcon, resolveStepIcon } from "@/lib/checkoutStepIcons"
+import { imageOptimization } from "@/lib/image-optimization"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
 import type { CheckoutStep } from "@/types/checkout"
@@ -167,14 +169,14 @@ export default function ScrollySectionNav({
       <div className="bg-checkout-navbar-bg/85 px-2.5 py-1.5 backdrop-blur-xl">
         <div className="flex items-center gap-1.5">
           {brandLogoUrl ? (
-            // Small tenant logo, sized 28px. Next/image not used because
-            // tenant icon URLs come from arbitrary CDNs and don't need
-            // SSR-time optimisation at this scale.
-            // biome-ignore lint/performance/noImgElement: tenant logo, sized small, no need for next/image SSR
-            <img
+            <Image
               src={brandLogoUrl}
               alt={brandLabel ?? "Tenant logo"}
+              width={28}
+              height={28}
+              priority
               className="size-7 shrink-0 rounded-md object-contain"
+              {...imageOptimization(brandLogoUrl)}
             />
           ) : null}
           <div

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -17,6 +17,7 @@ import QuantitySelector, {
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
 import SoldOutBadge from "@/components/ui/SoldOutBadge"
+import { imageOptimization } from "@/lib/image-optimization"
 import { getProductAvailability } from "@/lib/product-availability"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -190,7 +191,9 @@ function SectionHeader({ section }: { section: TemplateSection }) {
               src={section.image_url!}
               alt={section.label || ""}
               fill
+              sizes="32px"
               className="object-cover"
+              {...imageOptimization(section.image_url!)}
             />
           </div>
         ) : (
@@ -299,7 +302,9 @@ function CompactCard({
             src={product.image_url}
             alt={product.name}
             fill
+            sizes="56px"
             className="object-cover"
+            {...imageOptimization(product.image_url)}
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center">
@@ -427,7 +432,14 @@ function ProductImageCarousel({
   return (
     <>
       <div {...imageClickProps}>
-        <Image src={images[safeIdx]} alt={alt} fill className="object-cover" />
+        <Image
+          src={images[safeIdx]}
+          alt={alt}
+          fill
+          sizes="(max-width: 768px) 100vw, 672px"
+          className="object-cover"
+          {...imageOptimization(images[safeIdx])}
+        />
         {hasMany && showChevrons && (
           <>
             <button
@@ -649,7 +661,9 @@ function DefaultSectionCard({
               src={heroImage}
               alt={section.label}
               fill
+              sizes="(max-width: 768px) 100vw, 672px"
               className="object-cover"
+              {...imageOptimization(heroImage)}
             />
           ) : (
             <div className="absolute inset-0 flex items-center justify-center">
@@ -846,7 +860,9 @@ function ShowcaseSectionCard({
             src={heroImage}
             alt={section.label || ""}
             fill
+            sizes="(max-width: 768px) 100vw, 672px"
             className="object-cover"
+            {...imageOptimization(heroImage)}
           />
           <div className="absolute inset-0 bg-gradient-to-b from-black/10 via-transparent to-black/50" />
           {section.label && (

--- a/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
@@ -11,6 +11,7 @@ import {
 import Image from "next/image"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { Button } from "@/components/ui/button"
+import { imageOptimization } from "@/lib/image-optimization"
 import { cn } from "@/lib/utils"
 import type { VariantProps } from "../registries/variantRegistry"
 
@@ -128,6 +129,7 @@ export function LightboxOverlay({
           width={1200}
           height={800}
           className="w-full h-auto max-h-[80vh] object-contain rounded-lg"
+          {...imageOptimization(current.url)}
         />
         {current.caption && (
           <p className="text-white/80 text-sm text-center mt-3">
@@ -182,7 +184,9 @@ function CarouselGallery({
                   src={img.url}
                   alt={img.caption || ""}
                   fill
+                  sizes="(max-width: 768px) 100vw, 672px"
                   className="object-cover"
+                  {...imageOptimization(img.url)}
                 />
               </div>
             </div>
@@ -254,12 +258,16 @@ function MasonryGallery({
             aria-label={img.caption || `View image ${i + 1}`}
           >
             <div className="rounded-xl overflow-hidden shadow-sm border border-border group">
-              {/* biome-ignore lint: masonry items use native img for natural height */}
-              <img
+              {/* Masonry items keep their natural height: width/height are
+                  zeroed and CSS (w-full h-auto) drives layout. */}
+              <Image
                 src={img.url}
                 alt={img.caption || ""}
+                width={0}
+                height={0}
+                sizes="(max-width: 640px) 50vw, 33vw"
                 className="w-full h-auto block transition-transform duration-200 group-hover:scale-[1.02]"
-                loading="lazy"
+                {...imageOptimization(img.url)}
               />
               {img.caption && (
                 <div className="px-3 py-2">
@@ -313,7 +321,9 @@ function LightboxGallery({
               src={img.url}
               alt={img.caption || ""}
               fill
+              sizes="(max-width: 640px) 50vw, 224px"
               className="object-cover transition-transform duration-200 group-hover:scale-105"
+              {...imageOptimization(img.url)}
             />
           </button>
         ))}

--- a/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMerchImage.tsx
@@ -8,6 +8,7 @@ import QuantitySelector, {
   supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
 import SoldOutBadge from "@/components/ui/SoldOutBadge"
+import { imageOptimization } from "@/lib/image-optimization"
 import { getProductAvailability } from "@/lib/product-availability"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -130,7 +131,9 @@ function MerchDefaultItem({
               src={product.image_url}
               alt={product.name}
               fill
+              sizes="56px"
               className="object-cover"
+              {...imageOptimization(product.image_url)}
             />
           ) : (
             <ShoppingBag className="w-6 h-6 text-muted-foreground" />
@@ -196,7 +199,9 @@ function MerchDefaultItem({
                 src={product.image_url}
                 alt={product.name}
                 fill
+                sizes="64px"
                 className="object-cover"
+                {...imageOptimization(product.image_url)}
               />
             ) : (
               <ShoppingBag className="w-7 h-7 text-muted-foreground" />
@@ -304,7 +309,9 @@ function MerchGrid({ products, getQuantity, onQuantityChange }: CardListProps) {
                     src={product.image_url}
                     alt={product.name}
                     fill
+                    sizes="(max-width: 640px) 50vw, 336px"
                     className="object-cover"
+                    {...imageOptimization(product.image_url)}
                   />
                 ) : (
                   <ShoppingBag className="w-10 h-10 text-muted-foreground" />
@@ -401,7 +408,9 @@ function MerchCompact({
                     src={product.image_url}
                     alt={product.name}
                     fill
+                    sizes="44px"
                     className="object-cover"
+                    {...imageOptimization(product.image_url)}
                   />
                 ) : (
                   <ShoppingBag className="w-4 h-4 text-muted-foreground" />

--- a/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketCard.tsx
@@ -12,6 +12,7 @@ import type {
   TicketSectionVM,
 } from "@/hooks/checkout/useTicketsStep"
 import { useTicketsStep } from "@/hooks/checkout/useTicketsStep"
+import { imageOptimization } from "@/lib/image-optimization"
 import { stepCardSurfaceStyle } from "@/lib/stepCardSurface"
 import { cn } from "@/lib/utils"
 import { formatCurrency } from "@/types/checkout"
@@ -519,9 +520,10 @@ function PassSystemSectionCard({
             alt={section.label}
             fill
             sizes="(max-width: 768px) 100vw, 720px"
-            quality={95}
+            quality={75}
             className="object-cover"
             priority={false}
+            {...imageOptimization(section.image_url)}
           />
         </div>
       )}
@@ -603,9 +605,10 @@ function OpenCheckoutSectionCard({
             alt={section.label}
             fill
             sizes="(max-width: 768px) 100vw, 720px"
-            quality={95}
+            quality={75}
             className="object-cover"
             priority={false}
+            {...imageOptimization(section.image_url)}
           />
         </div>
       )}

--- a/portal/src/components/profile/HumanForm.tsx
+++ b/portal/src/components/profile/HumanForm.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next"
 import { RiTelegram2Line } from "react-icons/ri"
 import type { HumanPublic } from "@/client"
 import uploadFileToS3 from "@/helpers/upload"
+import { imageOptimization } from "@/lib/image-optimization"
 import { Button } from "../ui/button"
 import { Card } from "../ui/card"
 import { Input } from "../ui/input"
@@ -106,7 +107,11 @@ const HumanForm = ({
                 src={editForm?.picture_url || userData?.picture_url}
                 alt="Profile"
                 fill
+                sizes="64px"
                 className="rounded-full object-cover"
+                {...imageOptimization(
+                  editForm?.picture_url || userData?.picture_url,
+                )}
               />
             ) : (
               <User className="w-8 h-8 text-primary" />

--- a/portal/src/components/profile/PopupsHistory.tsx
+++ b/portal/src/components/profile/PopupsHistory.tsx
@@ -2,6 +2,7 @@ import { Calendar, Clock, MapPin } from "lucide-react"
 import Image from "next/image"
 import { useTranslation } from "react-i18next"
 import type { HumanProfileStatsPopup, PopupPublic } from "@/client"
+import { imageOptimization } from "@/lib/image-optimization"
 import { cn } from "@/lib/utils"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCityProvider } from "@/providers/cityProvider"
@@ -25,6 +26,7 @@ function PopupThumb({
           fill
           sizes="(max-width: 768px) 100vw, 33vw"
           className="object-cover"
+          {...imageOptimization(imageUrl)}
         />
       </div>
     )

--- a/portal/src/components/profile/TopMatchStats.tsx
+++ b/portal/src/components/profile/TopMatchStats.tsx
@@ -2,6 +2,7 @@ import { Users } from "lucide-react"
 import Image from "next/image"
 import { useCallback, useEffect, useState } from "react"
 import type { HumanPublic } from "@/client"
+import { imageOptimization } from "@/lib/image-optimization"
 import type { EventParticipant } from "@/types/StatsSocialLayer"
 import { Avatar } from "../ui/avatar"
 import { Card } from "../ui/card"
@@ -130,6 +131,7 @@ const TopMatchStats = ({
                           width={32}
                           height={32}
                           className="w-full h-full object-cover rounded-full"
+                          {...imageOptimization(match.image_url)}
                         />
                       ) : (
                         <div className="w-full h-full bg-gradient-to-br from-blue-400 to-purple-500 rounded-full flex items-center justify-center text-primary-foreground text-xs font-semibold">

--- a/portal/src/lib/background-image.ts
+++ b/portal/src/lib/background-image.ts
@@ -31,9 +31,12 @@ function isVideoUrl(url: string): boolean {
 
 export type CheckoutBackground =
   | { type: "none"; className: string }
-  | { type: "image"; className: string; style: React.CSSProperties }
+  | { type: "image"; className: string; url: string }
   | { type: "video"; className: string; url: string }
 
+// Image backgrounds render through <CheckoutBackgroundImage> (a fixed
+// full-viewport next/image layer), replicating the previous CSS
+// `background-attachment: fixed` behavior with optimized loading.
 export function getCheckoutBackground(
   popup: PopupPublic | null | undefined,
   context: CheckoutBackgroundContext,
@@ -48,30 +51,5 @@ export function getCheckoutBackground(
     return { type: "video", className: "", url }
   }
 
-  return {
-    type: "image",
-    className: "",
-    style: {
-      backgroundImage: `url(${url})`,
-      backgroundSize: "cover",
-      backgroundPosition: "center",
-      backgroundRepeat: "no-repeat",
-      backgroundAttachment: "fixed",
-    },
-  }
-}
-
-// Back-compat wrapper. Returns the spread-onto-main shape image consumers
-// have always used. Video URLs now collapse to the empty/no-bg case so
-// callers that haven't migrated to <CheckoutBackgroundLayer> don't break.
-export function getBackgroundProps(
-  popup: PopupPublic | null | undefined,
-  context: CheckoutBackgroundContext,
-): {
-  className: string
-  style: React.CSSProperties | undefined
-} {
-  const bg = getCheckoutBackground(popup, context)
-  if (bg.type === "image") return { className: bg.className, style: bg.style }
-  return { className: bg.className || "bg-background", style: undefined }
+  return { type: "image", className: "", url }
 }

--- a/portal/src/lib/image-optimization.ts
+++ b/portal/src/lib/image-optimization.ts
@@ -1,0 +1,38 @@
+// Single source of truth for the hosts allowed through the Next.js image
+// optimizer. next.config.ts derives `images.remotePatterns` from this list,
+// so adding a CDN here is enough to enable optimization for it.
+export const OPTIMIZED_IMAGE_HOSTS = [
+  // Backoffice uploads (production CDN in front of storage).
+  "cdn.edgeos.world",
+  // INTERIM: tenants that configured popups via the API host images on raw
+  // GCS buckets (e.g. egypt-eclipse). Remove once backend CDN ingestion
+  // re-homes those images — this entry opens the optimizer to ANY public
+  // GCS bucket, not just ours.
+  "storage.googleapis.com",
+  // Legacy S3 bucket — kept for older records still pointing at it.
+  "simplefi.s3.us-east-2.amazonaws.com",
+]
+
+function isOptimizableImageSrc(src: string | null | undefined): boolean {
+  if (!src) return false
+  // Same-origin static assets are always optimizable.
+  if (src.startsWith("/")) return true
+  try {
+    return OPTIMIZED_IMAGE_HOSTS.includes(new URL(src).hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Spread onto a next/image `<Image>` whose src comes from data (tenant
+ * assets, admin-entered template URLs, blob:/data: upload previews).
+ * next/image throws at runtime for remote hosts missing from
+ * `remotePatterns`, so unknown hosts fall back to the raw URL instead of
+ * crashing the page.
+ */
+export function imageOptimization(src: string | null | undefined): {
+  unoptimized: boolean
+} {
+  return { unoptimized: !isOptimizableImageSrc(src) }
+}


### PR DESCRIPTION
## Summary
- Replaces every native `img` in the portal with `next/image` so tenant imagery is resized to the rendered size, converted to AVIF/WebP and lazy-loaded.
- `OPTIMIZED_IMAGE_HOSTS` (`src/lib/image-optimization.ts`) is the single source of truth for optimizer-allowed hosts; `next.config.ts` derives `remotePatterns` from it. Unknown hosts fall back to the raw URL via `imageOptimization()` instead of crashing at runtime.
- `storage.googleapis.com` is allowed as a documented interim until backend CDN ingestion re-homes API-configured tenant images (it was costing eclipse ~7 MiB of unoptimized images per checkout visit).
- Checkout background moves from CSS `background-image` to a `next/image` component with `priority`; ticket card covers drop from quality 95 to 75.

## Review notes
First PR of a 7-slice chain. Verified: portal build, biome, and Lighthouse comparison on production build (image delivery savings confirmed via `/_next/image` with srcset in DOM).