### PR TITLE
feat(backoffice): allow marking popups as ended from the status select

### DIFF
--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -82,6 +82,7 @@ interface PopupFormProps {
 const POPUP_STATUSES = [
   { value: "draft", label: "Draft" },
   { value: "active", label: "Active" },
+  { value: "ended", label: "Ended" },
 ] as const
 
 const AVAILABLE_LANGUAGES = [


### PR DESCRIPTION
## Summary

- Adds the "Ended" option to the popup status select in the backoffice, so admins can manually mark a popup as ended.
- Motivation: the `popup_ended_transition` job is the only automatic path to `ended`, and environments without scheduled jobs (dev/staging) never transition popups, which hides the ended-popup portal experience shipped in #452.

## Changes

| File | Change |
|------|--------|
| `backoffice/src/components/forms/PopupForm.tsx` | Add `{ value: "ended", label: "Ended" }` to `POPUP_STATUSES` |

## Test plan

- [x] `pnpm --filter backoffice run build` passes
- [x] Biome pre-commit hooks pass
- [x] Reviewed: admin popup list has no status filter, so popups marked ended remain visible in the backoffice

## Notes (non-blocking)

- The create form also offers "Ended", so a brand-new popup can be created already ended. Harmless but semantically odd; can be gated to edit mode later if it becomes a footgun.
- The status badge renders "ended" with the same secondary variant as "draft".