### PR TITLE
feat(portal): unify first-render loading into a single loader

### DIFF
--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -6,6 +6,7 @@ import { CheckoutBackgroundImage } from "@/components/CheckoutBackgroundImage"
 import { CheckoutBackgroundVideo } from "@/components/CheckoutBackgroundVideo"
 import { OpenCheckoutRuntime } from "@/components/checkout-flow/OpenCheckoutRuntime"
 import { SidebarProvider } from "@/components/Sidebar/SidebarComponents"
+import { Loader } from "@/components/ui/Loader"
 import useAuth from "@/hooks/useAuth"
 import { getCheckoutBackground } from "@/lib/background-image"
 import { useCheckoutRuntime } from "./hooks/useCheckoutRuntime"
@@ -26,13 +27,7 @@ export default function OpenTicketingCheckoutPage() {
     : undefined
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="text-sm text-muted-foreground">
-          {t("openCheckout.loading")}
-        </div>
-      </div>
-    )
+    return <Loader />
   }
 
   if (isError || !runtime) {

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -3,6 +3,7 @@
 import { useParams, useRouter, useSearchParams } from "next/navigation"
 import type { ReactNode } from "react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Loader } from "@/components/ui/Loader"
 import { readAndClearPendingPaymentRedirectState } from "@/hooks/usePaymentRedirect"
 import { useCheckout } from "@/providers/checkoutProvider"
 import CheckoutToast from "./CheckoutToast"
@@ -425,20 +426,8 @@ function ScrollyCheckoutFlowInner({
     return null
   }
 
-  if (isSimpleFIReturn) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-current opacity-60" />
-      </div>
-    )
-  }
-
-  if (isInitialLoading) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-current opacity-60" />
-      </div>
-    )
+  if (isSimpleFIReturn || isInitialLoading) {
+    return <Loader />
   }
 
   const lastSectionId = allSections[allSections.length - 1]?.id

--- a/portal/src/components/ui/Loader.tsx
+++ b/portal/src/components/ui/Loader.tsx
@@ -1,12 +1,13 @@
-// import { Loader2 } from 'lucide-react'
-
+/**
+ * Canonical full-screen loader. Every sequential loading gate on first
+ * render (route fallback, tenant resolution, checkout runtime, checkout
+ * init) renders this same component so the user perceives one continuous
+ * loader instead of a chain of different ones.
+ */
 export function Loader() {
   return (
-    <div className="fixed m-auto inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="text-center">
-        {/* <Loader2 className="h-10 w-10 animate-spin text-primary mx-auto" /> */}
-        <p className="mt-2 text-sm text-muted-foreground">Loading...</p>
-      </div>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
+      <div className="h-12 w-12 animate-spin rounded-full border-t-2 border-b-2 border-current opacity-60" />
     </div>
   )
 }

--- a/portal/src/providers/tenantProvider.tsx
+++ b/portal/src/providers/tenantProvider.tsx
@@ -10,6 +10,7 @@ import {
 import type { TenantPublic } from "@/client"
 import { ApiError, TenantsService } from "@/client"
 import "@/lib/api-client"
+import { Loader } from "@/components/ui/Loader"
 import { extractSubdomain } from "@/lib/tenant"
 import { resolveHostname } from "@/lib/tenant-resolution"
 
@@ -125,11 +126,7 @@ export const TenantProvider = ({
   }, [initialTenantId, initialTenantSlug])
 
   if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-neutral-100">
-        <div className="animate-spin h-8 w-8 border-4 border-gray-300 border-t-gray-900 rounded-full" />
-      </div>
-    )
+    return <Loader />
   }
 
   if (error) {


### PR DESCRIPTION
## Summary
- First render used to cascade through three visibly different loading states (route fallback text, tenant-resolution spinner, checkout runtime text, plus the checkout init spinner).
- All gates now render the same full-screen `Loader` (theme-aware spinner, no hardcoded copy), so the user perceives one continuous loader.
- `Loader` previously rendered only the text "Loading..." because its spinner icon had been commented out; it is now the canonical loader and the untranslated string is gone.

## Review notes
Slice 3/7, stacked on #425 → fix/checkout-scroll-snap — review only the last commit.