### PR TITLE
fix(checkout): translate empty-state and error copy

### DIFF
--- a/portal/src/components/checkout-flow/DynamicProductStep.tsx
+++ b/portal/src/components/checkout-flow/DynamicProductStep.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useTranslation } from "react-i18next"
 import type { TicketingStepPublic } from "@/client"
 import { Button } from "@/components/ui/button"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -21,6 +22,7 @@ export default function DynamicProductStep({
   isFirstSection,
 }: DynamicProductStepProps) {
   const { getProductsForStep } = useCheckout()
+  const { t } = useTranslation()
 
   const filtered = getProductsForStep(stepConfig)
 
@@ -40,13 +42,14 @@ export default function DynamicProductStep({
     if (filtered.length > 0) {
       return (
         <div className="flex flex-col items-center justify-center py-12 text-center">
-          <p className="text-gray-500 mb-2">Step configuration error.</p>
+          <p className="text-gray-500 mb-2">
+            {t("checkout.step_config_error")}
+          </p>
           <p className="text-xs text-gray-400 mb-6">
-            No template assigned to this step. Please contact your
-            administrator.
+            {t("checkout.step_config_error_detail")}
           </p>
           <Button variant="outline" onClick={onSkip}>
-            Continue
+            {t("common.continue")}
           </Button>
         </div>
       )
@@ -60,11 +63,9 @@ export default function DynamicProductStep({
   if (!VariantComponent || (!isContentOnly && filtered.length === 0)) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
-        <p className="text-gray-500 mb-6">
-          No products available for this step.
-        </p>
+        <p className="text-gray-500 mb-6">{t("checkout.no_products")}</p>
         <Button variant="outline" onClick={onSkip}>
-          Continue
+          {t("common.continue")}
         </Button>
       </div>
     )

--- a/portal/src/components/checkout-flow/steps/PassSelectionSection.tsx
+++ b/portal/src/components/checkout-flow/steps/PassSelectionSection.tsx
@@ -453,6 +453,7 @@ function AttendeePassCardBody({
   isEditing,
   allAttendees,
 }: AttendeePassCardBodyProps) {
+  const { t } = useTranslation()
   const isChild =
     attendee.category === "kid" ||
     attendee.category === "teen" ||
@@ -508,7 +509,7 @@ function AttendeePassCardBody({
   if (standardProducts.length === 0) {
     return (
       <div className="text-center py-8 text-muted-foreground text-sm">
-        No passes available for this attendee category.
+        {t("checkout.no_passes_for_category")}
       </div>
     )
   }

--- a/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import Image from "next/image"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { imageOptimization } from "@/lib/image-optimization"
 import { cn } from "@/lib/utils"
@@ -429,6 +430,7 @@ export default function VariantImageGallery({
   onSkip,
   templateConfig,
 }: VariantProps) {
+  const { t } = useTranslation()
   const images = parseImages(templateConfig)
   const variant = (templateConfig?.variant as string) || "carousel"
 
@@ -436,11 +438,9 @@ export default function VariantImageGallery({
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <ImageIcon className="w-12 h-12 text-muted-foreground mb-4" />
-        <p className="text-muted-foreground mb-6">
-          No images available for this step.
-        </p>
+        <p className="text-muted-foreground mb-6">{t("checkout.no_images")}</p>
         <Button variant="outline" onClick={onSkip}>
-          Continue
+          {t("common.continue")}
         </Button>
       </div>
     )

--- a/portal/src/components/checkout-flow/variants/VariantMealPlanSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantMealPlanSelect.tsx
@@ -24,6 +24,7 @@
 
 import { Sparkles } from "lucide-react"
 import { Fragment, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { deriveProductState, type ProductSaleState } from "@/lib/product-state"
@@ -138,6 +139,7 @@ export default function VariantMealPlanSelect({
     setMealPlanDietaryRestriction,
     setMealPlanSpecialRequest,
   } = useCheckout()
+  const { t } = useTranslation()
 
   // Filter to meal-plan products only (the registry passes the step-resolved
   // product list; we still defensively filter so a misconfigured step can't
@@ -200,7 +202,7 @@ export default function VariantMealPlanSelect({
   if (mealPlanProducts.length === 0 || weeklyProducts.length === 0) {
     return (
       <div className="rounded-2xl border border-border bg-card px-4 py-6 text-center text-sm text-muted-foreground">
-        No meal plans available.
+        {t("checkout.no_meal_plans")}
       </div>
     )
   }

--- a/portal/src/components/checkout-flow/variants/VariantPatronPreset.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantPatronPreset.tsx
@@ -2,6 +2,7 @@
 
 import { Heart } from "lucide-react"
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 import { useCheckout } from "@/providers/checkoutProvider"
@@ -39,6 +40,7 @@ export default function VariantPatronPreset({
   templateConfig,
 }: VariantProps) {
   const { cart, setPatronAmount, clearPatron } = useCheckout()
+  const { t } = useTranslation()
   const { presets, allowCustom, minimum } = parseTemplateConfig(templateConfig)
 
   const product = products[0]
@@ -91,10 +93,10 @@ export default function VariantPatronPreset({
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <Heart className="w-12 h-12 text-muted-foreground mb-4" />
         <p className="text-muted-foreground mb-6">
-          No contribution options available.
+          {t("checkout.no_contributions")}
         </p>
         <Button variant="outline" onClick={onSkip}>
-          Continue
+          {t("common.continue")}
         </Button>
       </div>
     )

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -321,6 +321,7 @@ function AttendeePassRows({
   isEditing: boolean
   sections: TemplateSection[]
 }) {
+  const { t } = useTranslation()
   const groups = buildSectionGroups(attendee, sections)
 
   // Wide scope passed to the strategy: every product id visible to this
@@ -339,7 +340,7 @@ function AttendeePassRows({
   if (groups.length === 0) {
     return (
       <div className="px-5 py-8 text-center text-sm text-muted-foreground">
-        No passes available.
+        {t("checkout.no_passes")}
       </div>
     )
   }
@@ -910,7 +911,9 @@ function CompactAttendeeCard({
       </div>
 
       {visibleProducts.length === 0 ? (
-        <p className="text-xs text-muted-foreground">No passes available.</p>
+        <p className="text-xs text-muted-foreground">
+          {t("checkout.no_passes")}
+        </p>
       ) : (
         <div className="flex flex-wrap gap-2">
           {visibleProducts.map((p) => {

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -275,7 +275,15 @@
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
     "payment_error": "Something went wrong with your payment. Please try again.",
-    "no_video": "No video available for this step."
+    "no_products": "No products available for this step.",
+    "no_images": "No images available for this step.",
+    "no_video": "No video available for this step.",
+    "no_passes": "No passes available.",
+    "no_passes_for_category": "No passes available for this attendee category.",
+    "no_meal_plans": "No meal plans available.",
+    "no_contributions": "No contribution options available.",
+    "step_config_error": "Step configuration error.",
+    "step_config_error_detail": "No template assigned to this step. Please contact your administrator."
   },
   "openCheckout": {
     "loading": "Loading checkout...",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -275,7 +275,15 @@
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
     "payment_error": "Something went wrong with your payment. Please try again.",
-    "no_video": "No hay video disponible para este paso."
+    "no_products": "No hay productos disponibles para este paso.",
+    "no_images": "No hay imágenes disponibles para este paso.",
+    "no_video": "No hay video disponible para este paso.",
+    "no_passes": "No hay pases disponibles.",
+    "no_passes_for_category": "No hay pases disponibles para esta categoría de asistente.",
+    "no_meal_plans": "No hay planes de comidas disponibles.",
+    "no_contributions": "No hay opciones de contribución disponibles.",
+    "step_config_error": "Error de configuración del paso.",
+    "step_config_error_detail": "No se asignó una plantilla a este paso. Contactá a tu administrador."
   },
   "openCheckout": {
     "loading": "Cargando checkout...",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -251,7 +251,15 @@
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
     "payment_error": "Something went wrong with your payment. Please try again.",
-    "no_video": "Ekkert myndband í boði fyrir þetta skref."
+    "no_products": "Engar vörur í boði fyrir þetta skref.",
+    "no_images": "Engar myndir í boði fyrir þetta skref.",
+    "no_video": "Ekkert myndband í boði fyrir þetta skref.",
+    "no_passes": "Engir passar í boði.",
+    "no_passes_for_category": "Engir passar í boði fyrir þennan gestaflokk.",
+    "no_meal_plans": "Engir matarpakkar í boði.",
+    "no_contributions": "Engir framlagsmöguleikar í boði.",
+    "step_config_error": "Villa í uppsetningu skrefs.",
+    "step_config_error_detail": "Ekkert sniðmát er tengt þessu skrefi. Hafðu samband við stjórnanda."
   },
   "openCheckout": {
     "loading": "Hleður greiðslu...",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -261,7 +261,15 @@
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
     "payment_error": "Something went wrong with your payment. Please try again.",
-    "no_video": "此步骤暂无可用视频。"
+    "no_products": "此步骤暂无可用产品。",
+    "no_images": "此步骤暂无可用图片。",
+    "no_video": "此步骤暂无可用视频。",
+    "no_passes": "暂无可用通行证。",
+    "no_passes_for_category": "此参与者类别暂无可用通行证。",
+    "no_meal_plans": "暂无可用餐饮计划。",
+    "no_contributions": "暂无可用捐助选项。",
+    "step_config_error": "步骤配置错误。",
+    "step_config_error_detail": "此步骤未分配模板。请联系管理员。"
   },
   "openCheckout": {
     "loading": "正在加载结账...",


### PR DESCRIPTION
## Summary
- Every checkout empty state (no products, passes, images, meal plans or contribution options, and the step configuration error) plus its Continue button was hardcoded in English.
- All of them now use i18n keys, added to the four portal locales (en/es/is/zh).

## Review notes
Slice 6/7 — review only the last commit.