### PR TITLE
perf(checkout): load the YouTube embed behind a click facade

### DIFF
--- a/portal/src/components/checkout-flow/variants/VariantYouTubeVideo.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantYouTubeVideo.tsx
@@ -1,6 +1,9 @@
 "use client"
 
 import { Play } from "lucide-react"
+import Image from "next/image"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import type { VariantProps } from "../registries/variantRegistry"
 
@@ -11,10 +14,16 @@ function extractVideoId(url: string): string | null {
   return match?.[1] ?? null
 }
 
+// Facade pattern: mounting the real YouTube iframe pulls the full player
+// (hundreds of KB of third-party JS) the moment the section renders. Until
+// the user actually presses play we only show the video thumbnail, then
+// swap in the iframe with autoplay so the click still starts playback.
 export default function VariantYouTubeVideo({
   onSkip,
   templateConfig,
 }: VariantProps) {
+  const { t } = useTranslation()
+  const [playing, setPlaying] = useState(false)
   const youtubeUrl = (templateConfig?.youtube_url as string) || ""
   const videoId = youtubeUrl ? extractVideoId(youtubeUrl) : null
 
@@ -22,26 +31,51 @@ export default function VariantYouTubeVideo({
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <Play className="w-12 h-12 text-muted-foreground mb-4" />
-        <p className="text-muted-foreground mb-6">
-          No video available for this step.
-        </p>
+        <p className="text-muted-foreground mb-6">{t("checkout.no_video")}</p>
         <Button variant="outline" onClick={onSkip}>
-          Continue
+          {t("common.continue")}
         </Button>
       </div>
     )
   }
 
+  const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
+
   return (
     <div className="space-y-6">
       <div className="relative w-full aspect-video rounded-2xl overflow-hidden shadow-sm border border-border bg-black">
-        <iframe
-          src={`https://www.youtube.com/embed/${videoId}`}
-          title="YouTube video"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowFullScreen
-          className="absolute inset-0 w-full h-full"
-        />
+        {playing ? (
+          <iframe
+            src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1`}
+            title="YouTube video"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className="absolute inset-0 w-full h-full"
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setPlaying(true)}
+            aria-label={t("checkout.video.play_youtube_aria")}
+            className="group absolute inset-0 h-full w-full cursor-pointer"
+          >
+            <Image
+              src={thumbnailUrl}
+              alt=""
+              fill
+              sizes="(max-width: 768px) 100vw, 672px"
+              className="object-cover"
+              // YouTube's own CDN — never in our optimizer allowlist, and the
+              // thumbnail is already small; serve it as-is.
+              unoptimized
+            />
+            <span className="absolute inset-0 flex items-center justify-center bg-black/30 transition-colors group-hover:bg-black/40">
+              <span className="flex h-16 w-16 items-center justify-center rounded-full bg-black/70 transition-transform group-hover:scale-110">
+                <Play className="ml-1 h-8 w-8 fill-white text-white" />
+              </span>
+            </span>
+          </button>
+        )}
       </div>
     </div>
   )

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -255,7 +255,8 @@
       "play_aria": "Play background video",
       "pause_aria": "Pause background video",
       "mute_aria": "Mute background video",
-      "unmute_aria": "Unmute background video"
+      "unmute_aria": "Unmute background video",
+      "play_youtube_aria": "Play video"
     },
     "housing": {
       "carousel": {
@@ -273,7 +274,8 @@
       "promo_discount_eligible_label": "Promo Discount (eligible items)"
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
-    "payment_error": "Something went wrong with your payment. Please try again."
+    "payment_error": "Something went wrong with your payment. Please try again.",
+    "no_video": "No video available for this step."
   },
   "openCheckout": {
     "loading": "Loading checkout...",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -255,7 +255,8 @@
       "play_aria": "Reproducir video de fondo",
       "pause_aria": "Pausar video de fondo",
       "mute_aria": "Silenciar video de fondo",
-      "unmute_aria": "Activar sonido del video de fondo"
+      "unmute_aria": "Activar sonido del video de fondo",
+      "play_youtube_aria": "Reproducir video"
     },
     "housing": {
       "carousel": {
@@ -273,7 +274,8 @@
       "promo_discount_eligible_label": "Descuento (items elegibles)"
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
-    "payment_error": "Something went wrong with your payment. Please try again."
+    "payment_error": "Something went wrong with your payment. Please try again.",
+    "no_video": "No hay video disponible para este paso."
   },
   "openCheckout": {
     "loading": "Cargando checkout...",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -231,7 +231,8 @@
       "play_aria": "Spila bakgrunnsmyndband",
       "pause_aria": "Stöðva bakgrunnsmyndband",
       "mute_aria": "Slökkva á hljóði bakgrunnsmyndbands",
-      "unmute_aria": "Kveikja á hljóði bakgrunnsmyndbands"
+      "unmute_aria": "Kveikja á hljóði bakgrunnsmyndbands",
+      "play_youtube_aria": "Spila myndband"
     },
     "housing": {
       "carousel": {
@@ -249,7 +250,8 @@
       "promo_discount_eligible_label": "Afsláttur (gjaldgengar vörur)"
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
-    "payment_error": "Something went wrong with your payment. Please try again."
+    "payment_error": "Something went wrong with your payment. Please try again.",
+    "no_video": "Ekkert myndband í boði fyrir þetta skref."
   },
   "openCheckout": {
     "loading": "Hleður greiðslu...",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -241,7 +241,8 @@
       "play_aria": "播放背景视频",
       "pause_aria": "暂停背景视频",
       "mute_aria": "静音背景视频",
-      "unmute_aria": "取消静音背景视频"
+      "unmute_aria": "取消静音背景视频",
+      "play_youtube_aria": "播放视频"
     },
     "housing": {
       "carousel": {
@@ -259,7 +260,8 @@
       "promo_discount_eligible_label": "促销折扣（符合条件的商品）"
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
-    "payment_error": "Something went wrong with your payment. Please try again."
+    "payment_error": "Something went wrong with your payment. Please try again.",
+    "no_video": "此步骤暂无可用视频。"
   },
   "openCheckout": {
     "loading": "正在加载结账...",


### PR DESCRIPTION
## Summary
- The eager YouTube iframe pulled the full player (hundreds of KB of third-party JS plus cookies) the moment the video section rendered.
- The step now shows only the video thumbnail (`hqdefault.jpg`, always available) with a play overlay; the real player mounts on click against `youtube-nocookie.com` with `autoplay=1` so the click still starts playback.
- Empty-state and play-button copy are translated (en/es/is/zh).

## Review notes
Slice 5/7 — review only the last commit.