### PR TITLE
feat(payments): SimpleFi cancel methods and sweeper settings

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -127,5 +127,27 @@ class Settings(BaseSettings):
     # This is a global safety net; per-popup `installments_max` may set a lower cap.
     MAX_ALLOWED_INSTALLMENTS: int = 12
 
+    # ---------------------------------------------------------------------------
+    # Pending payment sweeper + supersede (ADR-5; global, not per-popup)
+    # These are provider-level operational constants, not per-tenant product flags.
+    # ---------------------------------------------------------------------------
+
+    # Master kill-switch for the sweeper job. Set to false to disable globally.
+    PENDING_SWEEP_ENABLED: bool = True
+
+    # Age threshold (minutes) beyond which a PENDING SimpleFi payment is a
+    # candidate for status reconciliation. Default matches SimpleFi's ~15-min
+    # provider-side expiry with a safety margin.
+    PENDING_SWEEP_STALE_MINUTES: int = 20
+
+    # Maximum number of stale payments processed per sweeper run. Keeps each
+    # run bounded and predictable.
+    PENDING_SWEEP_BATCH_SIZE: int = 200
+
+    # When true, supersede_pending_payments runs at the start of create_payment
+    # and create_open_ticketing_payment to cancel the buyer's prior PENDING
+    # payment before creating a new one.
+    SUPERSEDE_PENDING_ENABLED: bool = True
+
 
 settings = Settings()

--- a/backend/app/services/simplefi/client.py
+++ b/backend/app/services/simplefi/client.py
@@ -1,5 +1,6 @@
 import urllib.parse
 from decimal import Decimal
+from enum import StrEnum
 from typing import Any
 
 import httpx
@@ -13,6 +14,38 @@ from tenacity import (
 )
 
 from app.core.config import settings
+
+# ---------------------------------------------------------------------------
+# Cancel outcome helpers (ADR-3)
+# ---------------------------------------------------------------------------
+
+# SimpleFi uses "canceled" (one L) for payment_requests and "cancelled" (two L)
+# for installment_plans. Both spellings are accepted throughout this module.
+TERMINAL_CANCEL_STATUSES: frozenset[str] = frozenset(
+    {"canceled", "cancelled", "expired", "refunded"}
+)
+APPROVED_STATUSES: frozenset[str] = frozenset({"approved", "active", "completed"})
+
+
+class CancelOutcome(StrEnum):
+    """Result of a SimpleFi cancel call, used by supersede and sweeper logic."""
+
+    CANCELED = "canceled"
+    ALREADY_APPROVED = "already_approved"
+
+
+class CancelOutcomeAmbiguousError(Exception):
+    """Raised when a cancel response cannot be classified as a definitive outcome.
+
+    Callers MUST treat this exception as 'do not release holds' — the resource
+    is in an indeterminate state (e.g. still 'pending', empty, or unknown status)
+    and releasing holds would risk a double-spend.
+    """
+
+
+def _normalize_cancel_status(status: str) -> str:
+    """Return the status string lowercased and stripped for classification."""
+    return status.lower().strip()
 
 
 class SimpleFIPaymentResponse(BaseModel):
@@ -292,6 +325,178 @@ class SimpleFIClient:
         data = self._make_request("GET", f"/payment_requests/{payment_request_id}")
 
         payload = data.get("payment_request", data)
+        return SimpleFIPaymentRequestStatus(
+            id=payload["id"],
+            status=payload["status"],
+        )
+
+    # ------------------------------------------------------------------
+    # Non-retrying request helper (ADR-3)
+    # ------------------------------------------------------------------
+
+    def _non_retrying_request(self, method: str, endpoint: str) -> httpx.Response:
+        """Make a single HTTP request without the tenacity retry loop.
+
+        Unlike ``_make_request``, this method:
+        - Returns the raw ``httpx.Response`` so callers can inspect the status
+          code before deciding how to classify the outcome.
+        - Does NOT retry on ``HTTPStatusError`` or ``RequestError`` — a 4xx
+          from a cancel call carries semantic meaning (already terminal) and
+          must not be retried away.
+        """
+        url = f"{self.base_url}{endpoint}"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.request(method, url, headers=headers)
+        logger.info(
+            "SimpleFI {} {} -> {}",
+            method,
+            url,
+            response.status_code,
+        )
+        return response
+
+    # ------------------------------------------------------------------
+    # Outcome classifier (shared by both cancel methods)
+    # ------------------------------------------------------------------
+
+    def _non_retrying_get_status(
+        self, endpoint: str, nested_key: str
+    ) -> SimpleFIPaymentRequestStatus:
+        """Fetch a resource's status with a SINGLE non-retrying GET attempt.
+
+        Used as the 4xx-cancel fallback so the call remains bounded to one
+        attempt instead of the retrying ``_make_request`` path (3 attempts,
+        exponential back-off, up to ~30 s on a checkout-blocking call).
+
+        On failure — transport error or any non-2xx response — the exception
+        propagates directly.  Callers MUST treat any exception as
+        'do not release holds'.
+
+        Args:
+            endpoint: GET endpoint, e.g. ``/payment_requests/{id}``.
+            nested_key: Key used to unwrap a nested payload, e.g.
+                ``"payment_request"`` or ``"installment_plan"``.
+        """
+        response = self._non_retrying_request("GET", endpoint)
+        response.raise_for_status()
+        data = response.json()
+        payload = data.get(nested_key, data)
+        return SimpleFIPaymentRequestStatus(
+            id=payload["id"],
+            status=payload["status"],
+        )
+
+    def _classify_cancel_status(
+        self, status: str, resource_id: str, resource_type: str
+    ) -> CancelOutcome:
+        """Map a normalized SimpleFi status string to a ``CancelOutcome``.
+
+        Raises ``CancelOutcomeAmbiguousError`` if the status cannot be
+        classified (e.g. still 'pending', empty, or unknown after a cancel).
+        Callers MUST treat it as 'do not release holds'.
+        """
+        normalized = _normalize_cancel_status(status)
+        if normalized in TERMINAL_CANCEL_STATUSES:
+            return CancelOutcome.CANCELED
+        if normalized in APPROVED_STATUSES:
+            return CancelOutcome.ALREADY_APPROVED
+        raise CancelOutcomeAmbiguousError(
+            f"Cannot classify {resource_type} {resource_id!r}: "
+            f"unresolvable status={status!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # Cancel methods (ADR-3)
+    # ------------------------------------------------------------------
+
+    def cancel_payment_request(self, payment_id: str) -> CancelOutcome:
+        """Cancel a SimpleFi payment_request without retrying.
+
+        Outcome mapping (ADR-3):
+        - 2xx with terminal status (canceled/cancelled/expired/refunded) → CANCELED
+        - 2xx or 4xx with approved/active/completed → ALREADY_APPROVED
+        - 2xx with unresolvable status (pending/empty/unknown) → raises
+          ``CancelOutcomeAmbiguousError``; callers MUST not release holds
+        - 4xx (already terminal) → single non-retrying re-read via
+          ``_non_retrying_get_status`` to classify; on re-read failure the
+          exception propagates (= do not release holds)
+        - 5xx → raise ``HTTPStatusError``
+        - Transport/timeout → raise ``RequestError``
+        """
+        response = self._non_retrying_request(
+            "PUT", f"/payment_requests/{payment_id}/cancel"
+        )
+
+        if response.status_code < 400:
+            data = response.json()
+            status = data.get("status", "")
+            return self._classify_cancel_status(status, payment_id, "payment_request")
+
+        if response.status_code < 500:
+            # 4xx: resource already in a terminal or approved state — re-read the
+            # current status with a SINGLE non-retrying attempt so this
+            # checkout-blocking path cannot stall for up to ~30 s under the
+            # retrying _make_request path. On re-read failure the exception
+            # propagates; callers must not release holds.
+            logger.warning(
+                "SimpleFI cancel payment_request {} returned {} — re-reading status (single attempt)",
+                payment_id,
+                response.status_code,
+            )
+            current = self._non_retrying_get_status(
+                f"/payment_requests/{payment_id}", "payment_request"
+            )
+            return self._classify_cancel_status(
+                current.status, payment_id, "payment_request"
+            )
+
+        # 5xx: genuine server error — raise
+        response.raise_for_status()
+        raise RuntimeError("unreachable")  # satisfy type checker
+
+    def cancel_installment_plan(self, plan_id: str) -> CancelOutcome:
+        """Cancel a SimpleFi installment_plan without retrying.
+
+        Identical outcome mapping to ``cancel_payment_request`` but targets the
+        ``/installment_plans`` endpoint. On 4xx, falls back to a SINGLE
+        non-retrying status re-read via ``_non_retrying_get_status`` (not the
+        retrying ``_make_request`` path) so the fallback stays bounded to one
+        extra attempt. On re-read failure the exception propagates; callers must
+        not release holds.
+
+        Note: SimpleFi uses 'cancelled' (two L) in installment_plan status
+        responses; the normalizer accepts both spellings.
+        """
+        response = self._non_retrying_request(
+            "PUT", f"/installment_plans/{plan_id}/cancel"
+        )
+
+        if response.status_code < 400:
+            data = response.json()
+            status = data.get("status", "")
+            return self._classify_cancel_status(status, plan_id, "installment_plan")
+
+        if response.status_code < 500:
+            logger.warning(
+                "SimpleFI cancel installment_plan {} returned {} — re-reading status (single attempt)",
+                plan_id,
+                response.status_code,
+            )
+            current = self._non_retrying_get_status(
+                f"/installment_plans/{plan_id}", "installment_plan"
+            )
+            return self._classify_cancel_status(
+                current.status, plan_id, "installment_plan"
+            )
+
+        response.raise_for_status()
+        raise RuntimeError("unreachable")
+
+    def get_installment_plan_status(self, plan_id: str) -> SimpleFIPaymentRequestStatus:
+        """Fetch the latest status for an existing SimpleFI installment plan."""
+        data = self._make_request("GET", f"/installment_plans/{plan_id}")
+        payload = data.get("installment_plan", data)
         return SimpleFIPaymentRequestStatus(
             id=payload["id"],
             status=payload["status"],

--- a/backend/tests/test_simplefi_cancel_methods.py
+++ b/backend/tests/test_simplefi_cancel_methods.py
@@ -1,0 +1,715 @@
+"""Tests for SimpleFi client cancel/status methods (pending-payment-hold-release PR 1).
+
+Covers:
+- CancelOutcome enum (task 1.1)
+- _normalize_cancel_status — both 'canceled' (one-L) and 'cancelled' (two-L),
+  approved/active/completed, and still-pending (task 1.1)
+- _non_retrying_request — bypasses retry loop and returns raw httpx.Response (task 1.2)
+- cancel_payment_request — outcome classification + 4xx fallback + transport propagation (task 1.3)
+- cancel_installment_plan — 'cancelled' two-L + active/completed semantics (task 1.4)
+- get_installment_plan_status — status-only GET (task 1.4)
+- CancelOutcomeAmbiguousError — raised for pending/missing/unknown status (review fixes)
+- Single-attempt fallback bound — 4xx re-read uses _non_retrying_request, not _make_request
+"""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from app.services.simplefi.client import (
+    CancelOutcome,
+    CancelOutcomeAmbiguousError,
+    SimpleFIClient,
+    SimpleFIPaymentRequestStatus,
+    _normalize_cancel_status,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for httpx.Response used in cancel-method unit tests."""
+
+    def __init__(self, status_code: int, json_data: dict) -> None:
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self) -> dict:
+        return self._json_data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=httpx.Request(
+                    "PUT", "https://apidev.simplefi.tech/payment_requests/x/cancel"
+                ),
+                response=httpx.Response(self.status_code),
+            )
+
+
+def _stub_non_retrying(monkeypatch, response: _FakeResponse) -> dict:
+    """Patch SimpleFIClient._non_retrying_request and capture call arguments."""
+    captured: dict = {}
+
+    def fake(_self, method: str, endpoint: str) -> _FakeResponse:
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        return response
+
+    monkeypatch.setattr(SimpleFIClient, "_non_retrying_request", fake)
+    return captured
+
+
+def _stub_non_retrying_sequence(monkeypatch, responses: list) -> None:
+    """Stub _non_retrying_request to yield items from responses in sequence.
+
+    Each list item is either a _FakeResponse (returned) or an Exception
+    instance (raised). Useful when a single test triggers multiple calls to
+    _non_retrying_request — e.g. the cancel PUT followed by the fallback
+    status GET.
+    """
+    call_count = [0]
+
+    def fake(_self, _method: str, _endpoint: str) -> _FakeResponse:
+        idx = call_count[0]
+        call_count[0] += 1
+        item = responses[idx]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(SimpleFIClient, "_non_retrying_request", fake)
+
+
+def _stub_make_request(monkeypatch, return_value: dict) -> None:
+    """Patch SimpleFIClient._make_request (retrying, used by public status getters)."""
+
+    def fake(_self, _method: str, _endpoint: str, _json=None) -> dict:
+        return return_value
+
+    monkeypatch.setattr(SimpleFIClient, "_make_request", fake)
+
+
+# ---------------------------------------------------------------------------
+# Task 1.1 — CancelOutcome enum (value-pinned assertions)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_outcome_canceled_value_is_string_canceled() -> None:
+    assert CancelOutcome.CANCELED == "canceled"
+
+
+def test_cancel_outcome_already_approved_value_is_string_already_approved() -> None:
+    assert CancelOutcome.ALREADY_APPROVED == "already_approved"
+
+
+def test_cancel_outcome_canceled_and_already_approved_are_distinct() -> None:
+    assert CancelOutcome.CANCELED != CancelOutcome.ALREADY_APPROVED
+
+
+# ---------------------------------------------------------------------------
+# Task 1.1 — _normalize_cancel_status
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_canceled_one_l() -> None:
+    assert _normalize_cancel_status("canceled") == "canceled"
+
+
+def test_normalize_cancelled_two_l() -> None:
+    # SimpleFi installment_plans use the two-L spelling
+    assert _normalize_cancel_status("cancelled") == "cancelled"
+
+
+def test_normalize_expired() -> None:
+    assert _normalize_cancel_status("expired") == "expired"
+
+
+def test_normalize_refunded() -> None:
+    assert _normalize_cancel_status("refunded") == "refunded"
+
+
+def test_normalize_approved() -> None:
+    assert _normalize_cancel_status("approved") == "approved"
+
+
+def test_normalize_active() -> None:
+    assert _normalize_cancel_status("active") == "active"
+
+
+def test_normalize_completed() -> None:
+    assert _normalize_cancel_status("completed") == "completed"
+
+
+def test_normalize_pending() -> None:
+    assert _normalize_cancel_status("pending") == "pending"
+
+
+def test_normalize_strips_whitespace() -> None:
+    assert _normalize_cancel_status("  Canceled  ") == "canceled"
+
+
+def test_normalize_is_case_insensitive() -> None:
+    assert _normalize_cancel_status("CANCELLED") == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.2 — _non_retrying_request bypasses retry loop
+# ---------------------------------------------------------------------------
+
+
+def test_non_retrying_request_does_not_call_make_request(monkeypatch) -> None:
+    """_non_retrying_request must never delegate to the retrying _make_request."""
+
+    def forbidden_make_request(_self, *_args, **_kwargs):  # pragma: no cover
+        raise AssertionError(
+            "_make_request must not be called from _non_retrying_request"
+        )
+
+    monkeypatch.setattr(SimpleFIClient, "_make_request", forbidden_make_request)
+
+    captured_calls: list[dict] = []
+
+    def fake_httpx_request(_self, method, url, **_kwargs):
+        captured_calls.append({"method": method, "url": url})
+        return SimpleNamespace(
+            status_code=200,
+            text="{}",
+            json=lambda: {"id": "x", "status": "canceled"},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(httpx.Client, "request", fake_httpx_request)
+
+    client = SimpleFIClient("fake-key")
+    client._non_retrying_request("DELETE", "/payment_requests/test-id")
+
+    assert len(captured_calls) == 1, "exactly one HTTP call, no retry"
+    assert captured_calls[0]["method"] == "DELETE"
+    assert "/payment_requests/test-id" in captured_calls[0]["url"]
+
+
+def test_non_retrying_request_transport_error_propagates_immediately(
+    monkeypatch,
+) -> None:
+    """Transport errors must not be caught or retried — they propagate directly."""
+    call_count = [0]
+
+    def fake_httpx_request(_self, _method, _url, **_kwargs):
+        call_count[0] += 1
+        raise httpx.ConnectError("Network failure")
+
+    monkeypatch.setattr(httpx.Client, "request", fake_httpx_request)
+
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.ConnectError):
+        client._non_retrying_request("DELETE", "/payment_requests/test-id")
+
+    assert call_count[0] == 1, "no retry: called exactly once"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — cancel_payment_request: happy path
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_payment_request_2xx_canceled_status_returns_canceled(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "canceled"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_payment_request_2xx_cancelled_two_l_returns_canceled(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "cancelled"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_payment_request_2xx_expired_returns_canceled(monkeypatch) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "expired"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_payment_request_2xx_refunded_returns_canceled(monkeypatch) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "refunded"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_payment_request_2xx_approved_returns_already_approved(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "approved"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.ALREADY_APPROVED
+
+
+def test_cancel_payment_request_2xx_active_returns_already_approved(
+    monkeypatch,
+) -> None:
+    # 'active' appears in some SimpleFi entity types to mean money committed
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "active"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.ALREADY_APPROVED
+
+
+def test_cancel_payment_request_2xx_completed_returns_already_approved(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "completed"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.ALREADY_APPROVED
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — cancel_payment_request: ambiguous status (review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_payment_request_2xx_pending_raises_ambiguous(monkeypatch) -> None:
+    """2xx body with 'pending' status cannot be classified — must raise."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "pending"})
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(CancelOutcomeAmbiguousError):
+        client.cancel_payment_request("pr-1")
+
+
+def test_cancel_payment_request_2xx_missing_status_raises_ambiguous(
+    monkeypatch,
+) -> None:
+    """2xx body with no 'status' key is unclassifiable — must raise."""
+    _stub_non_retrying(monkeypatch, _FakeResponse(200, {"id": "pr-1"}))
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(CancelOutcomeAmbiguousError):
+        client.cancel_payment_request("pr-1")
+
+
+def test_cancel_payment_request_4xx_then_fallback_pending_raises_ambiguous(
+    monkeypatch,
+) -> None:
+    """4xx cancel + single-attempt re-read returns 'pending' → must raise."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(
+                200, {"payment_request": {"id": "pr-1", "status": "pending"}}
+            ),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(CancelOutcomeAmbiguousError):
+        client.cancel_payment_request("pr-1")
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — cancel_payment_request: 4xx fallback (single-attempt, review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_payment_request_4xx_then_status_expired_returns_canceled(
+    monkeypatch,
+) -> None:
+    """4xx from cancel → single-attempt re-read → expired → CANCELED."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(
+                200, {"payment_request": {"id": "pr-1", "status": "expired"}}
+            ),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_payment_request_4xx_then_status_approved_returns_already_approved(
+    monkeypatch,
+) -> None:
+    """4xx from cancel → single-attempt re-read → approved → ALREADY_APPROVED."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(404, {}),
+            _FakeResponse(
+                200, {"payment_request": {"id": "pr-1", "status": "approved"}}
+            ),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.ALREADY_APPROVED
+
+
+def test_cancel_payment_request_4xx_then_status_cancelled_two_l_returns_canceled(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(
+                200, {"payment_request": {"id": "pr-1", "status": "cancelled"}}
+            ),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_payment_request("pr-1") == CancelOutcome.CANCELED
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — cancel_payment_request: fallback failure propagates (review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_payment_request_4xx_then_fallback_transport_error_raises(
+    monkeypatch,
+) -> None:
+    """4xx cancel + single-attempt re-read transport error → exception propagates."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            httpx.ConnectError("network failure"),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.ConnectError):
+        client.cancel_payment_request("pr-1")
+
+
+def test_cancel_payment_request_4xx_then_fallback_5xx_raises(monkeypatch) -> None:
+    """4xx cancel + single-attempt re-read returns 5xx → exception propagates."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(503, {}),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.HTTPStatusError):
+        client.cancel_payment_request("pr-1")
+
+
+# ---------------------------------------------------------------------------
+# Task 1.3 — cancel_payment_request: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_payment_request_5xx_raises(monkeypatch) -> None:
+    """5xx must raise — no fallback."""
+    _stub_non_retrying(monkeypatch, _FakeResponse(500, {}))
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.HTTPStatusError):
+        client.cancel_payment_request("pr-1")
+
+
+def test_cancel_payment_request_transport_error_raises(monkeypatch) -> None:
+    """Transport / timeout errors must propagate — no retry, no fallback."""
+
+    def fake_non_retrying(_self, _method, _endpoint):
+        raise httpx.ConnectError("timeout")
+
+    monkeypatch.setattr(SimpleFIClient, "_non_retrying_request", fake_non_retrying)
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.ConnectError):
+        client.cancel_payment_request("pr-1")
+
+
+def test_cancel_payment_request_does_not_call_make_request_on_2xx(monkeypatch) -> None:
+    """On 2xx the retrying _make_request must never be called."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-1", "status": "canceled"})
+    )
+
+    def forbidden(_self, *_args, **_kwargs):  # pragma: no cover
+        raise AssertionError("_make_request must not be called on 2xx cancel")
+
+    monkeypatch.setattr(SimpleFIClient, "_make_request", forbidden)
+    client = SimpleFIClient("fake-key")
+    result = client.cancel_payment_request("pr-1")
+    assert result == CancelOutcome.CANCELED
+
+
+def test_cancel_payment_request_endpoint_path(monkeypatch) -> None:
+    """Cancel must PUT to the /payment_requests/{id}/cancel endpoint."""
+    captured = _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "pr-abc", "status": "canceled"})
+    )
+    client = SimpleFIClient("fake-key")
+    client.cancel_payment_request("pr-abc")
+    assert captured["method"] == "PUT"
+    assert captured["endpoint"] == "/payment_requests/pr-abc/cancel"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — get_installment_plan_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_installment_plan_status_returns_status_object(monkeypatch) -> None:
+    _stub_make_request(
+        monkeypatch,
+        {"installment_plan": {"id": "plan-1", "status": "pending"}},
+    )
+    client = SimpleFIClient("fake-key")
+    result = client.get_installment_plan_status("plan-1")
+    assert isinstance(result, SimpleFIPaymentRequestStatus)
+    assert result.id == "plan-1"
+    assert result.status == "pending"
+
+
+def test_get_installment_plan_status_handles_flat_payload(monkeypatch) -> None:
+    """Some SimpleFi responses return a flat dict instead of a nested key."""
+    _stub_make_request(monkeypatch, {"id": "plan-2", "status": "active"})
+    client = SimpleFIClient("fake-key")
+    result = client.get_installment_plan_status("plan-2")
+    assert result.id == "plan-2"
+    assert result.status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — cancel_installment_plan: happy path
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_installment_plan_cancelled_two_l_returns_canceled(monkeypatch) -> None:
+    """installment_plans use 'cancelled' (two L) — must normalize correctly."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "cancelled"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_installment_plan_canceled_one_l_also_returns_canceled(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "canceled"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_installment_plan_active_returns_already_approved(monkeypatch) -> None:
+    """'active' on an installment_plan means money committed — race lost."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "active"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.ALREADY_APPROVED
+
+
+def test_cancel_installment_plan_completed_returns_already_approved(
+    monkeypatch,
+) -> None:
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "completed"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.ALREADY_APPROVED
+
+
+def test_cancel_installment_plan_2xx_expired_returns_canceled(monkeypatch) -> None:
+    """expired is a terminal status — symmetry with cancel_payment_request."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "expired"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.CANCELED
+
+
+def test_cancel_installment_plan_2xx_refunded_returns_canceled(monkeypatch) -> None:
+    """refunded is a terminal status — symmetry with cancel_payment_request."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "refunded"})
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.CANCELED
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — cancel_installment_plan: ambiguous status (review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_installment_plan_2xx_pending_raises_ambiguous(monkeypatch) -> None:
+    """2xx body with 'pending' status cannot be classified — must raise."""
+    _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-1", "status": "pending"})
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(CancelOutcomeAmbiguousError):
+        client.cancel_installment_plan("plan-1")
+
+
+def test_cancel_installment_plan_2xx_missing_status_raises_ambiguous(
+    monkeypatch,
+) -> None:
+    """2xx body with no 'status' key is unclassifiable — must raise."""
+    _stub_non_retrying(monkeypatch, _FakeResponse(200, {"id": "plan-1"}))
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(CancelOutcomeAmbiguousError):
+        client.cancel_installment_plan("plan-1")
+
+
+def test_cancel_installment_plan_4xx_then_fallback_pending_raises_ambiguous(
+    monkeypatch,
+) -> None:
+    """4xx cancel + single-attempt re-read returns 'pending' → must raise."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(
+                200, {"installment_plan": {"id": "plan-1", "status": "pending"}}
+            ),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(CancelOutcomeAmbiguousError):
+        client.cancel_installment_plan("plan-1")
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — cancel_installment_plan: 4xx fallback (single-attempt, review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_installment_plan_4xx_falls_back_to_status_getter(monkeypatch) -> None:
+    """4xx cancel + single-attempt re-read → classified from live status."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(
+                200, {"installment_plan": {"id": "plan-1", "status": "cancelled"}}
+            ),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    assert client.cancel_installment_plan("plan-1") == CancelOutcome.CANCELED
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — cancel_installment_plan: fallback failure propagates (review fix)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_installment_plan_4xx_then_fallback_transport_error_raises(
+    monkeypatch,
+) -> None:
+    """4xx cancel + single-attempt re-read transport error → exception propagates."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            httpx.ConnectError("network failure"),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.ConnectError):
+        client.cancel_installment_plan("plan-1")
+
+
+def test_cancel_installment_plan_4xx_then_fallback_5xx_raises(monkeypatch) -> None:
+    """4xx cancel + single-attempt re-read returns 5xx → exception propagates."""
+    _stub_non_retrying_sequence(
+        monkeypatch,
+        [
+            _FakeResponse(422, {}),
+            _FakeResponse(503, {}),
+        ],
+    )
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.HTTPStatusError):
+        client.cancel_installment_plan("plan-1")
+
+
+# ---------------------------------------------------------------------------
+# Task 1.4 — cancel_installment_plan: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_installment_plan_5xx_raises(monkeypatch) -> None:
+    _stub_non_retrying(monkeypatch, _FakeResponse(503, {}))
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.HTTPStatusError):
+        client.cancel_installment_plan("plan-1")
+
+
+def test_cancel_installment_plan_transport_error_raises(monkeypatch) -> None:
+    def fake_non_retrying(_self, _method, _endpoint):
+        raise httpx.TimeoutException("timed out")
+
+    monkeypatch.setattr(SimpleFIClient, "_non_retrying_request", fake_non_retrying)
+    client = SimpleFIClient("fake-key")
+    with pytest.raises(httpx.TimeoutException):
+        client.cancel_installment_plan("plan-1")
+
+
+def test_cancel_installment_plan_endpoint_path(monkeypatch) -> None:
+    """Cancel must PUT to the /installment_plans/{id}/cancel endpoint."""
+    captured = _stub_non_retrying(
+        monkeypatch, _FakeResponse(200, {"id": "plan-xyz", "status": "cancelled"})
+    )
+    client = SimpleFIClient("fake-key")
+    client.cancel_installment_plan("plan-xyz")
+    assert captured["method"] == "PUT"
+    assert captured["endpoint"] == "/installment_plans/plan-xyz/cancel"
+
+
+# ---------------------------------------------------------------------------
+# Task 1.5 — global settings defaults
+# ---------------------------------------------------------------------------
+
+
+def test_pending_sweep_enabled_default() -> None:
+    from app.core.config import settings
+
+    assert settings.PENDING_SWEEP_ENABLED is True
+
+
+def test_pending_sweep_stale_minutes_default() -> None:
+    from app.core.config import settings
+
+    assert settings.PENDING_SWEEP_STALE_MINUTES == 20
+
+
+def test_pending_sweep_batch_size_default() -> None:
+    from app.core.config import settings
+
+    assert settings.PENDING_SWEEP_BATCH_SIZE == 200
+
+
+def test_supersede_pending_enabled_default() -> None:
+    from app.core.config import settings
+
+    assert settings.SUPERSEDE_PENDING_ENABLED is True


### PR DESCRIPTION
## Summary

Foundation slice (1/4) of the pending-payment hold release chain.

- Adds `cancel_payment_request` / `cancel_installment_plan` to the SimpleFi client (`PUT /{resource}/{id}/cancel`, validated against the live sandbox API).
- Adds a `CancelOutcome` classifier with a typed `CancelOutcomeAmbiguousError`. Contract: any ambiguity or error on the cancel path means holds are NOT released.
- Adds a non-retrying request variant so the already-approved race signal is not hidden by retries, plus a single-attempt 4xx status fallback. This fallback is required, not defensive: SimpleFi returns identical 400 bodies (text detail, no status field) for cancel-on-terminal and cancel-on-approved, so classification must re-read the status.
- Adds 4 global settings: `SUPERSEDE_PENDING_ENABLED`, `PENDING_SWEEP_ENABLED`, `PENDING_SWEEP_STALE_MINUTES` (default 20), `PENDING_SWEEP_BATCH_SIZE`. Global on purpose: provider-tied operational backstop, approved exception to the popup-scoped convention.

No behavior change for existing flows. Nothing calls these methods until PR 2.

## Testing

- 55 unit tests (`tests/test_simplefi_cancel_methods.py`), including the ambiguity contract (pending / missing / unknown status raises) and fallback-failure propagation.
- Cancel endpoints and 4xx shapes validated live against `apidev.simplefi.tech`.

Part of the chain: PR1 (this) → PR2 supersede → PR3 sweeper → PR4 portal. Merge in order, retargeting as each lands.