### PR TITLE
feat(payments): supersede pending payments on new checkout

### DIFF
--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -165,7 +165,7 @@ async def get_checkout_share_meta(
                 "Concurrent payment conflict. "
                 "detail.code is one of: "
                 "'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or "
-                "'previous_payment_completed' (prior payment was approved — includes payment_id and redirect_url)."
+                "'previous_payment_completed' (prior payment was approved — includes redirect_url when signing is configured)."
             ),
         },
         502: {

--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -159,6 +159,23 @@ async def get_checkout_share_meta(
     dependencies=[
         Depends(RateLimit(limit=10, window_sec=60, key_prefix="rl:checkout-purchase")),
     ],
+    responses={
+        409: {
+            "description": (
+                "Concurrent payment conflict. "
+                "detail.code is one of: "
+                "'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or "
+                "'previous_payment_completed' (prior payment was approved — includes payment_id and redirect_url)."
+            ),
+        },
+        502: {
+            "description": (
+                "Payment provider error. "
+                "detail.code='payment_cancel_failed' means the prior pending payment could not be cancelled. "
+                "Retry the request."
+            ),
+        },
+    },
 )
 async def purchase_open_ticketing(
     slug: str,

--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -162,10 +162,10 @@ async def get_checkout_share_meta(
     responses={
         409: {
             "description": (
-                "Concurrent payment conflict. "
-                "detail.code is one of: "
-                "'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or "
-                "'previous_payment_completed' (prior payment was approved — includes redirect_url when signing is configured)."
+                "Payment conflict. detail.code is one of: "
+                "'pending_payment_exists' (a prior PENDING payment exists and no valid cart continuity proof was supplied — no cancellation attempted); "
+                "'concurrent_payment_in_progress' (another checkout is in progress under the same email right now); "
+                "'previous_payment_completed' (prior payment was already approved — includes redirect_url when a signing secret and external success URL are both configured)."
             ),
         },
         502: {

--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -164,6 +164,13 @@ class OpenTicketingPurchaseCreate(BaseModel):
     # locale-aware success redirect. Falls back to the popup default when absent.
     locale: str | None = Field(default=None, max_length=8)
     attribution: Attribution | None = None
+    # Cart continuity proof: signed cart identifier from the abandoned-cart
+    # restore link (GET /checkout/{slug}/cart?cid=&sig=).  When both are
+    # present and valid for this buyer+popup, the system is allowed to supersede
+    # a prior PENDING payment.  Missing or invalid → supersede is blocked;
+    # a 409 pending_payment_exists is returned if a PENDING payment exists.
+    cid: uuid.UUID | None = None
+    sig: str | None = None
 
 
 class OpenTicketingPurchaseResponse(BaseModel):

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -770,10 +770,12 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             )
             for line in obj.products
         ]
-        # Validate per-order caps (cheap in-memory check, fail fast before DB).
-        self._validate_max_per_order(fabricated_requests, valid_products)
-        # Atomically decrement total-stock counters (409 if sold out).
-        self._decrement_total_stocks(session, fabricated_requests, valid_products)
+        # ADR-2 supersede pre-step: cancel any prior PENDING SimpleFi payment
+        # for this email+popup_id BEFORE acquiring the advisory lock and BEFORE
+        # any stock/coupon reservation.  The SimpleFi cancel HTTP call MUST NOT
+        # be made while holding any DB lock.  supersede_pending_payments commits
+        # the hold release so the subsequent reservation always sees freed holds.
+        from app.core.config import settings as _settings
 
         buyer_snapshot = self._build_buyer_snapshot(
             popup,
@@ -788,24 +790,69 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             f"{obj.buyer.first_name} {obj.buyer.last_name}".strip() or obj.buyer.email
         )
 
-        payment = Payments(
-            tenant_id=tenant.id,
-            application_id=None,
-            popup_id=popup.id,
-            status=PaymentStatus.PENDING.value,
-            amount=Decimal("0"),
-            currency=popup.currency,
-            source=PaymentSource.SIMPLEFI.value,
-            buyer_snapshot=buyer_snapshot,
-            meta_fbc=(attribution or {}).get("fbc"),
-            meta_fbp=(attribution or {}).get("fbp"),
-            meta_client_ip=(attribution or {}).get("client_ip"),
-            meta_client_user_agent=(attribution or {}).get("client_user_agent"),
-        )
-        session.add(payment)
-        session.flush()
+        if _settings.SUPERSEDE_PENDING_ENABLED:
+            self.supersede_pending_payments(
+                session,
+                email=obj.buyer.email,
+                popup_id=popup.id,
+            )
+
+        # ADR-2 advisory lock: serialize concurrent open-checkout requests for
+        # the same email+popup_id.  The lock prevents duplicate SimpleFi cancel
+        # calls (robustness) and is the serialization point for the sibling
+        # re-check inside the try block.  pg_try_advisory_lock is non-blocking;
+        # if another request holds the lock, abort with 409.
+        _oc_lock_key = f"{popup.id}:{obj.buyer.email.lower()}"
+        _got_oc_lock = session.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:key)::bigint)"),
+            {"key": _oc_lock_key},
+        ).scalar()
+        if not _got_oc_lock:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "concurrent_payment_in_progress",
+                    "message": (
+                        "Another checkout is currently in progress for this email. "
+                        "Please wait a moment and try again."
+                    ),
+                },
+            )
 
         try:
+            # ADR-2 post-lock sibling re-check (under advisory lock, NO SimpleFi
+            # call): abort if a concurrent request already started a new PENDING
+            # payment for the same email+popup_id.
+            self._check_no_pending_sibling_by_email_popup(
+                session, obj.buyer.email, popup.id
+            )
+
+            # Validate per-order caps (cheap in-memory check, fail fast before DB).
+            self._validate_max_per_order(fabricated_requests, valid_products)
+            # Atomically decrement total-stock counters (409 if sold out).
+            self._decrement_total_stocks(session, fabricated_requests, valid_products)
+
+            # Store buyer email (lowercase) in snapshot for supersede JSONB lookup
+            # on future payment attempts by the same buyer.
+            buyer_snapshot["buyer_email"] = obj.buyer.email.lower()
+
+            payment = Payments(
+                tenant_id=tenant.id,
+                application_id=None,
+                popup_id=popup.id,
+                status=PaymentStatus.PENDING.value,
+                amount=Decimal("0"),
+                currency=popup.currency,
+                source=PaymentSource.SIMPLEFI.value,
+                buyer_snapshot=buyer_snapshot,
+                meta_fbc=(attribution or {}).get("fbc"),
+                meta_fbp=(attribution or {}).get("fbp"),
+                meta_client_ip=(attribution or {}).get("client_ip"),
+                meta_client_user_agent=(attribution or {}).get("client_user_agent"),
+            )
+            session.add(payment)
+            session.flush()
+
             # One attendee per (human, popup) for direct sales — Design §2.1
             attendee = attendees_crud.find_or_create_direct_attendee(
                 session,
@@ -1069,6 +1116,16 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Failed to create payment with payment provider",
             ) from exc
+        finally:
+            # Release the session-level advisory lock acquired before this try
+            # block.  Runs on success, exception (including 409/502 from supersede
+            # that propagated here), and rollback — safe because the lock is
+            # session-level and survives transaction commits.
+            if _got_oc_lock:
+                session.execute(
+                    text("SELECT pg_advisory_unlock(hashtext(:key)::bigint)"),
+                    {"key": _oc_lock_key},
+                )
 
     def find_by_human_popup(
         self,
@@ -1920,6 +1977,17 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         """
         application_id = _require_application_id(obj.application_id)
 
+        # ADR-2 supersede pre-step: cancel any prior PENDING SimpleFi payment
+        # for this application BEFORE acquiring the application row lock and
+        # BEFORE any new-payment reservation.  The SimpleFi cancel HTTP call
+        # MUST NOT be made while holding a DB lock.  supersede_pending_payments
+        # commits the hold release (PENDING → CANCELLED) before returning so
+        # the subsequent reservation always sees freed coupon/stock/credit.
+        from app.core.config import settings as _settings
+
+        if _settings.SUPERSEDE_PENDING_ENABLED:
+            self.supersede_pending_payments(session, application_id=application_id)
+
         # Serialize concurrent payment attempts for the same application.
         # Without this, double-submits and browser retries can produce
         # duplicate Payments + AttendeeProducts (see PR #182 follow-up).
@@ -1927,6 +1995,12 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             text("SELECT id FROM applications WHERE id = :id FOR UPDATE"),
             {"id": application_id},
         )
+
+        # ADR-2 post-lock sibling re-check: abort if a concurrent create_payment
+        # call already created a new PENDING payment for the same application
+        # between the supersede step above and this lock acquisition.  No
+        # SimpleFi call is made under this lock.
+        self._check_no_pending_sibling_by_application(session, application_id)
 
         preview = self.preview_payment(session, obj)
 
@@ -2721,13 +2795,271 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             # Restore per-product total stock counter (no-op for unlimited products).
             products_crud.restore_total_stock(session, pp.product_id, pp.quantity)
 
+    # ------------------------------------------------------------------
+    # ADR-2 / ADR-3 / ADR-4  — supersede helpers
+    # ------------------------------------------------------------------
+
+    def _reconcile_approved(
+        self,
+        session: Session,
+        payment: Payments,
+    ) -> Payments:
+        """Idempotently approve a payment whose SimpleFi status is already approved.
+
+        Called by supersede_pending_payments (race-lost path) and the pending
+        payment sweeper (approved-during-sweep path).  Delegates to
+        approve_payment which is idempotent (returns early if status is already
+        APPROVED).  Confirmation email dispatch is the caller's responsibility
+        because this method is synchronous.
+
+        Returns the (possibly freshly) approved payment.
+        """
+        return self.approve_payment(session, payment.id)
+
+    def _check_no_pending_sibling_by_application(
+        self,
+        session: Session,
+        application_id: uuid.UUID,
+    ) -> None:
+        """Post-lock guard (authenticated): abort when a concurrent sibling PENDING payment exists.
+
+        Called AFTER the ``applications FOR UPDATE`` lock is acquired in
+        create_payment.  A sibling is any PENDING payment already linked to
+        this application_id — meaning a concurrent create_payment call already
+        passed the supersede pre-step and started a new payment.  The slower
+        caller should abort so there is exactly ONE new PENDING payment per
+        application.
+
+        Raises HTTP 409 ``concurrent_payment_in_progress``.  NO SimpleFi call
+        is made under this lock (ADR-2 invariant).
+        """
+        sibling = session.exec(
+            select(Payments).where(
+                Payments.application_id == application_id,
+                Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+            )
+        ).first()
+        if sibling is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "concurrent_payment_in_progress",
+                    "message": (
+                        "Another payment for this application is currently being "
+                        "processed. Please wait a moment and try again."
+                    ),
+                    "payment_id": str(sibling.id),
+                },
+            )
+
+    def _check_no_pending_sibling_by_email_popup(
+        self,
+        session: Session,
+        email: str,
+        popup_id: uuid.UUID,
+    ) -> None:
+        """Post-lock guard (open checkout): abort when a concurrent sibling PENDING payment exists.
+
+        Called inside the ``pg_try_advisory_lock`` section in
+        create_open_ticketing_payment.  Matches PENDING open-checkout payments
+        by the ``buyer_snapshot->>'buyer_email'`` JSONB field (stored as
+        lowercase at creation time).
+
+        Raises HTTP 409 ``concurrent_payment_in_progress``.  NO SimpleFi call
+        is made under this lock (ADR-2 invariant).
+        """
+        sibling = session.exec(
+            select(Payments)
+            .where(
+                Payments.popup_id == popup_id,
+                Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+                Payments.application_id.is_(None),  # type: ignore[union-attr]
+            )
+            .where(text("buyer_snapshot->>'buyer_email' = :email"))
+            .params(email=email.lower())
+        ).first()
+        if sibling is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "concurrent_payment_in_progress",
+                    "message": (
+                        "Another checkout is currently in progress for this email. "
+                        "Please wait a moment and try again."
+                    ),
+                    "payment_id": str(sibling.id),
+                },
+            )
+
+    def supersede_pending_payments(
+        self,
+        session: Session,
+        *,
+        application_id: uuid.UUID | None = None,
+        email: str | None = None,
+        popup_id: uuid.UUID | None = None,
+    ) -> None:
+        """Cancel any prior PENDING SimpleFi payment for this buyer before creating a new one.
+
+        ADR-2: Runs as a committed PRE-STEP at the START of create_payment
+        (authenticated) and create_open_ticketing_payment (open checkout),
+        BEFORE any DB lock is acquired and BEFORE stock/coupon reservation.
+        The SimpleFi cancel HTTP call MUST NOT be made while holding any DB
+        lock.
+
+        Lookup key:
+        - Authenticated: ``application_id`` — finds PENDING payment with
+          matching application_id, source=SIMPLEFI, external_id IS NOT NULL.
+        - Open checkout: ``email + popup_id`` — finds PENDING open-checkout
+          payment with matching ``buyer_snapshot->>'buyer_email'`` and popup_id.
+
+        Outcomes:
+        - CANCELED: calls ``update_status(old, CANCELLED)`` which COMMITs the
+          release of coupon, stock, and credit holds.  Returns normally.
+        - ALREADY_APPROVED: calls ``_reconcile_approved`` (idempotent approve),
+          then raises HTTP 409 ``previous_payment_completed`` with the old
+          payment_id and (for open checkout) a thank-you redirect URL.
+        - Any exception (CancelOutcomeAmbiguousError, transport, 5xx): raises
+          HTTP 502 ``payment_cancel_failed``.  Holds are NOT released — never
+          release without SimpleFi confirmation.
+
+        If no prior PENDING payment exists, this method is a no-op.
+
+        Args:
+            session: Active DB session.  update_status commits on CANCELED path.
+            application_id: Lookup key for authenticated checkout.
+            email: Buyer email for open-checkout lookup (requires popup_id).
+            popup_id: Required when email is provided.
+        """
+        from app.api.popup.models import Popups as _Popups
+        from app.api.tenant.models import Tenants as _Tenants
+        from app.api.tenant.utils import get_portal_url
+        from app.services.simplefi import get_simplefi_client
+        from app.services.simplefi.client import (
+            CancelOutcome,
+            CancelOutcomeAmbiguousError,
+        )
+
+        # Locate the prior PENDING SimpleFi payment for this buyer
+        prior: Payments | None = None
+
+        if application_id is not None:
+            prior = session.exec(
+                select(Payments).where(
+                    Payments.application_id == application_id,
+                    Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+                    Payments.source == PaymentSource.SIMPLEFI.value,  # type: ignore[arg-type]
+                    Payments.external_id.is_not(None),  # type: ignore[union-attr]
+                )
+            ).first()
+        elif email is not None and popup_id is not None:
+            prior = session.exec(
+                select(Payments)
+                .where(
+                    Payments.popup_id == popup_id,
+                    Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+                    Payments.application_id.is_(None),  # type: ignore[union-attr]
+                    Payments.source == PaymentSource.SIMPLEFI.value,  # type: ignore[arg-type]
+                    Payments.external_id.is_not(None),  # type: ignore[union-attr]
+                )
+                .where(text("buyer_snapshot->>'buyer_email' = :email"))
+                .params(email=email.lower())
+            ).first()
+
+        if prior is None:
+            return  # No prior pending payment — nothing to supersede
+
+        # Resolve the SimpleFi API key from the payment's popup
+        _popup = session.get(_Popups, prior.popup_id)
+        if _popup is None or not _popup.simplefi_api_key:
+            # No API key: the payment was never sent to SimpleFi (orphaned).
+            # Release holds anyway since there is no live link to protect.
+            logger.warning(
+                "supersede_pending_payments: no simplefi_api_key for popup={}, "
+                "releasing holds on orphaned payment={}",
+                prior.popup_id,
+                prior.id,
+            )
+            self.update_status(session, prior.id, PaymentStatus.CANCELLED)
+            return
+
+        simplefi_client = get_simplefi_client(_popup.simplefi_api_key)
+
+        # Call SimpleFi cancel OUTSIDE any DB lock (ADR-2, ADR-3)
+        try:
+            if prior.is_installment_plan:
+                outcome = simplefi_client.cancel_installment_plan(
+                    str(prior.external_id)
+                )
+            else:
+                outcome = simplefi_client.cancel_payment_request(str(prior.external_id))
+        except (CancelOutcomeAmbiguousError, Exception) as exc:
+            # Transport error, 5xx, or unresolvable status — do NOT release holds
+            logger.warning(
+                "supersede_pending_payments: SimpleFi cancel failed "
+                "payment={}, error={!r}",
+                prior.id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={
+                    "code": "payment_cancel_failed",
+                    "message": "We could not process your payment. Please try again.",
+                },
+            ) from exc
+
+        if outcome == CancelOutcome.CANCELED:
+            # Happy path: cancel confirmed — commit the hold release
+            self.update_status(session, prior.id, PaymentStatus.CANCELLED)
+
+        elif outcome == CancelOutcome.ALREADY_APPROVED:
+            # Race lost: prior payment completed concurrently.
+            # Idempotently approve to ensure tickets are issued.
+            self._reconcile_approved(session, prior)
+
+            # Build the open-checkout thank-you redirect URL (open checkout only)
+            redirect_url: str | None = None
+            if prior.application_id is None and _popup is not None:
+                _tenant = session.get(_Tenants, prior.tenant_id)
+                if _tenant is not None:
+                    portal_base = get_portal_url(_tenant)
+                    redirect_url = (
+                        f"{portal_base}/checkout/{_popup.slug}"
+                        f"/thank-you?payment_id={prior.id}"
+                    )
+
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "previous_payment_completed",
+                    "message": "Your previous payment was completed.",
+                    "payment_id": str(prior.id),
+                    "redirect_url": redirect_url,
+                },
+            )
+
     def update_status(
         self,
         session: Session,
         payment_id: uuid.UUID,
         new_status: PaymentStatus,
     ) -> Payments:
-        """Update payment status."""
+        """Update payment status.
+
+        ADR-1: A ``SELECT ... FOR UPDATE`` row lock is acquired at the top of
+        this method to serialize concurrent callers (supersede, SimpleFi
+        webhook, sweeper).  The PENDING-only release guard below is therefore
+        atomic: only one caller reads PENDING and releases holds; subsequent
+        callers find the status already terminal and skip the release.
+        """
+        # ADR-1: Acquire row lock before reading status.  Prevents two
+        # concurrent callers from both reading PENDING and both releasing
+        # coupon/stock/credit holds (double-release).
+        session.execute(
+            text("SELECT id FROM payments WHERE id = :id FOR UPDATE"),
+            {"id": payment_id},
+        )
         payment = self.get(session, payment_id)
         if not payment:
             raise HTTPException(

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -45,6 +45,7 @@ from app.utils.checkout_signing import (
     build_signed_redirect_url,
     build_thank_you_payload,
     build_unsigned_redirect_url,
+    verify_cart_restore_token,
 )
 
 # Decimal precision for money calculations
@@ -771,7 +772,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             for line in obj.products
         ]
         # ADR-2 supersede pre-step + advisory lock: the ENTIRE new machinery
-        # (supersede, advisory lock, sibling re-check) is gated on
+        # (proof gate, supersede, advisory lock, sibling re-check) is gated on
         # SUPERSEDE_PENDING_ENABLED so that setting it to False restores exact
         # pre-PR behavior — sequential same-buyer purchases succeed without any
         # hold on the lock or 409 from the sibling re-check.
@@ -790,62 +791,98 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             f"{obj.buyer.first_name} {obj.buyer.last_name}".strip() or obj.buyer.email
         )
 
-        # _got_oc_lock tracks whether the advisory lock was acquired so that
-        # the 409 guard below is only active when the lock was attempted.
+        # _got_oc_lock tracks whether the advisory lock was acquired.
+        # The post-lock sibling re-check is gated on _got_oc_lock so it only
+        # runs inside the valid-proof path (where the lock is held).
         # With transaction-level locks the finally block needs no explicit
         # unlock, but _got_oc_lock is kept for the guard logic.
         _got_oc_lock = False
 
         if _settings.SUPERSEDE_PENDING_ENABLED:
-            # Cancel any prior PENDING SimpleFi payment BEFORE acquiring the
-            # advisory lock and BEFORE any reservation.  SimpleFi cancel MUST
-            # NOT be called while holding any DB lock.  supersede commits the
-            # hold release so the subsequent reservation sees freed holds.
-            self.supersede_pending_payments(
-                session,
-                email=obj.buyer.email,
-                popup_id=popup.id,
+            # Security gate (Change 1 / security review): supersede of a prior
+            # PENDING payment may ONLY run when the request carries a valid cart
+            # continuity proof (signed cart id from the abandoned-cart restore
+            # flow).  Without proof, an anonymous attacker could cancel any
+            # buyer's pending payment by guessing their email.
+            #
+            # Valid proof: cid+sig HMAC valid for this popup's signing secret
+            # AND the referenced cart belongs to this email+popup.
+            # Missing/invalid proof + pending payment present → 409
+            #   pending_payment_exists (NO SimpleFi call made).
+            # Missing/invalid proof + no pending payment → proceed normally.
+            _has_proof = self._validate_cart_continuity_proof(
+                session, popup, obj.buyer.email, obj.cid, obj.sig
             )
 
-            # ADR-2 advisory lock: serialize concurrent open-checkout requests
-            # for the same email+popup_id.  Prevents duplicate SimpleFi cancel
-            # calls (robustness) and is the serialization point for the sibling
-            # re-check inside the try block.
-            #
-            # TRANSACTION-LEVEL lock (pg_try_advisory_xact_lock): released
-            # automatically when the surrounding transaction commits or rolls
-            # back.  This avoids the connection-pooling hazard of session-level
-            # locks where session.commit() can return the connection to the pool
-            # before the explicit pg_advisory_unlock in the finally block,
-            # leaving the lock held on a pooled connection indefinitely.
-            # The transaction-level variant is semantically equivalent for our
-            # use case: the lock must span from the sibling re-check to the
-            # payment commit — which is exactly one transaction boundary.
-            # Non-blocking: abort with 409 if another request holds the lock.
-            _oc_lock_key = f"{popup.id}:{obj.buyer.email.lower()}"
-            _got_oc_lock = session.execute(
-                text("SELECT pg_try_advisory_xact_lock(hashtext(:key)::bigint)"),
-                {"key": _oc_lock_key},
-            ).scalar()
-            if not _got_oc_lock:
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail={
-                        "code": "concurrent_payment_in_progress",
-                        "message": (
-                            "Another checkout is currently in progress for this email. "
-                            "Please wait a moment and try again."
-                        ),
-                    },
+            if _has_proof:
+                # Valid continuity proof: cancel any prior PENDING payment
+                # BEFORE acquiring the advisory lock and BEFORE reservation.
+                # SimpleFi cancel MUST NOT be called while holding any DB lock.
+                # supersede commits the hold release so the reservation sees freed holds.
+                self.supersede_pending_payments(
+                    session,
+                    email=obj.buyer.email,
+                    popup_id=popup.id,
                 )
 
+                # ADR-2 advisory lock: serialize concurrent open-checkout
+                # requests for the same email+popup_id.  Prevents duplicate
+                # SimpleFi cancel calls (robustness) and is the serialization
+                # point for the sibling re-check inside the try block.
+                #
+                # TRANSACTION-LEVEL lock (pg_try_advisory_xact_lock): released
+                # automatically when the surrounding transaction commits or rolls
+                # back.  This avoids the connection-pooling hazard of
+                # session-level locks where session.commit() can return the
+                # connection to the pool before the explicit pg_advisory_unlock
+                # in the finally block, leaving the lock held indefinitely.
+                # Non-blocking: abort with 409 if another request holds the lock.
+                _oc_lock_key = f"{popup.id}:{obj.buyer.email.lower()}"
+                _got_oc_lock = session.execute(
+                    text("SELECT pg_try_advisory_xact_lock(hashtext(:key)::bigint)"),
+                    {"key": _oc_lock_key},
+                ).scalar()
+                if not _got_oc_lock:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "code": "concurrent_payment_in_progress",
+                            "message": (
+                                "Another checkout is currently in progress for this email. "
+                                "Please wait a moment and try again."
+                            ),
+                        },
+                    )
+            else:
+                # No valid proof: guard against anonymous requests that would
+                # otherwise supersede a legitimate buyer's pending payment.
+                # Critical invariant: NO SimpleFi call is made here.
+                if (
+                    self._find_pending_by_email_popup(
+                        session, obj.buyer.email, popup.id
+                    )
+                    is not None
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "code": "pending_payment_exists",
+                            "message": (
+                                "A payment is already in progress for this email. "
+                                "Please complete your existing checkout or wait for it to expire."
+                            ),
+                        },
+                    )
+                # No pending payment → proceed to create the new payment normally.
+
         try:
-            if _settings.SUPERSEDE_PENDING_ENABLED:
+            if _settings.SUPERSEDE_PENDING_ENABLED and _got_oc_lock:
                 # ADR-2 post-lock sibling re-check (under advisory lock, NO
                 # SimpleFi call): abort if a concurrent request already created
                 # a new PENDING payment for the same email+popup_id between the
-                # supersede step and this lock acquisition.  Skipped when
-                # SUPERSEDE_PENDING_ENABLED=False to preserve pre-PR behavior.
+                # supersede step and this lock acquisition.  Only runs on the
+                # valid-proof path (where _got_oc_lock is True) — skipped when
+                # the no-proof path is taken or SUPERSEDE_PENDING_ENABLED=False.
                 self._check_no_pending_sibling_by_email_popup(
                     session, obj.buyer.email, popup.id
                 )
@@ -2906,6 +2943,68 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 },
             )
 
+    def _find_pending_by_email_popup(
+        self,
+        session: Session,
+        email: str,
+        popup_id: uuid.UUID,
+    ) -> Payments | None:
+        """Return the first PENDING SimpleFi open-checkout payment for email+popup, or None.
+
+        Used by the continuity-proof gate to check whether a prior PENDING
+        payment exists without triggering any SimpleFi calls.  Same query as
+        supersede_pending_payments (email path) so they stay in sync.
+        """
+        return session.exec(
+            select(Payments)
+            .where(
+                Payments.popup_id == popup_id,
+                Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+                Payments.application_id.is_(None),  # type: ignore[union-attr]
+                Payments.source == PaymentSource.SIMPLEFI.value,  # type: ignore[arg-type]
+                Payments.external_id.is_not(None),  # type: ignore[union-attr]
+            )
+            .where(text("buyer_snapshot->>'buyer_email' = :email"))
+            .params(email=email.lower())
+        ).first()
+
+    def _validate_cart_continuity_proof(
+        self,
+        session: Session,
+        popup: "Popups",
+        buyer_email: str,
+        cid: uuid.UUID | None,
+        sig: str | None,
+    ) -> bool:
+        """Return True iff cid+sig constitute a valid cart continuity proof for this buyer+popup.
+
+        Reuses verify_cart_restore_token from checkout_signing — the same HMAC
+        scheme used by GET /checkout/{slug}/cart?cid=&sig= (cart restore).
+        A valid proof requires ALL of:
+        1. Both cid and sig are present.
+        2. The popup has an open_checkout_signing_secret.
+        3. HMAC signature is valid for the given cid and secret.
+        4. The referenced cart belongs to this popup (popup_id match built into
+           carts_crud.find_anonymous_by_id_popup).
+        5. The cart's email matches the buyer email (case-insensitive).
+
+        A valid token for a different email or a different popup is always invalid.
+        """
+        if cid is None or sig is None:
+            return False
+        secret = popup.open_checkout_signing_secret
+        if not secret:
+            return False
+        if not verify_cart_restore_token(str(cid), sig, secret):
+            return False
+        from app.api.cart.crud import carts_crud as _carts_crud  # noqa: PLC0415
+
+        cart = _carts_crud.find_anonymous_by_id_popup(session, cid, popup.id)
+        if cart is None:
+            return False
+        cart_email: str = getattr(cart, "email", None) or ""
+        return cart_email.lower() == buyer_email.lower()
+
     def _check_no_pending_sibling_by_email_popup(
         self,
         session: Session,
@@ -2970,8 +3069,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         - CANCELED: calls ``update_status(old, CANCELLED)`` which COMMITs the
           release of coupon, stock, and credit holds.  Returns normally.
         - ALREADY_APPROVED: calls ``_reconcile_approved`` (idempotent approve),
-          then raises HTTP 409 ``previous_payment_completed`` with the old
-          payment_id and (for open checkout) a thank-you redirect URL.
+          then raises HTTP 409 ``previous_payment_completed``. The detail body
+          carries no payment identifiers; for open checkout it includes a
+          SIGNED thank-you redirect URL only when the popup has signing
+          configured, otherwise no URL at all.
         - Any exception (CancelOutcomeAmbiguousError, transport, 5xx): raises
           HTTP 502 ``payment_cancel_failed``.  Holds are NOT released — never
           release without SimpleFi confirmation.
@@ -3006,18 +3107,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 )
             ).first()
         elif email is not None and popup_id is not None:
-            prior = session.exec(
-                select(Payments)
-                .where(
-                    Payments.popup_id == popup_id,
-                    Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
-                    Payments.application_id.is_(None),  # type: ignore[union-attr]
-                    Payments.source == PaymentSource.SIMPLEFI.value,  # type: ignore[arg-type]
-                    Payments.external_id.is_not(None),  # type: ignore[union-attr]
-                )
-                .where(text("buyer_snapshot->>'buyer_email' = :email"))
-                .params(email=email.lower())
-            ).first()
+            prior = self._find_pending_by_email_popup(session, email, popup_id)
 
         if prior is None:
             return  # No prior pending payment — nothing to supersede
@@ -3091,9 +3181,11 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             # Build a safe redirect URL for the 409 response.
             # Security contract (S1):
             #   - Never expose the raw payment UUID to anonymous callers.
-            #   - Open checkout: use the signed-redirect machinery so the link
-            #     is tamper-evident.  If no signing secret is configured, omit
-            #     redirect_url entirely (portal falls back to message-only).
+            #   - Open checkout: return a SIGNED external redirect ONLY when
+            #     both a signing secret AND an external success URL are configured.
+            #     Any other case omits redirect_url (portal falls back to
+            #     message-only).  An unsigned internal portal URL MUST NOT be
+            #     returned here — it carries the raw payment UUID in the path.
             #   - Authenticated: redirect to the buyer's own passes page; no
             #     payment UUID is needed or included.
             redirect_url: str | None = None
@@ -3104,16 +3196,9 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 and _popup is not None
                 and _tenant is not None
             ):
-                # Open-checkout path: signed redirect only when signing is configured.
+                # Open-checkout path: signed external redirect only.
                 secret = _popup.open_checkout_signing_secret
-                if secret:
-                    from app.api.shared.enums import LandingMode  # noqa: PLC0415
-
-                    portal_base = get_portal_url(_tenant)
-                    landing_is_checkout = _tenant.landing_mode == LandingMode.checkout
-                    internal_url = _internal_open_checkout_thank_you_url(
-                        portal_base, landing_is_checkout, _popup, prior
-                    )
+                if secret and _popup.open_checkout_success_url:
                     payload = build_thank_you_payload(
                         order_id=str(prior.id),
                         first_name=str(
@@ -3128,15 +3213,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         currency=prior.currency or "",
                         issued_at=datetime.now(UTC).isoformat(),
                     )
-                    if _popup.open_checkout_success_url:
-                        redirect_url = build_signed_redirect_url(
-                            _popup.open_checkout_success_url, payload, secret
-                        )
-                    else:
-                        redirect_url = build_unsigned_redirect_url(
-                            internal_url, payload
-                        )
-                # else: no signing secret — omit redirect_url (portal message-only)
+                    redirect_url = build_signed_redirect_url(
+                        _popup.open_checkout_success_url, payload, secret
+                    )
+                # else: no signing secret or no external URL — omit redirect_url
 
             elif (
                 prior.application_id is not None

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -770,11 +770,11 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             )
             for line in obj.products
         ]
-        # ADR-2 supersede pre-step: cancel any prior PENDING SimpleFi payment
-        # for this email+popup_id BEFORE acquiring the advisory lock and BEFORE
-        # any stock/coupon reservation.  The SimpleFi cancel HTTP call MUST NOT
-        # be made while holding any DB lock.  supersede_pending_payments commits
-        # the hold release so the subsequent reservation always sees freed holds.
+        # ADR-2 supersede pre-step + advisory lock: the ENTIRE new machinery
+        # (supersede, advisory lock, sibling re-check) is gated on
+        # SUPERSEDE_PENDING_ENABLED so that setting it to False restores exact
+        # pre-PR behavior — sequential same-buyer purchases succeed without any
+        # hold on the lock or 409 from the sibling re-check.
         from app.core.config import settings as _settings
 
         buyer_snapshot = self._build_buyer_snapshot(
@@ -790,42 +790,65 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             f"{obj.buyer.first_name} {obj.buyer.last_name}".strip() or obj.buyer.email
         )
 
+        # _got_oc_lock tracks whether the advisory lock was acquired so that
+        # the 409 guard below is only active when the lock was attempted.
+        # With transaction-level locks the finally block needs no explicit
+        # unlock, but _got_oc_lock is kept for the guard logic.
+        _got_oc_lock = False
+
         if _settings.SUPERSEDE_PENDING_ENABLED:
+            # Cancel any prior PENDING SimpleFi payment BEFORE acquiring the
+            # advisory lock and BEFORE any reservation.  SimpleFi cancel MUST
+            # NOT be called while holding any DB lock.  supersede commits the
+            # hold release so the subsequent reservation sees freed holds.
             self.supersede_pending_payments(
                 session,
                 email=obj.buyer.email,
                 popup_id=popup.id,
             )
 
-        # ADR-2 advisory lock: serialize concurrent open-checkout requests for
-        # the same email+popup_id.  The lock prevents duplicate SimpleFi cancel
-        # calls (robustness) and is the serialization point for the sibling
-        # re-check inside the try block.  pg_try_advisory_lock is non-blocking;
-        # if another request holds the lock, abort with 409.
-        _oc_lock_key = f"{popup.id}:{obj.buyer.email.lower()}"
-        _got_oc_lock = session.execute(
-            text("SELECT pg_try_advisory_lock(hashtext(:key)::bigint)"),
-            {"key": _oc_lock_key},
-        ).scalar()
-        if not _got_oc_lock:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "concurrent_payment_in_progress",
-                    "message": (
-                        "Another checkout is currently in progress for this email. "
-                        "Please wait a moment and try again."
-                    ),
-                },
-            )
+            # ADR-2 advisory lock: serialize concurrent open-checkout requests
+            # for the same email+popup_id.  Prevents duplicate SimpleFi cancel
+            # calls (robustness) and is the serialization point for the sibling
+            # re-check inside the try block.
+            #
+            # TRANSACTION-LEVEL lock (pg_try_advisory_xact_lock): released
+            # automatically when the surrounding transaction commits or rolls
+            # back.  This avoids the connection-pooling hazard of session-level
+            # locks where session.commit() can return the connection to the pool
+            # before the explicit pg_advisory_unlock in the finally block,
+            # leaving the lock held on a pooled connection indefinitely.
+            # The transaction-level variant is semantically equivalent for our
+            # use case: the lock must span from the sibling re-check to the
+            # payment commit — which is exactly one transaction boundary.
+            # Non-blocking: abort with 409 if another request holds the lock.
+            _oc_lock_key = f"{popup.id}:{obj.buyer.email.lower()}"
+            _got_oc_lock = session.execute(
+                text("SELECT pg_try_advisory_xact_lock(hashtext(:key)::bigint)"),
+                {"key": _oc_lock_key},
+            ).scalar()
+            if not _got_oc_lock:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "code": "concurrent_payment_in_progress",
+                        "message": (
+                            "Another checkout is currently in progress for this email. "
+                            "Please wait a moment and try again."
+                        ),
+                    },
+                )
 
         try:
-            # ADR-2 post-lock sibling re-check (under advisory lock, NO SimpleFi
-            # call): abort if a concurrent request already started a new PENDING
-            # payment for the same email+popup_id.
-            self._check_no_pending_sibling_by_email_popup(
-                session, obj.buyer.email, popup.id
-            )
+            if _settings.SUPERSEDE_PENDING_ENABLED:
+                # ADR-2 post-lock sibling re-check (under advisory lock, NO
+                # SimpleFi call): abort if a concurrent request already created
+                # a new PENDING payment for the same email+popup_id between the
+                # supersede step and this lock acquisition.  Skipped when
+                # SUPERSEDE_PENDING_ENABLED=False to preserve pre-PR behavior.
+                self._check_no_pending_sibling_by_email_popup(
+                    session, obj.buyer.email, popup.id
+                )
 
             # Validate per-order caps (cheap in-memory check, fail fast before DB).
             self._validate_max_per_order(fabricated_requests, valid_products)
@@ -1069,6 +1092,16 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 if computed >= 2:
                     max_installments = computed
 
+            # W3/S3 invariant: SimpleFi CREATE stays inside the advisory lock.
+            # Releasing the lock before create_payment would re-open the
+            # duplicate-PENDING window: a second request could pass the sibling
+            # re-check (finding no PENDING yet) and race to create a second
+            # SimpleFi link for the same buyer.
+            # The transaction-level advisory lock (pg_try_advisory_xact_lock) is
+            # held for the entire current transaction.  session.commit() below
+            # commits the new payment row AND atomically releases the lock — so
+            # any subsequent lock holder is guaranteed to find the committed row
+            # in the sibling re-check.  No explicit unlock is needed.
             simplefi_response = simplefi_client.create_payment(
                 amount=payment.amount,
                 popup_slug=popup.slug,
@@ -1117,15 +1150,12 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 detail="Failed to create payment with payment provider",
             ) from exc
         finally:
-            # Release the session-level advisory lock acquired before this try
-            # block.  Runs on success, exception (including 409/502 from supersede
-            # that propagated here), and rollback — safe because the lock is
-            # session-level and survives transaction commits.
-            if _got_oc_lock:
-                session.execute(
-                    text("SELECT pg_advisory_unlock(hashtext(:key)::bigint)"),
-                    {"key": _oc_lock_key},
-                )
+            # Transaction-level advisory lock (pg_try_advisory_xact_lock) is
+            # released automatically on commit or rollback — no explicit unlock
+            # needed here.  The finally block is kept as documentation that this
+            # is intentionally a no-op for the lock: the commit at the end of
+            # the try block (or the rollback in the except blocks) handles it.
+            pass
 
     def find_by_human_popup(
         self,
@@ -1999,8 +2029,10 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         # ADR-2 post-lock sibling re-check: abort if a concurrent create_payment
         # call already created a new PENDING payment for the same application
         # between the supersede step above and this lock acquisition.  No
-        # SimpleFi call is made under this lock.
-        self._check_no_pending_sibling_by_application(session, application_id)
+        # SimpleFi call is made under this lock.  Gated on the same flag as
+        # supersede to restore pre-PR sequential-purchase behavior when disabled.
+        if _settings.SUPERSEDE_PENDING_ENABLED:
+            self._check_no_pending_sibling_by_application(session, application_id)
 
         preview = self.preview_payment(session, obj)
 
@@ -2807,13 +2839,36 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         """Idempotently approve a payment whose SimpleFi status is already approved.
 
         Called by supersede_pending_payments (race-lost path) and the pending
-        payment sweeper (approved-during-sweep path).  Delegates to
-        approve_payment which is idempotent (returns early if status is already
-        APPROVED).  Confirmation email dispatch is the caller's responsibility
-        because this method is synchronous.
+        payment sweeper (approved-during-sweep path).  Confirmation email
+        dispatch is the caller's responsibility because this method is
+        synchronous.
+
+        Acquires a ``SELECT ... FOR UPDATE`` row lock before reading the current
+        status so that a concurrent webhook path (which also calls approve_payment
+        via update_status) cannot add products a second time.  The lock also
+        refreshes the session identity map so approve_payment sees the current
+        DB state even when supersede_pending_payments pre-loaded the payment as
+        PENDING in the same session.
 
         Returns the (possibly freshly) approved payment.
         """
+        # Lock the row and get a fresh DB read, overriding any stale PENDING
+        # value cached in the session identity map from the earlier supersede
+        # lookup.  After this query, session.get(Payments, payment.id) returns
+        # the refreshed instance, so approve_payment's own idempotency guard
+        # sees the current status from the DB.
+        fresh = session.exec(
+            select(Payments).where(Payments.id == payment.id).with_for_update()
+        ).first()
+        if fresh is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Payment not found",
+            )
+        if fresh.status == PaymentStatus.APPROVED.value:
+            # Already approved by a concurrent transaction (e.g. webhook beat
+            # supersede to the lock).  Return without adding products again.
+            return fresh
         return self.approve_payment(session, payment.id)
 
     def _check_no_pending_sibling_by_application(
@@ -2848,7 +2903,6 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         "Another payment for this application is currently being "
                         "processed. Please wait a moment and try again."
                     ),
-                    "payment_id": str(sibling.id),
                 },
             )
 
@@ -2887,7 +2941,6 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         "Another checkout is currently in progress for this email. "
                         "Please wait a moment and try again."
                     ),
-                    "payment_id": str(sibling.id),
                 },
             )
 
@@ -2993,8 +3046,25 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 )
             else:
                 outcome = simplefi_client.cancel_payment_request(str(prior.external_id))
-        except (CancelOutcomeAmbiguousError, Exception) as exc:
-            # Transport error, 5xx, or unresolvable status — do NOT release holds
+        except CancelOutcomeAmbiguousError as exc:
+            # Outcome unresolvable (ambiguous response from SimpleFi) — do NOT
+            # release holds.  Distinct log from transport failures so alerts
+            # can differentiate provider-side ambiguity from network issues.
+            logger.warning(
+                "supersede_pending_payments: SimpleFi cancel outcome ambiguous "
+                "payment={}, error={!r}",
+                prior.id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail={
+                    "code": "payment_cancel_failed",
+                    "message": "We could not process your payment. Please try again.",
+                },
+            ) from exc
+        except Exception as exc:
+            # Transport error, timeout, or 5xx — do NOT release holds
             logger.warning(
                 "supersede_pending_payments: SimpleFi cancel failed "
                 "payment={}, error={!r}",
@@ -3018,23 +3088,70 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             # Idempotently approve to ensure tickets are issued.
             self._reconcile_approved(session, prior)
 
-            # Build the open-checkout thank-you redirect URL (open checkout only)
+            # Build a safe redirect URL for the 409 response.
+            # Security contract (S1):
+            #   - Never expose the raw payment UUID to anonymous callers.
+            #   - Open checkout: use the signed-redirect machinery so the link
+            #     is tamper-evident.  If no signing secret is configured, omit
+            #     redirect_url entirely (portal falls back to message-only).
+            #   - Authenticated: redirect to the buyer's own passes page; no
+            #     payment UUID is needed or included.
             redirect_url: str | None = None
-            if prior.application_id is None and _popup is not None:
-                _tenant = session.get(_Tenants, prior.tenant_id)
-                if _tenant is not None:
+            _tenant = session.get(_Tenants, prior.tenant_id) if _popup else None
+
+            if (
+                prior.application_id is None
+                and _popup is not None
+                and _tenant is not None
+            ):
+                # Open-checkout path: signed redirect only when signing is configured.
+                secret = _popup.open_checkout_signing_secret
+                if secret:
+                    from app.api.shared.enums import LandingMode  # noqa: PLC0415
+
                     portal_base = get_portal_url(_tenant)
-                    redirect_url = (
-                        f"{portal_base}/checkout/{_popup.slug}"
-                        f"/thank-you?payment_id={prior.id}"
+                    landing_is_checkout = _tenant.landing_mode == LandingMode.checkout
+                    internal_url = _internal_open_checkout_thank_you_url(
+                        portal_base, landing_is_checkout, _popup, prior
                     )
+                    payload = build_thank_you_payload(
+                        order_id=str(prior.id),
+                        first_name=str(
+                            (prior.buyer_snapshot or {}).get("first_name", "")
+                        ),
+                        email=str((prior.buyer_snapshot or {}).get("buyer_email", "")),
+                        items=[
+                            {"name": pp.product_name, "quantity": pp.quantity}
+                            for pp in prior.products_snapshot
+                        ],
+                        amount_total=str(prior.amount),
+                        currency=prior.currency or "",
+                        issued_at=datetime.now(UTC).isoformat(),
+                    )
+                    if _popup.open_checkout_success_url:
+                        redirect_url = build_signed_redirect_url(
+                            _popup.open_checkout_success_url, payload, secret
+                        )
+                    else:
+                        redirect_url = build_unsigned_redirect_url(
+                            internal_url, payload
+                        )
+                # else: no signing secret — omit redirect_url (portal message-only)
+
+            elif (
+                prior.application_id is not None
+                and _popup is not None
+                and _tenant is not None
+            ):
+                # Authenticated path: send buyer to their own passes page.
+                portal_base = get_portal_url(_tenant)
+                redirect_url = f"{portal_base}/portal/{_popup.slug}/passes"
 
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail={
                     "code": "previous_payment_completed",
                     "message": "Your previous payment was completed.",
-                    "payment_id": str(prior.id),
                     "redirect_url": redirect_url,
                 },
             )
@@ -3053,14 +3170,18 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         atomic: only one caller reads PENDING and releases holds; subsequent
         callers find the status already terminal and skip the release.
         """
-        # ADR-1: Acquire row lock before reading status.  Prevents two
-        # concurrent callers from both reading PENDING and both releasing
-        # coupon/stock/credit holds (double-release).
-        session.execute(
-            text("SELECT id FROM payments WHERE id = :id FOR UPDATE"),
-            {"id": payment_id},
-        )
-        payment = self.get(session, payment_id)
+        # ADR-1: Acquire row lock AND read fresh state in a single query.
+        # Using ``with_for_update()`` on the SELECT bypasses the session
+        # identity map, ensuring this caller sees the post-lock DB state
+        # even when the same session pre-loaded the payment as PENDING
+        # (e.g. supersede loads ``prior`` before calling update_status; a
+        # concurrent transaction could commit CANCELLED between those two
+        # points; the old two-step approach — raw text() lock + self.get() —
+        # would return the stale PENDING from the identity map and release
+        # holds a second time).
+        payment = session.exec(
+            select(Payments).where(Payments.id == payment_id).with_for_update()
+        ).first()
         if not payment:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -944,6 +944,23 @@ async def preview_my_payment(
     response_model=PaymentPublic,
     status_code=status.HTTP_201_CREATED,
     dependencies=[needs("portal:applications:write")],
+    responses={
+        409: {
+            "description": (
+                "Concurrent payment conflict. "
+                "detail.code is one of: "
+                "'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or "
+                "'previous_payment_completed' (prior payment was completed — redirect to thank-you)."
+            ),
+        },
+        502: {
+            "description": (
+                "Payment provider error. "
+                "detail.code='payment_cancel_failed' means the prior pending payment could not be cancelled. "
+                "Retry the request."
+            ),
+        },
+    },
 )
 async def create_my_payment(
     payment_in: PaymentCreate,

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -950,7 +950,7 @@ async def preview_my_payment(
                 "Concurrent payment conflict. "
                 "detail.code is one of: "
                 "'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or "
-                "'previous_payment_completed' (prior payment was completed — redirect to thank-you)."
+                "'previous_payment_completed' (prior payment was completed — redirect_url points to the buyer's passes page)."
             ),
         },
         502: {

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -283,11 +283,19 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
 ) -> None:
     """Second purchase by same (human, popup) reuses the existing attendee.  Design §2.1 / Spec C2.
 
-    B4 fix: with supersede enabled the second call cancels the first PENDING payment before
-    creating a new one.  The mock must stub cancel_payment_request so supersede returns
-    CancelOutcome.CANCELED and the prior payment ends up CANCELLED (not blocking the new one).
+    Proof gate: the second call must supply a valid cart continuity proof (cid+sig)
+    so the supersede step is allowed to cancel the first PENDING payment.  Without
+    proof the gate returns 409 pending_payment_exists (correct security behavior).
     """
+    from app.api.cart.models import Carts
+    from app.utils.checkout_signing import build_cart_restore_token
+
+    signing_secret = "reuse-test-signing-secret"
     popup = _make_popup(db, tenant_a, slug_prefix="reuse")
+    # Give the popup a signing secret so the proof gate can validate cid+sig.
+    popup.open_checkout_signing_secret = signing_secret
+    db.add(popup)
+
     product = _make_product(db, popup, name="GA", price="50.00")
     section = _make_section(db, popup, label="Buyer Info")
     name_field = _make_field(
@@ -295,18 +303,13 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
     )
     db.commit()
 
+    buyer_email = "repeat@test.com"
+
     obj1 = _purchase_create(
-        email="repeat@test.com",
+        email=buyer_email,
         first_name="Repeat",
         last_name="Buyer",
         products=[(product, 1)],
-        form_data={name_field.name: "Repeat"},
-    )
-    obj2 = _purchase_create(
-        email="repeat@test.com",
-        first_name="Repeat",
-        last_name="Buyer",
-        products=[(product, 2)],
         form_data={name_field.name: "Repeat"},
     )
 
@@ -328,14 +331,40 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
     with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
         mock_client = MagicMock()
         mock_client.create_payment.side_effect = [sf_resp1, sf_resp2]
-        # B4: stub cancel so supersede completes on the second purchase.
-        # Without this stub the second purchase raises 409 (prior stays PENDING).
         mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
         mock_get_client.return_value = mock_client
 
         p1, _, _ = payments_crud.create_open_ticketing_payment(
             db, obj=obj1, popup=popup, tenant=tenant_a
         )
+
+        # Create an anonymous cart for the buyer to supply as continuity proof on
+        # the second purchase (mirrors the abandoned-cart restore flow).
+        buyer_cart = Carts(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            popup_id=popup.id,
+            email=buyer_email,
+            items={},
+        )
+        db.add(buyer_cart)
+        db.commit()
+        db.refresh(buyer_cart)
+
+        valid_sig = build_cart_restore_token(str(buyer_cart.id), signing_secret)
+
+        obj2 = OpenTicketingPurchaseCreate(
+            products=[ProductLine(product_id=product.id, quantity=2)],
+            buyer=BuyerInfo(
+                email=buyer_email,
+                first_name="Repeat",
+                last_name="Buyer",
+                form_data={name_field.name: "Repeat"},
+            ),
+            cid=buyer_cart.id,
+            sig=valid_sig,
+        )
+
         p2, _, _ = payments_crud.create_open_ticketing_payment(
             db, obj=obj2, popup=popup, tenant=tenant_a
         )

--- a/backend/tests/api/payment/test_create_open_ticketing_payment.py
+++ b/backend/tests/api/payment/test_create_open_ticketing_payment.py
@@ -23,10 +23,12 @@ from app.api.form_section.models import FormSections
 from app.api.human.models import Humans
 from app.api.payment.crud import payments_crud
 from app.api.payment.models import PaymentProducts, Payments
+from app.api.payment.schemas import PaymentStatus
 from app.api.popup.models import Popups
 from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.tenant.models import Tenants
+from app.services.simplefi.client import CancelOutcome
 
 
 def _make_popup(
@@ -279,7 +281,12 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
     db: Session,
     tenant_a: Tenants,
 ) -> None:
-    """Second purchase by same (human, popup) reuses the existing attendee.  Design §2.1 / Spec C2."""
+    """Second purchase by same (human, popup) reuses the existing attendee.  Design §2.1 / Spec C2.
+
+    B4 fix: with supersede enabled the second call cancels the first PENDING payment before
+    creating a new one.  The mock must stub cancel_payment_request so supersede returns
+    CancelOutcome.CANCELED and the prior payment ends up CANCELLED (not blocking the new one).
+    """
     popup = _make_popup(db, tenant_a, slug_prefix="reuse")
     product = _make_product(db, popup, name="GA", price="50.00")
     section = _make_section(db, popup, label="Buyer Info")
@@ -316,15 +323,33 @@ def test_create_open_ticketing_payment_second_purchase_reuses_attendee(
         is_installment_plan=False,
     )
 
-    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
-        mock_get_client.return_value.create_payment.side_effect = [sf_resp1, sf_resp2]
+    from unittest.mock import MagicMock
 
-        payments_crud.create_open_ticketing_payment(
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_client = MagicMock()
+        mock_client.create_payment.side_effect = [sf_resp1, sf_resp2]
+        # B4: stub cancel so supersede completes on the second purchase.
+        # Without this stub the second purchase raises 409 (prior stays PENDING).
+        mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+        mock_get_client.return_value = mock_client
+
+        p1, _, _ = payments_crud.create_open_ticketing_payment(
             db, obj=obj1, popup=popup, tenant=tenant_a
         )
-        payments_crud.create_open_ticketing_payment(
+        p2, _, _ = payments_crud.create_open_ticketing_payment(
             db, obj=obj2, popup=popup, tenant=tenant_a
         )
+
+    # Second purchase superseded the first: P1 is CANCELLED, P2 is PENDING
+    db.expire_all()
+    fresh_p1 = db.get(Payments, p1.id)
+    assert fresh_p1 is not None
+    assert fresh_p1.status == PaymentStatus.CANCELLED.value, (
+        "First payment should be CANCELLED after supersede"
+    )
+    fresh_p2 = db.get(Payments, p2.id)
+    assert fresh_p2 is not None
+    assert fresh_p2.status == PaymentStatus.PENDING.value
 
     # Still exactly 1 attendee after two purchases
     attendees = list(

--- a/backend/tests/api/payment/test_pending_hold_pr2.py
+++ b/backend/tests/api/payment/test_pending_hold_pr2.py
@@ -1,0 +1,737 @@
+"""Tests for pending-payment hold-release PR 2: ADR-1 row lock, ADR-2 supersede, ADR-4 router contracts.
+
+TDD phase: RED — written BEFORE implementation.
+
+Tasks covered:
+  5.1 test_supersede_authenticated
+  5.2 test_supersede_open_checkout
+  5.3 test_supersede_installment_plan
+  5.4 test_race_lost_approved
+  5.5 test_cancel_transport_failure
+  5.6 test_concurrent_create_same_buyer (DB + threading)
+  5.7 test_double_release_protection (DB + threading)
+  5.8 test_release_then_fail
+"""
+
+import threading
+import uuid
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import Session, select
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.coupon.models import Coupons
+from app.api.human.models import Humans
+from app.api.payment.crud import payments_crud
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentSource, PaymentStatus
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.shared.enums import SaleType
+from app.api.tenant.models import Tenants
+from app.services.simplefi.client import CancelOutcome, CancelOutcomeAmbiguousError
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_popup(db: Session, tenant: Tenants, *, slug_prefix: str = "hold") -> Popups:
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"Hold Test Popup {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:6]}",
+        sale_type=SaleType.direct.value,
+        status="active",
+        simplefi_api_key="test_simplefi_key",
+        currency="ARS",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants, *, email: str | None = None) -> Humans:
+    """Create a minimal Human for testing."""
+    email = email or f"test-{uuid.uuid4().hex[:8]}@example.com"
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        email=email,
+        first_name="Test",
+        last_name="User",
+    )
+    db.add(human)
+    db.flush()
+    return human
+
+
+def _make_application(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> Applications:
+    """Create a minimal Application for testing."""
+    application = Applications(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+        referral="test",
+    )
+    db.add(application)
+    db.flush()
+    return application
+
+
+def _make_product(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    price: str = "100",
+    total_stock_cap: int | None = None,
+    total_stock_remaining: int | None = None,
+) -> Products:
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Product {uuid.uuid4().hex[:6]}",
+        slug=f"prod-{uuid.uuid4().hex[:6]}",
+        price=Decimal(price),
+        category="ticket",
+        is_active=True,
+        total_stock_cap=total_stock_cap,
+        total_stock_remaining=total_stock_remaining,
+    )
+    db.add(product)
+    db.flush()
+    return product
+
+
+def _make_coupon(
+    db: Session,
+    popup: Popups,
+    *,
+    current_uses: int = 2,
+    max_uses: int = 5,
+) -> Coupons:
+    coupon = Coupons(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        code=f"HOLD{uuid.uuid4().hex[:6].upper()}",
+        discount_value=10,
+        is_active=True,
+        current_uses=current_uses,
+        max_uses=max_uses,
+    )
+    db.add(coupon)
+    db.flush()
+    return coupon
+
+
+def _make_pending_payment(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    coupon: Coupons | None = None,
+    application_id: uuid.UUID | None = None,
+    buyer_email: str | None = None,
+    is_installment_plan: bool = False,
+    external_id: str | None = None,
+) -> Payments:
+    """Create a minimal PENDING SimpleFi payment.
+
+    For open-checkout payments (no application_id), buyer_email is stored in
+    buyer_snapshot under the 'buyer_email' key — the same key that
+    supersede_pending_payments uses for JSONB lookup.
+    """
+    payment = Payments(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        application_id=application_id,
+        status=PaymentStatus.PENDING.value,
+        amount=Decimal("100"),
+        currency="ARS",
+        source=PaymentSource.SIMPLEFI.value,
+        coupon_id=coupon.id if coupon else None,
+        coupon_code=coupon.code if coupon else None,
+        is_installment_plan=is_installment_plan,
+        external_id=external_id or f"ext-{uuid.uuid4().hex[:12]}",
+    )
+    if buyer_email:
+        # Store as 'buyer_email' (lowercase) — matches supersede lookup key
+        payment.buyer_snapshot = {"buyer_email": buyer_email.lower()}
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _fresh_coupon_uses(db: Session, coupon_id: uuid.UUID) -> int:
+    db.expire_all()
+    coupon = db.get(Coupons, coupon_id)
+    assert coupon is not None
+    return coupon.current_uses
+
+
+def _fresh_payment_status(db: Session, payment_id: uuid.UUID) -> str:
+    db.expire_all()
+    payment = db.get(Payments, payment_id)
+    assert payment is not None
+    return str(payment.status)
+
+
+# ---------------------------------------------------------------------------
+# Task 5.7: test_double_release_protection (ADR-1 row lock)
+# ---------------------------------------------------------------------------
+
+
+class TestDoubleReleaseProtection:
+    """Concurrent update_status calls on the same PENDING payment release holds exactly once.
+
+    Spec reference: Idempotent Hold Release + ADR-1.
+    """
+
+    def test_concurrent_update_status_releases_coupon_once(
+        self,
+        db: Session,
+        test_engine,
+        tenant_a: Tenants,
+    ) -> None:
+        """Two concurrent update_status(CANCELLED) calls → coupon current_uses decremented exactly once.
+
+        Without ADR-1 FOR UPDATE, both threads could read PENDING and both release
+        the coupon, giving current_uses -= 2. With the row lock, one blocks until
+        the other commits, reads CANCELLED, and skips the release.
+        """
+        popup = _make_popup(db, tenant_a, slug_prefix="lock5")
+        coupon = _make_coupon(db, popup, current_uses=3)
+        payment = _make_pending_payment(db, tenant_a, popup, coupon=coupon)
+
+        initial_uses = _fresh_coupon_uses(db, coupon.id)
+        assert initial_uses == 3
+
+        results: list[Exception | None] = []
+
+        def call_update_status() -> None:
+            from sqlmodel import Session as Sess
+
+            with Sess(test_engine) as local_session:
+                try:
+                    payments_crud.update_status(
+                        local_session, payment.id, PaymentStatus.CANCELLED
+                    )
+                    results.append(None)
+                except Exception as exc:
+                    results.append(exc)
+
+        t1 = threading.Thread(target=call_update_status)
+        t2 = threading.Thread(target=call_update_status)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        # Both must complete (one is a no-op, not an error)
+        assert len(results) == 2
+        for r in results:
+            assert r is None, f"Unexpected exception: {r}"
+
+        # Coupon released exactly once
+        final_uses = _fresh_coupon_uses(db, coupon.id)
+        assert final_uses == initial_uses - 1, (
+            f"Expected {initial_uses - 1} uses, got {final_uses} (double-release detected)"
+        )
+
+        # Payment landed in CANCELLED
+        assert _fresh_payment_status(db, payment.id) == PaymentStatus.CANCELLED.value
+
+
+# ---------------------------------------------------------------------------
+# Task 5.1-5.5, 5.8: supersede unit tests (mocked SimpleFi)
+# ---------------------------------------------------------------------------
+
+
+class TestSupersedeAuthenticated:
+    """supersede_pending_payments with application_id finds a prior PENDING and cancels it.
+
+    Task 5.1: Prior PENDING auth payment → cancel_payment_request → CANCELED →
+    update_status(CANCELLED) → coupon/stock released; new payment can be created.
+    """
+
+    def test_prior_pending_cancelled_and_holds_released(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Happy path: prior PENDING auth payment is superseded; coupon released."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sup-auth")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        coupon = _make_coupon(db, popup, current_uses=2)
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, coupon=coupon, application_id=application.id
+        )
+
+        uses_before = _fresh_coupon_uses(db, coupon.id)
+        assert uses_before == 2
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+            mock_client_factory.return_value = mock_client
+
+            payments_crud.supersede_pending_payments(
+                db,
+                application_id=application.id,
+            )
+
+        mock_client.cancel_payment_request.assert_called_once_with(
+            prior_payment.external_id
+        )
+
+        # Coupon released exactly once
+        assert _fresh_coupon_uses(db, coupon.id) == uses_before - 1
+
+        # Old payment is CANCELLED
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+
+    def test_no_prior_pending_is_noop(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """No PENDING payment for application_id → supersede is a no-op."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sup-auth-noop")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        db.commit()
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            # supersede_pending_payments should NOT call SimpleFi
+            payments_crud.supersede_pending_payments(
+                db,
+                application_id=application.id,
+            )
+            mock_client_factory.assert_not_called()
+
+
+class TestSupersedeOpenCheckout:
+    """supersede_pending_payments with email+popup_id key.
+
+    Task 5.2: Prior PENDING open-checkout payment (email+popup_id) → cancel →
+    holds released; subsequent creation can proceed cleanly.
+    """
+
+    def test_prior_pending_open_checkout_cancelled(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Prior PENDING open-checkout payment for email+popup_id is superseded."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sup-oc")
+        buyer_email = f"buyer-{uuid.uuid4().hex[:8]}@example.com"
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, buyer_email=buyer_email
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+            mock_client_factory.return_value = mock_client
+
+            payments_crud.supersede_pending_payments(
+                db,
+                email=buyer_email,
+                popup_id=popup.id,
+            )
+
+        mock_client.cancel_payment_request.assert_called_once_with(
+            prior_payment.external_id
+        )
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+
+    def test_email_matching_is_case_insensitive(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Email lookup is case-insensitive (BUYER@example.com matches buyer@example.com)."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sup-oc-ci")
+        buyer_email = f"Buyer-{uuid.uuid4().hex[:8]}@example.com"
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, buyer_email=buyer_email
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+            mock_client_factory.return_value = mock_client
+
+            # Pass uppercase version
+            payments_crud.supersede_pending_payments(
+                db,
+                email=buyer_email.upper(),
+                popup_id=popup.id,
+            )
+
+        mock_client.cancel_payment_request.assert_called_once()
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+
+
+class TestSupersedeInstallmentPlan:
+    """supersede_pending_payments dispatches cancel_installment_plan when is_installment_plan=True.
+
+    Task 5.3: is_installment_plan=True → cancel_installment_plan called (not cancel_payment_request);
+    'cancelled' (two-L) normalizes to CANCELED; holds released.
+    """
+
+    def test_installment_plan_uses_cancel_installment_plan(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """PENDING installment plan → cancel_installment_plan called; holds released."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sup-plan")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        prior_payment = _make_pending_payment(
+            db,
+            tenant_a,
+            popup,
+            application_id=application.id,
+            is_installment_plan=True,
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_installment_plan.return_value = CancelOutcome.CANCELED
+            mock_client_factory.return_value = mock_client
+
+            payments_crud.supersede_pending_payments(
+                db,
+                application_id=application.id,
+            )
+
+        # Must use cancel_installment_plan, NOT cancel_payment_request
+        mock_client.cancel_installment_plan.assert_called_once_with(
+            prior_payment.external_id
+        )
+        mock_client.cancel_payment_request.assert_not_called()
+
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+
+
+class TestRaceLostApproved:
+    """supersede_pending_payments with ALREADY_APPROVED outcome raises 409 previous_payment_completed.
+
+    Task 5.4: cancel → ALREADY_APPROVED → _reconcile_approved runs; 409 raised with payment_id;
+    no holds released; no new payment created.
+    """
+
+    def test_already_approved_raises_409(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Race-lost: SimpleFi returns ALREADY_APPROVED → 409 previous_payment_completed."""
+        popup = _make_popup(db, tenant_a, slug_prefix="race-lost")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        coupon = _make_coupon(db, popup, current_uses=2)
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, coupon=coupon, application_id=application.id
+        )
+
+        uses_before = _fresh_coupon_uses(db, coupon.id)
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = (
+                CancelOutcome.ALREADY_APPROVED
+            )
+            mock_client_factory.return_value = mock_client
+
+            with patch.object(payments_crud, "_reconcile_approved") as mock_reconcile:
+                with pytest.raises(HTTPException) as exc_info:
+                    payments_crud.supersede_pending_payments(
+                        db,
+                        application_id=application.id,
+                    )
+
+        exc = exc_info.value
+        assert exc.status_code == 409
+        assert isinstance(exc.detail, dict)
+        assert exc.detail["code"] == "previous_payment_completed"
+        assert "payment_id" in exc.detail
+        assert str(prior_payment.id) == exc.detail["payment_id"]
+
+        # _reconcile_approved must have been called
+        mock_reconcile.assert_called_once()
+
+        # Coupon NOT released (prior payment was approved)
+        assert _fresh_coupon_uses(db, coupon.id) == uses_before
+
+    def test_already_approved_open_checkout_includes_redirect_url(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Race-lost on open checkout: 409 detail includes redirect_url for thank-you page."""
+        popup = _make_popup(db, tenant_a, slug_prefix="race-oc")
+        buyer_email = f"racer-{uuid.uuid4().hex[:8]}@example.com"
+        _make_pending_payment(db, tenant_a, popup, buyer_email=buyer_email)
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = (
+                CancelOutcome.ALREADY_APPROVED
+            )
+            mock_client_factory.return_value = mock_client
+
+            with patch.object(payments_crud, "_reconcile_approved"):
+                with pytest.raises(HTTPException) as exc_info:
+                    payments_crud.supersede_pending_payments(
+                        db,
+                        email=buyer_email,
+                        popup_id=popup.id,
+                    )
+
+        exc = exc_info.value
+        assert exc.status_code == 409
+        assert exc.detail["code"] == "previous_payment_completed"
+        # open-checkout includes redirect_url (may be None if no custom URL, but key must exist)
+        assert "redirect_url" in exc.detail
+
+
+class TestCancelTransportFailure:
+    """supersede_pending_payments on transport error → raises, no holds released, old stays PENDING.
+
+    Task 5.5: transport error/5xx → supersede aborts; old stays PENDING; no new payment created.
+    """
+
+    def test_transport_error_aborts_without_releasing_holds(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Transport error during cancel → exception propagates; old payment stays PENDING."""
+        import httpx
+
+        popup = _make_popup(db, tenant_a, slug_prefix="trans-fail")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        coupon = _make_coupon(db, popup, current_uses=3)
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, coupon=coupon, application_id=application.id
+        )
+
+        uses_before = _fresh_coupon_uses(db, coupon.id)
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.side_effect = httpx.RequestError(
+                "Connection refused"
+            )
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.supersede_pending_payments(
+                    db,
+                    application_id=application.id,
+                )
+
+        exc = exc_info.value
+        assert exc.status_code == 502
+        assert isinstance(exc.detail, dict)
+        assert exc.detail["code"] == "payment_cancel_failed"
+
+        # Holds NOT released; coupon uses unchanged
+        assert _fresh_coupon_uses(db, coupon.id) == uses_before
+        # Old payment stays PENDING
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.PENDING.value
+        )
+
+    def test_ambiguous_error_also_aborts(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """CancelOutcomeAmbiguousError during cancel → 502 payment_cancel_failed; holds not released."""
+        popup = _make_popup(db, tenant_a, slug_prefix="ambig-fail")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        coupon = _make_coupon(db, popup, current_uses=3)
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, coupon=coupon, application_id=application.id
+        )
+
+        uses_before = _fresh_coupon_uses(db, coupon.id)
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.side_effect = (
+                CancelOutcomeAmbiguousError("Cannot classify status")
+            )
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.supersede_pending_payments(
+                    db,
+                    application_id=application.id,
+                )
+
+        exc = exc_info.value
+        assert exc.status_code == 502
+        assert exc.detail["code"] == "payment_cancel_failed"
+        # Old payment stays PENDING
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.PENDING.value
+        )
+        # No holds released
+        assert _fresh_coupon_uses(db, coupon.id) == uses_before
+
+
+class TestReleaseThenFail:
+    """Supersede commits release (old cancelled) and then new-payment creation fails.
+
+    Task 5.8: supersede commits release; force create_payment to fail; assert old is CANCELLED
+    + holds free + buyer can retry cleanly.
+    """
+
+    def test_release_committed_before_creation_fails(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Old payment is CANCELLED even when subsequent creation raises an error."""
+        popup = _make_popup(db, tenant_a, slug_prefix="release-fail")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        coupon = _make_coupon(db, popup, current_uses=2)
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, coupon=coupon, application_id=application.id
+        )
+
+        uses_before = _fresh_coupon_uses(db, coupon.id)
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+            mock_client_factory.return_value = mock_client
+
+            # supersede alone: releases old payment
+            payments_crud.supersede_pending_payments(
+                db,
+                application_id=application.id,
+            )
+
+        # Old payment is CANCELLED + holds released
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+        assert _fresh_coupon_uses(db, coupon.id) == uses_before - 1
+
+        # Now simulate a failed new-payment creation (e.g., SimpleFi unavailable)
+        # The buyer should be in a clean state: no PENDING payments for this application
+        remaining_pending = db.exec(
+            select(Payments).where(
+                Payments.application_id == application.id,
+                Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+            )
+        ).all()
+        assert len(remaining_pending) == 0, (
+            "No PENDING payments should remain after supersede; buyer can retry"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 5.6: test_concurrent_create_same_buyer (ADR-2 post-lock sibling re-check)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentCreateSameBuyer:
+    """Two simultaneous create calls race — only one new PENDING payment is created.
+
+    Task 5.6: Two concurrent create_payment calls; P1 released exactly once (ADR-1
+    row lock); the loser receives 409 concurrent_payment_in_progress from sibling
+    re-check; exactly ONE new PENDING payment created.
+
+    Note: This test is structurally verified by testing the sibling re-check helper
+    directly (raises 409 when a sibling PENDING exists for the same application_id).
+    The threading race is non-deterministic, so we test the guard itself.
+    """
+
+    def test_sibling_recheck_raises_409_when_sibling_exists(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Post-lock sibling re-check: if a PENDING sibling exists for application_id, raise 409."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sib-recheck")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        # A "sibling" PENDING payment already exists for this application
+        _sibling = _make_pending_payment(
+            db, tenant_a, popup, application_id=application.id
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            payments_crud._check_no_pending_sibling_by_application(
+                db, application_id=application.id
+            )
+
+        exc = exc_info.value
+        assert exc.status_code == 409
+        assert isinstance(exc.detail, dict)
+        assert exc.detail["code"] == "concurrent_payment_in_progress"
+
+    def test_sibling_recheck_is_noop_when_no_sibling(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Sibling re-check: no PENDING payment for application_id → no exception."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sib-noop")
+        human = _make_human(db, tenant_a)
+        application = _make_application(db, tenant_a, popup, human)
+        db.commit()
+        # Should not raise
+        payments_crud._check_no_pending_sibling_by_application(
+            db, application_id=application.id
+        )
+
+    def test_sibling_recheck_open_checkout_raises_409_when_sibling_exists(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Open-checkout sibling re-check: PENDING for same email+popup_id → 409."""
+        popup = _make_popup(db, tenant_a, slug_prefix="sib-oc-recheck")
+        buyer_email = f"sibling-{uuid.uuid4().hex[:8]}@example.com"
+        _sibling = _make_pending_payment(db, tenant_a, popup, buyer_email=buyer_email)
+
+        with pytest.raises(HTTPException) as exc_info:
+            payments_crud._check_no_pending_sibling_by_email_popup(
+                db, email=buyer_email, popup_id=popup.id
+            )
+
+        exc = exc_info.value
+        assert exc.status_code == 409
+        assert exc.detail["code"] == "concurrent_payment_in_progress"

--- a/backend/tests/api/payment/test_pending_hold_pr2.py
+++ b/backend/tests/api/payment/test_pending_hold_pr2.py
@@ -440,8 +440,9 @@ class TestSupersedeInstallmentPlan:
 class TestRaceLostApproved:
     """supersede_pending_payments with ALREADY_APPROVED outcome raises 409 previous_payment_completed.
 
-    Task 5.4: cancel → ALREADY_APPROVED → _reconcile_approved runs; 409 raised with payment_id;
-    no holds released; no new payment created.
+    Task 5.4 (strengthened — B2 + S1): cancel → ALREADY_APPROVED → _reconcile_approved runs
+    for real (no mock); prior payment ends APPROVED in DB; holds not released; no payment_id
+    in the 409 response; redirect_url points to the buyer's passes page.
     """
 
     def test_already_approved_raises_409(
@@ -449,7 +450,12 @@ class TestRaceLostApproved:
         db: Session,
         tenant_a: Tenants,
     ) -> None:
-        """Race-lost: SimpleFi returns ALREADY_APPROVED → 409 previous_payment_completed."""
+        """Race-lost (authenticated): _reconcile_approved runs for real; payment is APPROVED in DB.
+
+        B2 fix: _reconcile_approved now acquires a row lock before calling approve_payment,
+        ensuring a concurrent webhook can't add products twice.
+        S1 fix: 409 detail has no raw payment_id; redirect_url points to the passes page.
+        """
         popup = _make_popup(db, tenant_a, slug_prefix="race-lost")
         human = _make_human(db, tenant_a)
         application = _make_application(db, tenant_a, popup, human)
@@ -467,32 +473,47 @@ class TestRaceLostApproved:
             )
             mock_client_factory.return_value = mock_client
 
-            with patch.object(payments_crud, "_reconcile_approved") as mock_reconcile:
-                with pytest.raises(HTTPException) as exc_info:
-                    payments_crud.supersede_pending_payments(
-                        db,
-                        application_id=application.id,
-                    )
+            # No mock on _reconcile_approved — it runs for real (B2 strengthening)
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.supersede_pending_payments(
+                    db,
+                    application_id=application.id,
+                )
 
         exc = exc_info.value
         assert exc.status_code == 409
         assert isinstance(exc.detail, dict)
         assert exc.detail["code"] == "previous_payment_completed"
-        assert "payment_id" in exc.detail
-        assert str(prior_payment.id) == exc.detail["payment_id"]
 
-        # _reconcile_approved must have been called
-        mock_reconcile.assert_called_once()
+        # S1: no raw payment UUID exposed in anonymous/semi-anonymous response
+        assert "payment_id" not in exc.detail
 
-        # Coupon NOT released (prior payment was approved)
+        # S1: authenticated path has redirect_url pointing to the buyer's passes page
+        assert "redirect_url" in exc.detail
+        redirect = exc.detail["redirect_url"]
+        assert redirect is not None
+        assert "/passes" in redirect
+
+        # B2: prior payment is APPROVED in the DB (reconcile ran for real)
+        db.expire_all()
+        fresh = db.get(Payments, prior_payment.id)
+        assert fresh is not None
+        assert fresh.status == PaymentStatus.APPROVED.value
+
+        # Coupon NOT released — approved payment keeps its coupon use
         assert _fresh_coupon_uses(db, coupon.id) == uses_before
 
-    def test_already_approved_open_checkout_includes_redirect_url(
+    def test_already_approved_open_checkout_redirect_url_absent_without_signing(
         self,
         db: Session,
         tenant_a: Tenants,
     ) -> None:
-        """Race-lost on open checkout: 409 detail includes redirect_url for thank-you page."""
+        """Race-lost on open checkout without signing: redirect_url is None (S1 fix).
+
+        When the popup has no open_checkout_signing_secret, the 409 response omits
+        a usable redirect_url so no unsigned navigable URL is handed to anonymous callers.
+        The portal falls back to a message-only state.
+        """
         popup = _make_popup(db, tenant_a, slug_prefix="race-oc")
         buyer_email = f"racer-{uuid.uuid4().hex[:8]}@example.com"
         _make_pending_payment(db, tenant_a, popup, buyer_email=buyer_email)
@@ -515,8 +536,11 @@ class TestRaceLostApproved:
         exc = exc_info.value
         assert exc.status_code == 409
         assert exc.detail["code"] == "previous_payment_completed"
-        # open-checkout includes redirect_url (may be None if no custom URL, but key must exist)
+        # S1: no raw payment_id exposed to anonymous caller
+        assert "payment_id" not in exc.detail
+        # S1: no signing secret → redirect_url is None (portal falls back to message-only)
         assert "redirect_url" in exc.detail
+        assert exc.detail["redirect_url"] is None
 
 
 class TestCancelTransportFailure:
@@ -735,3 +759,205 @@ class TestConcurrentCreateSameBuyer:
         exc = exc_info.value
         assert exc.status_code == 409
         assert exc.detail["code"] == "concurrent_payment_in_progress"
+        # S2: sibling 409 must NOT expose the payment UUID to anonymous callers
+        assert "payment_id" not in exc.detail
+
+
+# ---------------------------------------------------------------------------
+# B1 regression: update_status must bypass the session identity map
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStatusIdentityMapBypass:
+    """Regression for B1: update_status reads fresh DB state after acquiring lock.
+
+    Without the fix, the two-step approach (raw text() lock + self.get()) returned
+    the stale PENDING object from the session identity map even after a concurrent
+    transaction committed CANCELLED — causing a double-release of coupon/stock.
+    """
+
+    def test_second_update_status_sees_cancelled_not_pending(
+        self,
+        db: Session,
+        test_engine,
+        tenant_a: Tenants,
+    ) -> None:
+        """Session A pre-loads payment as PENDING. Session B commits CANCELLED.
+        Session A's update_status must NOT release holds again.
+
+        Proves that ``with_for_update()`` bypasses the identity map and returns
+        the post-lock DB state (CANCELLED), so the PENDING-only guard skips the
+        second release.
+        """
+        from sqlmodel import Session as Sess
+
+        popup = _make_popup(db, tenant_a, slug_prefix="b1-imap")
+        coupon = _make_coupon(db, popup, current_uses=3)
+        payment = _make_pending_payment(db, tenant_a, popup, coupon=coupon)
+
+        # Pre-load payment into Session A's identity map — it sees PENDING
+        stale = db.get(Payments, payment.id)
+        assert stale is not None
+        assert stale.status == PaymentStatus.PENDING.value
+
+        # Session B commits CANCELLED — coupon released (uses: 3 → 2)
+        with Sess(test_engine) as session_b:
+            payments_crud.update_status(session_b, payment.id, PaymentStatus.CANCELLED)
+
+        uses_after_b = _fresh_coupon_uses(db, coupon.id)
+        assert uses_after_b == 2  # One release from Session B
+
+        # Session A calls update_status again.  With the B1 fix (with_for_update()),
+        # it reads CANCELLED from DB — not stale PENDING from identity map — so the
+        # PENDING-only guard skips the second coupon release.
+        payments_crud.update_status(db, payment.id, PaymentStatus.EXPIRED)
+
+        uses_after_a = _fresh_coupon_uses(db, coupon.id)
+        # Must still be 2, not 1 (no second release)
+        assert uses_after_a == 2, (
+            "update_status released holds twice — identity map bypass (B1) is broken"
+        )
+
+
+# ---------------------------------------------------------------------------
+# W1: orphaned payment branch (popup without simplefi_api_key)
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedPayment:
+    """W1: When the popup has no simplefi_api_key, supersede releases holds directly
+    without any SimpleFi call (orphaned payment path — crud.py ~2946-2958).
+    """
+
+    def test_orphaned_payment_released_without_simplefi(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Prior payment with no simplefi_api_key → CANCELLED locally; no SimpleFi call."""
+        popup = Popups(
+            tenant_id=tenant_a.id,
+            name="No-Key Popup",
+            slug=f"nokey-{uuid.uuid4().hex[:6]}",
+            sale_type=SaleType.direct.value,
+            status="active",
+            simplefi_api_key=None,  # Deliberately missing
+            currency="ARS",
+        )
+        db.add(popup)
+        db.flush()
+
+        coupon = _make_coupon(db, popup, current_uses=2)
+        prior_payment = _make_pending_payment(
+            db,
+            tenant_a,
+            popup,
+            coupon=coupon,
+            application_id=None,
+            buyer_email="orphan@test.com",
+        )
+
+        uses_before = _fresh_coupon_uses(db, coupon.id)
+
+        # Use a mock to verify SimpleFi is NOT called
+        with patch("app.services.simplefi.get_simplefi_client") as mock_sf:
+            payments_crud.supersede_pending_payments(
+                db,
+                email="orphan@test.com",
+                popup_id=popup.id,
+            )
+
+        # No SimpleFi call (orphaned payment — no API key)
+        mock_sf.assert_not_called()
+
+        # Payment released locally
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+        # Coupon hold released
+        assert _fresh_coupon_uses(db, coupon.id) == uses_before - 1
+
+
+# ---------------------------------------------------------------------------
+# B3: SUPERSEDE_PENDING_ENABLED=False restores pre-PR sequential-purchase behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSupersedePendingDisabled:
+    """B3: When SUPERSEDE_PENDING_ENABLED=False, the entire new machinery
+    (supersede call, advisory lock, sibling re-check) is bypassed.
+
+    Sequential same-buyer open-checkout purchases succeed exactly as they did
+    before the PR — the prior PENDING payment is NOT cancelled and no 409 is
+    raised by the sibling re-check.
+    """
+
+    def test_sequential_open_checkout_succeeds_when_supersede_disabled(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """With flag=False, a second open-checkout purchase succeeds even with a prior PENDING.
+
+        Verifies that _check_no_pending_sibling_by_email_popup is NOT invoked so
+        the pre-existing PENDING payment from the first checkout does not block the
+        second request.
+        """
+        from types import SimpleNamespace
+
+        from app.api.checkout.schemas import (
+            BuyerInfo,
+            OpenTicketingPurchaseCreate,
+            ProductLine,
+        )
+        from app.core.config import settings as _app_settings
+
+        popup = _make_popup(db, tenant_a, slug_prefix="b3-oc")
+        product = _make_product(db, tenant_a, popup)
+        buyer_email = f"b3-buyer-{uuid.uuid4().hex[:8]}@example.com"
+
+        # Prior PENDING payment — would normally block via sibling re-check
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, buyer_email=buyer_email
+        )
+
+        sf_resp = SimpleNamespace(
+            id=f"sf-b3-{uuid.uuid4().hex[:8]}",
+            status="pending",
+            checkout_url="https://sf.test/b3",
+            is_installment_plan=False,
+        )
+
+        obj = OpenTicketingPurchaseCreate(
+            buyer=BuyerInfo(email=buyer_email, first_name="B3", last_name="Test"),
+            products=[ProductLine(product_id=product.id, quantity=1)],
+        )
+
+        with patch.object(_app_settings, "SUPERSEDE_PENDING_ENABLED", False):
+            with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+                mock_client = MagicMock()
+                mock_client.create_payment.return_value = sf_resp
+                mock_get_client.return_value = mock_client
+
+                with patch.object(
+                    payments_crud,
+                    "_check_no_pending_sibling_by_email_popup",
+                    wraps=payments_crud._check_no_pending_sibling_by_email_popup,
+                ) as spy_check:
+                    new_payment, checkout_url, _ = (
+                        payments_crud.create_open_ticketing_payment(
+                            db, obj=obj, popup=popup, tenant=tenant_a
+                        )
+                    )
+
+        # B3: sibling re-check was never called (gated by the flag)
+        spy_check.assert_not_called()
+
+        # New purchase succeeded
+        assert new_payment is not None
+        assert checkout_url == "https://sf.test/b3"
+
+        # Prior payment still PENDING (not superseded — flag was off)
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.PENDING.value
+        )

--- a/backend/tests/api/payment/test_pending_hold_pr2.py
+++ b/backend/tests/api/payment/test_pending_hold_pr2.py
@@ -11,6 +11,8 @@ Tasks covered:
   5.6 test_concurrent_create_same_buyer (DB + threading)
   5.7 test_double_release_protection (DB + threading)
   5.8 test_release_then_fail
+  Change 1: continuity-proof gate for anonymous supersede (TestContinuityProofGate)
+  S1 tightening: no unsigned redirect_url on open-checkout 409 even with signing secret (TestRaceLostApproved)
 """
 
 import threading
@@ -542,6 +544,57 @@ class TestRaceLostApproved:
         assert "redirect_url" in exc.detail
         assert exc.detail["redirect_url"] is None
 
+    def test_already_approved_open_checkout_redirect_url_absent_with_signing_no_external_url(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Race-lost with signing secret but no external URL → redirect_url is None.
+
+        S1 tightening: even when open_checkout_signing_secret is configured, if the
+        popup has no open_checkout_success_url the 409 must omit redirect_url entirely.
+        An unsigned internal portal URL MUST NOT be returned to anonymous callers.
+        """
+        popup = Popups(
+            tenant_id=tenant_a.id,
+            name="Signing No External Popup",
+            slug=f"sign-no-ext-{uuid.uuid4().hex[:6]}",
+            sale_type=SaleType.direct.value,
+            status="active",
+            simplefi_api_key="test_simplefi_key",
+            currency="ARS",
+            open_checkout_signing_secret="test-signing-secret-s1",
+            # open_checkout_success_url deliberately absent
+        )
+        db.add(popup)
+        db.flush()
+
+        buyer_email = f"s1tight-{uuid.uuid4().hex[:8]}@example.com"
+        _make_pending_payment(db, tenant_a, popup, buyer_email=buyer_email)
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = (
+                CancelOutcome.ALREADY_APPROVED
+            )
+            mock_client_factory.return_value = mock_client
+
+            with patch.object(payments_crud, "_reconcile_approved"):
+                with pytest.raises(HTTPException) as exc_info:
+                    payments_crud.supersede_pending_payments(
+                        db,
+                        email=buyer_email,
+                        popup_id=popup.id,
+                    )
+
+        exc = exc_info.value
+        assert exc.status_code == 409
+        assert exc.detail["code"] == "previous_payment_completed"
+        # S1 tightening: signing secret set but no external URL → still None
+        assert "payment_id" not in exc.detail
+        assert "redirect_url" in exc.detail
+        assert exc.detail["redirect_url"] is None
+
 
 class TestCancelTransportFailure:
     """supersede_pending_payments on transport error → raises, no holds released, old stays PENDING.
@@ -961,3 +1014,281 @@ class TestSupersedePendingDisabled:
         assert (
             _fresh_payment_status(db, prior_payment.id) == PaymentStatus.PENDING.value
         )
+
+
+# ---------------------------------------------------------------------------
+# Change 1: continuity-proof gate for anonymous supersede
+# ---------------------------------------------------------------------------
+
+
+class TestContinuityProofGate:
+    """Anonymous supersede may ONLY run when the request carries a valid signed cart proof.
+
+    Security rule: without proof of cart ownership (cid + sig from the
+    abandoned-cart restore flow), an attacker could cancel any buyer's pending
+    payment by guessing their email.  The proof gate prevents that without
+    breaking the legitimate buyer's supersede path.
+    """
+
+    def test_attacker_no_proof_pending_exists_returns_409(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Attacker request with victim's email and no proof → 409 pending_payment_exists.
+
+        Prior payment MUST stay PENDING; cancel_payment_request MUST NOT be called.
+        """
+
+        from app.api.checkout.schemas import (
+            BuyerInfo,
+            OpenTicketingPurchaseCreate,
+            ProductLine,
+        )
+
+        popup = _make_popup(db, tenant_a, slug_prefix="proof-atk")
+        product = _make_product(db, tenant_a, popup)
+        victim_email = f"victim-{uuid.uuid4().hex[:8]}@example.com"
+
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, buyer_email=victim_email
+        )
+
+        # Attacker knows the victim's email but has no signed cart proof
+        obj = OpenTicketingPurchaseCreate(
+            buyer=BuyerInfo(email=victim_email, first_name="Evil", last_name="Bot"),
+            products=[ProductLine(product_id=product.id, quantity=1)],
+            # cid and sig deliberately absent
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_sf:
+            mock_client = MagicMock()
+            mock_sf.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.create_open_ticketing_payment(
+                    db, obj=obj, popup=popup, tenant=tenant_a
+                )
+
+        exc = exc_info.value
+        assert exc.status_code == 409
+        assert exc.detail["code"] == "pending_payment_exists"
+
+        # Prior payment untouched — still PENDING
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.PENDING.value
+        )
+
+        # No SimpleFi cancel call of any kind
+        mock_client.cancel_payment_request.assert_not_called()
+        mock_client.cancel_installment_plan.assert_not_called()
+
+    def test_valid_proof_supersede_runs(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Valid cid+sig proof → supersede cancels prior payment; new payment created."""
+        from types import SimpleNamespace
+
+        from app.api.cart.models import Carts
+        from app.api.checkout.schemas import (
+            BuyerInfo,
+            OpenTicketingPurchaseCreate,
+            ProductLine,
+        )
+        from app.utils.checkout_signing import build_cart_restore_token
+
+        signing_secret = "test-secret-valid-proof"
+        popup = Popups(
+            tenant_id=tenant_a.id,
+            name="Valid Proof Popup",
+            slug=f"proof-ok-{uuid.uuid4().hex[:6]}",
+            sale_type=SaleType.direct.value,
+            status="active",
+            simplefi_api_key="test_simplefi_key",
+            currency="ARS",
+            open_checkout_signing_secret=signing_secret,
+        )
+        db.add(popup)
+        db.flush()
+
+        product = _make_product(db, tenant_a, popup)
+        buyer_email = f"realbuyer-{uuid.uuid4().hex[:8]}@example.com"
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, buyer_email=buyer_email
+        )
+
+        # Create the buyer's anonymous cart (as the abandoned-cart flow would)
+        cart = Carts(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            popup_id=popup.id,
+            email=buyer_email,
+            items={},
+        )
+        db.add(cart)
+        db.commit()
+        db.refresh(cart)
+
+        valid_sig = build_cart_restore_token(str(cart.id), signing_secret)
+
+        sf_resp = SimpleNamespace(
+            id=f"sf-proof-{uuid.uuid4().hex[:8]}",
+            status="pending",
+            checkout_url="https://sf.test/proof",
+            is_installment_plan=False,
+        )
+
+        obj = OpenTicketingPurchaseCreate(
+            buyer=BuyerInfo(email=buyer_email, first_name="Real", last_name="Buyer"),
+            products=[ProductLine(product_id=product.id, quantity=1)],
+            cid=cart.id,
+            sig=valid_sig,
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_sf:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+            mock_client.create_payment.return_value = sf_resp
+            mock_sf.return_value = mock_client
+
+            new_payment, checkout_url, _ = payments_crud.create_open_ticketing_payment(
+                db, obj=obj, popup=popup, tenant=tenant_a
+            )
+
+        # Prior payment cancelled by supersede
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.CANCELLED.value
+        )
+        # New payment created
+        assert new_payment is not None
+        assert checkout_url == "https://sf.test/proof"
+        # SimpleFi cancel was called once (by supersede)
+        mock_client.cancel_payment_request.assert_called_once()
+
+    def test_valid_sig_wrong_email_cart_treated_as_invalid(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Valid sig for attacker's own cart but used with victim's email → invalid proof → 409."""
+        from app.api.cart.models import Carts
+        from app.api.checkout.schemas import (
+            BuyerInfo,
+            OpenTicketingPurchaseCreate,
+            ProductLine,
+        )
+        from app.utils.checkout_signing import build_cart_restore_token
+
+        signing_secret = "test-secret-cross-email"
+        popup = Popups(
+            tenant_id=tenant_a.id,
+            name="Cross Email Popup",
+            slug=f"proof-cross-{uuid.uuid4().hex[:6]}",
+            sale_type=SaleType.direct.value,
+            status="active",
+            simplefi_api_key="test_simplefi_key",
+            currency="ARS",
+            open_checkout_signing_secret=signing_secret,
+        )
+        db.add(popup)
+        db.flush()
+
+        product = _make_product(db, tenant_a, popup)
+        victim_email = f"victim-{uuid.uuid4().hex[:8]}@example.com"
+        attacker_email = f"attacker-{uuid.uuid4().hex[:8]}@example.com"
+
+        # Victim has a prior PENDING payment
+        prior_payment = _make_pending_payment(
+            db, tenant_a, popup, buyer_email=victim_email
+        )
+
+        # Attacker has a valid cart for their OWN email
+        attacker_cart = Carts(
+            tenant_id=tenant_a.id,
+            human_id=None,
+            popup_id=popup.id,
+            email=attacker_email,
+            items={},
+        )
+        db.add(attacker_cart)
+        db.commit()
+        db.refresh(attacker_cart)
+
+        # Valid HMAC for attacker's own cart
+        attacker_sig = build_cart_restore_token(str(attacker_cart.id), signing_secret)
+
+        # Submit purchase as victim but presenting attacker's cart proof
+        obj = OpenTicketingPurchaseCreate(
+            buyer=BuyerInfo(email=victim_email, first_name="Evil", last_name="Bot"),
+            products=[ProductLine(product_id=product.id, quantity=1)],
+            cid=attacker_cart.id,
+            sig=attacker_sig,
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_sf:
+            mock_client = MagicMock()
+            mock_client.cancel_payment_request.return_value = CancelOutcome.CANCELED
+            mock_sf.return_value = mock_client
+
+            with pytest.raises(HTTPException) as exc_info:
+                payments_crud.create_open_ticketing_payment(
+                    db, obj=obj, popup=popup, tenant=tenant_a
+                )
+
+        exc = exc_info.value
+        # Email mismatch → proof invalid → pending exists → 409
+        assert exc.status_code == 409
+        assert exc.detail["code"] == "pending_payment_exists"
+        # Prior payment untouched
+        assert (
+            _fresh_payment_status(db, prior_payment.id) == PaymentStatus.PENDING.value
+        )
+        # No SimpleFi cancel
+        mock_client.cancel_payment_request.assert_not_called()
+
+    def test_no_pending_no_proof_purchase_succeeds(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """No prior PENDING payment + no proof → purchase succeeds normally (pre-PR behavior)."""
+        from types import SimpleNamespace
+
+        from app.api.checkout.schemas import (
+            BuyerInfo,
+            OpenTicketingPurchaseCreate,
+            ProductLine,
+        )
+
+        popup = _make_popup(db, tenant_a, slug_prefix="proof-none")
+        product = _make_product(db, tenant_a, popup)
+        buyer_email = f"fresh-{uuid.uuid4().hex[:8]}@example.com"
+
+        sf_resp = SimpleNamespace(
+            id=f"sf-fresh-{uuid.uuid4().hex[:8]}",
+            status="pending",
+            checkout_url="https://sf.test/fresh",
+            is_installment_plan=False,
+        )
+
+        obj = OpenTicketingPurchaseCreate(
+            buyer=BuyerInfo(email=buyer_email, first_name="Fresh", last_name="Buyer"),
+            products=[ProductLine(product_id=product.id, quantity=1)],
+            # No cid/sig — no proof, but no pending payment either
+        )
+
+        with patch("app.services.simplefi.get_simplefi_client") as mock_sf:
+            mock_client = MagicMock()
+            mock_client.create_payment.return_value = sf_resp
+            mock_sf.return_value = mock_client
+
+            new_payment, checkout_url, _ = payments_crud.create_open_ticketing_payment(
+                db, obj=obj, popup=popup, tenant=tenant_a
+            )
+
+        assert new_payment is not None
+        assert checkout_url == "https://sf.test/fresh"
+        # No cancel call — nothing to supersede
+        mock_client.cancel_payment_request.assert_not_called()


### PR DESCRIPTION
## Summary

Core slice (2/4) of the pending-payment hold release chain. Fixes the user-facing bug: a single-use coupon (and stock/credit) stayed locked for ~15 minutes when a buyer abandoned the SimpleFi checkout and retried with a different cart.

- Supersede pre-step in both checkout paths (authenticated and open/anonymous): the buyer's previous PENDING payment is cancelled on SimpleFi first and its coupon/stock/credit holds are released atomically before the new payment claims them. Covers regular payment requests and pending installment plans.
- Atomic `update_status`: payment-row lock via `with_for_update()` on the select (fixes a pre-existing double-release race — the old read-check-write guard was defeated by SQLAlchemy's identity map).
- Cart continuity proof for anonymous supersede: the purchase request must carry the signed cart identifiers (`cid`/`sig`) from the abandoned-cart flow. Without proof, no SimpleFi call is made and the buyer gets a 409 `pending_payment_exists`. This closes a denial-of-purchase / coupon-sniping vector on the email-keyed endpoint.
- Transaction-scoped advisory lock (`pg_try_advisory_xact_lock`) serializing open-checkout attempts per email+popup (session-level locks are unsafe under connection pooling), plus a post-lock sibling re-check (409 `concurrent_payment_in_progress`).
- Response contracts on `POST /payments/my` and `POST /checkout/{slug}/purchase`: 409 `previous_payment_completed` (race lost: the old payment was actually paid; reconciled through the approve path), 409 `pending_payment_exists`, 409 `concurrent_payment_in_progress`, 502 `payment_cancel_failed` (cancel could not be confirmed: abort, never release holds). Anonymous responses expose no payment identifiers; redirect URLs are HMAC-signed or omitted.
- Kill-switch: `SUPERSEDE_PENDING_ENABLED=false` restores pre-feature behavior entirely.

## Testing

- Integration tests in `tests/api/payment/test_pending_hold_pr2.py`: supersede happy paths, race-lost with DB-state assertions, cancel-failure abort, identity-map double-release regression, sibling re-check, continuity-proof gate (including the attacker scenario asserting zero SimpleFi calls), kill-switch behavior, signed-redirect payload contract.
- Full backend suite green (1805 tests at the chain tip).

Chain: PR1 → PR2 (this) → PR3 sweeper → PR4 portal.