### PR TITLE
feat(ticketing-step): re-host external images on the CDN at save time

### DIFF
--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -18,6 +18,7 @@ from app.core.dependencies.users import (
     CurrentHuman,
     HumanTenantSession,
 )
+from app.services.image_ingestion import ImageIngestionService
 
 router = APIRouter(prefix="/ticketing-steps", tags=["ticketing-steps"])
 
@@ -150,10 +151,24 @@ async def create_ticketing_step(
         step_in.template, step_in.template_config, step_in.popup_id, db
     )
 
-    from app.api.ticketing_step.models import TicketingSteps
-
     step_data = step_in.model_dump()
     step_data["tenant_id"] = tenant_id
+
+    # CDN image ingestion: rewrite external image URLs to CDN before commit.
+    # Pattern B (async hook, mirrors _validate_template_config_fk precedent).
+    # Fail-open: any per-URL failure keeps the original URL; the save still succeeds.
+    _svc = ImageIngestionService()
+    if step_data.get("template_config") is not None:
+        step_data["template_config"] = await _svc.ingest_template_config(
+            step_data.get("template"), step_data["template_config"], tenant_id
+        )
+    if step_data.get("watermark") is not None:
+        step_data["watermark"] = await _svc.ingest_url(
+            step_data["watermark"], tenant_id
+        )
+
+    from app.api.ticketing_step.models import TicketingSteps
+
     step = TicketingSteps(**step_data)
 
     db.add(step)
@@ -194,6 +209,16 @@ async def update_ticketing_step(
         _validate_template_config_fk(
             effective_template, effective_config, step.popup_id, db
         )
+
+    # CDN image ingestion: rewrite external image URLs to CDN before commit.
+    # Pattern B (async hook). Fail-open: failures keep original URL; save succeeds.
+    _svc = ImageIngestionService()
+    if step_in.template_config is not None:
+        step_in.template_config = await _svc.ingest_template_config(
+            effective_template, step_in.template_config, step.tenant_id
+        )
+    if step_in.watermark is not None:
+        step_in.watermark = await _svc.ingest_url(step_in.watermark, step.tenant_id)
 
     updated = crud.ticketing_steps_crud.update(db, step, step_in)
     return TicketingStepPublic.model_validate(updated)

--- a/backend/app/services/image_ingestion.py
+++ b/backend/app/services/image_ingestion.py
@@ -523,28 +523,30 @@ class ImageIngestionService:
     ) -> dict | None:
         """Ingest image URLs inside a ticketing-step ``template_config`` dict.
 
-        Dispatch by *template* type:
-          ``gallery``      → ``config["images"]`` list via ``ingest_urls``
-          ``rich_text``    → ``config["html"]`` string via ``ingest_html``
-          ``ticket_select``→ each ``section["image_url"]`` via ``ingest_url``
-          other / unknown  → config returned unchanged (safe no-op)
+        Dispatch by *template* type (real backoffice template names):
+          ``image-gallery``            → ``config["images"]`` via ``ingest_urls``
+          ``rich-text``                → ``config["html"]`` via ``ingest_html``
+          ``ticket-select``/``ticket-card`` → each ``section["image_url"]``
+          other / unknown              → config returned unchanged (safe no-op)
 
         Returns ``None`` when *config* is ``None``.
         """
         if config is None:
             return None
 
-        if template == "gallery":
+        if template == "image-gallery":
             images: list[str] = config.get("images") or []
             new_images = await self.ingest_urls(images, tenant_id)
             return {**config, "images": new_images}
 
-        if template == "rich_text":
+        if template == "rich-text":
             html: str = config.get("html") or ""
             new_html = await self.ingest_html(html, tenant_id)
             return {**config, "html": new_html}
 
-        if template == "ticket_select":
+        # Both ticket-select and ticket-card carry sections[].image_url cover
+        # images (see portal VariantTicketCard / VariantTicketSelect).
+        if template in ("ticket-select", "ticket-card"):
             sections: list[dict] = config.get("sections") or []
             new_sections = []
             for section in sections:

--- a/backend/tests/api/ticketing_step/test_cdn_ingestion.py
+++ b/backend/tests/api/ticketing_step/test_cdn_ingestion.py
@@ -1,0 +1,397 @@
+"""Integration tests for CDN image ingestion in ticketing-step create/update paths.
+
+Slice 2 coverage (all template shapes + watermark + idempotency + fail-open):
+  - image-gallery template: images[] external URL → CDN URL
+  - rich-text template: <img src> → CDN URL
+  - rich-text entity-encoded src (&amp;) → CDN URL  (regression guard)
+  - ticket-select template: sections[].image_url → CDN URL
+  - watermark (top-level field): external URL → CDN URL
+  - idempotency: CDN URL in input → unchanged; fetch_image not called
+  - fail-open: IngestionError → original URL kept; step still saves (201)
+  - PATCH update wiring: same ingestion runs on changed template_config / watermark
+
+Network layer is always faked: fetch_image and get_storage_service are patched so
+no real HTTP requests are made. Pattern matches unit tests in tests/services/.
+"""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.api.popup.models import Popups
+
+# CDN base used by the fake storage
+CDN_BASE = "https://cdn.test.example.com"
+# External URLs that should be ingested
+EXTERNAL_A = "https://external.example.com/img-a.jpg"
+EXTERNAL_B = "https://other.example.com/img-b.png"
+# A URL already hosted on CDN (must match CDN_BASE host for idempotency check)
+CDN_EXISTING = f"{CDN_BASE}/preexisting/image.jpg"
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _mock_storage() -> MagicMock:
+    """Return a minimal storage mock: upload_bytes is a no-op, get_public_url returns CDN URL."""
+    s = MagicMock()
+    s.get_public_url.side_effect = lambda key: f"{CDN_BASE}/{key}"
+    return s
+
+
+def _step_body(popup_id: uuid.UUID, **extra) -> dict:
+    return {
+        "popup_id": str(popup_id),
+        "step_type": "tickets",
+        "title": f"cdn-test-{uuid.uuid4().hex[:6]}",
+        **extra,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Create (POST) — verify ingestion runs before persist
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCdnIngestionCreate:
+    """POST /ticketing-steps — CDN ingestion must rewrite external URLs before commit."""
+
+    def test_gallery_images_replaced_with_cdn_url(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """image-gallery template: images[] external URLs → CDN URLs in persisted step."""
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    template="image-gallery",
+                    template_config={"images": [EXTERNAL_A, EXTERNAL_B]},
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        images = resp.json()["template_config"]["images"]
+        assert len(images) == 2
+        assert images[0].startswith(CDN_BASE + "/"), images[0]
+        assert images[1].startswith(CDN_BASE + "/"), images[1]
+        assert "external.example.com" not in images[0]
+        assert "other.example.com" not in images[1]
+        # fetch_image called once per external URL
+        assert fetch_mock.call_count == 2
+
+    def test_rich_text_img_src_replaced_with_cdn_url(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """rich-text template: <img src> in html → CDN URL; other markup untouched."""
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        html_in = f'<p>Hello</p><img src="{EXTERNAL_A}"><span>world</span>'
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    template="rich-text",
+                    template_config={"html": html_in},
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        stored_html = resp.json()["template_config"]["html"]
+        assert "external.example.com" not in stored_html
+        assert CDN_BASE in stored_html
+        # Non-image markup preserved byte-for-byte
+        assert "<p>Hello</p>" in stored_html
+        assert "<span>world</span>" in stored_html
+
+    def test_rich_text_entity_encoded_src_replaced(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """rich-text: &amp; entity-encoded query string in src is correctly rewritten.
+
+        Regression guard: html.parser decodes entities → decoded URL is fetched → raw
+        attribute form (&amp;) is replaced in the original string (design WARNING 3).
+        """
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        html_in = '<img src="https://external.example.com/i?a=1&amp;b=2">'
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    template="rich-text",
+                    template_config={"html": html_in},
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        stored_html = resp.json()["template_config"]["html"]
+        # The entity-encoded src must be gone; CDN URL must be present
+        assert "external.example.com" not in stored_html
+        assert CDN_BASE in stored_html
+
+    def test_ticket_select_section_image_url_replaced(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """ticket-select template: sections[].image_url → CDN URL."""
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        section = {
+            "key": "general",
+            "label": "General",
+            "order": 0,
+            "product_ids": [],
+            "image_url": EXTERNAL_A,
+        }
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    template="ticket-select",
+                    template_config={"sections": [section]},
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        stored_sections = resp.json()["template_config"]["sections"]
+        assert len(stored_sections) == 1
+        stored_image_url = stored_sections[0]["image_url"]
+        assert stored_image_url.startswith(CDN_BASE + "/"), stored_image_url
+        assert "external.example.com" not in stored_image_url
+
+    def test_watermark_replaced_with_cdn_url(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """watermark top-level field: external URL → CDN URL on create."""
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    # Use a simple template so template_config ingestion is a no-op
+                    template="image-gallery",
+                    template_config={"images": []},
+                    watermark=EXTERNAL_A,
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        watermark = resp.json()["watermark"]
+        assert watermark is not None
+        assert watermark.startswith(CDN_BASE + "/"), watermark
+        assert "external.example.com" not in watermark
+
+    def test_cdn_url_unchanged_idempotent(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """Images already on the CDN host are returned unchanged; fetch_image not called."""
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        # Patch settings so that CDN_BASE host is recognized as the CDN host set
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+            patch("app.services.image_ingestion.settings") as mock_settings,
+        ):
+            mock_settings.STORAGE_PUBLIC_URL = CDN_BASE
+            mock_settings.STORAGE_ENDPOINT_URL = None
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    template="image-gallery",
+                    template_config={"images": [CDN_EXISTING]},
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        images = resp.json()["template_config"]["images"]
+        assert images[0] == CDN_EXISTING, "CDN URL must be unchanged"
+        fetch_mock.assert_not_called()
+
+    def test_fail_open_keeps_original_url_on_ingest_error(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """IngestionError during fetch → original URL kept; step saves successfully (fail-open)."""
+        from app.services.image_ingestion import IngestionError
+
+        fetch_mock = AsyncMock(side_effect=IngestionError("simulated network error"))
+        mock_storage = _mock_storage()
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ticketing-steps",
+                headers=_auth(admin_token_tenant_a),
+                json=_step_body(
+                    popup_tenant_a.id,
+                    template="image-gallery",
+                    template_config={"images": [EXTERNAL_A]},
+                ),
+            )
+        assert resp.status_code == 201, resp.text
+        images = resp.json()["template_config"]["images"]
+        # Original URL preserved (fail-open)
+        assert images[0] == EXTERNAL_A
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Update (PATCH) — verify ingestion runs on changed template_config / watermark
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCdnIngestionUpdate:
+    """PATCH /ticketing-steps/{id} — CDN ingestion must rewrite fields before commit."""
+
+    def _create_baseline_step(
+        self,
+        client: TestClient,
+        token: str,
+        popup_id: uuid.UUID,
+    ) -> str:
+        """Create a plain step (no external URLs) to use as a PATCH base.
+
+        No ingestion patches needed: no template_config or watermark are provided,
+        so the ingestion hook is skipped entirely on this initial create.
+        """
+        resp = client.post(
+            "/api/v1/ticketing-steps",
+            headers=_auth(token),
+            json={
+                "popup_id": str(popup_id),
+                "step_type": "tickets",
+                "title": f"cdn-baseline-{uuid.uuid4().hex[:6]}",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        return resp.json()["id"]
+
+    def test_gallery_images_ingested_on_update(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """PATCH with image-gallery template_config: images[] external → CDN."""
+        step_id = self._create_baseline_step(
+            client, admin_token_tenant_a, popup_tenant_a.id
+        )
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.patch(
+                f"/api/v1/ticketing-steps/{step_id}",
+                headers=_auth(admin_token_tenant_a),
+                json={
+                    "template": "image-gallery",
+                    "template_config": {"images": [EXTERNAL_A]},
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        images = resp.json()["template_config"]["images"]
+        assert len(images) == 1
+        assert images[0].startswith(CDN_BASE + "/"), images[0]
+        assert "external.example.com" not in images[0]
+
+    def test_watermark_ingested_on_update(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        """PATCH watermark field only: external URL → CDN URL."""
+        step_id = self._create_baseline_step(
+            client, admin_token_tenant_a, popup_tenant_a.id
+        )
+        fetch_mock = AsyncMock(return_value=(b"img-bytes", "image/jpeg"))
+        mock_storage = _mock_storage()
+        with (
+            patch("app.services.image_ingestion.fetch_image", fetch_mock),
+            patch(
+                "app.services.image_ingestion.get_storage_service",
+                return_value=mock_storage,
+            ),
+        ):
+            resp = client.patch(
+                f"/api/v1/ticketing-steps/{step_id}",
+                headers=_auth(admin_token_tenant_a),
+                json={"watermark": EXTERNAL_A},
+            )
+        assert resp.status_code == 200, resp.text
+        watermark = resp.json()["watermark"]
+        assert watermark is not None
+        assert watermark.startswith(CDN_BASE + "/"), watermark
+        assert "external.example.com" not in watermark

--- a/backend/tests/services/test_image_ingestion.py
+++ b/backend/tests/services/test_image_ingestion.py
@@ -701,7 +701,7 @@ def test_ingest_template_config_gallery_replaces_images() -> None:
             svc, "ingest_urls", new=AsyncMock(return_value=[cdn_a, cdn_b])
         ):
             return await svc.ingest_template_config(
-                "gallery",
+                "image-gallery",
                 {"images": ["https://ext.com/a.jpg", "https://ext.com/b.jpg"]},
                 TENANT_ID,
             )
@@ -719,7 +719,7 @@ def test_ingest_template_config_rich_text_rewrites_html() -> None:
         svc = ImageIngestionService()
         with patch.object(svc, "ingest_html", new=AsyncMock(return_value=new_html)):
             return await svc.ingest_template_config(
-                "rich_text",
+                "rich-text",
                 {"html": original_html},
                 TENANT_ID,
             )
@@ -740,7 +740,7 @@ def test_ingest_template_config_ticket_select_replaces_section_image_url() -> No
 
         with patch.object(svc, "ingest_url", new=AsyncMock(side_effect=fake_ingest)):
             return await svc.ingest_template_config(
-                "ticket_select",
+                "ticket-select",
                 {
                     "sections": [
                         {"image_url": "https://ext.com/img.jpg", "label": "VIP"}
@@ -753,6 +753,29 @@ def test_ingest_template_config_ticket_select_replaces_section_image_url() -> No
     assert result is not None
     assert result["sections"][0]["image_url"] == cdn_url
     assert result["sections"][0]["label"] == "VIP"  # non-image fields preserved
+
+
+def test_ingest_template_config_ticket_card_replaces_section_image_url() -> None:
+    """ticket-card carries the same sections[].image_url as ticket-select."""
+    cdn_url = "https://cdn.example.com/section.jpg"
+
+    async def _run() -> dict:
+        svc = ImageIngestionService()
+
+        async def fake_ingest(_url: str, _tenant_id: uuid.UUID) -> str:
+            return cdn_url
+
+        with patch.object(svc, "ingest_url", new=AsyncMock(side_effect=fake_ingest)):
+            return await svc.ingest_template_config(
+                "ticket-card",
+                {"sections": [{"image_url": "https://ext.com/c.jpg", "label": "GA"}]},
+                TENANT_ID,
+            )
+
+    result = asyncio.run(_run())
+    assert result is not None
+    assert result["sections"][0]["image_url"] == cdn_url
+    assert result["sections"][0]["label"] == "GA"
 
 
 def test_ingest_template_config_per_item_fail_isolation() -> None:
@@ -773,7 +796,7 @@ def test_ingest_template_config_per_item_fail_isolation() -> None:
             svc, "ingest_urls", new=AsyncMock(side_effect=fake_ingest_urls)
         ):
             return await svc.ingest_template_config(
-                "gallery",
+                "image-gallery",
                 {"images": ["https://ext.com/a.jpg", original_b]},
                 TENANT_ID,
             )
@@ -787,7 +810,7 @@ def test_ingest_template_config_per_item_fail_isolation() -> None:
 def test_ingest_template_config_none_config_returns_none() -> None:
     """None config is passed through unchanged."""
     svc = ImageIngestionService()
-    result = asyncio.run(svc.ingest_template_config("gallery", None, TENANT_ID))
+    result = asyncio.run(svc.ingest_template_config("image-gallery", None, TENANT_ID))
     assert result is None
 
 


### PR DESCRIPTION
## Summary
- Wires the ingestion service into ticketing-step create and update: before persisting, external image URLs in `template_config` are downloaded and replaced with CDN URLs.
- Covers gallery images, rich-text embedded `<img>` srcs, ticket-select and ticket-card section covers, and the top-level watermark. Dispatch is per-template (typed walkers), mirroring the existing attendee-category validation hook.
- Fail-open: a URL whose ingestion fails keeps its original value and the save still succeeds. Re-saving a URL already on the CDN is a no-op.

## Review notes
Slice 2/3, stacked on #432 — review only the last commit. 9 integration tests. Note: re-saving an existing rich-text step through this endpoint re-homes its embedded images (this is how eclipse's remaining external images will be migrated — no separate backfill script).