### PR TITLE
fix(checkout): sold-out card lightbox rendering and oversized image uploads

### DIFF
--- a/backoffice/src/hooks/useFileUpload.ts
+++ b/backoffice/src/hooks/useFileUpload.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react"
 import { UploadsService } from "@/client"
+import { compressImage } from "@/lib/compress-image"
 
 export type UploadStatus =
   | "idle"
@@ -68,11 +69,15 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
       try {
         setUploadProgress({ status: "getting-url", progress: 0 })
 
+        // Downscale/re-encode before requesting the URL so the presigned
+        // content type matches the bytes actually sent.
+        const upload = await compressImage(file)
+
         const { upload_url, public_url, key } =
           await UploadsService.getPresignedUploadUrl({
             requestBody: {
-              filename: file.name,
-              content_type: file.type,
+              filename: upload.name,
+              content_type: upload.type,
             },
           })
 
@@ -105,8 +110,8 @@ export function useFileUpload(options: UseFileUploadOptions = {}) {
           })
 
           xhr.open("PUT", upload_url)
-          xhr.setRequestHeader("Content-Type", file.type)
-          xhr.send(file)
+          xhr.setRequestHeader("Content-Type", upload.type)
+          xhr.send(upload)
         })
 
         setUploadProgress({ status: "success", progress: 100 })

--- a/backoffice/src/lib/compress-image.ts
+++ b/backoffice/src/lib/compress-image.ts
@@ -1,0 +1,76 @@
+// Client-side image compression for direct-to-storage uploads. Uploads go
+// browser -> S3 via presigned PUT, so the backend never sees the bytes and
+// this is the only place a resize can happen. Originals arriving at 4-8 MB
+// exceed the Next.js image optimizer's 7s upstream fetch timeout in the
+// portal, breaking product card images entirely.
+
+// Long edge cap. Largest render is the checkout lightbox (~1200px CSS), so
+// 2560 covers 2x DPR with headroom.
+const MAX_DIMENSION = 2560
+const WEBP_QUALITY = 0.82
+// Skip re-encoding only when the image needs no downscale AND is already
+// at or below this size; an in-dimension file above it still shrinks
+// meaningfully from the WebP re-encode alone.
+const SKIP_BYTES = 500 * 1024
+
+// GIFs would lose animation through a canvas; anything non-image (video,
+// pdf) passes through untouched.
+const COMPRESSIBLE_TYPES = ["image/jpeg", "image/png", "image/webp"]
+
+function replaceExtension(name: string, extension: string): string {
+  const base = name.includes(".") ? name.slice(0, name.lastIndexOf(".")) : name
+  return `${base}.${extension}`
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number,
+): Promise<Blob | null> {
+  return new Promise((resolve) => canvas.toBlob(resolve, type, quality))
+}
+
+/**
+ * Downscale and re-encode an image file as WebP before upload. Returns the
+ * original file untouched when compression does not apply (non-image, GIF,
+ * already small and within dimensions) or would not help (re-encoded output
+ * larger than the source). Never throws: on any decode/encode failure the
+ * original file is returned so the upload path stays functional.
+ */
+export async function compressImage(file: File): Promise<File> {
+  if (!COMPRESSIBLE_TYPES.includes(file.type)) return file
+
+  try {
+    // from-image bakes EXIF orientation into the pixels so the re-encoded
+    // copy cannot render rotated.
+    const bitmap = await createImageBitmap(file, {
+      imageOrientation: "from-image",
+    })
+
+    try {
+      const scale = Math.min(
+        1,
+        MAX_DIMENSION / Math.max(bitmap.width, bitmap.height),
+      )
+      if (scale === 1 && file.size <= SKIP_BYTES) return file
+
+      const canvas = document.createElement("canvas")
+      canvas.width = Math.round(bitmap.width * scale)
+      canvas.height = Math.round(bitmap.height * scale)
+      const ctx = canvas.getContext("2d")
+      if (!ctx) return file
+      ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height)
+
+      const blob = await canvasToBlob(canvas, "image/webp", WEBP_QUALITY)
+      if (!blob || blob.size >= file.size) return file
+
+      return new File([blob], replaceExtension(file.name, "webp"), {
+        type: "image/webp",
+      })
+    } finally {
+      bitmap.close()
+    }
+  } catch {
+    return file
+  }
+}

--- a/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import Image from "next/image"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { imageOptimization } from "@/lib/image-optimization"
@@ -82,7 +83,10 @@ export function LightboxOverlay({
   const current = images[index]
   if (!current) return null
 
-  return (
+  // Portal to <body>: hosts like a sold-out product card carry opacity < 1,
+  // which creates a stacking context that would trap this fixed overlay and
+  // render it semi-transparent over the page.
+  return createPortal(
     <div
       className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center"
       onClick={(e) => {
@@ -141,7 +145,8 @@ export function LightboxOverlay({
           {index + 1} / {images.length}
         </p>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }
 

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -8,7 +8,6 @@ import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
   resolveBlockedStepperProps,
   resolveMaxQuantity,
-  supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
 import type { TemplateSection } from "@/hooks/checkout/ticketSections"
 import {


### PR DESCRIPTION
## Summary

Two related fixes for open-checkout images, plus a lint autofix:

- **Lightbox broken on sold-out products**: sold-out cards apply `opacity-60`, which creates a CSS stacking context that trapped the `fixed` `LightboxOverlay` rendered inside the card (it inherited the opacity and its z-index stopped competing at page level). The overlay now mounts via `createPortal(document.body)`. SSR-safe: the overlay only mounts after a click, so `document` is always available.
- **Blank card images / `/_next/image` 500s / slow first render**: housing images reach the CDN as 4-8.5 MB originals. The Next.js image optimizer has a hardcoded 7s upstream fetch timeout, and cold CloudFront fetches of those files exceed it (`TimeoutError` -> 500 -> blank image). Uploads go browser -> S3 via presigned PUT, so the backend never sees the bytes: backoffice uploads now downscale to a 2560px long edge and re-encode as WebP (q0.82) client-side before the PUT. GIF/video/PDF pass through untouched; any decode failure or a larger-than-source result falls back to the original file. No backend changes: `image/webp` is already allowlisted.
- `VariantTicketSelect.tsx`: one-line biome autofix (unused import) picked up by the project lint.

## Changes

| File | Change |
|------|--------|
| `portal/.../VariantImageGallery.tsx` | `LightboxOverlay` renders through `createPortal` to `document.body` |
| `backoffice/src/lib/compress-image.ts` | New client-side downscale + WebP re-encode helper (fail-open) |
| `backoffice/src/hooks/useFileUpload.ts` | Compress before requesting the presigned URL so content type matches the sent bytes |
| `portal/.../VariantTicketSelect.tsx` | Biome autofix: drop unused import |

## Notes

- Existing oversized CDN assets are not fixed by this PR; they need re-upload (or a one-off re-ingestion script) to benefit.
- Portal's own upload hook and `shared-form-ui` still upload originals; same pattern can be applied later if needed.

## Test plan

- [x] `pnpm --filter portal run lint && pnpm --filter portal run build`
- [x] `pnpm --filter backoffice run lint && pnpm --filter backoffice run build`
- [x] Reproduced the optimizer 500s locally (7.0s `TimeoutError` in dev server log) and verified the same URLs return 200 once the CDN is warm
- [ ] Manual: open a sold-out housing product's images at sol-gathering checkout and verify the lightbox renders opaque