### PR TITLE
fix(portal/checkout): open-checkout UI batch — stepper insert, housing cards, nav pill, timezone dates

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.4
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tailwindcss/typography':
+        specifier: ^0.5.15
+        version: 0.5.20(tailwindcss@4.2.1)
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.21(react@19.2.4)
@@ -2453,6 +2456,11 @@ packages:
 
   '@tailwindcss/postcss@4.2.1':
     resolution: {integrity: sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==}
+
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
   '@tailwindcss/vite@4.2.1':
     resolution: {integrity: sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w==}
@@ -4868,6 +4876,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -7703,6 +7715,11 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.2.1
 
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.2.1)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.2.1
+
   '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.1
@@ -10405,6 +10422,11 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/portal/package.json
+++ b/portal/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@tailwindcss/typography": "^0.5.15",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
     "@tsparticles/engine": "^3.7.1",

--- a/portal/src/app/globals.css
+++ b/portal/src/app/globals.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/portal/src/components/checkout-flow/ScrollySectionNav.tsx
+++ b/portal/src/components/checkout-flow/ScrollySectionNav.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { motion } from "framer-motion"
 import { Check } from "lucide-react"
 import Image from "next/image"
 import {
@@ -24,8 +25,8 @@ export type WatermarkStyle = "none" | "ghost" | "stroke" | "bold"
 const resolveIcon = (section: { id: string; template?: string | null }) =>
   resolveStepIcon({ stepType: section.id, template: section.template })
 
-// Measuring the active tab to place the sliding pill must happen before the
-// browser paints (otherwise the pill lands a frame late on first render).
+// The expanded/compact decision must happen before the browser paints
+// (otherwise the row flashes in the wrong mode on first render).
 // useLayoutEffect does that on the client; fall back to useEffect on the
 // server so SSR doesn't warn about a no-op layout effect.
 const useIsomorphicLayoutEffect =
@@ -108,7 +109,6 @@ export default function ScrollySectionNav({
   const trackRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([])
-  const [pill, setPill] = useState<{ left: number; width: number } | null>(null)
   const [compact, setCompact] = useState(false)
   // Width the labelled row needs, captured while expanded. Used as the
   // hysteresis threshold so the boundary doesn't flap between modes.
@@ -139,8 +139,6 @@ export default function ScrollySectionNav({
           setCompact(false)
         }
       }
-      const btn = buttonRefs.current[activeIndex]
-      if (btn) setPill({ left: btn.offsetLeft, width: btn.offsetWidth })
     }
 
     recalc()
@@ -202,16 +200,6 @@ export default function ScrollySectionNav({
                   compact ? "w-full" : "w-max",
                 )}
               >
-                {pill && (
-                  <div
-                    aria-hidden
-                    className="pointer-events-none absolute inset-y-0 left-0 rounded-lg bg-checkout-badge-bg shadow-sm transition-[transform,width] duration-300 ease-out"
-                    style={{
-                      width: `${pill.width}px`,
-                      transform: `translateX(${pill.left}px)`,
-                    }}
-                  />
-                )}
                 {sections.map((section, index) => {
                   const Icon = resolveIcon(section)
                   const isActive = section.id === activeSection
@@ -238,7 +226,7 @@ export default function ScrollySectionNav({
                       aria-current={isActive ? "step" : undefined}
                       aria-invalid={isIncomplete || undefined}
                       className={cn(
-                        "relative z-10 flex h-7 items-center justify-center text-xs font-semibold transition-[color,opacity] duration-200",
+                        "relative z-0 flex h-7 items-center justify-center text-xs font-semibold transition-[color,opacity] duration-200",
                         // Compact equal-width icons vs. expanded content-width
                         // labelled tabs.
                         compact
@@ -254,6 +242,17 @@ export default function ScrollySectionNav({
                             : "text-checkout-badge-title-disabled hover:opacity-70",
                       )}
                     >
+                      {isActive && (
+                        <motion.div
+                          aria-hidden
+                          layoutId="checkout-nav-active-pill"
+                          className="pointer-events-none absolute inset-0 -z-10 bg-checkout-badge-bg shadow-sm"
+                          // Style (not a class) so framer can scale-correct the
+                          // corners while the pill morphs between tabs.
+                          style={{ borderRadius: 8 }}
+                          transition={{ duration: 0.3, ease: "easeOut" }}
+                        />
+                      )}
                       {RegistryIcon ? (
                         <RegistryIcon className="size-3.5 shrink-0" />
                       ) : emoji ? (

--- a/portal/src/components/checkout-flow/SnapSection.tsx
+++ b/portal/src/components/checkout-flow/SnapSection.tsx
@@ -18,7 +18,14 @@ export default function SnapSection({
   widthClass?: string
 }) {
   const ref = useRef<HTMLElement>(null)
-  const [visible, setVisible] = useState(false)
+  // null until the IntersectionObserver reports for the first time. The
+  // distinction matters: a section that is ALREADY on screen at that first
+  // report (the above-the-fold one) must keep its server-rendered, fully
+  // visible state — hiding it to replay the entrance animation makes the
+  // title flash: paint → hide → animate back in. Entrance animations are
+  // only for sections the user scrolls INTO.
+  const [visible, setVisible] = useState<boolean | null>(null)
+  const hasBeenHiddenRef = useRef(false)
 
   useEffect(() => {
     const el = ref.current
@@ -32,6 +39,7 @@ export default function SnapSection({
   }, [])
 
   useEffect(() => {
+    if (visible === null) return
     const el = ref.current
     if (!el) return
 
@@ -41,7 +49,7 @@ export default function SnapSection({
     const titleEl = el.querySelector<HTMLElement>("[data-section-title]")
     const subtitleEl = el.querySelector<HTMLElement>("[data-section-subtitle]")
 
-    if (visible) {
+    if (visible && hasBeenHiddenRef.current) {
       if (watermarkChars.length > 0) {
         gsap.fromTo(
           watermarkChars,
@@ -70,7 +78,8 @@ export default function SnapSection({
           { opacity: 1, y: 0, duration: 0.45, ease: "power1.out", delay: 0.3 },
         )
       }
-    } else {
+    } else if (!visible) {
+      hasBeenHiddenRef.current = true
       if (watermarkChars.length > 0) {
         gsap.set(watermarkChars, { opacity: 0, y: 60, filter: "blur(8px)" })
       }

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -191,7 +191,7 @@ export default function ConfirmStep() {
       ) : null}
 
       {checkoutError && (
-        <div className="bg-white border border-destructive rounded-2xl p-4 flex items-start gap-3">
+        <div className="bg-destructive/10 border border-destructive rounded-2xl p-4 flex items-start gap-3">
           <AlertCircle className="w-5 h-5 text-destructive shrink-0 mt-0.5" />
           <div>
             <h4 className="font-medium text-destructive">Error</h4>

--- a/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
+++ b/portal/src/components/checkout-flow/steps/ConfirmStep.tsx
@@ -42,6 +42,7 @@ export default function ConfirmStep() {
     buyerValues,
     buyerGeneralError,
     removeMealPlan,
+    housingDatesShown,
   } = useCheckout()
   const { getCity } = useCityProvider()
   const popup = getCity()
@@ -334,10 +335,14 @@ export default function ConfirmStep() {
                       ? `${cart.housing.nights} night${cart.housing.nights !== 1 ? "s" : ""}`
                       : "Full stay"}
                   </p>
-                  <p className="text-xs text-muted-foreground">
-                    {formatCheckoutDate(cart.housing.checkIn)} –{" "}
-                    {formatCheckoutDate(cart.housing.checkOut)}
-                  </p>
+                  {/* With the date picker hidden these are just the popup's
+                      default dates, not a stay the buyer chose. */}
+                  {housingDatesShown && (
+                    <p className="text-xs text-muted-foreground">
+                      {formatCheckoutDate(cart.housing.checkIn)} –{" "}
+                      {formatCheckoutDate(cart.housing.checkOut)}
+                    </p>
+                  )}
                   {isNonDiscountable(cart.housing.product) && (
                     <p className="text-xs text-muted-foreground/70">
                       {notEligibleCaption}

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -9,7 +9,7 @@ import {
   Home,
 } from "lucide-react"
 import Image from "next/image"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import ExpandableDescription from "@/components/ui/ExpandableDescription"
@@ -214,6 +214,51 @@ function SectionHeader({ section }: { section: TemplateSection }) {
   )
 }
 
+/* ── Selectable card shell ───────────────────────────────── */
+
+/**
+ * Card-level select target rendered as a div with button semantics instead
+ * of a native <button>: these cards contain interactive children (carousel
+ * arrows, quantity steppers, "See more") and nesting buttons is invalid
+ * HTML — React logs hydration errors for it. All inner controls call
+ * stopPropagation, so card activation only fires on the surface itself.
+ */
+function SelectableCard({
+  disabled,
+  onActivate,
+  className,
+  children,
+}: {
+  disabled: boolean
+  onActivate: () => void
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a native <button> cannot contain the card's inner buttons
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      onClick={() => {
+        if (!disabled) onActivate()
+      }}
+      onKeyDown={(e) => {
+        // Only when the card surface itself is focused — inner controls
+        // own their keyboard behavior.
+        if (disabled || e.target !== e.currentTarget) return
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onActivate()
+        }
+      }}
+      className={cn(!disabled && "cursor-pointer", className)}
+    >
+      {children}
+    </div>
+  )
+}
+
 /* ── Compact card row (single product) ───────────────────── */
 
 function CompactCard({
@@ -250,11 +295,9 @@ function CompactCard({
   const soldOut = state === "sold_out"
 
   return (
-    <button
-      type="button"
+    <SelectableCard
       disabled={!canSelect}
-      onClick={() => {
-        if (!canSelect) return
+      onActivate={() => {
         if (supportsQty && quantity === 0) {
           onIncrement()
         } else {
@@ -341,7 +384,7 @@ function CompactCard({
           {formatCurrency(totalPrice)}
         </p>
       </div>
-    </button>
+    </SelectableCard>
   )
 }
 
@@ -499,6 +542,7 @@ function GridCard({
   onSelect,
   onIncrement,
   onDecrement,
+  horizontal = false,
 }: {
   product: ProductsPass
   nights: number
@@ -508,6 +552,12 @@ function GridCard({
   onSelect: () => void
   onIncrement: () => void
   onDecrement: () => void
+  /**
+   * Full-width horizontal layout (image left, content right) for sections
+   * holding a single product, so the 2-column grid doesn't leave half a
+   * row empty. Stacks vertically again on mobile.
+   */
+  horizontal?: boolean
 }) {
   const totalPrice = pricePerDay ? product.price * nights : product.price
   const compareTotal = product.compare_price
@@ -524,11 +574,9 @@ function GridCard({
   const soldOut = state === "sold_out"
 
   return (
-    <button
-      type="button"
+    <SelectableCard
       disabled={!canSelect}
-      onClick={() => {
-        if (!canSelect) return
+      onActivate={() => {
         if (supportsQty && quantity === 0) {
           onIncrement()
         } else {
@@ -537,44 +585,28 @@ function GridCard({
       }}
       className={cn(
         "relative flex flex-col rounded-2xl border overflow-hidden text-left transition-all bg-checkout-card-bg",
+        horizontal && "sm:col-span-2 sm:flex-row",
         isSelected
           ? "border-primary ring-2 ring-primary/20"
           : "border-border hover:border-muted-foreground/30",
         !canSelect && "opacity-60 cursor-not-allowed hover:border-border",
       )}
     >
-      <ProductImageCarousel
-        images={productImages(product)}
-        alt={product.name}
-        aspectClass="aspect-[4/3]"
-      />
+      <div className={cn("relative", horizontal && "sm:w-2/5 sm:shrink-0")}>
+        <ProductImageCarousel
+          images={productImages(product)}
+          alt={product.name}
+          aspectClass="aspect-[4/3]"
+        />
 
-      {!canSelect ? (
-        soldOut && (
+        {!canSelect && soldOut && (
           <div className="absolute top-2 right-2">
             <SaleStateBadge state="sold_out" />
           </div>
-        )
-      ) : supportsQty ? (
-        <div className="absolute top-2 right-2 rounded-full bg-background/90 backdrop-blur-sm shadow-sm px-1.5 py-0.5">
-          <QuantitySelector
-            value={quantity}
-            max={maxQty}
-            onIncrement={onIncrement}
-            onDecrement={onDecrement}
-            onAdd={onIncrement}
-            size="sm"
-          />
-        </div>
-      ) : (
-        isSelected && (
-          <div className="absolute top-2 right-2 w-6 h-6 rounded-full bg-primary flex items-center justify-center">
-            <Check className="w-3.5 h-3.5 text-primary-foreground" />
-          </div>
-        )
-      )}
+        )}
+      </div>
 
-      <div className="p-3">
+      <div className={cn("p-3", horizontal && "sm:flex-1 sm:self-center")}>
         <p className="font-semibold text-pass-title text-sm leading-tight">
           {product.name}
         </p>
@@ -610,19 +642,34 @@ function GridCard({
               {formatCurrency(totalPrice)}
             </span>
           )}
-          <span
-            className={cn(
-              "text-xs px-2 py-0.5 rounded-full font-medium",
-              isSelected
-                ? "bg-primary/15 text-primary"
-                : "bg-muted text-muted-foreground",
-            )}
-          >
-            {isSelected ? "Selected" : "Select"}
-          </span>
+          {canSelect && supportsQty ? (
+            // Single add affordance: the "+" lives where "Select" used to
+            // be and expands into the -/n/+ stepper once in the cart. The
+            // card border/ring carries the selected state.
+            <QuantitySelector
+              value={quantity}
+              max={maxQty}
+              onIncrement={onIncrement}
+              onDecrement={onDecrement}
+              onAdd={onIncrement}
+              size="sm"
+              tone="accent"
+            />
+          ) : (
+            <span
+              className={cn(
+                "text-xs px-2 py-0.5 rounded-full font-medium",
+                isSelected
+                  ? "bg-primary/15 text-primary"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {isSelected ? "Selected" : "Select"}
+            </span>
+          )}
         </div>
       </div>
-    </button>
+    </SelectableCard>
   )
 }
 
@@ -708,12 +755,10 @@ function DefaultSectionCard({
           const quantity = getQuantity(product.id)
 
           return (
-            <button
+            <SelectableCard
               key={product.id}
-              type="button"
               disabled={!canSelect}
-              onClick={() => {
-                if (!canSelect) return
+              onActivate={() => {
                 if (supportsQty && quantity === 0) {
                   onIncrement(product.id)
                 } else {
@@ -786,7 +831,7 @@ function DefaultSectionCard({
                   {formatCurrency(totalPrice)}
                 </p>
               </div>
-            </button>
+            </SelectableCard>
           )
         })}
       </div>
@@ -919,12 +964,10 @@ function ShowcaseSectionCard({
             const quantity = getQuantity(product.id)
 
             return (
-              <button
+              <SelectableCard
                 key={product.id}
-                type="button"
                 disabled={!canSelect}
-                onClick={() => {
-                  if (!canSelect) return
+                onActivate={() => {
                   if (supportsQty && quantity === 0) {
                     onIncrement(product.id)
                   } else {
@@ -1014,7 +1057,7 @@ function ShowcaseSectionCard({
                     )}
                   </div>
                 )}
-              </button>
+              </SelectableCard>
             )
           })}
         </div>
@@ -1124,6 +1167,7 @@ function HousingGrid({
                 onSelect={() => onProductSelect(product.id)}
                 onIncrement={() => onIncrement(product.id)}
                 onDecrement={() => onDecrement(product.id)}
+                horizontal={products.length === 1}
               />
             ))}
           </div>

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -81,7 +81,13 @@ function buildHousingSectionGroups(
 }
 
 function formatDateInput(date: Date): string {
-  return date.toISOString().split("T")[0]
+  // Local calendar components, NOT toISOString(): these Dates are local
+  // midnights (see parseDate), and the UTC rendering of a local midnight
+  // falls on the previous day anywhere east of UTC.
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, "0")
+  const d = String(date.getDate()).padStart(2, "0")
+  return `${y}-${m}-${d}`
 }
 
 function parseDate(dateStr: string): Date {

--- a/portal/src/components/checkout-flow/variants/VariantRichText.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantRichText.tsx
@@ -185,9 +185,12 @@ export default function VariantRichText({
 
   return (
     <div
+      // Typography colors follow the tenant theme tokens instead of the
+      // fixed light-on-dark `prose-invert` palette, which is illegible the
+      // moment a popup picks a light theme.
       className={`${WIDTH_CLASSES[config.max_width ?? "wide"]} ${
         ALIGNMENT_CLASSES[config.alignment ?? "center"]
-      } prose prose-invert prose-headings:font-semibold prose-a:underline`}
+      } prose prose-headings:font-semibold prose-a:underline [--tw-prose-body:var(--foreground)] [--tw-prose-headings:var(--foreground)] [--tw-prose-lead:var(--muted-foreground)] [--tw-prose-links:var(--primary)] [--tw-prose-bold:var(--foreground)] [--tw-prose-counters:var(--muted-foreground)] [--tw-prose-bullets:var(--muted-foreground)] [--tw-prose-hr:var(--border)] [--tw-prose-quotes:var(--foreground)] [--tw-prose-quote-borders:var(--border)] [--tw-prose-captions:var(--muted-foreground)] [--tw-prose-code:var(--foreground)] [--tw-prose-pre-code:var(--foreground)] [--tw-prose-pre-bg:var(--muted)] [--tw-prose-th-borders:var(--border)] [--tw-prose-td-borders:var(--border)]`}
     >
       {content}
     </div>

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -200,7 +200,6 @@ export default function VariantTicketSelect({
     return (
       <OpenCheckoutSectionLayout
         sections={view.sections}
-        onToggle={view.toggleRow}
         onQuantityChange={view.setRowQuantity}
       />
     )
@@ -1103,11 +1102,9 @@ function CompactAttendeeCard({
  */
 function OpenCheckoutRow({
   row,
-  onToggle,
   onQuantityChange,
 }: {
   row: TicketRowVM
-  onToggle: (attendeeId: string, product: ProductsPass) => void
   onQuantityChange: (
     attendeeId: string,
     product: ProductsPass,
@@ -1117,7 +1114,6 @@ function OpenCheckoutRow({
   const { t } = useTranslation()
   const { product, quantity, maxQuantity, selected, disabled } = row
   const isAdded = quantity > 0 || selected
-  const showStepper = supportsQuantitySelector(product.max_per_order)
   const hasDiscount =
     product.compare_price != null && product.compare_price > product.price
   const total = product.price * (quantity > 0 ? quantity : 1)
@@ -1141,53 +1137,42 @@ function OpenCheckoutRow({
             />
           )}
         </div>
-        {showStepper ? (
-          <QuantitySelector
-            size="md"
-            value={quantity}
-            min={0}
-            max={maxQuantity}
-            disabled={disabled}
-            onIncrement={() => onQuantityChange("", product, quantity + 1)}
-            onDecrement={() =>
-              onQuantityChange("", product, Math.max(0, quantity - 1))
-            }
-            onAdd={() => onQuantityChange("", product, 1)}
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => onToggle("", product)}
-            disabled={disabled}
-            aria-label={isAdded ? "Remove from cart" : "Add to cart"}
-            className={cn(
-              "h-8 px-3 rounded-lg text-xs font-semibold transition-all flex items-center gap-1 shrink-0",
-              isAdded
-                ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                : "bg-card border border-border text-foreground hover:bg-muted",
-              disabled && "cursor-not-allowed opacity-50",
-            )}
-          >
-            {isAdded ? (
-              <>
-                <Check className="w-3.5 h-3.5" />
-                Added
-              </>
-            ) : (
-              <>+&nbsp;Add</>
-            )}
-          </button>
-        )}
+        {/* Single add affordance for every row: the stepper degrades
+            gracefully for max_per_order = 1 products (the "+" disables at
+            the cap, "−" removes), so no separate Add/Added toggle needed. */}
+        <QuantitySelector
+          size="md"
+          value={quantity}
+          min={0}
+          max={maxQuantity}
+          disabled={disabled}
+          onIncrement={() => onQuantityChange("", product, quantity + 1)}
+          onDecrement={() =>
+            onQuantityChange("", product, Math.max(0, quantity - 1))
+          }
+          onAdd={() => onQuantityChange("", product, 1)}
+        />
         <div className="text-right shrink-0 min-w-16">
-          {isAdded && quantity > 1 && (
+          {/* The compare price is a per-unit anchor, so it must sit next to
+              the unit price. Stacking it against the line total reads as if
+              it were the pre-discount total. */}
+          {isAdded && quantity > 1 ? (
             <p className="text-xs text-muted-foreground">
-              {quantity} × {formatCurrency(product.price)}
+              {quantity} ×{" "}
+              {hasDiscount && product.compare_price != null && (
+                <span className="line-through">
+                  {formatCurrency(product.compare_price)}
+                </span>
+              )}{" "}
+              {formatCurrency(product.price)}
             </p>
-          )}
-          {hasDiscount && product.compare_price != null && (
-            <p className="text-xs text-muted-foreground line-through">
-              {formatCurrency(product.compare_price)}
-            </p>
+          ) : (
+            hasDiscount &&
+            product.compare_price != null && (
+              <p className="text-xs text-muted-foreground line-through">
+                {formatCurrency(product.compare_price)}
+              </p>
+            )
           )}
           <span
             className={cn(
@@ -1205,11 +1190,9 @@ function OpenCheckoutRow({
 
 function OpenCheckoutSectionLayout({
   sections,
-  onToggle,
   onQuantityChange,
 }: {
   sections: TicketSectionVM[]
-  onToggle: (attendeeId: string, product: ProductsPass) => void
   onQuantityChange: (
     attendeeId: string,
     product: ProductsPass,
@@ -1236,7 +1219,6 @@ function OpenCheckoutSectionLayout({
             <OpenCheckoutRow
               key={row.product.id}
               row={row}
-              onToggle={onToggle}
               onQuantityChange={onQuantityChange}
             />
           ))}

--- a/portal/src/hooks/checkout/useTicketsStep.ts
+++ b/portal/src/hooks/checkout/useTicketsStep.ts
@@ -338,14 +338,30 @@ export function useTicketsStep({
         removeDynamicItem(stepType, product.id)
         return
       }
-      updateDynamicQuantity(stepType, product.id, qty)
+      const alreadyInCart = (cart.dynamicItems[stepType] ?? []).some(
+        (i) => i.productId === product.id,
+      )
+      if (alreadyInCart) {
+        updateDynamicQuantity(stepType, product.id, qty)
+        return
+      }
+      // updateDynamicQuantity can only mutate existing items; first add must insert
+      addDynamicItem(stepType, {
+        productId: product.id,
+        product,
+        quantity: qty,
+        price: product.price * qty,
+        stepType,
+      })
     },
     [
       checkoutMode,
       attendeePasses,
       parsedSections,
       toggleProduct,
+      cart,
       stepType,
+      addDynamicItem,
       removeDynamicItem,
       updateDynamicQuantity,
     ],

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -93,6 +93,9 @@ interface CheckoutContextValue {
   selectHousing: (productId: string, checkIn: string, checkOut: string) => void
   updateHousingQuantity: (quantity: number) => void
   clearHousing: () => void
+  /** False when the housing step hides its date picker (show_dates: false) —
+   * cart check-in/out are then popup defaults, not user-chosen stay dates. */
+  housingDatesShown: boolean
   updateMerchQuantity: (productId: string, quantity: number) => void
   setPatronAmount: (
     productId: string,
@@ -379,15 +382,25 @@ export function CheckoutProvider({
   )
 
   // Item selection hooks
+  // With the date picker hidden the check-in/out stored in the cart are just
+  // the popup's start/end dates, never user-chosen — summaries shouldn't
+  // present them as stay dates.
+  const housingDatesShown = useMemo(() => {
+    const step = configuredSteps.find((s) => s.step_type === "housing")
+    if (!step?.template_config) return true
+    const cfg = step.template_config as Record<string, unknown>
+    return cfg.show_dates !== false
+  }, [configuredSteps])
+
   const housingPricePerDay = useMemo(() => {
     const step = configuredSteps.find((s) => s.step_type === "housing")
     if (!step?.template_config) return true
     const cfg = step.template_config as Record<string, unknown>
     // When the housing step hides the date picker, the per-night multiplication
     // is meaningless — force flat pricing so totals use product.price directly.
-    if (cfg.show_dates === false) return false
+    if (!housingDatesShown) return false
     return cfg.price_per_day !== false
-  }, [configuredSteps])
+  }, [configuredSteps, housingDatesShown])
 
   const {
     housing,
@@ -1374,6 +1387,7 @@ export function CheckoutProvider({
     selectHousing,
     updateHousingQuantity,
     clearHousing,
+    housingDatesShown,
     updateMerchQuantity,
     setPatronAmount,
     clearPatron,

--- a/portal/src/types/checkout.ts
+++ b/portal/src/types/checkout.ts
@@ -230,10 +230,16 @@ export function formatPrice(
 }
 
 export function formatCheckoutDate(date: string | Date): string {
+  // Date-only strings ("YYYY-MM-DD") parse as UTC midnight, so they must be
+  // formatted in UTC too — formatting them in the viewer's zone shifts the
+  // calendar date back a day anywhere west of UTC and makes SSR (UTC) and
+  // client render different text.
+  const isDateOnly = typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
   const d = typeof date === "string" ? new Date(date) : date
   return d.toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
+    ...(isDateOnly ? { timeZone: "UTC" } : {}),
   })
 }
 

--- a/portal/src/types/checkout.ts
+++ b/portal/src/types/checkout.ts
@@ -234,7 +234,8 @@ export function formatCheckoutDate(date: string | Date): string {
   // formatted in UTC too — formatting them in the viewer's zone shifts the
   // calendar date back a day anywhere west of UTC and makes SSR (UTC) and
   // client render different text.
-  const isDateOnly = typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
+  const isDateOnly =
+    typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
   const d = typeof date === "string" ? new Date(date) : date
   return d.toLocaleDateString("en-US", {
     month: "short",


### PR DESCRIPTION
## Summary

Batch of open-checkout fixes for the portal, found while debugging the Sol Gathering direct-sale popup and then auditing the checkout flow for fragile visual implementations. Every fix was browser-verified (Playwright/Edge) against the local portal pointed at the production API.

## Related Issue

N/A — found during direct-sale checkout testing on Sol Gathering.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Changes Made

- **Tickets step (open checkout):** the "+" stepper never inserted the first unit — `setRowQuantity` routed through `updateDynamicQuantity`, which can only mutate items already in the cart. First add now inserts via `addDynamicItem` (which also fires add-to-cart tracking).
- **Tickets step:** all rows now use the same `QuantitySelector` (products with `max_per_order = 1` had a separate "+ Add" toggle); the stepper degrades gracefully at the cap. Discounted price block pairs the struck compare price with the unit price instead of the line total.
- **Housing (grid template):** sections holding a single product render a full-width horizontal card instead of leaving half a grid row empty; the duplicate add affordances ("+" overlay on the photo + decorative "Select" pill) are consolidated into one accent stepper at the card's bottom-right.
- **Housing (all four layouts):** cards were native `<button>` elements containing carousel arrows, steppers and "See more" buttons — invalid HTML raising React hydration errors. Replaced with a `SelectableCard` shell (div with button role + keyboard activation); inner controls already stopped propagation, so behavior is unchanged.
- **Checkout nav:** the active-step pill was a floating div positioned from a frozen `offsetWidth` snapshot that went stale on post-paint reflows (visibly oversized on first render). It is now a `motion.div` with `layoutId` inside the active button — sized by CSS, slide animation via framer-motion shared layout.
- **Section entrance animation:** the above-the-fold section's title/watermark painted (SSR), blinked out, and re-animated on every load. Entrance now only plays for sections the user scrolls into.
- **Timezone-safe calendar dates:** `formatCheckoutDate` parsed date-only strings as UTC but formatted local (buyers west of UTC saw the previous day + SSR/client hydration mismatch); `formatDateInput` serialized local midnights via `toISOString` (day shift east of UTC). Calendar dates no longer cross zone conversions.
- **Housing dates in summary:** with `show_dates: false` the stored check-in/out are just the popup's start/end dates, never buyer-chosen — the confirm summary no longer presents them as stay dates (`housingDatesShown` exposed from the checkout provider).
- **Rich-text step:** `prose prose-invert` classes were dead code — `@tailwindcss/typography` was never installed. Installed and loaded the plugin, with prose color slots wired to the tenant theme tokens (prose-invert would have been illegible on light themes). Also themed the ConfirmStep payment-error box (`bg-white` → `bg-destructive/10`, matching its sibling).

## Testing

- [ ] Backend tests pass (`bash scripts/test.sh`) — no backend changes
- [ ] Backend linting passes (`bash scripts/lint.sh`) — no backend changes
- [ ] Backoffice builds successfully (`pnpm run build`) — no backoffice changes
- [ ] Backoffice linting passes (`pnpm run lint`) — no backoffice changes
- [x] Manual testing performed — full checkout walkthrough (tickets, housing, info validation, review) with Playwright/Edge against prod data on `sol-gathering.localhost:3000`; date logic verified in America/Los_Angeles, Asia/Tokyo and UTC browser contexts; hydration errors confirmed gone (0 nested buttons in DOM)

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed — not needed
- [ ] I have added tests for new functionality — UI fixes, browser-verified
- [x] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed — no API changes
- [ ] Database migrations are included if schema changed — no schema changes
