### PR TITLE
fix(checkout): snap sections to the viewport while scrolling

### DIFF
--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -201,13 +201,15 @@ function ScrollyCheckoutFlowInner({
     const sectionsSnapshot = allSections
 
     const prevSnapType = mainEl.style.scrollSnapType
-    // `proximity` (not `mandatory`): sections here can be 2-3 viewport
-    // heights tall (ticket/housing card lists). Mandatory snap turns the
-    // gaps between snap points into dead zones — a moderate touch flick
-    // that ends mid-gap gets yanked back to the previous section, which
-    // on phones feels like the page refusing to scroll. Proximity keeps
-    // the aligned-landing behaviour near section tops and frees the rest.
-    mainEl.style.scrollSnapType = "y proximity"
+    // `mandatory`: every section has min-height equal to the scrollport, so
+    // a scroll can never rest straddling two sections — it always settles
+    // aligned to a section top. Sections TALLER than the scrollport
+    // (ticket/housing card lists) still scroll freely inside themselves:
+    // per the scroll-snap spec, a snap area larger than the snapport is a
+    // valid rest position anywhere it fully covers the snapport.
+    // `proximity` was tried before and let the scroll settle in the empty
+    // space between section content, leaving huge blank screens.
+    mainEl.style.scrollSnapType = "y mandatory"
 
     const sectionEls = sectionsSnapshot
       .map((s) => document.getElementById(s.id))
@@ -470,7 +472,11 @@ function ScrollyCheckoutFlowInner({
           <SnapSection
             key={section.id}
             id={section.id}
-            bottomPadding={section.id === lastSectionId ? "4rem" : "50vh"}
+            // Bottom padding stays small so short sections are exactly one
+            // scrollport tall (mandatory snap then has a single rest position
+            // for them). It only needs to clear the floating cart footer on
+            // tall sections.
+            bottomPadding={section.id === lastSectionId ? "4rem" : "8rem"}
             widthClass={isStackedCards ? "max-w-6xl" : "max-w-2xl"}
           >
             {/* Header and footer stay in the narrow column even when the step

--- a/portal/src/components/checkout-flow/SnapSection.tsx
+++ b/portal/src/components/checkout-flow/SnapSection.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from "react"
 export default function SnapSection({
   id,
   children,
-  bottomPadding = "50vh",
+  bottomPadding = "8rem",
   // Most steps read as a centred column; card-grid steps pass a wider class so
   // their cards have room to sit side by side. Both literals live here and at
   // the call site so Tailwind keeps them.
@@ -89,6 +89,14 @@ export default function SnapSection({
     }
   }, [visible])
 
+  // Single-axis scroll model. Every section is at least one viewport tall
+  // (`--snap-section-h` = the scroll container's clientHeight) and content
+  // taller than that simply extends the section — it scrolls on the MAIN
+  // axis like any web page. Combined with `scroll-snap-type: y mandatory`
+  // on the container this gives crisp per-section snapping for short
+  // sections while tall ones stay freely scrollable (a snap area larger
+  // than the snapport is a valid rest position anywhere it covers it, per
+  // the scroll-snap spec). No nested scrollers, no snap juggling.
   return (
     <section
       id={id}


### PR DESCRIPTION
## Summary
- Switches the checkout scroll container from `scroll-snap-type: y proximity` to `y mandatory`: a scroll can no longer rest straddling two sections showing a huge blank gap (the reported bug).
- Shrinks the 50vh inter-section padding that manufactured that gap to 8rem (4rem on the last section).
- Sections taller than the viewport (ticket/housing lists) stay freely scrollable — a snap area larger than the snapport is a valid rest position per the CSS scroll-snap spec, so no JS is needed for them.

## Review notes
Slice 2/7, stacked on #425 — review only the last commit. Verified with Playwright on desktop and mobile viewports: partial scrolls settle aligned, tall sections free-scroll, nav jumps land exactly.