### PR TITLE
feat(portal): handle supersede payment contracts

### DIFF
--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -1362,7 +1362,10 @@ async def _handle_installment_plan_activated(
             if getattr(payment, "installments_paid", new_paid) != new_paid:
                 payment.installments_paid = new_paid
                 changed = True
-            if plan_source is not None and getattr(payment, "source", None) != plan_source:
+            if (
+                plan_source is not None
+                and getattr(payment, "source", None) != plan_source
+            ):
                 payment.source = plan_source
                 changed = True
             if changed:

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -11866,6 +11866,29 @@ export const OpenTicketingPurchaseCreateSchema = {
                     type: 'null'
                 }
             ]
+        },
+        cid: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Cid'
+        },
+        sig: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Sig'
         }
     },
     type: 'object',

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2110,7 +2110,9 @@ export class CheckoutService {
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
-                422: 'Validation Error'
+                409: "Payment conflict. detail.code is one of: 'pending_payment_exists' (a prior PENDING payment exists and no valid cart continuity proof was supplied — no cancellation attempted); 'concurrent_payment_in_progress' (another checkout is in progress under the same email right now); 'previous_payment_completed' (prior payment was already approved — includes redirect_url when a signing secret and external success URL are both configured).",
+                422: 'Validation Error',
+                502: "Payment provider error. detail.code='payment_cancel_failed' means the prior pending payment could not be cancelled. Retry the request."
             }
         });
     }
@@ -6214,7 +6216,9 @@ export class PaymentsService {
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
-                422: 'Validation Error'
+                409: "Concurrent payment conflict. detail.code is one of: 'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or 'previous_payment_completed' (prior payment was completed — redirect_url points to the buyer's passes page).",
+                422: 'Validation Error',
+                502: "Payment provider error. detail.code='payment_cancel_failed' means the prior pending payment could not be cancelled. Retry the request."
             }
         });
     }

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2577,6 +2577,8 @@ export type OpenTicketingPurchaseCreate = {
     fbp?: (string | null);
     locale?: (string | null);
     attribution?: (Attribution | null);
+    cid?: (string | null);
+    sig?: (string | null);
 };
 
 /**

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -11866,6 +11866,29 @@ export const OpenTicketingPurchaseCreateSchema = {
                     type: 'null'
                 }
             ]
+        },
+        cid: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Cid'
+        },
+        sig: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Sig'
         }
     },
     type: 'object',

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2110,7 +2110,9 @@ export class CheckoutService {
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
-                422: 'Validation Error'
+                409: "Payment conflict. detail.code is one of: 'pending_payment_exists' (a prior PENDING payment exists and no valid cart continuity proof was supplied — no cancellation attempted); 'concurrent_payment_in_progress' (another checkout is in progress under the same email right now); 'previous_payment_completed' (prior payment was already approved — includes redirect_url when a signing secret and external success URL are both configured).",
+                422: 'Validation Error',
+                502: "Payment provider error. detail.code='payment_cancel_failed' means the prior pending payment could not be cancelled. Retry the request."
             }
         });
     }
@@ -6214,7 +6216,9 @@ export class PaymentsService {
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {
-                422: 'Validation Error'
+                409: "Concurrent payment conflict. detail.code is one of: 'concurrent_payment_in_progress' (another PENDING payment exists and could not be superseded) or 'previous_payment_completed' (prior payment was completed — redirect_url points to the buyer's passes page).",
+                422: 'Validation Error',
+                502: "Payment provider error. detail.code='payment_cancel_failed' means the prior pending payment could not be cancelled. Retry the request."
             }
         });
     }

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2577,6 +2577,8 @@ export type OpenTicketingPurchaseCreate = {
     fbp?: (string | null);
     locale?: (string | null);
     attribution?: (Attribution | null);
+    cid?: (string | null);
+    sig?: (string | null);
 };
 
 /**

--- a/portal/src/hooks/checkout/errorDispatch.test.ts
+++ b/portal/src/hooks/checkout/errorDispatch.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment node
+// Tests for the pure payment error-dispatch helper and extractCartMeta.
+// No React, no DOM, no mocks — everything is deterministic pure-function logic.
+
+import { describe, expect, it } from "vitest"
+import { dispatchPaymentError, extractCartMeta } from "./errorDispatch"
+
+// ---------------------------------------------------------------------------
+// extractCartMeta
+// ---------------------------------------------------------------------------
+
+describe("extractCartMeta", () => {
+  it("returns cid and sig from a populated ref", () => {
+    const ref = { current: { cartId: "cart-abc", restoreToken: "tok-xyz" } }
+    expect(extractCartMeta(ref)).toEqual({ cid: "cart-abc", sig: "tok-xyz" })
+  })
+
+  it("returns undefined for null values inside ref.current", () => {
+    const ref = { current: { cartId: null, restoreToken: null } }
+    expect(extractCartMeta(ref)).toEqual({ cid: undefined, sig: undefined })
+  })
+
+  it("returns undefined when ref itself is null", () => {
+    expect(extractCartMeta(null)).toEqual({ cid: undefined, sig: undefined })
+  })
+
+  it("returns undefined when ref is undefined", () => {
+    expect(extractCartMeta(undefined)).toEqual({
+      cid: undefined,
+      sig: undefined,
+    })
+  })
+
+  it("returns cid only when restoreToken is null", () => {
+    const ref = { current: { cartId: "cart-1", restoreToken: null } }
+    const result = extractCartMeta(ref)
+    expect(result.cid).toBe("cart-1")
+    expect(result.sig).toBeUndefined()
+  })
+
+  it("returns sig only when cartId is null", () => {
+    const ref = { current: { cartId: null, restoreToken: "sig-1" } }
+    const result = extractCartMeta(ref)
+    expect(result.cid).toBeUndefined()
+    expect(result.sig).toBe("sig-1")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// dispatchPaymentError — previous_payment_completed
+// ---------------------------------------------------------------------------
+
+describe("dispatchPaymentError — previous_payment_completed", () => {
+  it("open-ticketing + redirect_url → navigate href, block resubmit, persistent banner", () => {
+    const result = dispatchPaymentError(
+      {
+        code: "previous_payment_completed",
+        redirect_url: "https://example.com/success",
+      },
+      "open-ticketing",
+      "my-popup",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("openCheckout.previous_payment_completed")
+    expect(result!.blockResubmit).toBe(true)
+    expect(result!.setPersistentError).toBe(true)
+    expect(result!.navigate).toEqual({
+      type: "href",
+      url: "https://example.com/success",
+    })
+  })
+
+  it("open-ticketing + no redirect_url → no navigation, block resubmit, persistent banner (F1 stranded-buyer fix)", () => {
+    const result = dispatchPaymentError(
+      { code: "previous_payment_completed" },
+      "open-ticketing",
+      "my-popup",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("openCheckout.previous_payment_completed")
+    expect(result!.blockResubmit).toBe(true)
+    expect(result!.setPersistentError).toBe(true)
+    expect(result!.navigate).toBeNull()
+  })
+
+  it("open-ticketing + empty redirect_url → no navigation (empty string is falsy)", () => {
+    const result = dispatchPaymentError(
+      { code: "previous_payment_completed", redirect_url: "" },
+      "open-ticketing",
+      "my-popup",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.navigate).toBeNull()
+  })
+
+  it("application + popupSlug → router-push to /passes, block resubmit, persistent banner", () => {
+    const result = dispatchPaymentError(
+      { code: "previous_payment_completed" },
+      "application",
+      "edge-popup",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("checkout.previous_payment_completed")
+    expect(result!.blockResubmit).toBe(true)
+    expect(result!.setPersistentError).toBe(true)
+    expect(result!.navigate).toEqual({
+      type: "router-push",
+      path: "/portal/edge-popup/passes",
+    })
+  })
+
+  it("application + null slug → no navigation, still blocks resubmit and shows persistent banner", () => {
+    const result = dispatchPaymentError(
+      { code: "previous_payment_completed" },
+      "application",
+      null,
+    )
+    expect(result).not.toBeNull()
+    expect(result!.navigate).toBeNull()
+    expect(result!.blockResubmit).toBe(true)
+    expect(result!.setPersistentError).toBe(true)
+  })
+
+  it("application ignores redirect_url (navigation always uses router-push to /passes)", () => {
+    const result = dispatchPaymentError(
+      {
+        code: "previous_payment_completed",
+        redirect_url: "https://should-be-ignored.com",
+      },
+      "application",
+      "my-popup",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.navigate).toEqual({
+      type: "router-push",
+      path: "/portal/my-popup/passes",
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// dispatchPaymentError — payment_cancel_failed / concurrent_payment_in_progress
+// ---------------------------------------------------------------------------
+
+describe("dispatchPaymentError — payment_cancel_failed / concurrent_payment_in_progress", () => {
+  it("payment_cancel_failed (open-ticketing) → retryable: no block, persistent banner, no nav", () => {
+    const result = dispatchPaymentError(
+      { code: "payment_cancel_failed" },
+      "open-ticketing",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("openCheckout.payment_cancel_failed")
+    expect(result!.blockResubmit).toBe(false)
+    expect(result!.setPersistentError).toBe(true)
+    expect(result!.navigate).toBeNull()
+  })
+
+  it("concurrent_payment_in_progress (open-ticketing) → same retryable treatment as cancel_failed", () => {
+    const result = dispatchPaymentError(
+      { code: "concurrent_payment_in_progress" },
+      "open-ticketing",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("openCheckout.payment_cancel_failed")
+    expect(result!.blockResubmit).toBe(false)
+    expect(result!.setPersistentError).toBe(true)
+    expect(result!.navigate).toBeNull()
+  })
+
+  it("payment_cancel_failed (application) → checkout prefix, retryable", () => {
+    const result = dispatchPaymentError(
+      { code: "payment_cancel_failed" },
+      "application",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("checkout.payment_cancel_failed")
+    expect(result!.blockResubmit).toBe(false)
+  })
+
+  it("concurrent_payment_in_progress (application) → checkout prefix, retryable", () => {
+    const result = dispatchPaymentError(
+      { code: "concurrent_payment_in_progress" },
+      "application",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("checkout.payment_cancel_failed")
+    expect(result!.blockResubmit).toBe(false)
+  })
+
+  it("502 payment_cancel_failed → same retryable treatment (backend reuses code on both 409 and 502)", () => {
+    // The backend returns detail.code = "payment_cancel_failed" on both
+    // 409 (sibling race) and 502 (SimpleFi cancel API error). The hook
+    // receives the same code either way and should treat both as retryable.
+    const result = dispatchPaymentError(
+      { code: "payment_cancel_failed" },
+      "open-ticketing",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.blockResubmit).toBe(false)
+    expect(result!.messageKey).toBe("openCheckout.payment_cancel_failed")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// dispatchPaymentError — pending_payment_exists
+// ---------------------------------------------------------------------------
+
+describe("dispatchPaymentError — pending_payment_exists", () => {
+  it("open-ticketing → openCheckout prefix, no block, persistent banner, no nav", () => {
+    const result = dispatchPaymentError(
+      { code: "pending_payment_exists" },
+      "open-ticketing",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("openCheckout.pending_payment_wait")
+    expect(result!.blockResubmit).toBe(false)
+    expect(result!.setPersistentError).toBe(true)
+    expect(result!.navigate).toBeNull()
+  })
+
+  it("application → checkout prefix (defensive: backend only sends this in open-ticketing)", () => {
+    const result = dispatchPaymentError(
+      { code: "pending_payment_exists" },
+      "application",
+      "slug",
+    )
+    expect(result).not.toBeNull()
+    expect(result!.messageKey).toBe("checkout.pending_payment_wait")
+    expect(result!.blockResubmit).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// dispatchPaymentError — unrecognised / null codes
+// ---------------------------------------------------------------------------
+
+describe("dispatchPaymentError — unrecognised codes fall through", () => {
+  it("returns null for an unrecognised code", () => {
+    expect(
+      dispatchPaymentError(
+        { code: "some_unknown_error" },
+        "open-ticketing",
+        null,
+      ),
+    ).toBeNull()
+  })
+
+  it("returns null when code is undefined", () => {
+    expect(dispatchPaymentError({}, "open-ticketing", null)).toBeNull()
+  })
+
+  it("returns null when detail is empty object", () => {
+    expect(dispatchPaymentError({}, "application", "slug")).toBeNull()
+  })
+})

--- a/portal/src/hooks/checkout/errorDispatch.ts
+++ b/portal/src/hooks/checkout/errorDispatch.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure error-dispatch helper for the payment-submit flow.
+ *
+ * Keeping the error-code → action mapping separate from the React hook lets
+ * us test every branch without mounting the full checkout context.
+ */
+
+export type CartMeta = {
+  cartId: string | null
+  restoreToken: string | null
+}
+
+export type NavigateAction =
+  | { type: "href"; url: string }
+  | { type: "router-push"; path: string }
+
+export type PaymentErrorDispatch = {
+  /** i18n translation key — pass through t() before displaying */
+  messageKey: string
+  /** When true, set paymentCompleteRef.current = true to block resubmit */
+  blockResubmit: boolean
+  /** When true, surface via setPromoError (persistent banner) */
+  setPersistentError: boolean
+  /** Navigation to perform after surfacing the error, or null */
+  navigate: NavigateAction | null
+}
+
+/**
+ * Extracts cid/sig from the open-cart meta ref for inclusion in the purchase
+ * request body. Both values are undefined (omitted) when not present.
+ */
+export function extractCartMeta(
+  ref: { current: CartMeta } | null | undefined,
+): { cid: string | undefined; sig: string | undefined } {
+  return {
+    cid: ref?.current.cartId ?? undefined,
+    sig: ref?.current.restoreToken ?? undefined,
+  }
+}
+
+/**
+ * Maps a structured API error detail to the set of actions the hook must
+ * perform. Returns null when the code is unrecognised (caller falls through
+ * to generic error handling).
+ */
+export function dispatchPaymentError(
+  detail: { code?: string; redirect_url?: string },
+  submitMode: "application" | "open-ticketing",
+  popupSlug: string | null,
+): PaymentErrorDispatch | null {
+  const prefix = submitMode === "open-ticketing" ? "openCheckout" : "checkout"
+
+  if (detail.code === "previous_payment_completed") {
+    // Buyer already has a completed purchase.  Navigate when possible so they
+    // can see it.  When no redirect_url is available (open-ticketing without a
+    // configured external success URL) or when the slug is absent (edge case),
+    // fall back to a persistent banner so the buyer is not silently stranded.
+    const navigate: NavigateAction | null =
+      submitMode === "open-ticketing" && detail.redirect_url
+        ? { type: "href", url: detail.redirect_url }
+        : submitMode === "application" && popupSlug
+          ? { type: "router-push", path: `/portal/${popupSlug}/passes` }
+          : null
+
+    return {
+      messageKey: `${prefix}.previous_payment_completed`,
+      blockResubmit: true,
+      setPersistentError: true,
+      navigate,
+    }
+  }
+
+  if (
+    detail.code === "payment_cancel_failed" ||
+    detail.code === "concurrent_payment_in_progress"
+  ) {
+    // Transient / retryable: the prior payment cancel failed or a sibling
+    // checkout raced this one.  Do NOT block resubmission.
+    return {
+      messageKey: `${prefix}.payment_cancel_failed`,
+      blockResubmit: false,
+      setPersistentError: true,
+      navigate: null,
+    }
+  }
+
+  if (detail.code === "pending_payment_exists") {
+    // Open-checkout only: no valid cart continuity proof was supplied.
+    // The sweeper will eventually expire the old payment; ask the buyer
+    // to wait rather than blocking resubmission outright.
+    return {
+      messageKey: `${prefix}.pending_payment_wait`,
+      blockResubmit: false,
+      setPersistentError: true,
+      navigate: null,
+    }
+  }
+
+  return null
+}

--- a/portal/src/hooks/checkout/useOpenCartPersistence.ts
+++ b/portal/src/hooks/checkout/useOpenCartPersistence.ts
@@ -464,5 +464,5 @@ export function useOpenCartPersistence({
     cartMetaRef.current = { cartId: null, restoreToken: null }
   }, [popupSlug])
 
-  return { scheduleSave, clearOpenCart }
+  return { scheduleSave, clearOpenCart, cartMetaRef }
 }

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect, useState } from "react"
+import { type MutableRefObject, useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import type { CheckoutMode } from "@/checkout/popupCheckoutPolicy"
@@ -22,6 +22,7 @@ import type {
   SelectedPatronItem,
 } from "@/types/checkout"
 import { buildPaymentProducts } from "./buildPaymentProducts"
+import { dispatchPaymentError, extractCartMeta } from "./errorDispatch"
 
 interface UsePaymentSubmitParams {
   applicationId: string | undefined
@@ -55,6 +56,13 @@ interface UsePaymentSubmitParams {
   } | null
   editPassesEnabled: boolean
   popupName?: string | null
+  /** Ref from useOpenCartPersistence exposing cartId and restoreToken for the
+   *  continuity-proof gate. Must be provided for open-ticketing flows; ignored
+   *  in application mode. */
+  openCartMetaRef?: MutableRefObject<{
+    cartId: string | null
+    restoreToken: string | null
+  }> | null
 }
 
 interface PaymentSubmitResult {
@@ -89,6 +97,7 @@ export function usePaymentSubmit({
   buyerData,
   editPassesEnabled,
   popupName,
+  openCartMetaRef = null,
 }: UsePaymentSubmitParams) {
   const { t, i18n } = useTranslation()
   const queryClient = useQueryClient()
@@ -211,6 +220,10 @@ export function usePaymentSubmit({
                 },
                 coupon_code: promoCodeValid ? promoCode : undefined,
                 insurance: insurance || undefined,
+                // Cart continuity proof: allows the backend to supersede an
+                // existing PENDING payment for the same email+popup pair.
+                // The backend ignores these fields when no PENDING payment exists.
+                ...extractCartMeta(openCartMetaRef),
               },
             })
           : await PaymentsService.createMyPayment({
@@ -324,12 +337,46 @@ export function usePaymentSubmit({
       return { success: true }
     } catch (err: unknown) {
       console.error("Payment failed:", err)
-      const apiDetail =
-        err instanceof ApiError &&
-        typeof (err.body as Record<string, unknown> | null)?.detail === "string"
-          ? ((err.body as Record<string, unknown>).detail as string)
+
+      const apiBody =
+        err instanceof ApiError
+          ? (err.body as Record<string, unknown> | null)
           : null
-      const isCouponError = apiDetail?.startsWith("Coupon code")
+
+      // Machine-code branch: detail is an object carrying a .code field.
+      // Checked before the string-detail coupon branch so structured errors
+      // are never mis-classified by the startsWith("Coupon code") guard.
+      if (
+        apiBody !== null &&
+        typeof apiBody?.detail === "object" &&
+        apiBody.detail !== null
+      ) {
+        const detail = apiBody.detail as {
+          code?: string
+          redirect_url?: string
+        }
+        const dispatch = dispatchPaymentError(detail, submitMode, popupSlug)
+        if (dispatch !== null) {
+          const msg = t(dispatch.messageKey)
+          toast.error(msg)
+          if (dispatch.blockResubmit) paymentCompleteRef.current = true
+          if (dispatch.setPersistentError) setPromoError(msg)
+          if (dispatch.navigate?.type === "href") {
+            window.location.href = dispatch.navigate.url
+          } else if (dispatch.navigate?.type === "router-push") {
+            router.push(dispatch.navigate.path)
+          }
+          setIsSubmitting(false)
+          return { success: false, error: msg }
+        }
+      }
+
+      // String-detail branch: coupon error and generic fallback.
+      const apiDetailStr =
+        apiBody !== null && typeof apiBody?.detail === "string"
+          ? (apiBody.detail as string)
+          : null
+      const isCouponError = apiDetailStr?.startsWith("Coupon code")
       if (isCouponError) {
         clearPromoCode()
         const errorMsg = t("checkout.coupon_no_longer_valid")
@@ -376,6 +423,7 @@ export function usePaymentSubmit({
     isSubmitting,
     t,
     i18n.language,
+    openCartMetaRef,
   ])
 
   return { submitPayment, isSubmitting }

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -283,7 +283,10 @@
     "no_meal_plans": "No meal plans available.",
     "no_contributions": "No contribution options available.",
     "step_config_error": "Step configuration error.",
-    "step_config_error_detail": "No template assigned to this step. Please contact your administrator."
+    "step_config_error_detail": "No template assigned to this step. Please contact your administrator.",
+    "previous_payment_completed": "Your previous payment was completed.",
+    "pending_payment_wait": "You have a pending payment. Please wait a few minutes.",
+    "payment_cancel_failed": "We could not process your payment. Please try again."
   },
   "openCheckout": {
     "loading": "Loading checkout...",
@@ -308,7 +311,10 @@
     "thank_you_description": "Thank you for your purchase. We sent your confirmation and ticket details by email.",
     "thank_you_cta": "Go to portal",
     "thank_you_order_summary": "Order summary",
-    "thank_you_total": "Total"
+    "thank_you_total": "Total",
+    "previous_payment_completed": "Your previous payment was completed.",
+    "payment_cancel_failed": "We could not process your payment. Please try again.",
+    "pending_payment_wait": "You have a pending payment. Please wait a few minutes."
   },
   "passes": {
     "your_passes": "Your Passes",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -283,7 +283,10 @@
     "no_meal_plans": "No hay planes de comidas disponibles.",
     "no_contributions": "No hay opciones de contribución disponibles.",
     "step_config_error": "Error de configuración del paso.",
-    "step_config_error_detail": "No se asignó una plantilla a este paso. Contactá a tu administrador."
+    "step_config_error_detail": "No se asignó una plantilla a este paso. Contactá a tu administrador.",
+    "previous_payment_completed": "Tu pago anterior fue completado.",
+    "pending_payment_wait": "Tenés un pago pendiente. Por favor, esperá unos minutos.",
+    "payment_cancel_failed": "No pudimos procesar tu pago. Por favor, intentá de nuevo."
   },
   "openCheckout": {
     "loading": "Cargando checkout...",
@@ -308,7 +311,10 @@
     "thank_you_description": "Gracias por tu compra. Te enviamos la confirmación y los detalles de tus tickets por email.",
     "thank_you_cta": "Ir al portal",
     "thank_you_order_summary": "Resumen de la orden",
-    "thank_you_total": "Total"
+    "thank_you_total": "Total",
+    "previous_payment_completed": "Tu pago anterior fue completado.",
+    "payment_cancel_failed": "No pudimos procesar tu pago. Por favor, intentá de nuevo.",
+    "pending_payment_wait": "Tenés un pago pendiente. Por favor, esperá unos minutos."
   },
   "passes": {
     "your_passes": "Tus Pases",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -259,7 +259,10 @@
     "no_meal_plans": "Engir matarpakkar í boði.",
     "no_contributions": "Engir framlagsmöguleikar í boði.",
     "step_config_error": "Villa í uppsetningu skrefs.",
-    "step_config_error_detail": "Ekkert sniðmát er tengt þessu skrefi. Hafðu samband við stjórnanda."
+    "step_config_error_detail": "Ekkert sniðmát er tengt þessu skrefi. Hafðu samband við stjórnanda.",
+    "previous_payment_completed": "Fyrri greiðsla þín var lokið.",
+    "pending_payment_wait": "Þú ert með greiðslu í bið. Bíddu í nokkrar mínútur.",
+    "payment_cancel_failed": "Okkur tókst ekki að afgreiða greiðsluna. Reyndu aftur."
   },
   "openCheckout": {
     "loading": "Hleður greiðslu...",
@@ -284,7 +287,10 @@
     "thank_you_description": "Takk fyrir kaupin. Við sendum staðfestingu og miðaupplýsingar með tölvupósti.",
     "thank_you_cta": "Fara í vefgátt",
     "thank_you_order_summary": "Yfirlit pöntunar",
-    "thank_you_total": "Samtals"
+    "thank_you_total": "Samtals",
+    "previous_payment_completed": "Fyrri greiðsla þín var lokið.",
+    "payment_cancel_failed": "Okkur tókst ekki að afgreiða greiðsluna. Reyndu aftur.",
+    "pending_payment_wait": "Þú ert með greiðslu í bið. Bíddu í nokkrar mínútur."
   },
   "passes": {
     "your_passes": "Passarnir þínir",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -269,7 +269,10 @@
     "no_meal_plans": "暂无可用餐饮计划。",
     "no_contributions": "暂无可用捐助选项。",
     "step_config_error": "步骤配置错误。",
-    "step_config_error_detail": "此步骤未分配模板。请联系管理员。"
+    "step_config_error_detail": "此步骤未分配模板。请联系管理员。",
+    "previous_payment_completed": "您之前的付款已完成。",
+    "pending_payment_wait": "您有一笔待处理的付款，请等待几分钟。",
+    "payment_cancel_failed": "我们无法处理您的付款，请重试。"
   },
   "openCheckout": {
     "loading": "正在加载结账...",
@@ -294,7 +297,10 @@
     "thank_you_description": "感谢您的购买。我们已通过电子邮件发送您的确认信息和门票详情。",
     "thank_you_cta": "前往门户",
     "thank_you_order_summary": "订单摘要",
-    "thank_you_total": "总计"
+    "thank_you_total": "总计",
+    "previous_payment_completed": "您之前的付款已完成。",
+    "payment_cancel_failed": "我们无法处理您的付款，请重试。",
+    "pending_payment_wait": "您有一笔待处理的付款，请等待几分钟。"
   },
   "passes": {
     "your_passes": "我的通行证",

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -544,26 +544,29 @@ export function CheckoutProvider({
   const openCartBuyerEmail =
     typeof buyerValues.email === "string" ? buyerValues.email : ""
 
-  const { scheduleSave: scheduleOpenCartSave, clearOpenCart } =
-    useOpenCartPersistence({
-      popupSlug: openCartPopupSlug ?? "",
-      selectionStateRef,
-      products,
-      housingPricePerDay,
-      restorationSetters: {
-        setHousing,
-        setMerch,
-        setPatron,
-        setMealPlans: setSelectedMealPlans,
-        setInsurance,
-      },
-      hasRestoredCheckoutRef,
-      paymentCompleteRef,
-      buyerEmail: openCartBuyerEmail,
-      initialStep,
-      cid: openCartCid,
-      sig: openCartSig,
-    })
+  const {
+    scheduleSave: scheduleOpenCartSave,
+    clearOpenCart,
+    cartMetaRef: openCartMetaRef,
+  } = useOpenCartPersistence({
+    popupSlug: openCartPopupSlug ?? "",
+    selectionStateRef,
+    products,
+    housingPricePerDay,
+    restorationSetters: {
+      setHousing,
+      setMerch,
+      setPatron,
+      setMealPlans: setSelectedMealPlans,
+      setInsurance,
+    },
+    hasRestoredCheckoutRef,
+    paymentCompleteRef,
+    buyerEmail: openCartBuyerEmail,
+    initialStep,
+    cid: openCartCid,
+    sig: openCartSig,
+  })
 
   // Promo code hook
   const {
@@ -1162,6 +1165,7 @@ export function CheckoutProvider({
     submitMode,
     editPassesEnabled,
     popupName: city?.name ?? null,
+    openCartMetaRef,
     buyerData:
       submitMode === "open-ticketing"
         ? {


### PR DESCRIPTION
## Summary

Final slice (4/4) of the pending-payment hold release chain: portal-side handling of the new backend contracts.

- Pure `errorDispatch` helper mapping the 409/502 machine codes to mode-aware i18n messages (`openCheckout.*` for open ticketing, `checkout.*` for authenticated): `previous_payment_completed`, `pending_payment_exists`, `concurrent_payment_in_progress`, `payment_cancel_failed`.
- "Previous payment completed" shows a persistent banner (not just a toast); when the backend provides a signed redirect URL the buyer is navigated to their purchase; resubmission stays blocked because the purchase already exists.
- Open-checkout purchases now send the cart continuity proof (`cid`/`sig`) from the persisted cart state, enabling the backend supersede for same-browser retries.
- 7 new i18n keys across en/es/is/zh, matching each file's existing tone.
- OpenAPI clients regenerated (portal + backoffice) for the new schema fields and response docs.

## Testing

- 22 unit tests for the dispatch helper (`errorDispatch.test.ts`): every code × both modes, redirect present/empty/absent, cart-meta extraction edge cases.
- `pnpm --filter portal run build` and lint green. Note: 18 pre-existing vitest failures on dev (react-i18next mock lacks `i18n`) are unrelated and tracked as a follow-up.

Chain: PR1 → PR2 → PR3 → PR4 (this). Merge in order, retargeting as each lands.