### PR TITLE
perf(checkout): prioritize first-section images and optimize rich-text images

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       gsap:
         specifier: ^3.14.2
         version: 3.14.2
+      html-react-parser:
+        specifier: ^6.1.4
+        version: 6.1.4(@types/react@19.2.14)(react@19.2.4)
       i18next:
         specifier: ^25.8.13
         version: 25.10.10(typescript@5.9.3)
@@ -3567,11 +3570,27 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dompurify@3.4.3:
     resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3934,6 +3953,9 @@ packages:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
     engines: {node: '>=16.9.0'}
 
+  html-dom-parser@8.0.0:
+    resolution: {integrity: sha512-cWLJ8mt930VceOzVfY/J+T1ou9v3ENT0BgWqy5aEZjdFp37TYLXULjX8u0vD2rBpFAkK5IofOPl0y4Gq0QLIyA==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3945,8 +3967,21 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
+  html-react-parser@6.1.4:
+    resolution: {integrity: sha512-oNZVIuYir7XOFuQZ7mtvcIC5cTYBVqCDOhJ1rSH4V1nVDs71bHZXFlKdpSuOm5TZT7V2uxCxA7HqTkCNHW32KQ==}
+    peerDependencies:
+      '@types/react': 0.14 || 15 || 16 || 17 || 18 || 19
+      react: 0.14 || 15 || 16 || 17 || 18 || 19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -5026,6 +5061,9 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
+
   react-qr-code@2.0.18:
     resolution: {integrity: sha512-v1Jqz7urLMhkO6jkgJuBYhnqvXagzceg3qJUWayuCK/c6LTIonpWbwxR1f1APGd4xrW/QcQEovNrAojbUz65Tg==}
     peerDependencies:
@@ -5369,8 +5407,14 @@ packages:
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
+  style-to-js@2.0.1:
+    resolution: {integrity: sha512-j5whjFV29FyWf+/gWc/Fax7DQqojc5CzZ2kxOCuSMoZDGdciF+Ki1HyZ/GPOxdbfIw0suKUBmG1I3qa7JZKRTA==}
+
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  style-to-object@2.0.0:
+    resolution: {integrity: sha512-3zaRtBpwCy9AnYQYfgZ8tIMPn/PlQpW3wtRMB+w0xVtBzo8/m7KKGi7cR56yQ6udLz5MPzwRqfKOZ3O+Oc6VpA==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -8850,6 +8894,18 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
+  domelementtype@3.0.0: {}
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
+
   dompurify@3.2.7:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -8857,6 +8913,12 @@ snapshots:
   dompurify@3.4.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dotenv@16.6.1: {}
 
@@ -9258,6 +9320,11 @@ snapshots:
 
   hono@4.12.3: {}
 
+  html-dom-parser@8.0.0:
+    dependencies:
+      domhandler: 6.0.1
+      htmlparser2: 12.0.0
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -9272,7 +9339,24 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
+  html-react-parser@6.1.4(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      domhandler: 6.0.1
+      html-dom-parser: 8.0.0
+      react: 19.2.4
+      react-property: 2.0.2
+      style-to-js: 2.0.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   html-url-attributes@3.0.1: {}
+
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
 
   http-errors@2.0.1:
     dependencies:
@@ -10614,6 +10698,8 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  react-property@2.0.2: {}
+
   react-qr-code@2.0.18(react@19.2.4):
     dependencies:
       prop-types: 15.8.1
@@ -11069,7 +11155,15 @@ snapshots:
     dependencies:
       style-to-object: 1.0.14
 
+  style-to-js@2.0.1:
+    dependencies:
+      style-to-object: 2.0.0
+
   style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  style-to-object@2.0.0:
     dependencies:
       inline-style-parser: 0.2.7
 

--- a/portal/package.json
+++ b/portal/package.json
@@ -45,6 +45,7 @@
     "framer-motion": "^11.12.0",
     "geist": "^1.3.1",
     "gsap": "^3.14.2",
+    "html-react-parser": "^6.1.4",
     "i18next": "^25.8.13",
     "isomorphic-dompurify": "^3.13.0",
     "js-cookie": "^3.0.5",

--- a/portal/src/components/checkout-flow/DynamicProductStep.tsx
+++ b/portal/src/components/checkout-flow/DynamicProductStep.tsx
@@ -12,11 +12,13 @@ import EditPassesToggle from "./shared/EditPassesToggle"
 interface DynamicProductStepProps {
   stepConfig: TicketingStepPublic
   onSkip?: () => void
+  isFirstSection?: boolean
 }
 
 export default function DynamicProductStep({
   stepConfig,
   onSkip,
+  isFirstSection,
 }: DynamicProductStepProps) {
   const { getProductsForStep } = useCheckout()
 
@@ -76,6 +78,7 @@ export default function DynamicProductStep({
       templateConfig={
         (stepConfig.template_config as Record<string, unknown>) ?? null
       }
+      isFirstSection={isFirstSection}
     />
   )
 

--- a/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/ScrollyCheckoutFlow.tsx
@@ -406,21 +406,39 @@ function ScrollyCheckoutFlowInner({
     }
   }, [allSections, isInitialLoading, markStepVisited])
 
-  const renderSectionContent = (section: (typeof allSections)[number]) => {
+  const renderSectionContent = (
+    section: (typeof allSections)[number],
+    index: number,
+  ) => {
     const { stepType, config } = section
+    // First section is above the fold: its images are LCP candidates and
+    // must load eagerly with high priority instead of lazily.
+    const isFirstSection = index === 0
 
     if (stepType === "buyer") return <OpenCheckoutBuyerStep />
     if (stepType === "confirm") return <ConfirmStep />
 
     if (stepType === "passes" || stepType === "tickets") {
       if (shouldUseDynamicStep(config ?? undefined)) {
-        return <DynamicProductStep stepConfig={config!} onSkip={() => {}} />
+        return (
+          <DynamicProductStep
+            stepConfig={config!}
+            onSkip={() => {}}
+            isFirstSection={isFirstSection}
+          />
+        )
       }
       return <PassSelectionSection />
     }
 
     if (config) {
-      return <DynamicProductStep stepConfig={config} onSkip={() => {}} />
+      return (
+        <DynamicProductStep
+          stepConfig={config}
+          onSkip={() => {}}
+          isFirstSection={isFirstSection}
+        />
+      )
     }
 
     return null
@@ -446,7 +464,7 @@ function ScrollyCheckoutFlowInner({
         brandLabel={brandLabel}
       />
       <CheckoutToast onChipClick={scrollToStep} />
-      {allSections.map((section) => {
+      {allSections.map((section, sectionIndex) => {
         const { config } = section
         // The ticket-card "stacked" layout renders a responsive grid of cards,
         // which needs more width than the default centred column. Other steps
@@ -484,7 +502,7 @@ function ScrollyCheckoutFlowInner({
                 showWatermark={config?.show_watermark ?? true}
               />
             </div>
-            {renderSectionContent(section)}
+            {renderSectionContent(section, sectionIndex)}
             {(() => {
               const ft = (
                 config?.template_config as Record<string, unknown> | undefined

--- a/portal/src/components/checkout-flow/registries/variantRegistry.ts
+++ b/portal/src/components/checkout-flow/registries/variantRegistry.ts
@@ -16,6 +16,10 @@ export interface VariantProps {
   stepType: string
   onSkip?: () => void
   templateConfig?: Record<string, unknown> | null
+  /** True when the variant renders inside the first checkout section, i.e.
+   *  above the fold on first paint. Variants use it to load their images
+   *  eagerly with high fetch priority (LCP) instead of lazily. */
+  isFirstSection?: boolean
 }
 
 export const VARIANT_REGISTRY: Record<string, ComponentType<VariantProps>> = {

--- a/portal/src/components/checkout-flow/variants/VariantRichText.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantRichText.tsx
@@ -1,7 +1,10 @@
 "use client"
 
+import parse, { Element } from "html-react-parser"
 import DOMPurify from "isomorphic-dompurify"
+import Image from "next/image"
 import { useMemo } from "react"
+import { imageOptimization } from "@/lib/image-optimization"
 import type { VariantProps } from "../registries/variantRegistry"
 
 // `isomorphic-dompurify` doesn't re-export its `Config` type, so we narrow
@@ -31,6 +34,11 @@ interface DOMPurifyConfig {
 // Security: DOMPurify runs server-side AND client-side. Script tags,
 // inline event handlers and `javascript:` URIs are stripped. Only the
 // allowlist below survives, which is intentionally narrow.
+//
+// Rendering: the sanitised HTML is parsed to React elements so `<img>`
+// tags whose host is allowed through the Next.js optimizer render as
+// `next/image` (resized, modern formats). Images on unknown hosts stay
+// as plain `<img>` with explicit loading attributes.
 // ---------------------------------------------------------------------------
 
 interface RichTextConfig {
@@ -99,16 +107,79 @@ const WIDTH_CLASSES: Record<
   wide: "max-w-3xl",
 }
 
-export default function VariantRichText({ templateConfig }: VariantProps) {
+// Loading attributes are injected AFTER sanitisation (they are not in
+// ALLOWED_ATTR, so admin-authored values are always stripped first).
+// Below-the-fold images load lazily so multi-MB content images don't
+// compete with the LCP for bandwidth; first-section images are LCP
+// candidates and load eagerly with high fetch priority instead.
+// NOTE: these attrs only survive on the plain-<img> fallback path — imgs
+// on optimizer-allowed hosts are replaced by next/image in richTextImage
+// below, which expresses the same intent via its `priority` prop.
+function withImageLoadingAttrs(
+  sanitizedHtml: string,
+  isFirstSection: boolean,
+): string {
+  const attrs = isFirstSection
+    ? 'fetchpriority="high" decoding="async"'
+    : 'loading="lazy" decoding="async"'
+  return sanitizedHtml.replaceAll("<img ", `<img ${attrs} `)
+}
+
+// Swap an authored <img> for next/image when its host is allowed through
+// the optimizer. Returning undefined keeps the sanitised <img> untouched
+// (it already carries the loading attributes injected above) — that is
+// the right call for unknown hosts, which next/image rejects at runtime.
+function richTextImage(node: Element, isFirstSection: boolean) {
+  const { src, alt, width, height, class: className } = node.attribs
+  if (!src || imageOptimization(src).unoptimized) {
+    return undefined
+  }
+  const w = Number.parseInt(width ?? "", 10)
+  const h = Number.parseInt(height ?? "", 10)
+  const hasDims = w > 0 && h > 0
+  return (
+    <Image
+      src={src}
+      alt={alt ?? ""}
+      // Without authored dimensions next/image still needs a ratio to
+      // reserve space; 4:3 placeholder + h-auto lets the real ratio take
+      // over once loaded — no worse than the zero reservation a plain
+      // <img> without dimensions gets.
+      width={hasDims ? w : 1200}
+      height={hasDims ? h : 900}
+      sizes="(max-width: 768px) 100vw, 768px"
+      priority={isFirstSection}
+      className={
+        hasDims ? className : `${className ?? ""} h-auto w-full`.trim()
+      }
+    />
+  )
+}
+
+export default function VariantRichText({
+  templateConfig,
+  isFirstSection = false,
+}: VariantProps) {
   const config = (templateConfig ?? {}) as RichTextConfig
   const html = typeof config.html === "string" ? config.html : ""
 
-  const sanitized = useMemo(
-    () => DOMPurify.sanitize(html, PURIFY_CONFIG),
-    [html],
-  )
+  const content = useMemo(() => {
+    const sanitized = withImageLoadingAttrs(
+      DOMPurify.sanitize(html, PURIFY_CONFIG),
+      isFirstSection,
+    )
+    if (!sanitized) return null
+    return parse(sanitized, {
+      replace: (node) => {
+        if (node instanceof Element && node.name === "img") {
+          return richTextImage(node, isFirstSection)
+        }
+        return undefined
+      },
+    })
+  }, [html, isFirstSection])
 
-  if (!sanitized) {
+  if (!content) {
     return null
   }
 
@@ -117,8 +188,8 @@ export default function VariantRichText({ templateConfig }: VariantProps) {
       className={`${WIDTH_CLASSES[config.max_width ?? "wide"]} ${
         ALIGNMENT_CLASSES[config.alignment ?? "center"]
       } prose prose-invert prose-headings:font-semibold prose-a:underline`}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitised by DOMPurify with the strict allowlist above
-      dangerouslySetInnerHTML={{ __html: sanitized }}
-    />
+    >
+      {content}
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- The measured LCP on image-led checkouts was a rich-text `img` discovered late and competing with every below-fold image for bandwidth.
- Sections now know when they render first (`isFirstSection` flows ScrollyCheckoutFlow → DynamicProductStep → variants): first-section images get `fetchpriority=high`, everything below the fold lazy-loads.
- Rich-text HTML is parsed to React after DOMPurify sanitization (`html-react-parser`): imgs on optimizer-allowed hosts render as `next/image` (responsive srcset, AVIF/WebP, `priority` above the fold); unknown hosts keep a plain img with explicit loading attributes.

## Review notes
Slice 4/7 — review only the last commit. Adds one dependency: `html-react-parser`. Verified in prod-build DOM: eclipse (non-allowed host) keeps plain imgs with correct loading attrs; CDN-hosted images serve through `/_next/image` with srcset.