### PR TITLE
fix(checkout): expose sold_out_override in the open-checkout runtime

### DIFF
--- a/backend/app/api/checkout/schemas.py
+++ b/backend/app/api/checkout/schemas.py
@@ -72,6 +72,7 @@ class CheckoutRuntimeProduct(BaseModel):
     sale_ends_at: datetime | None = None
     total_stock_cap: int | None = None
     total_stock_remaining: int | None = None
+    sold_out_override: bool = False
     max_per_order: int | None = None
     is_active: bool = True
     exclusive: bool = False

--- a/backend/tests/api/checkout/test_bootstrap.py
+++ b/backend/tests/api/checkout/test_bootstrap.py
@@ -62,6 +62,7 @@ def _make_product(
     is_active: bool = True,
     name: str = "General Admission",
     price: str = "100.00",
+    sold_out_override: bool = False,
 ) -> Products:
     product = Products(
         id=uuid.uuid4(),
@@ -72,6 +73,7 @@ def _make_product(
         price=price,
         is_active=is_active,
         category="ticket",
+        sold_out_override=sold_out_override,
     )
     db.add(product)
     db.flush()
@@ -333,6 +335,27 @@ def test_runtime_only_active_products(
     product_names = [p["name"] for p in body["products"]]
     assert "Active GA" in product_names
     assert "Inactive VIP" not in product_names
+
+
+def test_runtime_exposes_sold_out_override(
+    client: TestClient, db: Session, tenant_a: Tenants
+) -> None:
+    """Products carry sold_out_override so the portal can hide manually
+    sold-out products instead of deriving on_sale as available."""
+    popup = _make_direct_popup(db, tenant_a)
+    _make_product(db, popup, name="Sold Out GA", sold_out_override=True)
+    _make_product(db, popup, name="Available VIP")
+    db.commit()
+
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert response.status_code == 200, response.text
+    products = {p["name"]: p for p in response.json()["products"]}
+    assert products["Sold Out GA"]["sold_out_override"] is True
+    assert products["Available VIP"]["sold_out_override"] is False
 
 
 def test_runtime_rate_limit_triggers_429(

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -4680,6 +4680,11 @@ export const CheckoutRuntimeProductSchema = {
             ],
             title: 'Total Stock Remaining'
         },
+        sold_out_override: {
+            type: 'boolean',
+            title: 'Sold Out Override',
+            default: false
+        },
         max_per_order: {
             anyOf: [
                 {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -1077,6 +1077,7 @@ export type CheckoutRuntimeProduct = {
     sale_ends_at?: (string | null);
     total_stock_cap?: (number | null);
     total_stock_remaining?: (number | null);
+    sold_out_override?: boolean;
     max_per_order?: (number | null);
     is_active?: boolean;
     exclusive?: boolean;

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -4680,6 +4680,11 @@ export const CheckoutRuntimeProductSchema = {
             ],
             title: 'Total Stock Remaining'
         },
+        sold_out_override: {
+            type: 'boolean',
+            title: 'Sold Out Override',
+            default: false
+        },
         max_per_order: {
             anyOf: [
                 {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -1077,6 +1077,7 @@ export type CheckoutRuntimeProduct = {
     sale_ends_at?: (string | null);
     total_stock_cap?: (number | null);
     total_stock_remaining?: (number | null);
+    sold_out_override?: boolean;
     max_per_order?: (number | null);
     is_active?: boolean;
     exclusive?: boolean;


### PR DESCRIPTION
## Summary

- Follow-up to #439. `CheckoutRuntimeProduct` (anonymous `GET /checkout/{slug}/runtime`) is an explicit field list and never gained `sold_out_override`, so open checkout kept rendering manually sold-out products as available; only the decrement 409 stopped the purchase at payment time.
- Adds the field next to the stock fields. The crud builds the schema via `model_validate(p.model_dump())`, so it flows automatically; the portal already consumes it (`toProductsPass` spreads the runtime product into `deriveProductState`).
- Regenerated API clients for both frontends.

## Test plan

- [x] New test `test_runtime_exposes_sold_out_override`: runtime response carries `true` for an overridden product and `false` for a normal one (14 passed in the checkout bootstrap suite)
- [x] ruff clean; portal `pnpm run build` green with the regenerated client