### PR TITLE
fix(backend/uploads): key superadmin uploads under the active tenant folder

### DIFF
--- a/backend/app/api/upload/router.py
+++ b/backend/app/api/upload/router.py
@@ -1,13 +1,19 @@
 """Upload API router."""
 
 import uuid
+from typing import Annotated
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Header, HTTPException
 
 from app.api.upload.schemas import PresignedUrlRequest, PresignedUrlResponse
 from app.core.config import settings
-from app.core.dependencies.users import CurrentHuman, CurrentUser
+from app.core.dependencies.users import (
+    CurrentHuman,
+    CurrentUser,
+    SessionDep,
+    get_current_tenant,
+)
 from app.services.storage import storage_service
 
 router = APIRouter(prefix="/uploads", tags=["uploads"])
@@ -65,12 +71,23 @@ def _build_presigned_url(
 async def get_presigned_upload_url(
     request: PresignedUrlRequest,
     current_user: CurrentUser,
+    db: SessionDep,
+    x_tenant_id: Annotated[str | None, Header(alias="X-Tenant-Id")] = None,
 ) -> PresignedUrlResponse:
     """Generate a presigned URL for direct upload (backoffice staff)."""
+    # SUPERADMIN users have no tenant of their own, so their uploads would
+    # always key under superadmin/. The backoffice sends the active workspace
+    # in X-Tenant-Id on every request: honor it so assets land in that
+    # tenant's folder. Tenant-level uploads without a workspace (e.g. tenant
+    # logos) keep the superadmin/ fallback. Admins keep their own tenant and
+    # cannot be redirected by the header.
+    tenant_id: uuid.UUID | str | None = current_user.tenant_id
+    if tenant_id is None and x_tenant_id:
+        tenant_id = get_current_tenant(db, x_tenant_id).id
     return _build_presigned_url(
         request.filename,
         request.content_type,
-        current_user.tenant_id,
+        tenant_id,
         ALLOWED_BACKOFFICE_TYPES,
     )
 

--- a/backend/tests/api/upload/test_presigned_url.py
+++ b/backend/tests/api/upload/test_presigned_url.py
@@ -1,0 +1,97 @@
+"""Tenant folder resolution for presigned upload URLs.
+
+SUPERADMIN users carry no tenant_id of their own, so their uploads keyed
+under superadmin/ regardless of the workspace they were operating on. The
+backoffice sends the active workspace in X-Tenant-Id on every request; the
+endpoint honors it for superadmins and ignores it for tenant-bound admins.
+"""
+
+from unittest.mock import patch
+
+from app.core.config import settings
+
+UPLOAD_URL = "/api/v1/uploads/presigned-url"
+PAYLOAD = {"filename": "photo.png", "content_type": "image/png"}
+
+
+def storage_enabled():
+    return patch.multiple(
+        settings,
+        STORAGE_ACCESS_KEY="test-access-key",
+        STORAGE_SECRET_KEY="test-secret-key",
+    )
+
+
+class TestPresignedUrlTenantFolder:
+    def test_superadmin_with_tenant_header_keys_under_tenant(
+        self, client, superadmin_token, tenant_a
+    ):
+        with storage_enabled():
+            response = client.post(
+                UPLOAD_URL,
+                json=PAYLOAD,
+                headers={
+                    "Authorization": f"Bearer {superadmin_token}",
+                    "X-Tenant-Id": str(tenant_a.id),
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["key"].startswith(f"{tenant_a.id}/images/")
+
+    def test_superadmin_without_header_falls_back_to_superadmin_folder(
+        self, client, superadmin_token
+    ):
+        with storage_enabled():
+            response = client.post(
+                UPLOAD_URL,
+                json=PAYLOAD,
+                headers={"Authorization": f"Bearer {superadmin_token}"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["key"].startswith("superadmin/images/")
+
+    def test_admin_keeps_own_tenant_even_with_foreign_header(
+        self, client, admin_token_tenant_a, tenant_a, tenant_b
+    ):
+        with storage_enabled():
+            response = client.post(
+                UPLOAD_URL,
+                json=PAYLOAD,
+                headers={
+                    "Authorization": f"Bearer {admin_token_tenant_a}",
+                    "X-Tenant-Id": str(tenant_b.id),
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["key"].startswith(f"{tenant_a.id}/images/")
+
+    def test_superadmin_with_malformed_header_returns_400(
+        self, client, superadmin_token
+    ):
+        with storage_enabled():
+            response = client.post(
+                UPLOAD_URL,
+                json=PAYLOAD,
+                headers={
+                    "Authorization": f"Bearer {superadmin_token}",
+                    "X-Tenant-Id": "not-a-uuid",
+                },
+            )
+
+        assert response.status_code == 400
+
+    def test_superadmin_with_unknown_tenant_returns_404(self, client, superadmin_token):
+        with storage_enabled():
+            response = client.post(
+                UPLOAD_URL,
+                json=PAYLOAD,
+                headers={
+                    "Authorization": f"Bearer {superadmin_token}",
+                    "X-Tenant-Id": "00000000-0000-0000-0000-000000000000",
+                },
+            )
+
+        assert response.status_code == 404

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -8467,6 +8467,7 @@ export class UploadsService {
      * Generate a presigned URL for direct upload (backoffice staff).
      * @param data The data for the request.
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns PresignedUrlResponse Successful Response
      * @throws ApiError
      */
@@ -8474,6 +8475,9 @@ export class UploadsService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/uploads/presigned-url',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -6801,6 +6801,7 @@ export type TranslationsDeleteTranslationResponse = (void);
 
 export type UploadsGetPresignedUploadUrlData = {
     requestBody: PresignedUrlRequest;
+    xTenantId?: (string | null);
 };
 
 export type UploadsGetPresignedUploadUrlResponse = (PresignedUrlResponse);

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -8467,6 +8467,7 @@ export class UploadsService {
      * Generate a presigned URL for direct upload (backoffice staff).
      * @param data The data for the request.
      * @param data.requestBody
+     * @param data.xTenantId
      * @returns PresignedUrlResponse Successful Response
      * @throws ApiError
      */
@@ -8474,6 +8475,9 @@ export class UploadsService {
         return __request(OpenAPI, {
             method: 'POST',
             url: '/api/v1/uploads/presigned-url',
+            headers: {
+                'X-Tenant-Id': data.xTenantId
+            },
             body: data.requestBody,
             mediaType: 'application/json',
             errors: {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -6801,6 +6801,7 @@ export type TranslationsDeleteTranslationResponse = (void);
 
 export type UploadsGetPresignedUploadUrlData = {
     requestBody: PresignedUrlRequest;
+    xTenantId?: (string | null);
 };
 
 export type UploadsGetPresignedUploadUrlResponse = (PresignedUrlResponse);

--- a/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantTicketSelect.tsx
@@ -8,7 +8,6 @@ import ExpandableDescription from "@/components/ui/ExpandableDescription"
 import QuantitySelector, {
   resolveBlockedStepperProps,
   resolveMaxQuantity,
-  supportsQuantitySelector,
 } from "@/components/ui/QuantitySelector"
 import type { TemplateSection } from "@/hooks/checkout/ticketSections"
 import {


### PR DESCRIPTION
## Summary

Superadmin uploads always landed in the `superadmin/` storage folder instead of the tenant they were working on. Superadmins carry `tenant_id = NULL`, and the presigned-URL endpoint used `current_user.tenant_id` directly, ignoring the `X-Tenant-Id` workspace header the backoffice already sends on every request.

- When `current_user.tenant_id` is NULL and `X-Tenant-Id` is present, the tenant is resolved through the existing `get_current_tenant` helper (400 on malformed UUID, 404 on unknown/deleted tenant) and the object keys under `{tenant_id}/images/`.
- Superadmin without the header keeps the `superadmin/` fallback: tenant-level assets (e.g. logos in `TenantForm`) are uploaded before/without a workspace selection.
- Tenant-bound admins keep their own `tenant_id`; the header cannot redirect them into another tenant's folder.
- OpenAPI clients regenerated for both frontends (new optional header param).

## Changes

| File | Change |
|------|--------|
| `backend/app/api/upload/router.py` | Resolve `X-Tenant-Id` for tenant-less (superadmin) users on the backoffice presigned-URL endpoint |
| `backend/tests/api/upload/test_presigned_url.py` | New: covers superadmin+header, superadmin fallback, admin ignoring foreign header, 400/404 validation |
| `*/src/client/*.gen.ts` | Regenerated OpenAPI clients |
| `portal/.../VariantTicketSelect.tsx` | Biome autofix (unused import), separate commit |

## Test plan

- [x] `uv run pytest tests/api/upload` (5 passed)
- [x] `bash scripts/lint.sh` (ty + ruff)
- [x] `bash scripts/generate-client.sh` + both frontends build
- [x] Security review lens: no blockers; admins cannot cross-write via header, tenant id is UUID-validated before reaching the S3 key