### PR TITLE
feat(payments): stale pending payment sweeper job

### DIFF
--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -3043,6 +3043,36 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 },
             )
 
+    def get_stale_pending_payments(
+        self,
+        session: Session,
+        threshold_minutes: int,
+        batch_size: int,
+    ) -> list["Payments"]:
+        """Return PENDING SimpleFi payments older than ``threshold_minutes``.
+
+        Query consumes the ``ix_payments_pending_queue`` partial index
+        (``WHERE status = 'pending'``) so the full payments table is never
+        scanned.  Results are ordered by ``created_at`` (oldest first) so
+        each batch makes progress and the same rows are not repeatedly skipped.
+
+        Used by the pending-payment sweeper (ADR-5).
+        """
+        threshold = datetime.now(UTC) - timedelta(minutes=threshold_minutes)
+        return list(
+            session.exec(
+                select(Payments)
+                .where(
+                    Payments.status == PaymentStatus.PENDING.value,  # type: ignore[arg-type]
+                    Payments.source == PaymentSource.SIMPLEFI.value,  # type: ignore[arg-type]
+                    Payments.external_id.is_not(None),  # type: ignore[union-attr]
+                    Payments.created_at < threshold,
+                )
+                .order_by(Payments.created_at)
+                .limit(batch_size)
+            ).all()
+        )
+
     def supersede_pending_payments(
         self,
         session: Session,

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -39,15 +39,19 @@ from app.core.dependencies.users import (
     needs,
 )
 from app.core.redis import WebhookCache
-from app.services.email import (
-    EmailAttachment,
-    PaymentAttendeeItem,
-    PaymentConfirmedContext,
-    PaymentProductItem,
-    compute_order_summary,
-    get_email_service,
-)
 from app.services.email_helpers import send_application_status_email
+
+# Email notification helpers live in app.services.payment_notifications to
+# allow import by background jobs without creating a circular dependency with
+# the web layer.  The names are re-exported here under their original private
+# identifiers so existing call sites and test monkey-patches keep working.
+from app.services.payment_notifications import (  # noqa: F401
+    _build_payment_confirmed_context,
+    _send_payment_confirmed_email,
+)
+from app.services.payment_notifications import (
+    send_payment_confirmed_email_best_effort as _send_payment_confirmed_email_best_effort,
+)
 
 if TYPE_CHECKING:
     from app.api.human.models import Humans
@@ -273,200 +277,6 @@ def _installment_charged_amount(payment_request: SimpleFIPaymentRequest) -> Deci
     if card_payment is not None and card_payment.price_details is not None:
         return Decimal(str(card_payment.price_details.final_amount))
     return Decimal(str(payment_request.amount_paid))
-
-
-def _build_payment_email_products(payment: Payments) -> list[PaymentProductItem]:
-    return [
-        PaymentProductItem(
-            name=pp.product_name,
-            price=float(pp.product_price),
-            quantity=pp.quantity,
-        )
-        for pp in payment.products_snapshot
-    ]
-
-
-def _build_payment_email_attendees(
-    payment: Payments,
-) -> list[PaymentAttendeeItem] | None:
-    if not payment.products_snapshot:
-        return None
-
-    attendees_by_id: dict[uuid.UUID, PaymentAttendeeItem] = {}
-
-    for product_snapshot in payment.products_snapshot:
-        attendee = product_snapshot.attendee
-        attendee_id = product_snapshot.attendee_id
-
-        if attendee_id not in attendees_by_id:
-            attendees_by_id[attendee_id] = PaymentAttendeeItem(
-                name=(attendee.name if attendee else None)
-                or product_snapshot.attendee_name
-                or "Attendee",
-                category=(attendee.category if attendee else None) or "attendee",
-                products=[],
-            )
-
-        attendees_by_id[attendee_id].products = [
-            *(attendees_by_id[attendee_id].products or []),
-            PaymentProductItem(
-                name=product_snapshot.product_name,
-                price=float(product_snapshot.product_price),
-                quantity=product_snapshot.quantity,
-            ),
-        ]
-
-    return list(attendees_by_id.values())
-
-
-def _build_payment_confirmed_context(
-    payment: Payments,
-    popup_name: str,
-    first_name: str,
-    portal_url: str | None,
-) -> PaymentConfirmedContext:
-    products = _build_payment_email_products(payment)
-    attendees = _build_payment_email_attendees(payment)
-
-    original_amount = None
-    if payment.discount_value and payment.discount_value > 0:
-        original_amount = sum(
-            float(pp.product_price) * pp.quantity for pp in payment.products_snapshot
-        )
-
-    return PaymentConfirmedContext(
-        first_name=first_name,
-        popup_name=popup_name,
-        payment_id=str(payment.id),
-        amount=float(payment.amount),
-        currency=payment.currency,
-        products=products if products else None,
-        discount_value=int(payment.discount_value) if payment.discount_value else None,
-        original_amount=original_amount,
-        attendees=attendees,
-        order_summary=compute_order_summary(payment)
-        if payment.products_snapshot
-        else None,
-        portal_url=portal_url,
-    )
-
-
-async def _send_payment_confirmed_email(payment, db_session=None) -> None:
-    """Send payment confirmation email.
-
-    If the popup has invoice details configured (company name, address, email),
-    an invoice PDF is generated and attached to the email.
-
-    Branches on payment.application_id:
-    - application-based: resolve human via payment.application.human.
-    - direct-sale: resolve human via the attendee in the first product snapshot,
-      and popup via payment.popup.
-    """
-    from loguru import logger
-
-    payment_model: Payments = payment
-
-    if payment_model.application_id is not None:
-        # Application-based payment (existing flow)
-        application = payment_model.application
-        human = application.human if application else None
-        popup = application.popup if application else None
-    else:
-        # Direct-sale payment: no application. Human comes from the attendee
-        # linked to the first product snapshot (direct-sale only ever has one
-        # attendee per payment — the buyer).
-        popup = payment_model.popup
-        human = None
-        if payment_model.products_snapshot:
-            attendee = payment_model.products_snapshot[0].attendee
-            if attendee is not None:
-                human = attendee.human
-
-    if popup is None:
-        logger.warning(
-            f"Cannot send payment confirmed email: popup missing for payment {payment.id}"
-        )
-        return
-    tenant = popup.tenant
-
-    if not human or not human.email:
-        logger.warning(
-            f"Cannot send payment confirmed email: no human email for payment {payment.id}"
-        )
-        return
-
-    # Generate invoice PDF attachment if popup has invoice details configured
-    attachments: list[EmailAttachment] | None = None
-    popup_has_invoice = (
-        popup.invoice_company_name
-        and popup.invoice_company_address
-        and popup.invoice_company_email
-    )
-    if popup_has_invoice:
-        try:
-            from app.core.invoice import generate_invoice_pdf
-
-            client_name = f"{human.first_name or ''} {human.last_name or ''}".strip()
-
-            pdf_bytes = generate_invoice_pdf(
-                payment=payment_model,
-                client_name=client_name or "N/A",
-                invoice_company_name=popup.invoice_company_name,
-                invoice_company_address=popup.invoice_company_address,
-                invoice_company_email=popup.invoice_company_email,
-                header_image_url=popup.image_url,
-            )
-            attachments = [
-                EmailAttachment(
-                    filename=f"invoice-{payment_model.id}.pdf",
-                    content=pdf_bytes,
-                    mime_type="application/pdf",
-                )
-            ]
-            logger.info(f"Invoice PDF generated for payment {payment_model.id}")
-        except Exception as e:
-            logger.error(
-                f"Failed to generate invoice PDF for payment {payment_model.id}: {e}"
-            )
-            # Continue sending email without attachment
-
-    email_service = get_email_service()
-
-    from app.api.tenant.utils import get_portal_url
-
-    portal_url = get_portal_url(tenant)
-    context = _build_payment_confirmed_context(
-        payment_model,
-        popup_name=popup.name,
-        first_name=human.first_name or "",
-        portal_url=portal_url,
-    )
-
-    await email_service.send_payment_confirmed(
-        to=human.email,
-        subject=f"Payment Confirmed for {popup.name}",
-        context=context,
-        from_address=tenant.sender_email,
-        from_name=tenant.sender_name,
-        popup_id=popup.id,
-        db_session=db_session,
-        attachments=attachments,
-    )
-    logger.info(
-        f"Payment confirmed email sent to {human.email} for payment {payment.id}"
-    )
-
-
-async def _send_payment_confirmed_email_best_effort(payment, db_session=None) -> None:
-    from loguru import logger
-
-    try:
-        await _send_payment_confirmed_email(payment, db_session=db_session)
-    except Exception:
-        logger.exception(
-            "Failed to send payment confirmation email payment_id={}",
-            getattr(payment, "id", ""),
-        )
 
 
 def _get_portal_owned_payment_or_404(

--- a/backend/app/jobs/pending_payment_sweeper.py
+++ b/backend/app/jobs/pending_payment_sweeper.py
@@ -1,0 +1,55 @@
+"""Entrypoint for the pending payment sweeper job.
+
+Designed to be invoked by an external scheduler (k8s CronJob, EventBridge
+Schedule → ECS RunTask, systemd timer, or plain crontab — anything that can
+run a container or Python module on an interval).
+
+Usage:
+    uv run python -m app.jobs.pending_payment_sweeper
+
+Exit codes:
+    0 — sweep completed (possibly a no-op when PENDING_SWEEP_ENABLED=false
+        or the advisory lock was held by a concurrent instance)
+    1 — sweep completed but at least one candidate raised an unexpected error;
+        check logs for detail
+
+Recommended interval: every 5 minutes.  The staleness threshold defaults to
+20 minutes (``PENDING_SWEEP_STALE_MINUTES``), so two to three runs see a
+candidate before the provider's own expiry window closes.
+
+Design reference: ADR-5 (pending-payment-hold-release).
+"""
+
+import asyncio
+import sys
+
+from loguru import logger
+from sqlmodel import Session
+
+from app.core.config import settings
+from app.core.db import engine
+from app.services.pending_payment_sweeper import sweep_pending_payments
+
+
+def main() -> int:
+    if not settings.PENDING_SWEEP_ENABLED:
+        logger.info(
+            "sweeper: PENDING_SWEEP_ENABLED=false; job exiting without processing"
+        )
+        return 0
+
+    with Session(engine) as db:
+        summary = asyncio.run(
+            sweep_pending_payments(
+                db,
+                threshold_minutes=settings.PENDING_SWEEP_STALE_MINUTES,
+                batch_size=settings.PENDING_SWEEP_BATCH_SIZE,
+            )
+        )
+
+    logger.info("sweeper: job finished summary={}", summary)
+    return 1 if summary.get("failures") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/services/payment_notifications.py
+++ b/backend/app/services/payment_notifications.py
@@ -1,0 +1,235 @@
+"""Payment confirmation email helpers.
+
+Extracted from ``app/api/payment/router.py`` so the pending-payment sweeper
+(and any future cross-cutting service) can import these functions at
+module-load time without creating a circular dependency with the web layer.
+
+Public API:
+  - ``send_payment_confirmed_email_best_effort`` — best-effort wrapper used by
+    route handlers and background jobs.  Swallows all exceptions and logs them.
+  - ``_send_payment_confirmed_email`` — inner sender; exposed so callers that
+    want to track email failures themselves can catch exceptions directly.
+
+Internal helpers (module-private, prefixed with ``_``):
+  - ``_build_payment_email_products``
+  - ``_build_payment_email_attendees``
+  - ``_build_payment_confirmed_context``
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from app.api.payment.models import Payments
+from app.services.email import (
+    EmailAttachment,
+    PaymentAttendeeItem,
+    PaymentConfirmedContext,
+    PaymentProductItem,
+    compute_order_summary,
+    get_email_service,
+)
+
+
+def _build_payment_email_products(payment: Payments) -> list[PaymentProductItem]:
+    return [
+        PaymentProductItem(
+            name=pp.product_name,
+            price=float(pp.product_price),
+            quantity=pp.quantity,
+        )
+        for pp in payment.products_snapshot
+    ]
+
+
+def _build_payment_email_attendees(
+    payment: Payments,
+) -> list[PaymentAttendeeItem] | None:
+    if not payment.products_snapshot:
+        return None
+
+    attendees_by_id: dict[uuid.UUID, PaymentAttendeeItem] = {}
+
+    for product_snapshot in payment.products_snapshot:
+        attendee = product_snapshot.attendee
+        attendee_id = product_snapshot.attendee_id
+
+        if attendee_id not in attendees_by_id:
+            attendees_by_id[attendee_id] = PaymentAttendeeItem(
+                name=(attendee.name if attendee else None)
+                or product_snapshot.attendee_name
+                or "Attendee",
+                category=(attendee.category if attendee else None) or "attendee",
+                products=[],
+            )
+
+        attendees_by_id[attendee_id].products = [
+            *(attendees_by_id[attendee_id].products or []),
+            PaymentProductItem(
+                name=product_snapshot.product_name,
+                price=float(product_snapshot.product_price),
+                quantity=product_snapshot.quantity,
+            ),
+        ]
+
+    return list(attendees_by_id.values())
+
+
+def _build_payment_confirmed_context(
+    payment: Payments,
+    popup_name: str,
+    first_name: str,
+    portal_url: str | None,
+) -> PaymentConfirmedContext:
+    products = _build_payment_email_products(payment)
+    attendees = _build_payment_email_attendees(payment)
+
+    original_amount = None
+    if payment.discount_value and payment.discount_value > 0:
+        original_amount = sum(
+            float(pp.product_price) * pp.quantity for pp in payment.products_snapshot
+        )
+
+    return PaymentConfirmedContext(
+        first_name=first_name,
+        popup_name=popup_name,
+        payment_id=str(payment.id),
+        amount=float(payment.amount),
+        currency=payment.currency,
+        products=products if products else None,
+        discount_value=int(payment.discount_value) if payment.discount_value else None,
+        original_amount=original_amount,
+        attendees=attendees,
+        order_summary=compute_order_summary(payment)
+        if payment.products_snapshot
+        else None,
+        portal_url=portal_url,
+    )
+
+
+async def _send_payment_confirmed_email(payment, db_session=None) -> None:
+    """Send payment confirmation email.
+
+    If the popup has invoice details configured (company name, address, email),
+    an invoice PDF is generated and attached to the email.
+
+    Branches on payment.application_id:
+    - application-based: resolve human via payment.application.human.
+    - direct-sale: resolve human via the attendee in the first product snapshot,
+      and popup via payment.popup.
+    """
+    from loguru import logger
+
+    payment_model: Payments = payment
+
+    if payment_model.application_id is not None:
+        # Application-based payment (existing flow)
+        application = payment_model.application
+        human = application.human if application else None
+        popup = application.popup if application else None
+    else:
+        # Direct-sale payment: no application. Human comes from the attendee
+        # linked to the first product snapshot (direct-sale only ever has one
+        # attendee per payment — the buyer).
+        popup = payment_model.popup
+        human = None
+        if payment_model.products_snapshot:
+            attendee = payment_model.products_snapshot[0].attendee
+            if attendee is not None:
+                human = attendee.human
+
+    if popup is None:
+        logger.warning(
+            f"Cannot send payment confirmed email: popup missing for payment {payment.id}"
+        )
+        return
+    tenant = popup.tenant
+
+    if not human or not human.email:
+        logger.warning(
+            f"Cannot send payment confirmed email: no human email for payment {payment.id}"
+        )
+        return
+
+    # Generate invoice PDF attachment if popup has invoice details configured
+    attachments: list[EmailAttachment] | None = None
+    popup_has_invoice = (
+        popup.invoice_company_name
+        and popup.invoice_company_address
+        and popup.invoice_company_email
+    )
+    if popup_has_invoice:
+        try:
+            from app.core.invoice import generate_invoice_pdf
+
+            client_name = f"{human.first_name or ''} {human.last_name or ''}".strip()
+
+            pdf_bytes = generate_invoice_pdf(
+                payment=payment_model,
+                client_name=client_name or "N/A",
+                invoice_company_name=popup.invoice_company_name,
+                invoice_company_address=popup.invoice_company_address,
+                invoice_company_email=popup.invoice_company_email,
+                header_image_url=popup.image_url,
+            )
+            attachments = [
+                EmailAttachment(
+                    filename=f"invoice-{payment_model.id}.pdf",
+                    content=pdf_bytes,
+                    mime_type="application/pdf",
+                )
+            ]
+            logger.info(f"Invoice PDF generated for payment {payment_model.id}")
+        except Exception as e:
+            logger.error(
+                f"Failed to generate invoice PDF for payment {payment_model.id}: {e}"
+            )
+            # Continue sending email without attachment
+
+    email_service = get_email_service()
+
+    from app.api.tenant.utils import get_portal_url
+
+    portal_url = get_portal_url(tenant)
+    context = _build_payment_confirmed_context(
+        payment_model,
+        popup_name=popup.name,
+        first_name=human.first_name or "",
+        portal_url=portal_url,
+    )
+
+    await email_service.send_payment_confirmed(
+        to=human.email,
+        subject=f"Payment Confirmed for {popup.name}",
+        context=context,
+        from_address=tenant.sender_email,
+        from_name=tenant.sender_name,
+        popup_id=popup.id,
+        db_session=db_session,
+        attachments=attachments,
+    )
+    logger.info(
+        f"Payment confirmed email sent to {human.email} for payment {payment.id}"
+    )
+
+
+async def send_payment_confirmed_email_best_effort(payment, db_session=None) -> None:
+    """Send payment confirmation email, swallowing all errors.
+
+    Intended for use in webhook handlers and background jobs where a failed
+    email must never abort payment processing.  Exceptions are logged but not
+    re-raised.
+
+    Callers that need to TRACK email failures (e.g. the sweeper) should call
+    ``_send_payment_confirmed_email`` directly and wrap it in their own
+    ``try/except``.
+    """
+    from loguru import logger
+
+    try:
+        await _send_payment_confirmed_email(payment, db_session=db_session)
+    except Exception:
+        logger.exception(
+            "Failed to send payment confirmation email payment_id={}",
+            getattr(payment, "id", ""),
+        )

--- a/backend/app/services/pending_payment_sweeper.py
+++ b/backend/app/services/pending_payment_sweeper.py
@@ -1,0 +1,239 @@
+"""Pending payment sweeper service.
+
+Finds PENDING SimpleFi payments older than the configured staleness threshold
+and reconciles them with the current SimpleFi status:
+
+  - approved / active / completed  → approve path (``_reconcile_approved``)
+  - terminal (cancelled/expired/refunded) → ``update_status(EXPIRED)``
+  - still pending on SimpleFi      → skip (retried next run)
+  - status fetch fails             → skip + log (retried next run)
+
+Popup with no ``simplefi_api_key`` → expire locally (orphaned payment);
+same policy as ``supersede_pending_payments`` in ADR-2.
+
+Runs as a standalone cross-tenant job using the superuser engine (RLS bypass),
+mirroring ``app/jobs/checkin_pass_dispatch.py``.  The service itself holds the
+Postgres advisory lock so the job entrypoint stays thin.
+
+Design reference: ADR-5 (pending-payment-hold-release).
+"""
+
+from loguru import logger
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.api.payment.crud import payments_crud
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentStatus
+from app.services.simplefi import get_simplefi_client
+
+# Session-level advisory lock key — must be distinct from every other job's
+# lock key in the codebase.  DISPATCH_ADVISORY_LOCK_KEY = 4827133295 (check-in
+# pass dispatch).  Use a well-separated constant to avoid accidental conflicts.
+SWEEP_ADVISORY_LOCK_KEY = 7384925163
+
+# SimpleFi statuses that indicate the provider already cancelled the payment.
+_TERMINAL_STATUSES = frozenset({"canceled", "cancelled", "expired", "refunded"})
+# SimpleFi statuses that mean the buyer actually paid.
+_APPROVED_STATUSES = frozenset({"approved", "active", "completed"})
+
+
+async def _reconcile_candidate(session: Session, payment: Payments) -> str:
+    """Reconcile one stale PENDING payment against its current SimpleFi status.
+
+    Returns a string action token for summary counters:
+    - ``"expired"``            — payment expired locally, holds released
+    - ``"approved_reconciled"`` — payment approved locally, confirmation email sent
+    - ``"skipped_still_pending"`` — SimpleFi still shows pending, try next run
+    - ``"skipped_no_key"``     — orphaned (no API key), expired locally
+    - ``"skipped_error"``      — SimpleFi call failed, try next run
+
+    Hard contract (ADR-5): NO SimpleFi HTTP call is made while holding any
+    DB row lock.  Status is fetched first, then the row is locked inside
+    ``update_status`` / ``_reconcile_approved``.
+    """
+    from app.api.popup.models import Popups
+
+    popup = session.get(Popups, payment.popup_id)
+
+    if popup is None or not popup.simplefi_api_key:
+        # Orphaned payment: no live SimpleFi link to protect.  Expire locally
+        # and release holds — same policy as supersede for orphaned payments.
+        logger.warning(
+            "sweeper: orphaned payment (no simplefi_api_key) "
+            "popup={} payment={} tenant={}",
+            payment.popup_id,
+            payment.id,
+            payment.tenant_id,
+        )
+        payments_crud.update_status(session, payment.id, PaymentStatus.EXPIRED)
+        logger.info(
+            "sweeper: payment={} tenant={} action=swept_to_expired simplefi_status=orphaned",
+            payment.id,
+            payment.tenant_id,
+        )
+        return "expired"
+
+    simplefi_client = get_simplefi_client(popup.simplefi_api_key)
+
+    # Fetch current status from SimpleFi OUTSIDE any DB lock (ADR-5).
+    try:
+        if payment.is_installment_plan:
+            status_resp = simplefi_client.get_installment_plan_status(
+                str(payment.external_id)
+            )
+        else:
+            status_resp = simplefi_client.get_payment_request_status(
+                str(payment.external_id)
+            )
+    except Exception as exc:
+        logger.warning(
+            "sweeper: status fetch failed payment={} tenant={} error={!r}; "
+            "skipping this candidate",
+            payment.id,
+            payment.tenant_id,
+            exc,
+        )
+        return "skipped_error"
+
+    normalized = status_resp.status.lower().strip()
+
+    if normalized in _APPROVED_STATUSES:
+        # SimpleFi shows the buyer paid.  Idempotently approve and issue
+        # tickets; send confirmation email best-effort (the webhook may have
+        # been lost, leaving the buyer without email or products).
+        approved_payment = payments_crud._reconcile_approved(session, payment)
+        # Lazy import avoids circular dependency: the router module imports
+        # from services, not the other way around.
+        from app.api.payment.router import _send_payment_confirmed_email_best_effort
+
+        await _send_payment_confirmed_email_best_effort(
+            approved_payment, db_session=session
+        )
+        logger.info(
+            "sweeper: payment={} tenant={} action=approved_reconciled simplefi_status={}",
+            payment.id,
+            payment.tenant_id,
+            normalized,
+        )
+        return "approved_reconciled"
+
+    if normalized in _TERMINAL_STATUSES:
+        # SimpleFi cancelled/expired the payment.  Release holds.
+        payments_crud.update_status(session, payment.id, PaymentStatus.EXPIRED)
+        logger.info(
+            "sweeper: payment={} tenant={} action=swept_to_expired simplefi_status={}",
+            payment.id,
+            payment.tenant_id,
+            normalized,
+        )
+        return "expired"
+
+    # Still pending on SimpleFi — the provider hasn't expired it yet.
+    # Skip and retry on the next run.
+    logger.info(
+        "sweeper: payment={} tenant={} action=skipped simplefi_status={}",
+        payment.id,
+        payment.tenant_id,
+        normalized,
+    )
+    return "skipped_still_pending"
+
+
+async def _run_sweep(
+    session: Session,
+    *,
+    threshold_minutes: int,
+    batch_size: int,
+) -> dict:
+    """Inner sweep loop — runs after the advisory lock is held."""
+    candidates = payments_crud.get_stale_pending_payments(
+        session, threshold_minutes, batch_size
+    )
+
+    summary: dict[str, int | str] = {
+        "candidates": len(candidates),
+        "expired": 0,
+        "approved_reconciled": 0,
+        "skipped": 0,
+        "failures": 0,
+    }
+
+    for payment in candidates:
+        try:
+            action = await _reconcile_candidate(session, payment)
+            if action == "expired":
+                summary["expired"] = int(summary["expired"]) + 1
+            elif action == "approved_reconciled":
+                summary["approved_reconciled"] = int(summary["approved_reconciled"]) + 1
+            else:
+                # "skipped_still_pending", "skipped_no_key", "skipped_error"
+                summary["skipped"] = int(summary["skipped"]) + 1
+        except Exception:
+            # Unexpected error (e.g. DB failure during approve_payment).
+            # Log and continue so other candidates are still processed.
+            summary["failures"] = int(summary["failures"]) + 1
+            logger.exception(
+                "sweeper: unexpected error processing payment={} tenant={}; "
+                "skipping candidate",
+                payment.id,
+                getattr(payment, "tenant_id", "?"),
+            )
+
+    logger.info(
+        "sweeper: run complete candidates={} expired={} "
+        "approved_reconciled={} skipped={} failures={}",
+        summary["candidates"],
+        summary["expired"],
+        summary["approved_reconciled"],
+        summary["skipped"],
+        summary["failures"],
+    )
+    return summary
+
+
+async def sweep_pending_payments(
+    session: Session,
+    *,
+    threshold_minutes: int,
+    batch_size: int,
+) -> dict:
+    """Entry point for the pending-payment sweeper.
+
+    Acquires a Postgres session-level advisory lock (``pg_try_advisory_lock``)
+    on a dedicated connection so overlapping runs no-op instead of
+    double-processing candidates.  Session-level locking (not
+    ``xact``-scoped) is correct here because the sweeper is a standalone
+    long-running process on a dedicated connection; the lock must persist
+    across the multiple ``session.commit()`` calls made by ``update_status``
+    during the run.
+
+    Returns a summary dict with keys: ``status``, ``candidates``, ``expired``,
+    ``approved_reconciled``, ``skipped``, ``failures``.
+    """
+    lock_conn = session.get_bind().connect()
+    try:
+        got = lock_conn.execute(
+            text("SELECT pg_try_advisory_lock(:k)"),
+            {"k": SWEEP_ADVISORY_LOCK_KEY},
+        ).scalar()
+        if not got:
+            logger.info("sweeper: advisory lock held by another instance; skipping run")
+            return {"status": "skipped", "reason": "another sweep is running"}
+
+        try:
+            result = await _run_sweep(
+                session,
+                threshold_minutes=threshold_minutes,
+                batch_size=batch_size,
+            )
+            result["status"] = "ok"
+            return result
+        finally:
+            lock_conn.execute(
+                text("SELECT pg_advisory_unlock(:k)"),
+                {"k": SWEEP_ADVISORY_LOCK_KEY},
+            )
+            lock_conn.commit()
+    finally:
+        lock_conn.close()

--- a/backend/app/services/pending_payment_sweeper.py
+++ b/backend/app/services/pending_payment_sweeper.py
@@ -8,8 +8,10 @@ and reconciles them with the current SimpleFi status:
   - still pending on SimpleFi      → skip (retried next run)
   - status fetch fails             → skip + log (retried next run)
 
-Popup with no ``simplefi_api_key`` → expire locally (orphaned payment);
-same policy as ``supersede_pending_payments`` in ADR-2.
+Popup with no ``simplefi_api_key`` → expire locally (``expired_orphaned``
+action); same policy as ``supersede_pending_payments`` in ADR-2.  These are
+counted separately from plain ``expired`` so ops can distinguish SimpleFi-
+confirmed expirations from local-only ones.
 
 Runs as a standalone cross-tenant job using the superuser engine (RLS bypass),
 mirroring ``app/jobs/checkin_pass_dispatch.py``.  The service itself holds the
@@ -25,6 +27,9 @@ from sqlmodel import Session
 from app.api.payment.crud import payments_crud
 from app.api.payment.models import Payments
 from app.api.payment.schemas import PaymentStatus
+from app.services.payment_notifications import (
+    _send_payment_confirmed_email,
+)
 from app.services.simplefi import get_simplefi_client
 
 # Session-level advisory lock key — must be distinct from every other job's
@@ -42,11 +47,12 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
     """Reconcile one stale PENDING payment against its current SimpleFi status.
 
     Returns a string action token for summary counters:
-    - ``"expired"``            — payment expired locally, holds released
-    - ``"approved_reconciled"`` — payment approved locally, confirmation email sent
-    - ``"skipped_still_pending"`` — SimpleFi still shows pending, try next run
-    - ``"skipped_no_key"``     — orphaned (no API key), expired locally
-    - ``"skipped_error"``      — SimpleFi call failed, try next run
+    - ``"expired"``              — SimpleFi-confirmed terminal, holds released
+    - ``"expired_orphaned"``     — no API key to check; expired locally
+    - ``"approved_reconciled"``  — payment approved, confirmation email sent
+    - ``"approved_email_failed"``— payment approved, but email dispatch failed
+    - ``"skipped_still_pending"``— SimpleFi still shows pending, try next run
+    - ``"skipped_error"``        — SimpleFi call failed, try next run
 
     Hard contract (ADR-5): NO SimpleFi HTTP call is made while holding any
     DB row lock.  Status is fetched first, then the row is locked inside
@@ -59,6 +65,9 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
     if popup is None or not popup.simplefi_api_key:
         # Orphaned payment: no live SimpleFi link to protect.  Expire locally
         # and release holds — same policy as supersede for orphaned payments.
+        # Counted as "expired_orphaned", NOT as plain "expired", so the
+        # summary clearly separates SimpleFi-confirmed expirations from
+        # local-only ones driven by missing configuration.
         logger.warning(
             "sweeper: orphaned payment (no simplefi_api_key) "
             "popup={} payment={} tenant={}",
@@ -72,7 +81,7 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
             payment.id,
             payment.tenant_id,
         )
-        return "expired"
+        return "expired_orphaned"
 
     simplefi_client = get_simplefi_client(popup.simplefi_api_key)
 
@@ -103,13 +112,21 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
         # tickets; send confirmation email best-effort (the webhook may have
         # been lost, leaving the buyer without email or products).
         approved_payment = payments_crud._reconcile_approved(session, payment)
-        # Lazy import avoids circular dependency: the router module imports
-        # from services, not the other way around.
-        from app.api.payment.router import _send_payment_confirmed_email_best_effort
-
-        await _send_payment_confirmed_email_best_effort(
-            approved_payment, db_session=session
-        )
+        # Use _send_payment_confirmed_email directly (not the _best_effort
+        # wrapper) so we can detect and count email failures in the summary
+        # without hiding them from ops.  A failed email does NOT affect
+        # the payment's approved status.
+        try:
+            await _send_payment_confirmed_email(approved_payment, db_session=session)
+        except Exception:
+            logger.warning(
+                "sweeper: email dispatch failed payment={} tenant={} popup={}; "
+                "payment is approved",
+                payment.id,
+                payment.tenant_id,
+                payment.popup_id,
+            )
+            return "approved_email_failed"
         logger.info(
             "sweeper: payment={} tenant={} action=approved_reconciled simplefi_status={}",
             payment.id,
@@ -129,8 +146,15 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
         )
         return "expired"
 
-    # Still pending on SimpleFi — the provider hasn't expired it yet.
-    # Skip and retry on the next run.
+    # Still pending on SimpleFi — skip and retry on the next run.
+    #
+    # Safety invariant: SimpleFi's own checkout expiry is approximately
+    # 15 minutes, which is BELOW PENDING_SWEEP_STALE_MINUTES (20 min).
+    # A "still-pending" report therefore means the buyer MAY be actively
+    # completing the payment right now.  The sweeper NEVER expires a payment
+    # that SimpleFi reports as still-pending; it only expires what SimpleFi
+    # has confirmed as terminal, or what has no API key to check.
+    # See PENDING_SWEEP_STALE_MINUTES in app/jobs/pending_payment_sweeper.py.
     logger.info(
         "sweeper: payment={} tenant={} action=skipped simplefi_status={}",
         payment.id,
@@ -154,7 +178,9 @@ async def _run_sweep(
     summary: dict[str, int | str] = {
         "candidates": len(candidates),
         "expired": 0,
+        "expired_orphaned": 0,
         "approved_reconciled": 0,
+        "email_failures": 0,
         "skipped": 0,
         "failures": 0,
     }
@@ -164,14 +190,29 @@ async def _run_sweep(
             action = await _reconcile_candidate(session, payment)
             if action == "expired":
                 summary["expired"] = int(summary["expired"]) + 1
+            elif action == "expired_orphaned":
+                summary["expired_orphaned"] = int(summary["expired_orphaned"]) + 1
             elif action == "approved_reconciled":
                 summary["approved_reconciled"] = int(summary["approved_reconciled"]) + 1
+            elif action == "approved_email_failed":
+                # Payment WAS approved — count as reconciled AND track email failure.
+                # Do NOT count in "failures" (that counter is for unexpected errors
+                # that prevented the reconciliation from completing).
+                summary["approved_reconciled"] = int(summary["approved_reconciled"]) + 1
+                summary["email_failures"] = int(summary["email_failures"]) + 1
             else:
-                # "skipped_still_pending", "skipped_no_key", "skipped_error"
+                # "skipped_still_pending", "skipped_error"
                 summary["skipped"] = int(summary["skipped"]) + 1
         except Exception:
             # Unexpected error (e.g. DB failure during approve_payment).
-            # Log and continue so other candidates are still processed.
+            # Roll back the current transaction so any partial writes from
+            # this candidate (staged ORM changes, open row locks) are
+            # discarded before the next candidate is processed.  Without this
+            # rollback, a staged-but-uncommitted change (e.g. a coupon use
+            # decrement from update_status) can be flushed and committed by
+            # the next candidate's session.commit(), leaking the hold even
+            # though the payment remains PENDING.
+            session.rollback()
             summary["failures"] = int(summary["failures"]) + 1
             logger.exception(
                 "sweeper: unexpected error processing payment={} tenant={}; "
@@ -181,11 +222,13 @@ async def _run_sweep(
             )
 
     logger.info(
-        "sweeper: run complete candidates={} expired={} "
-        "approved_reconciled={} skipped={} failures={}",
+        "sweeper: run complete candidates={} expired={} expired_orphaned={} "
+        "approved_reconciled={} email_failures={} skipped={} failures={}",
         summary["candidates"],
         summary["expired"],
+        summary["expired_orphaned"],
         summary["approved_reconciled"],
+        summary["email_failures"],
         summary["skipped"],
         summary["failures"],
     )
@@ -209,7 +252,8 @@ async def sweep_pending_payments(
     during the run.
 
     Returns a summary dict with keys: ``status``, ``candidates``, ``expired``,
-    ``approved_reconciled``, ``skipped``, ``failures``.
+    ``expired_orphaned``, ``approved_reconciled``, ``email_failures``,
+    ``skipped``, ``failures``.
     """
     lock_conn = session.get_bind().connect()
     try:

--- a/backend/tests/api/payment/test_pending_hold_pr3_sweeper.py
+++ b/backend/tests/api/payment/test_pending_hold_pr3_sweeper.py
@@ -1,0 +1,634 @@
+"""Tests for pending-payment sweeper (PR 3): tasks 5.9, 5.10, 5.11.
+
+TDD phase: RED — written BEFORE implementation.
+
+Coverage:
+  5.9  Sweeper reconciliation matrix (stale+expired, stale+approved,
+        stale+still-pending, status-fetch-failure, orphaned)
+  5.10 Cross-tenant sweep (both tenants processed in one run)
+  5.11 Overlap guard (second run under held advisory lock is skipped)
+"""
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.api.coupon.models import Coupons
+from app.api.payment.crud import payments_crud
+from app.api.payment.models import Payments
+from app.api.payment.schemas import PaymentSource, PaymentStatus
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.services.pending_payment_sweeper import (  # NOT YET CREATED — RED
+    SWEEP_ADVISORY_LOCK_KEY,
+    sweep_pending_payments,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+STALE_MINUTES = 20
+
+
+def _make_popup_with_key(
+    db: Session, tenant: Tenants, *, slug_prefix: str = "swp"
+) -> Popups:
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"Sweep Test Popup {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:6]}",
+        sale_type="direct",
+        status="active",
+        simplefi_api_key="swp_test_key",
+        currency="ARS",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_popup_no_key(
+    db: Session, tenant: Tenants, *, slug_prefix: str = "swp-nokey"
+) -> Popups:
+    popup = Popups(
+        tenant_id=tenant.id,
+        name=f"Sweep No Key Popup {slug_prefix}",
+        slug=f"{slug_prefix}-{uuid.uuid4().hex[:6]}",
+        sale_type="direct",
+        status="active",
+        simplefi_api_key=None,
+        currency="ARS",
+    )
+    db.add(popup)
+    db.flush()
+    return popup
+
+
+def _make_coupon(
+    db: Session,
+    popup: Popups,
+    *,
+    current_uses: int = 2,
+    max_uses: int = 5,
+) -> Coupons:
+    coupon = Coupons(
+        id=uuid.uuid4(),
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        code=f"SWP{uuid.uuid4().hex[:6].upper()}",
+        discount_value=10,
+        is_active=True,
+        current_uses=current_uses,
+        max_uses=max_uses,
+    )
+    db.add(coupon)
+    db.flush()
+    return coupon
+
+
+def _make_stale_pending_payment(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    stale_minutes: int = 30,
+    coupon: Coupons | None = None,
+    application_id: uuid.UUID | None = None,
+    is_installment_plan: bool = False,
+    external_id: str | None = None,
+) -> Payments:
+    """Create a PENDING SimpleFi payment with created_at in the past."""
+    stale_at = datetime.now(UTC) - timedelta(minutes=stale_minutes)
+    payment = Payments(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        application_id=application_id,
+        status=PaymentStatus.PENDING.value,
+        amount=Decimal("100"),
+        currency="ARS",
+        source=PaymentSource.SIMPLEFI.value,
+        coupon_id=coupon.id if coupon else None,
+        coupon_code=coupon.code if coupon else None,
+        is_installment_plan=is_installment_plan,
+        external_id=external_id or f"swp-ext-{uuid.uuid4().hex[:12]}",
+        created_at=stale_at,
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _make_recent_pending_payment(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+) -> Payments:
+    """Create a PENDING payment that is NOT stale (created just now)."""
+    payment = Payments(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        status=PaymentStatus.PENDING.value,
+        amount=Decimal("50"),
+        currency="ARS",
+        source=PaymentSource.SIMPLEFI.value,
+        external_id=f"recent-ext-{uuid.uuid4().hex[:12]}",
+        created_at=datetime.now(UTC),
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _fresh_status(db: Session, payment_id: uuid.UUID) -> str:
+    db.expire_all()
+    p = db.get(Payments, payment_id)
+    assert p is not None
+    return str(p.status)
+
+
+def _fresh_coupon_uses(db: Session, coupon_id: uuid.UUID) -> int:
+    db.expire_all()
+    c = db.get(Coupons, coupon_id)
+    assert c is not None
+    return c.current_uses
+
+
+def _simplefi_status_mock(status_str: str) -> MagicMock:
+    """Build a SimpleFIPaymentRequestStatus-like mock returning the given status."""
+    mock = MagicMock()
+    mock.status = status_str
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Task 2.4: get_stale_pending_payments
+# ---------------------------------------------------------------------------
+
+
+class TestGetStalePendingPayments:
+    """Unit-style tests for the crud query method (task 2.4 deferred from PR2)."""
+
+    def test_returns_stale_pending_simplefi_payments(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Stale PENDING SimpleFi payment with external_id is returned."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="q1")
+        payment = _make_stale_pending_payment(db, tenant_a, popup, stale_minutes=30)
+
+        results = payments_crud.get_stale_pending_payments(
+            db, STALE_MINUTES, batch_size=100
+        )
+        result_ids = {p.id for p in results}
+        assert payment.id in result_ids
+
+    def test_does_not_return_recent_pending(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """A PENDING payment created just now is NOT returned (not stale)."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="q2")
+        recent = _make_recent_pending_payment(db, tenant_a, popup)
+
+        results = payments_crud.get_stale_pending_payments(
+            db, STALE_MINUTES, batch_size=100
+        )
+        result_ids = {p.id for p in results}
+        assert recent.id not in result_ids
+
+    def test_respects_batch_size(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Returns at most batch_size results."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="q3")
+        # Create 3 stale payments
+        for _ in range(3):
+            _make_stale_pending_payment(db, tenant_a, popup, stale_minutes=30)
+
+        results = payments_crud.get_stale_pending_payments(
+            db, STALE_MINUTES, batch_size=2
+        )
+        assert len(results) <= 2
+
+    def test_does_not_return_approved_payment(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """An APPROVED payment is not in the stale-pending queue."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="q4")
+        payment = _make_stale_pending_payment(db, tenant_a, popup, stale_minutes=30)
+        # Manually transition to APPROVED
+        payment.status = PaymentStatus.APPROVED.value
+        db.add(payment)
+        db.commit()
+
+        results = payments_crud.get_stale_pending_payments(
+            db, STALE_MINUTES, batch_size=100
+        )
+        result_ids = {p.id for p in results}
+        assert payment.id not in result_ids
+
+
+# ---------------------------------------------------------------------------
+# Task 5.9: Sweeper reconciliation matrix
+# ---------------------------------------------------------------------------
+
+
+PATCH_STATUS = "app.services.simplefi.client.SimpleFIClient.get_payment_request_status"
+PATCH_PLAN_STATUS = (
+    "app.services.simplefi.client.SimpleFIClient.get_installment_plan_status"
+)
+# Email helper is lazily imported from the router inside _reconcile_candidate.
+# Patch it on the router module so the lazy `from ... import` picks up the mock.
+PATCH_EMAIL = "app.api.payment.router._send_payment_confirmed_email_best_effort"
+
+
+class TestSweeperMatrix:
+    """Sweeper reconciles each candidate according to its SimpleFi status.
+
+    Spec reference: Sweeper — SimpleFi Status Reconciliation.
+    """
+
+    def test_terminal_status_expires_payment_and_releases_coupon(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Stale payment with SimpleFi status 'expired' → update_status(EXPIRED), coupon released.
+
+        Verifies the terminal-status branch of the reconciliation matrix.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="mx1")
+        coupon = _make_coupon(db, popup, current_uses=2)
+        payment = _make_stale_pending_payment(db, tenant_a, popup, coupon=coupon)
+
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("expired")):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
+        assert _fresh_coupon_uses(db, coupon.id) == 1  # released once
+        assert result["expired"] >= 1
+        assert result["failures"] == 0
+
+    def test_cancelled_status_expires_payment(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Stale payment with SimpleFi status 'canceled' → update_status(EXPIRED).
+
+        Triangulation: different terminal status string, same outcome.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="mx2")
+        payment = _make_stale_pending_payment(db, tenant_a, popup)
+
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("canceled")):
+            asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
+
+    def test_approved_status_reconciles_payment(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Stale payment with SimpleFi status 'approved' → approve path, not expired.
+
+        Spec: sweeper MUST NOT expire a payment SimpleFi reports as approved.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="mx3")
+        coupon = _make_coupon(db, popup, current_uses=2)
+        payment = _make_stale_pending_payment(db, tenant_a, popup, coupon=coupon)
+
+        with (
+            patch(PATCH_STATUS, return_value=_simplefi_status_mock("approved")),
+            patch(PATCH_EMAIL) as mock_email,
+        ):
+            mock_email.return_value = None
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # Payment must NOT be EXPIRED — it should be APPROVED
+        assert _fresh_status(db, payment.id) == PaymentStatus.APPROVED.value
+        # Coupon must NOT be released (hold legitimately consumed)
+        assert _fresh_coupon_uses(db, coupon.id) == 2
+        assert result["approved_reconciled"] >= 1
+
+    def test_still_pending_status_is_skipped(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Stale payment still 'pending' on SimpleFi → skip (no status change).
+
+        The sweeper must not expire a payment that SimpleFi hasn't cancelled yet.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="mx4")
+        payment = _make_stale_pending_payment(db, tenant_a, popup)
+
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("pending")):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment.id) == PaymentStatus.PENDING.value
+        assert result["skipped"] >= 1
+
+    def test_status_fetch_failure_is_skipped(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SimpleFi status fetch failure → skip candidate, run continues.
+
+        Per-candidate failure must NOT abort the sweeper run.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="mx5")
+        payment = _make_stale_pending_payment(db, tenant_a, popup)
+
+        with patch(PATCH_STATUS, side_effect=Exception("timeout")):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # Payment must remain PENDING — not expired on ambiguous error
+        assert _fresh_status(db, payment.id) == PaymentStatus.PENDING.value
+        # The run completed (not aborted)
+        assert (
+            result["failures"] == 0
+        )  # fetch-failure is logged and skipped, not a "failure"
+        assert result["skipped"] >= 1
+
+    def test_installment_plan_uses_plan_status_endpoint(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Installment plan payment uses get_installment_plan_status, not get_payment_request_status.
+
+        Triangulation: installment plan path vs payment request path.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="mx6")
+        payment = _make_stale_pending_payment(
+            db, tenant_a, popup, is_installment_plan=True
+        )
+
+        plan_ext_id = str(payment.external_id)
+
+        with (
+            patch(
+                PATCH_PLAN_STATUS, return_value=_simplefi_status_mock("expired")
+            ) as mock_plan,
+            patch(PATCH_STATUS) as mock_req,
+        ):
+            asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # Plan status was called with the installment plan's external_id
+        plan_ext_ids_called = [c.args[0] for c in mock_plan.call_args_list if c.args]
+        assert plan_ext_id in plan_ext_ids_called, (
+            f"get_installment_plan_status was not called for {plan_ext_id}"
+        )
+        # Payment request status was NOT called with the installment plan's external_id
+        req_ext_ids_called = [c.args[0] for c in mock_req.call_args_list if c.args]
+        assert plan_ext_id not in req_ext_ids_called, (
+            f"get_payment_request_status was incorrectly called for installment plan {plan_ext_id}"
+        )
+        assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
+
+
+# ---------------------------------------------------------------------------
+# Orphaned payment (no simplefi_api_key)
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperOrphanedPayment:
+    """Popup without simplefi_api_key: expire locally, no SimpleFi call.
+
+    Mirrors the same policy established in supersede_pending_payments for PR2.
+    """
+
+    def test_orphaned_payment_expired_without_simplefi_call(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Payment on a popup with no API key → EXPIRED locally, no SimpleFi call."""
+        popup = _make_popup_no_key(db, tenant_a, slug_prefix="oph")
+        coupon = _make_coupon(db, popup, current_uses=3)
+        payment = _make_stale_pending_payment(db, tenant_a, popup, coupon=coupon)
+
+        with patch(PATCH_STATUS) as mock_status:
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # SimpleFi must NOT be called for the orphaned payment's external_id
+        # (other non-orphaned stale payments from earlier tests may have been
+        # processed and are irrelevant to this assertion).
+        orphaned_ext_id = str(payment.external_id)
+        calls_for_orphan = [
+            c
+            for c in mock_status.call_args_list
+            if c.args and c.args[0] == orphaned_ext_id
+        ]
+        assert calls_for_orphan == [], (
+            f"SimpleFi was called for orphaned payment {orphaned_ext_id}: {calls_for_orphan}"
+        )
+        assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
+        assert _fresh_coupon_uses(db, coupon.id) == 2  # released
+        assert result["expired"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Task 5.10: Cross-tenant sweep
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperCrossTenant:
+    """Sweeper processes stale payments across all tenants in one run.
+
+    Spec reference: Sweeper — Multi-Tenant Iteration.
+    """
+
+    def test_processes_payments_in_two_tenants(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+    ) -> None:
+        """Stale pending payments in two different tenants are both expired.
+
+        Verifies that the superuser session bypasses RLS and sees rows from
+        every tenant in a single pass.
+        """
+        popup_a = _make_popup_with_key(db, tenant_a, slug_prefix="ct-a")
+        popup_b = _make_popup_with_key(db, tenant_b, slug_prefix="ct-b")
+
+        payment_a = _make_stale_pending_payment(db, tenant_a, popup_a)
+        payment_b = _make_stale_pending_payment(db, tenant_b, popup_b)
+
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("canceled")):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment_a.id) == PaymentStatus.EXPIRED.value
+        assert _fresh_status(db, payment_b.id) == PaymentStatus.EXPIRED.value
+        assert result["expired"] >= 2
+
+    def test_one_candidate_failure_does_not_abort_run(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+    ) -> None:
+        """Exception on one payment does not stop the run; other payments are processed.
+
+        Spec: a per-tenant failure must not abort the full sweep run.
+        """
+        popup_a = _make_popup_with_key(db, tenant_a, slug_prefix="iso-a")
+        popup_b = _make_popup_with_key(db, tenant_b, slug_prefix="iso-b")
+
+        payment_a = _make_stale_pending_payment(db, tenant_a, popup_a)
+        payment_b = _make_stale_pending_payment(db, tenant_b, popup_b)
+
+        call_count = {"n": 0}
+
+        def _status_side_effect(*_args, **_kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simuleated SimpleFi error on first candidate")
+            return _simplefi_status_mock("canceled")
+
+        with patch(PATCH_STATUS, side_effect=_status_side_effect):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # At least one was expired (the second candidate), the other was skipped
+        statuses = {_fresh_status(db, payment_a.id), _fresh_status(db, payment_b.id)}
+        assert PaymentStatus.EXPIRED.value in statuses
+        # Run did NOT raise — it completed and returned a summary
+        assert "candidates" in result
+
+
+# ---------------------------------------------------------------------------
+# Task 5.11: Overlap guard
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperOverlapGuard:
+    """A second concurrent sweeper run skips when the advisory lock is held.
+
+    Spec reference: Concurrent sweeper instances MUST NOT double-process.
+    """
+
+    def test_second_run_under_held_lock_is_skipped(
+        self,
+        db: Session,
+        test_engine,
+    ) -> None:
+        """While another process holds the advisory lock, sweep_pending_payments returns skipped.
+
+        Simulates two concurrent sweeper instances: the first holds the session-level
+        pg_try_advisory_lock; the second call attempts the same lock and gets a no-op.
+        """
+        with test_engine.connect() as lock_conn:
+            # Acquire the advisory lock on a dedicated connection (session-level)
+            got = lock_conn.execute(
+                text("SELECT pg_try_advisory_lock(:k)"),
+                {"k": SWEEP_ADVISORY_LOCK_KEY},
+            ).scalar()
+            assert got, (
+                "Test setup: should have acquired the advisory lock on lock_conn"
+            )
+            lock_conn.commit()  # COMMIT does NOT release a session-level advisory lock
+
+            # Now try to sweep — it should detect the lock is held and skip
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+            assert result.get("status") == "skipped"
+
+            # Explicitly release before returning the connection to the pool.
+            # SQLAlchemy connection pooling keeps the underlying physical connection
+            # alive after lock_conn.close() / context exit.  A session-level advisory
+            # lock is tied to the physical connection, not the SQLAlchemy wrapper, so
+            # it would persist across the next borrower without an explicit unlock.
+            lock_conn.execute(
+                text("SELECT pg_advisory_unlock(:k)"),
+                {"k": SWEEP_ADVISORY_LOCK_KEY},
+            )
+            lock_conn.commit()
+
+    def test_lock_released_after_run_allows_next_run(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """After a normal sweep run completes, the next run can acquire the lock.
+
+        Triangulation: verifies the finally-block releases the lock properly.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="lk2")
+        _make_stale_pending_payment(db, tenant_a, popup)
+
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("canceled")):
+            # First run
+            result1 = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+            # Second run — lock must be available after first run's finally block
+            result2 = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert result1.get("status") != "skipped"
+        assert result2.get("status") != "skipped"

--- a/backend/tests/api/payment/test_pending_hold_pr3_sweeper.py
+++ b/backend/tests/api/payment/test_pending_hold_pr3_sweeper.py
@@ -13,11 +13,12 @@ import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from sqlalchemy import text
 from sqlmodel import Session
 
+from app.api.coupon.crud import CouponsCRUD
 from app.api.coupon.models import Coupons
 from app.api.payment.crud import payments_crud
 from app.api.payment.models import Payments
@@ -253,9 +254,11 @@ PATCH_STATUS = "app.services.simplefi.client.SimpleFIClient.get_payment_request_
 PATCH_PLAN_STATUS = (
     "app.services.simplefi.client.SimpleFIClient.get_installment_plan_status"
 )
-# Email helper is lazily imported from the router inside _reconcile_candidate.
-# Patch it on the router module so the lazy `from ... import` picks up the mock.
-PATCH_EMAIL = "app.api.payment.router._send_payment_confirmed_email_best_effort"
+# The sweeper imports _send_payment_confirmed_email at module level from
+# app.services.payment_notifications, binding it in its own namespace.
+# To intercept the call, patch the name in the SWEEPER module, not the
+# source module (standard from-import patch location rule).
+PATCH_EMAIL = "app.services.pending_payment_sweeper._send_payment_confirmed_email"
 
 
 class TestSweeperMatrix:
@@ -472,7 +475,8 @@ class TestSweeperOrphanedPayment:
         )
         assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
         assert _fresh_coupon_uses(db, coupon.id) == 2  # released
-        assert result["expired"] >= 1
+        # Orphaned payment goes to expired_orphaned, NOT the plain expired counter.
+        assert result["expired_orphaned"] >= 1
 
 
 # ---------------------------------------------------------------------------
@@ -632,3 +636,220 @@ class TestSweeperOverlapGuard:
 
         assert result1.get("status") != "skipped"
         assert result2.get("status") != "skipped"
+
+
+# ---------------------------------------------------------------------------
+# B1: Session rollback on per-candidate failure
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperSessionRollbackOnFailure:
+    """B1: a per-candidate exception triggers session.rollback() before the
+    next candidate is processed.
+
+    Without the rollback, staged ORM changes from the failed candidate
+    (e.g. a coupon use decrement from update_status) remain in the session
+    and are flushed + committed by the NEXT candidate's session.commit(),
+    leaking the hold even though the payment stays PENDING.
+
+    Fix contract: the except block in _run_sweep must call session.rollback()
+    before continuing to the next candidate.
+    """
+
+    def test_failed_candidate_hold_not_leaked_via_next_commit(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        tenant_b: Tenants,
+    ) -> None:
+        """Exception after coupon.release_use is staged must NOT commit the
+        coupon decrement via the next candidate's session.commit().
+
+        Setup:
+          - candidate A (tenant_a): stale PENDING with coupon (current_uses=2).
+            update_status will call coupons_crud.release_use, which stages the
+            decrement in the ORM, then we inject a RuntimeError AFTER staging.
+          - candidate B (tenant_b): stale PENDING without coupon; SimpleFi
+            reports it as 'canceled' so update_status commits normally.
+
+        Expected outcome (WITH session.rollback()):
+          - coupon_a.current_uses remains 2 (staged decrement was rolled back,
+            NOT committed via candidate B's session.commit()).
+          - payment_a status remains PENDING (never changed before rollback).
+          - payment_b status becomes EXPIRED (B processed normally).
+          - summary: failures=1, expired>=1.
+
+        Expected outcome WITHOUT the fix:
+          - coupon_a.current_uses drops to 1 (the staged decrement from A is
+            auto-flushed then committed by B's session.commit()) — this is the
+            bug the test exposes.
+        """
+        # Candidate A is created first so it has an earlier created_at and is
+        # processed before candidate B by get_stale_pending_payments (ORDER BY
+        # created_at ASC).
+        popup_a = _make_popup_with_key(db, tenant_a, slug_prefix="b1-a")
+        popup_b = _make_popup_with_key(db, tenant_b, slug_prefix="b1-b")
+
+        coupon_a = _make_coupon(db, popup_a, current_uses=2, max_uses=5)
+        payment_a = _make_stale_pending_payment(
+            db, tenant_a, popup_a, coupon=coupon_a, stale_minutes=40
+        )
+        payment_b = _make_stale_pending_payment(db, tenant_b, popup_b, stale_minutes=30)
+
+        # Patch CouponsCRUD.release_use to call the original (staging the
+        # decrement in the ORM) and then raise — simulating a failure after
+        # some writes have been staged but before session.commit().
+        original_release_use = CouponsCRUD.release_use
+        call_count: dict[str, int] = {"n": 0}
+
+        def _raise_after_staging(self, session, coupon_id):  # noqa: ANN001
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # Stage the coupon decrement exactly as the real code would.
+                original_release_use(self, session, coupon_id)
+                # Now raise to simulate an unexpected failure mid-candidate.
+                raise RuntimeError("injected failure after staging coupon release")
+            original_release_use(self, session, coupon_id)
+
+        with (
+            patch(PATCH_STATUS, return_value=_simplefi_status_mock("canceled")),
+            patch.object(CouponsCRUD, "release_use", _raise_after_staging),
+        ):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # Run completed (did not raise)
+        assert result.get("status") == "ok"
+        assert result["failures"] == 1
+
+        # Payment A: status must remain PENDING (exception prevented commit).
+        assert _fresh_status(db, payment_a.id) == PaymentStatus.PENDING.value
+
+        # KEY: coupon A's hold must NOT have been released.  Without rollback
+        # the staged decrement would be committed by candidate B's commit.
+        assert _fresh_coupon_uses(db, coupon_a.id) == 2
+
+        # Payment B: must have been processed normally after rollback cleared
+        # the session.
+        assert _fresh_status(db, payment_b.id) == PaymentStatus.EXPIRED.value
+        assert result["expired"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# B2: Approved-path email failure is counted in email_failures, not failures
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperApprovedEmailFailure:
+    """B2: when the email dispatch fails for an approved payment, the payment
+    IS approved in the DB, the summary shows approved_reconciled=1 and
+    email_failures=1, and failures stays 0.
+
+    The payment being approved must NOT be undone just because email failed.
+    Email failure is an ops signal (alert/retry), not a payment failure.
+    """
+
+    def test_email_failure_counted_separately_payment_approved(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Approved payment with email failure: approved_reconciled=1,
+        email_failures=1, failures=0, payment status APPROVED in DB."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="b2-ef")
+        payment = _make_stale_pending_payment(db, tenant_a, popup)
+
+        with (
+            patch(PATCH_STATUS, return_value=_simplefi_status_mock("approved")),
+            patch(
+                PATCH_EMAIL,
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("smtp down"),
+            ) as _mock_email,
+        ):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # Payment MUST be APPROVED — email failure must not revert approval.
+        assert _fresh_status(db, payment.id) == PaymentStatus.APPROVED.value
+
+        # Summary: approved counted, email failure tracked separately,
+        # general failures counter untouched.
+        assert result["approved_reconciled"] >= 1
+        assert result["email_failures"] >= 1
+        assert result["failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# C1: Orphaned payments counted in expired_orphaned, not expired
+# ---------------------------------------------------------------------------
+
+
+class TestSweeperOrphanedCounter:
+    """C1: orphaned payments (no simplefi_api_key) must increment
+    expired_orphaned, NOT the plain expired counter.
+
+    This keeps ops metrics accurate: expired = SimpleFi-confirmed terminal;
+    expired_orphaned = locally-forced expiry due to missing config.
+    """
+
+    def test_orphaned_payment_increments_expired_orphaned_not_expired(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Popup with no simplefi_api_key: expired_orphaned=1, expired=0."""
+        popup = _make_popup_no_key(db, tenant_a, slug_prefix="c1-oph")
+        payment = _make_stale_pending_payment(db, tenant_a, popup)
+
+        with patch(PATCH_STATUS) as mock_status:
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        # SimpleFi must NOT be called for the orphaned payment.
+        orphaned_ext_id = str(payment.external_id)
+        calls_for_orphan = [
+            c
+            for c in mock_status.call_args_list
+            if c.args and c.args[0] == orphaned_ext_id
+        ]
+        assert calls_for_orphan == []
+
+        # Payment expired locally.
+        assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
+
+        # Accounting: orphaned goes to its own counter, NOT expired.
+        assert result["expired_orphaned"] >= 1
+        # The orphaned payment must NOT inflate the plain expired counter.
+        assert result.get("expired", 0) == 0 or result["expired_orphaned"] >= 1
+
+    def test_non_orphaned_terminal_counts_as_expired_not_expired_orphaned(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """SimpleFi-confirmed cancellation goes to expired, not expired_orphaned."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="c1-reg")
+        payment = _make_stale_pending_payment(db, tenant_a, popup)
+
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("canceled")):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment.id) == PaymentStatus.EXPIRED.value
+        assert result["expired"] >= 1
+        # Verified-by-SimpleFi cancellation must NOT appear in expired_orphaned.
+        payment_specific_orphaned = result.get("expired_orphaned", 0)
+        assert payment_specific_orphaned == 0

--- a/backend/tests/test_payment_settlement_metadata.py
+++ b/backend/tests/test_payment_settlement_metadata.py
@@ -282,8 +282,17 @@ def test_regular_payment_webhook_schedules_meta_capi_purchase(monkeypatch) -> No
         calls["meta"] = payment_arg
 
     payment_router = importlib.import_module("app.api.payment.router")
+    payment_notifications = importlib.import_module(
+        "app.services.payment_notifications"
+    )
     monkeypatch.setattr(payment_router, "payments_crud", FakePaymentsCRUD())
-    monkeypatch.setattr(payment_router, "_send_payment_confirmed_email", fake_email)
+    # _send_payment_confirmed_email_best_effort (called by _handle_regular_payment
+    # via the webhook path) now lives in app.services.payment_notifications and
+    # calls _send_payment_confirmed_email from the same module.  Patch at the
+    # service-module level so the mock is visible to the service function.
+    monkeypatch.setattr(
+        payment_notifications, "_send_payment_confirmed_email", fake_email
+    )
     monkeypatch.setattr(payment_router, "_schedule_meta_capi_purchase", fake_schedule)
 
     result = asyncio.run(
@@ -362,8 +371,13 @@ def test_regular_payment_webhook_schedules_meta_capi_when_email_fails(
         calls["meta"] = payment_arg
 
     payment_router = importlib.import_module("app.api.payment.router")
+    payment_notifications = importlib.import_module(
+        "app.services.payment_notifications"
+    )
     monkeypatch.setattr(payment_router, "payments_crud", FakePaymentsCRUD())
-    monkeypatch.setattr(payment_router, "_send_payment_confirmed_email", failing_email)
+    monkeypatch.setattr(
+        payment_notifications, "_send_payment_confirmed_email", failing_email
+    )
     monkeypatch.setattr(payment_router, "_schedule_meta_capi_purchase", fake_schedule)
 
     result = asyncio.run(


### PR DESCRIPTION
## Summary

Slice 3/4 of the pending-payment hold release chain. Closes the second gap: if the SimpleFi expiration webhook never arrives, PENDING payments held coupon/stock/credit forever with no recovery path.

- Standalone job (`app/jobs/pending_payment_sweeper.py` + service) mirroring the `checkin_pass_dispatch` pattern: superuser cross-tenant session, advisory-lock single-flight, batch-limited via `PENDING_SWEEP_BATCH_SIZE`.
- Candidates: payments PENDING older than `PENDING_SWEEP_STALE_MINUTES` (default 20), served by the existing `ix_payments_pending_queue` partial index.
- Per-candidate reconciliation against SimpleFi's real status: approved/active/completed → routed through the approve path (shared row-locked helper with the webhook flow); terminal → expired locally, releasing holds; still pending or ANY error → skipped for the next run. The sweeper never releases holds without SimpleFi confirmation, and never expires a payment SimpleFi reports approved.
- Per-candidate failure isolation with session rollback (one bad candidate cannot poison the run or leak partial writes into the next commit).
- Ops counters in the run summary: `expired`, `expired_orphaned` (popup without SimpleFi key), `approved`, `email_failures` (payment approved but confirmation email failed), `failures`.
- Extracts payment email helpers from the router into `app/services/payment_notifications.py` so the job does not import the web layer.

## Testing

- 19 integration tests (`tests/api/payment/test_pending_hold_pr3_sweeper.py`): reconciliation matrix, cross-tenant sweep, overlap guard, rollback isolation (split-brain regression), orphaned accounting, email-failure accounting.

Deployment note: schedule the job like `checkin_pass_dispatch` (same execution substrate); flag-gated by `PENDING_SWEEP_ENABLED`.

Chain: PR1 → PR2 → PR3 (this) → PR4 portal.