### PR TITLE
perf(portal): fix slow first render of carousel and lightbox images

### DIFF
--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -15,9 +15,12 @@ const nextConfig: NextConfig = {
       protocol: "https" as const,
       hostname,
     })),
-    // AVIF first (best compression for the photographic tenant imagery),
-    // WebP fallback for browsers without AVIF support.
-    formats: ["image/avif", "image/webp"],
+    // WebP only: AVIF shaves a few KB but its encode costs seconds of
+    // server CPU on every cold (image, width) variant, which shows up as
+    // 1-3s first renders in carousels and lightboxes. Sources are already
+    // compressed WebP at upload time, so AVIF's marginal savings never pay
+    // for that latency.
+    formats: ["image/webp"],
   },
 }
 

--- a/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHousingDate.tsx
@@ -421,6 +421,19 @@ function ProductImageCarousel({
 
   const safeIdx = idx < images.length ? idx : 0
 
+  // Adjacent slides stay mounted (transparent) so their variants are already
+  // in the browser cache when the user navigates; swapping src on a single
+  // <Image> keeps showing the old picture until the new one finishes
+  // downloading otherwise.
+  const neighborIdxs = hasMany
+    ? [
+        ...new Set([
+          (safeIdx + 1) % images.length,
+          (safeIdx - 1 + images.length) % images.length,
+        ]),
+      ].filter((i) => i !== safeIdx)
+    : []
+
   const next = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.stopPropagation()
     setIdx((i) => (i + 1) % images.length)
@@ -481,6 +494,18 @@ function ProductImageCarousel({
   return (
     <>
       <div {...imageClickProps}>
+        {neighborIdxs.map((i) => (
+          <Image
+            key={images[i]}
+            src={images[i]}
+            alt=""
+            aria-hidden
+            fill
+            sizes="(max-width: 768px) 100vw, 672px"
+            className="object-cover opacity-0 pointer-events-none"
+            {...imageOptimization(images[i])}
+          />
+        ))}
         <Image
           src={images[safeIdx]}
           alt={alt}

--- a/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantImageGallery.tsx
@@ -83,6 +83,19 @@ export function LightboxOverlay({
   const current = images[index]
   if (!current) return null
 
+  // Fetch the adjacent full-size images while the current one is on screen
+  // so prev/next swaps come from the browser cache. display:none images
+  // never load under native lazy loading, hence the explicit eager.
+  const neighbors =
+    images.length > 1
+      ? [
+          ...new Set([
+            (index + 1) % images.length,
+            (index - 1 + images.length) % images.length,
+          ]),
+        ].filter((i) => i !== index)
+      : []
+
   // Portal to <body>: hosts like a sold-out product card carry opacity < 1,
   // which creates a stacking context that would trap this fixed overlay and
   // render it semi-transparent over the page.
@@ -128,6 +141,19 @@ export function LightboxOverlay({
       )}
 
       <div className="max-w-4xl max-h-[80vh] w-full mx-4 relative">
+        {neighbors.map((i) => (
+          <Image
+            key={images[i].id}
+            src={images[i].url}
+            alt=""
+            aria-hidden
+            width={1200}
+            height={800}
+            loading="eager"
+            className="hidden"
+            {...imageOptimization(images[i].url)}
+          />
+        ))}
         <Image
           src={current.url}
           alt={current.caption || ""}


### PR DESCRIPTION
## Summary

Two independent causes of the 1-3s image swaps reported in the checkout housing carousels and lightbox:

- **AVIF encoding latency**: the optimizer had `formats: ["image/avif", "image/webp"]`, and sharp's AVIF encode costs seconds of server CPU for every cold (image, width) variant — measured 3.04s on a 54.9 KB lightbox image. Sources are already compressed WebP at upload time, so AVIF's few extra KB never pay for that latency. Now WebP only; the same cold 1080px variant serves in ~0.5s including the CDN fetch.
- **No prefetch on navigation**: the card carousel and the lightbox render a single `<Image>` and swap its `src`, so the old picture stays visible until the new one finishes downloading. Adjacent slides now stay mounted (transparent in the carousel, `hidden` + `loading="eager"` in the lightbox, since display:none images never load under native lazy loading), so prev/next swaps come from the browser cache.

## Changes

| File | Change |
|------|--------|
| `portal/next.config.ts` | `images.formats` narrowed to `["image/webp"]` |
| `portal/.../VariantHousingDate.tsx` | `ProductImageCarousel` keeps adjacent slides mounted for prefetch |
| `portal/.../VariantImageGallery.tsx` | `LightboxOverlay` eagerly fetches adjacent full-size images |

## Test plan

- [x] `pnpm --filter portal run lint` + `pnpm --filter portal run build`
- [x] Verified with `Accept: image/avif,...` that `/_next/image` now responds `Content-Type: image/webp`
- [x] Cold 1080px variant: ~0.5s (was ~3s with AVIF)
- [ ] Manual: navigate a housing carousel and lightbox; swaps should be instant after the first neighbor loads