### PR TITLE
perf(backend): eliminate N+1 queries and move pagination to SQL

### DIFF
--- a/backend/app/alembic/versions/fa4a726d54b8_add_attendees_email_index.py
+++ b/backend/app/alembic/versions/fa4a726d54b8_add_attendees_email_index.py
@@ -1,0 +1,27 @@
+"""add attendees email index
+
+Email is a hot filter column (attendee lookup by email in BO and check-in
+flows) but was never indexed. ix_attendees_application_id already exists
+from the initial schema (inline index=True), so only email is added here.
+
+Revision ID: fa4a726d54b8
+Revises: 849f058ee25f
+Create Date: 2026-07-08 17:03:01.147145
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fa4a726d54b8"
+down_revision = "849f058ee25f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_attendees_email", "attendees", ["email"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_attendees_email", table_name="attendees")

--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -215,6 +215,55 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
 
         return results, total
 
+    def find_pending_review(
+        self,
+        session: Session,
+        reviewer_id: uuid.UUID,
+        popup_ids: list[uuid.UUID] | None = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> tuple[list[Applications], int]:
+        """Find IN_REVIEW applications the reviewer has not reviewed yet.
+
+        The reviewed-by-me exclusion and pagination run in SQL so the count is
+        exact and no oversized candidate list is loaded into Python.
+        """
+        already_reviewed = (
+            exists()
+            .where(ApplicationReviews.application_id == Applications.id)
+            .where(ApplicationReviews.reviewer_id == reviewer_id)
+        )
+        base_statement = select(Applications).where(
+            Applications.status == ApplicationStatus.IN_REVIEW.value,
+            ~already_reviewed,
+        )
+
+        if popup_ids is not None:
+            base_statement = base_statement.where(
+                col(Applications.popup_id).in_(popup_ids)
+            )
+
+        count_statement = select(func.count()).select_from(base_statement.subquery())
+        total = session.exec(count_statement).one()
+
+        statement = (
+            base_statement.options(
+                selectinload(Applications.attendees)  # type: ignore[arg-type]
+                .selectinload(Attendees.attendee_products)  # type: ignore[arg-type]
+                .selectinload(AttendeeProducts.product),  # type: ignore[arg-type]
+                selectinload(Applications.attendees).selectinload(  # type: ignore[arg-type]
+                    Attendees.category_ref  # type: ignore[arg-type]
+                ),
+                selectinload(Applications.human),  # type: ignore[arg-type]
+            )
+            .order_by(desc(Applications.created_at))  # type: ignore[arg-type]
+            .offset(skip)
+            .limit(limit)
+        )
+        results = list(session.exec(statement).all())
+
+        return results, total
+
     def find_directory(
         self,
         session: Session,

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -514,15 +514,19 @@ async def grant_tickets_admin(
     # Best-effort post-commit confirmation emails. A mail failure here does
     # NOT undo the grant — the rows are already persisted and the admin can
     # resend manually if a recipient reports a missing email.
+    # IN (...) does not preserve input order — re-sort the batch fetch so
+    # emails go out in grant order. Missing ids are silently skipped.
+    payments_by_id = {p.id: p for p in payments_crud.get_many(db, payment_ids)}
     for payment_id in payment_ids:
+        payment = payments_by_id.get(payment_id)
+        if payment is None:
+            continue
         try:
-            payment = payments_crud.get(db, payment_id)
-            if payment is not None:
-                await _send_payment_confirmed_email(payment, db_session=db)
+            await _send_payment_confirmed_email(payment, db_session=db)
         except Exception:
             logger.exception(
                 "Failed to send PAYMENT_CONFIRMED for granted payment {}",
-                payment_id,
+                payment.id,
             )
 
     return AdminGrantTicketsResponse(granted=granted)

--- a/backend/app/api/application_review/router.py
+++ b/backend/app/api/application_review/router.py
@@ -252,7 +252,6 @@ async def list_pending_reviews(
     """
     from app.api.application.crud import applications_crud
     from app.api.application.router import _build_application_public
-    from app.api.application.schemas import ApplicationStatus
     from app.api.popup_reviewer.crud import popup_reviewers_crud
 
     reviewer_assignments = popup_reviewers_crud.find_by_user(db, current_user.id)
@@ -266,33 +265,19 @@ async def list_pending_reviews(
                 results=[],
                 paging=Paging(offset=skip, limit=limit, total=0),
             )
-
-        candidates = []
-        for pid in popup_ids:
-            apps, _ = applications_crud.find_by_popup(
-                db, pid, limit=1000, status_filter=ApplicationStatus.IN_REVIEW
-            )
-            candidates.extend(apps)
     else:
-        candidates, _ = applications_crud.find_by_status(
-            db,
-            status_filter=ApplicationStatus.IN_REVIEW,
-            popup_id=popup_id,
-            limit=1000,
-        )
+        popup_ids = [popup_id] if popup_id else None
 
-    reviewed_ids = set(
-        application_reviews_crud.get_decisions_by_reviewer_for_applications(
-            db, current_user.id, [c.id for c in candidates]
-        )
+    pending_apps, total = applications_crud.find_pending_review(
+        db,
+        reviewer_id=current_user.id,
+        popup_ids=popup_ids,
+        skip=skip,
+        limit=limit,
     )
-    pending_apps = [a for a in candidates if a.id not in reviewed_ids]
-
-    total = len(pending_apps)
-    paginated = pending_apps[skip : skip + limit]
 
     return ListModel(
-        results=[_build_application_public(a) for a in paginated],
+        results=[_build_application_public(a) for a in pending_apps],
         paging=Paging(offset=skip, limit=limit, total=total),
     )
 

--- a/backend/app/api/attendee/crud.py
+++ b/backend/app/api/attendee/crud.py
@@ -66,10 +66,30 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
         self,
         session: Session,
         application_id: uuid.UUID,
-    ) -> list[Attendees]:
-        """Get all attendees for an application."""
+        skip: int = 0,
+        limit: int = 100,
+    ) -> tuple[list[Attendees], int]:
+        """Find attendees for an application with pagination and eager loading."""
         statement = select(Attendees).where(Attendees.application_id == application_id)
-        return list(session.exec(statement).all())
+
+        count_statement = select(func.count()).select_from(statement.subquery())
+        total = session.exec(count_statement).one()
+
+        statement = (
+            statement.options(
+                selectinload(Attendees.attendee_products).selectinload(  # type: ignore[arg-type]
+                    AttendeeProducts.product  # ty: ignore[invalid-argument-type]
+                ),
+                selectinload(Attendees.category_ref),  # type: ignore[arg-type]
+            )
+            # Stable ordering so OFFSET/LIMIT pages are deterministic.
+            .order_by(Attendees.created_at, Attendees.id)  # type: ignore[arg-type]
+            .offset(skip)
+            .limit(limit)
+        )
+        results = list(session.exec(statement).all())
+
+        return results, total
 
     def find_by_email(
         self,
@@ -79,6 +99,8 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
         limit: int = 100,
     ) -> tuple[list[Attendees], int]:
         """Find attendees by email."""
+        from app.api.application.models import Applications
+
         statement = select(Attendees).where(Attendees.email == email.lower())
 
         count_statement = select(func.count()).select_from(statement.subquery())
@@ -89,6 +111,10 @@ class AttendeesCRUD(BaseCRUD[Attendees, AttendeeCreate, AttendeeUpdate]):
                 selectinload(Attendees.attendee_products).selectinload(  # type: ignore[arg-type]
                     AttendeeProducts.product  # ty: ignore[invalid-argument-type]
                 ),
+                selectinload(Attendees.application).selectinload(  # type: ignore[arg-type]
+                    Applications.popup  # ty: ignore[invalid-argument-type]
+                ),
+                selectinload(Attendees.popup),  # type: ignore[arg-type]
                 selectinload(Attendees.category_ref),  # type: ignore[arg-type]
             )
             .offset(skip)

--- a/backend/app/api/attendee/models.py
+++ b/backend/app/api/attendee/models.py
@@ -33,7 +33,8 @@ class Attendees(AttendeeBase, table=True):
 
     __table_args__ = (
         Index("ix_attendees_popup_id", "popup_id"),
-        # ix_attendees_category_id is created by the migration
+        Index("ix_attendees_human_popup", "human_id", "popup_id"),
+        Index("ix_attendees_email", "email"),
     )
 
     id: uuid.UUID = Field(

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -564,9 +564,9 @@ async def list_attendees(
     least one purchased/granted ticket when True, those without when False.
     """
     if application_id:
-        attendees = crud.attendees_crud.find_by_application(db, application_id)
-        total = len(attendees)
-        attendees = attendees[skip : skip + limit]
+        attendees, total = crud.attendees_crud.find_by_application(
+            db, application_id, skip=skip, limit=limit
+        )
     elif popup_id:
         attendees, total = crud.attendees_crud.find_by_popup(
             db,
@@ -892,11 +892,8 @@ async def get_tickets_by_email(
 
         # Resolve popup — direct-sale attendees have attendee.popup directly
         # Application-linked attendees may have attendee.application.popup
-        popup = None
-        if attendee.popup_id:
-            from app.api.popup.models import Popups
-
-            popup = db.get(Popups, attendee.popup_id)
+        # Both relationships are eager-loaded by find_by_email.
+        popup = attendee.popup
         if popup is None and attendee.application:
             popup = attendee.application.popup
         popup_name = popup.name if popup else "Unknown"

--- a/backend/app/api/form_field/crud.py
+++ b/backend/app/api/form_field/crud.py
@@ -138,9 +138,7 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         from app.api.form_section.crud import form_sections_crud
 
         configs = base_field_configs_crud.find_by_popup(session, popup_id)
-        sections, _ = form_sections_crud.find_by_popup(
-            session, popup_id, skip=0, limit=1000
-        )
+        sections, _ = form_sections_crud.find_by_popup(session, popup_id, limit=None)
         hidden_section_ids = {s.id for s in sections if s.hidden}
         errors: list[str] = []
 
@@ -205,9 +203,7 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         # validation for fields belonging to them.
         from app.api.form_section.crud import form_sections_crud
 
-        sections, _ = form_sections_crud.find_by_popup(
-            session, popup_id, skip=0, limit=1000
-        )
+        sections, _ = form_sections_crud.find_by_popup(session, popup_id, limit=None)
         hidden_section_ids = {s.id for s in sections if s.hidden}
 
         # When the request comes from the /groups Express Checkout, only
@@ -365,9 +361,7 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         # Load sections for this popup
         from app.api.form_section.crud import form_sections_crud
 
-        db_sections, _ = form_sections_crud.find_by_popup(
-            session, popup_id, skip=0, limit=100
-        )
+        db_sections, _ = form_sections_crud.find_by_popup(session, popup_id, limit=None)
 
         # Hidden sections are dropped from the schema entirely (and so are
         # their fields). The data + section row stay in the DB so the admin

--- a/backend/app/api/form_section/crud.py
+++ b/backend/app/api/form_section/crud.py
@@ -16,8 +16,13 @@ class FormSectionsCRUD(BaseCRUD[FormSections, FormSectionCreate, FormSectionUpda
         session: Session,
         popup_id: uuid.UUID,
         skip: int = 0,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> tuple[list[FormSections], int]:
+        """Find sections for a popup ordered by position.
+
+        limit=None returns all sections (no offset/limit) — callers that
+        post-filter in Python need the full set to paginate correctly.
+        """
         statement = (
             select(FormSections)
             .where(FormSections.popup_id == popup_id)
@@ -27,7 +32,8 @@ class FormSectionsCRUD(BaseCRUD[FormSections, FormSectionCreate, FormSectionUpda
         count_statement = select(func.count()).select_from(statement.subquery())
         total = session.exec(count_statement).one()
 
-        statement = statement.offset(skip).limit(limit)
+        if limit is not None:
+            statement = statement.offset(skip).limit(limit)
         results = list(session.exec(statement).all())
 
         return results, total

--- a/backend/app/api/form_section/router.py
+++ b/backend/app/api/form_section/router.py
@@ -42,14 +42,16 @@ async def list_form_sections(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Popup not found",
             )
-        sections, total = crud.form_sections_crud.find_by_popup(
-            db, popup_id=popup_id, skip=skip, limit=limit
+        # Fetch all sections for the popup (small set) so the flag filter
+        # runs before pagination — otherwise totals and pages are wrong.
+        all_sections, _ = crud.form_sections_crud.find_by_popup(
+            db, popup_id=popup_id, limit=None
         )
         # Gate special-kind sections by current popup flags so the backoffice
         # renders consistently with the portal after a flag is toggled off.
-        filtered = [s for s in sections if _section_allowed_by_flags(s, popup)]
-        sections = filtered
+        filtered = [s for s in all_sections if _section_allowed_by_flags(s, popup)]
         total = len(filtered)
+        sections = filtered[skip : skip + limit]
     else:
         sections, total = crud.form_sections_crud.find(db, skip=skip, limit=limit)
 

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -548,6 +548,13 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         statement = select(Payments).where(Payments.external_id == external_id)
         return session.exec(statement).first()
 
+    def get_many(self, session: Session, ids: list[uuid.UUID]) -> list[Payments]:
+        """Get payments by id in a single query. Missing ids are skipped."""
+        if not ids:
+            return []
+        statement = select(Payments).where(Payments.id.in_(ids))  # type: ignore[attr-defined]
+        return list(session.exec(statement).all())
+
     def _get_in_progress_installment_plan(
         self,
         session: Session,

--- a/backend/tests/api/application_review/test_pending_reviews.py
+++ b/backend/tests/api/application_review/test_pending_reviews.py
@@ -1,0 +1,177 @@
+"""Tests for GET /applications/pending-review (find_pending_review CRUD).
+
+The reviewed-by-me exclusion and pagination run in SQL: an application the
+current reviewer already reviewed is excluded, one reviewed only by a
+different reviewer still appears, and paging.total reflects the real
+pending count across skip/limit pages.
+
+Each test creates a fresh popup and filters by popup_id so it is isolated
+from the session-scoped shared fixtures (db / tenant_a have no per-test
+rollback).
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.application_review.models import ApplicationReviews
+from app.api.application_review.schemas import ReviewDecision
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.shared.enums import UserRole
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+from app.core.security import create_access_token
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _auth(user: Users, tenant: Tenants) -> dict[str, str]:
+    token = create_access_token(subject=user.id, token_type="user")
+    return {"Authorization": f"Bearer {token}", "X-Tenant-Id": str(tenant.id)}
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name="Pending Reviews Popup",
+        slug=f"pending-reviews-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_admin(db: Session, tenant: Tenants) -> Users:
+    user = Users(
+        email=f"pending-reviewer-{uuid.uuid4().hex[:8]}@test.com",
+        role=UserRole.ADMIN,
+        tenant_id=tenant.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_in_review_application(
+    db: Session, tenant: Tenants, popup: Popups
+) -> Applications:
+    """IN_REVIEW application with its own human (unique human+popup constraint)."""
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"pending-applicant-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Pending",
+        last_name="Applicant",
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.IN_REVIEW.value,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _make_review(
+    db: Session,
+    tenant: Tenants,
+    application: Applications,
+    reviewer: Users,
+) -> None:
+    """Insert a review row directly so the application status stays IN_REVIEW."""
+    db.add(
+        ApplicationReviews(
+            application_id=application.id,
+            reviewer_id=reviewer.id,
+            tenant_id=tenant.id,
+            decision=ReviewDecision.NO,
+        )
+    )
+    db.commit()
+
+
+def _get_pending(
+    client: TestClient,
+    reviewer: Users,
+    tenant: Tenants,
+    popup: Popups,
+    **params,
+) -> dict:
+    response = client.get(
+        "/api/v1/applications/pending-review",
+        params={"popup_id": str(popup.id), **params},
+        headers=_auth(reviewer, tenant),
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestListPendingReviews:
+    def test_excludes_only_apps_reviewed_by_current_reviewer(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        """Reviewed-by-me is excluded; reviewed-by-someone-else still appears."""
+        popup = _make_popup(db, tenant_a)
+        reviewer = _make_admin(db, tenant_a)
+        other_reviewer = _make_admin(db, tenant_a)
+
+        app_mine = _make_in_review_application(db, tenant_a, popup)
+        app_other = _make_in_review_application(db, tenant_a, popup)
+        app_fresh = _make_in_review_application(db, tenant_a, popup)
+
+        _make_review(db, tenant_a, app_mine, reviewer)
+        _make_review(db, tenant_a, app_other, other_reviewer)
+
+        data = _get_pending(client, reviewer, tenant_a, popup)
+        ids = {r["id"] for r in data["results"]}
+
+        assert str(app_mine.id) not in ids, (
+            "Application already reviewed by the current reviewer must be excluded"
+        )
+        assert str(app_other.id) in ids, (
+            "Application reviewed only by a different reviewer must still appear"
+        )
+        assert str(app_fresh.id) in ids
+        assert data["paging"]["total"] == 2
+
+    def test_pagination_total_reflects_real_pending_count(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        """total counts all pending apps while pages respect skip/limit."""
+        popup = _make_popup(db, tenant_a)
+        reviewer = _make_admin(db, tenant_a)
+
+        apps = [_make_in_review_application(db, tenant_a, popup) for _ in range(3)]
+        expected_ids = {str(a.id) for a in apps}
+
+        page_1 = _get_pending(client, reviewer, tenant_a, popup, skip=0, limit=2)
+        page_2 = _get_pending(client, reviewer, tenant_a, popup, skip=2, limit=2)
+
+        assert page_1["paging"]["total"] == 3
+        assert page_2["paging"]["total"] == 3
+        assert len(page_1["results"]) == 2
+        assert len(page_2["results"]) == 1
+
+        ids_1 = {r["id"] for r in page_1["results"]}
+        ids_2 = {r["id"] for r in page_2["results"]}
+        assert ids_1.isdisjoint(ids_2), "Pages must not overlap"
+        assert ids_1 | ids_2 == expected_ids

--- a/backend/tests/api/attendee/test_list_by_application_pagination.py
+++ b/backend/tests/api/attendee/test_list_by_application_pagination.py
@@ -1,0 +1,122 @@
+"""Tests for GET /attendees?application_id= pagination (find_by_application).
+
+The CRUD paginates in SQL with a stable ORDER BY (created_at, id): total is
+the full attendee count for the application, page size respects limit, and
+pages are disjoint so page 2 never repeats page 1.
+
+Each test creates a fresh popup/application so it is isolated from the
+session-scoped shared fixtures (db / tenant_a have no per-test rollback).
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.attendee.models import Attendees
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.api.user.models import Users
+from app.core.security import create_access_token
+
+
+def _auth(user: Users) -> dict[str, str]:
+    token = create_access_token(subject=user.id, token_type="user")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_application(db: Session, tenant: Tenants) -> Applications:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name="Attendee Pagination Popup",
+        slug=f"attendee-pagination-{uuid.uuid4().hex[:8]}",
+    )
+    db.add(popup)
+    db.flush()
+
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"attendee-pagination-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Page",
+        last_name="Owner",
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _make_attendees(
+    db: Session, tenant: Tenants, application: Applications, count: int
+) -> list[Attendees]:
+    attendees = [
+        Attendees(
+            id=uuid.uuid4(),
+            tenant_id=tenant.id,
+            popup_id=application.popup_id,
+            application_id=application.id,
+            name=f"Attendee {i}",
+        )
+        for i in range(count)
+    ]
+    db.add_all(attendees)
+    db.commit()
+    return attendees
+
+
+class TestListAttendeesByApplicationPagination:
+    def test_pagination_is_deterministic_and_total_is_full_count(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+        admin_user_tenant_a: Users,
+        client: TestClient,
+    ) -> None:
+        application = _make_application(db, tenant_a)
+        attendees = _make_attendees(db, tenant_a, application, count=5)
+        expected_ids = {str(a.id) for a in attendees}
+
+        def get_page(skip: int, limit: int) -> dict:
+            response = client.get(
+                "/api/v1/attendees",
+                params={
+                    "application_id": str(application.id),
+                    "skip": skip,
+                    "limit": limit,
+                },
+                headers=_auth(admin_user_tenant_a),
+            )
+            assert response.status_code == 200, response.text
+            return response.json()
+
+        page_1 = get_page(skip=0, limit=3)
+        page_2 = get_page(skip=3, limit=3)
+
+        # total is the full count even when the page is smaller
+        assert page_1["paging"]["total"] == 5
+        assert page_2["paging"]["total"] == 5
+        assert len(page_1["results"]) == 3
+        assert len(page_2["results"]) == 2
+
+        ids_1 = {r["id"] for r in page_1["results"]}
+        ids_2 = {r["id"] for r in page_2["results"]}
+        assert ids_1.isdisjoint(ids_2), (
+            "Page 2 must not repeat page 1 rows — ordering must be deterministic"
+        )
+        assert ids_1 | ids_2 == expected_ids
+
+        # Re-reading page 1 returns the same rows (stable ORDER BY)
+        assert {r["id"] for r in get_page(skip=0, limit=3)["results"]} == ids_1


### PR DESCRIPTION
## Summary

Fixes from a DB query audit: N+1 patterns, Python-side pagination, and a missing index on hot filter columns. No API schema changes (no OpenAPI client regen needed).

## Related Issue

N/A (internal performance audit)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- `attendees_crud.find_by_email` eager-loads `popup` and `application -> popup`, removing the per-attendee popup lookup (and lazy application access) in `get_tickets_by_email`
- `grant_tickets_admin` batch-fetches payments with `WHERE id IN (...)` via new `payments_crud.get_many`, preserving grant order for confirmation emails
- `find_by_application` paginates in SQL with stable `ORDER BY created_at, id` instead of fetching all attendees and slicing in Python
- Pending reviews: new `applications_crud.find_pending_review` filters with `NOT EXISTS` on the reviewer's own reviews in SQL, replacing the fetch-up-to-2000-then-filter-in-Python path; totals are now real counts
- Form sections list: flag filtering happens before total/slice so pagination totals are correct; fetch-all callers (including three stale `limit=1000`/`limit=100` truncation bugs in `form_field/crud.py`) migrated to `limit=None`
- New index `ix_attendees_email` (migration `fa4a726d54b8`, single head, upgrade/downgrade round-trip verified); `ix_attendees_human_popup` synced into the model `__table_args__`
- Tests: pending-review exclusion semantics + pagination, and attendee list-by-application pagination determinism

## Testing

- [x] Backend tests pass (targeted: `tests/api/attendee`, `tests/api/application`, `tests/api/application_review`, `tests/api/form_field` — 207 passed incl. 3 new)
- [x] Backend linting passes (`bash scripts/lint.sh`)
- [ ] Backoffice builds successfully (not applicable, backend only)
- [ ] Backoffice linting passes (not applicable, backend only)
- [x] Manual testing performed (migration round-trip against Postgres 17 testcontainer)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed (no schema changes)
- [x] Database migrations are included if schema changed