### PR TITLE
feat(payments): add configurable SimpleFi success redirect behavior

### DIFF
--- a/backend/app/alembic/versions/a8e3d7f4c2b9_popup_simplefi_success_behavior.py
+++ b/backend/app/alembic/versions/a8e3d7f4c2b9_popup_simplefi_success_behavior.py
@@ -1,0 +1,36 @@
+"""Add per-popup SimpleFi success redirect behavior.
+
+Forwarded to SimpleFi as ``redirect_urls.success_behavior`` on every payment
+created for the popup. ``manual`` (SimpleFi's default) keeps the buyer on
+SimpleFi's checkout until they click through to the success URL;
+``automatic`` redirects immediately after approval.
+
+Revision ID: a8e3d7f4c2b9
+Revises: fa4a726d54b8
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a8e3d7f4c2b9"
+down_revision: str | Sequence[str] | None = "fa4a726d54b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "popups",
+        sa.Column(
+            "simplefi_success_behavior",
+            sa.String(),
+            nullable=False,
+            server_default="manual",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("popups", "simplefi_success_behavior")

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -1174,6 +1174,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 installment_interval_count=popup.installments_interval_count,
                 user_email=buyer.email,
                 plan_name=popup.name,
+                success_behavior=popup.simplefi_success_behavior,
             )
 
             payment.external_id = simplefi_response.id
@@ -1507,6 +1508,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 portal_base_override=portal_base,
                 success_path=success_path,
                 cancel_path=cancel_path,
+                success_behavior=popup.simplefi_success_behavior,
             )
             logger.info(
                 "SimpleFI application fee payment created: application_id={} external_id={} provider_status={} checkout_url={}",
@@ -2454,6 +2456,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                 installment_interval_count=popup.installments_interval_count,
                 user_email=application.human.email if application.human else None,
                 plan_name=popup.name,
+                success_behavior=popup.simplefi_success_behavior,
             )
             logger.info(
                 "SimpleFI pass payment created: application_id={} external_id={} provider_status={} checkout_url={} is_installment_plan={}",

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -42,6 +42,7 @@ from app.api.product.product_state import ProductSaleState, derive_product_state
 from app.api.product.schemas import ProductPublic
 from app.api.shared.crud import BaseCRUD
 from app.utils.checkout_signing import (
+    append_query_params,
     build_signed_redirect_url,
     build_thank_you_payload,
     build_unsigned_redirect_url,
@@ -180,13 +181,19 @@ def _resolve_open_checkout_success_url(
     With no custom URL, the buyer stays on the portal thank-you, which carries
     the order data unsigned so it can render the summary (our own page — no HMAC
     needed).
+
+    The checkout language is always forwarded as a ``lang`` query param —
+    external and internal alike — outside the signed payload, so the landing
+    page can render in the buyer's language without touching HMAC verification.
     """
     custom = popup.open_checkout_success_url
     if custom:
         custom = custom.replace("{locale}", locale)
+        custom = append_query_params(custom, [("lang", locale)])
         secret = popup.open_checkout_signing_secret
         return build_signed_redirect_url(custom, payload, secret) if secret else custom
-    return build_unsigned_redirect_url(internal_thank_you_url, payload)
+    internal = append_query_params(internal_thank_you_url, [("lang", locale)])
+    return build_unsigned_redirect_url(internal, payload)
 
 
 def _internal_open_checkout_thank_you_url(
@@ -843,6 +850,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     session,
                     email=obj.buyer.email,
                     popup_id=popup.id,
+                    locale=obj.locale,
                 )
 
                 # ADR-2 advisory lock: serialize concurrent open-checkout
@@ -3103,6 +3111,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         application_id: uuid.UUID | None = None,
         email: str | None = None,
         popup_id: uuid.UUID | None = None,
+        locale: str | None = None,
     ) -> None:
         """Cancel any prior PENDING SimpleFi payment for this buyer before creating a new one.
 
@@ -3137,6 +3146,8 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             application_id: Lookup key for authenticated checkout.
             email: Buyer email for open-checkout lookup (requires popup_id).
             popup_id: Required when email is provided.
+            locale: Checkout language of the new purchase attempt, forwarded
+                to the 409 signed redirect. Falls back to the popup default.
         """
 
         # Locate the prior PENDING SimpleFi payment for this buyer
@@ -3158,7 +3169,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             return  # No prior pending payment — nothing to supersede
 
         self._supersede_located_pending(
-            session, prior, anonymous=(application_id is None)
+            session, prior, anonymous=(application_id is None), locale=locale
         )
 
     def _supersede_located_pending(
@@ -3167,6 +3178,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         prior: "Payments",
         *,
         anonymous: bool,
+        locale: str | None = None,
     ) -> None:
         """Cancel an already-located PENDING SimpleFi payment and release its holds.
 
@@ -3319,8 +3331,13 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                         issued_at=_now.isoformat(),
                         exp=int(_now.timestamp()) + 30 * 60,
                     )
+                    lang = locale or _popup.default_language or "en"
+                    success_base = _popup.open_checkout_success_url.replace(
+                        "{locale}", lang
+                    )
+                    success_base = append_query_params(success_base, [("lang", lang)])
                     redirect_url = build_signed_redirect_url(
-                        _popup.open_checkout_success_url, payload, secret
+                        success_base, payload, secret
                     )
                 # else: no signing secret or no external URL — omit redirect_url
 

--- a/backend/app/api/popup/schemas.py
+++ b/backend/app/api/popup/schemas.py
@@ -14,6 +14,7 @@ from app.api.shared.enums import (
     CheckoutMode,
     InstallmentInterval,
     SaleType,
+    SimpleFiSuccessBehavior,
     derive_checkout_mode,
 )
 from app.core.config import settings
@@ -163,6 +164,13 @@ class PopupBase(SQLModel):
     blog_url: str | None = None
     twitter_url: str | None = None
     simplefi_api_key: str | None = None
+    # Forwarded to SimpleFi as redirect_urls.success_behavior on every payment
+    # created for this popup. Manual (SimpleFi's default) keeps the buyer on
+    # SimpleFi's checkout until they click through to the success URL.
+    simplefi_success_behavior: SimpleFiSuccessBehavior = Field(
+        default=SimpleFiSuccessBehavior.manual,
+        sa_column=Column(String, nullable=False, server_default="manual"),
+    )
     terms_and_conditions_url: str | None = None
     # Per-popup redirect URLs for the open-checkout flow. When set, they
     # override the default portal thank-you / cancel pages forwarded to
@@ -283,6 +291,7 @@ class PopupCreate(SQLModel):
     blog_url: str | None = None
     twitter_url: str | None = None
     simplefi_api_key: str | None = None
+    simplefi_success_behavior: SimpleFiSuccessBehavior = SimpleFiSuccessBehavior.manual
     terms_and_conditions_url: str | None = None
     open_checkout_success_url: str | None = None
     open_checkout_cancel_url: str | None = None
@@ -381,6 +390,7 @@ class PopupUpdate(SQLModel):
     blog_url: str | None = None
     twitter_url: str | None = None
     simplefi_api_key: str | None = None
+    simplefi_success_behavior: SimpleFiSuccessBehavior | None = None
     terms_and_conditions_url: str | None = None
     open_checkout_success_url: str | None = None
     open_checkout_cancel_url: str | None = None

--- a/backend/app/api/shared/enums.py
+++ b/backend/app/api/shared/enums.py
@@ -116,6 +116,19 @@ class InstallmentInterval(StrEnum):
     year = "year"
 
 
+class SimpleFiSuccessBehavior(StrEnum):
+    """How SimpleFi redirects the buyer to the success URL after payment.
+
+    Mirrors SimpleFi's ``redirect_urls.success_behavior``:
+    - manual: the buyer clicks a button on SimpleFi's checkout to continue
+      (SimpleFi's default, and ours).
+    - automatic: SimpleFi redirects the buyer immediately after approval.
+    """
+
+    manual = "manual"
+    automatic = "automatic"
+
+
 def derive_checkout_mode(sale_type: SaleType) -> CheckoutMode:
     if sale_type == SaleType.direct:
         return CheckoutMode.simple_quantity

--- a/backend/app/services/simplefi/client.py
+++ b/backend/app/services/simplefi/client.py
@@ -142,6 +142,7 @@ class SimpleFIClient:
         installment_interval_count: int = 1,
         user_email: str | None = None,
         plan_name: str | None = None,
+        success_behavior: str = "manual",
     ) -> SimpleFIPaymentResponse:
         """
         Create a payment request OR an installment plan in SimpleFI.
@@ -180,6 +181,9 @@ class SimpleFIClient:
             user_email: Required when creating an installment plan.
             plan_name: Optional display name for the installment plan
                 (shown to the buyer in SimpleFi's UI).
+            success_behavior: "manual" (SimpleFi's default — the buyer clicks
+                through to the success URL) or "automatic" (SimpleFi redirects
+                immediately after approval).
 
         Returns:
             SimpleFIPaymentResponse with id, status, checkout_url, and
@@ -195,7 +199,11 @@ class SimpleFIClient:
             or f"{portal_base}/portal/{popup_slug}/passes/buy?checkout=success"
         )
         cancel_url = cancel_path or f"{portal_base}/portal/{popup_slug}/passes/buy"
-        redirect_urls = {"success_url": success_url, "cancel_url": cancel_url}
+        redirect_urls = {
+            "success_url": success_url,
+            "cancel_url": cancel_url,
+            "success_behavior": success_behavior,
+        }
 
         if max_installments is not None and max_installments >= 2:
             if not user_email:

--- a/backend/app/utils/checkout_signing.py
+++ b/backend/app/utils/checkout_signing.py
@@ -138,7 +138,13 @@ def build_thank_you_payload(
     }
 
 
-def _append_query(base_url: str, extra: list[tuple[str, str]]) -> str:
+def append_query_params(base_url: str, extra: list[tuple[str, str]]) -> str:
+    """Append query params to ``base_url``, preserving any existing ones.
+
+    Also used to forward the checkout language (``lang``) on the success
+    redirect — it travels as a plain query param, outside the signed payload,
+    so it never affects HMAC verification.
+    """
     parts = urlparse(base_url)
     query = parse_qsl(parts.query, keep_blank_values=True)
     query.extend(extra)
@@ -155,7 +161,7 @@ def build_signed_redirect_url(
     """
     d = encode_payload(payload)
     sig = sign_data_hex(d, secret)
-    return _append_query(base_url, [("d", d), ("sig", sig)])
+    return append_query_params(base_url, [("d", d), ("sig", sig)])
 
 
 def build_unsigned_redirect_url(base_url: str, payload: Mapping[str, Any]) -> str:
@@ -165,4 +171,4 @@ def build_unsigned_redirect_url(base_url: str, payload: Mapping[str, Any]) -> st
     order summary on a confirmation screen we control), so it needs no HMAC.
     Existing query params are preserved.
     """
-    return _append_query(base_url, [("data", encode_payload(payload))])
+    return append_query_params(base_url, [("data", encode_payload(payload))])

--- a/backend/tests/api/checkout/test_purchase.py
+++ b/backend/tests/api/checkout/test_purchase.py
@@ -653,7 +653,9 @@ def test_zero_amount_purchase_returns_custom_success_redirect_url(
     body = response.json()
     assert body["status"] == "approved"
     assert body["checkout_url"] == ""
-    assert body["redirect_url"] == "https://brand.example.com/thank-you"
+    # The checkout language always travels as a lang query param (popup
+    # default when the request carries no locale).
+    assert body["redirect_url"] == "https://brand.example.com/thank-you?lang=en"
     mock_get_client.assert_not_called()
 
 
@@ -711,7 +713,12 @@ def test_paid_purchase_signs_order_payload_into_simplefi_success_url(
         ]
 
     assert success_url.startswith("https://brand.example.com/thank-you")
+    # lang travels as a plain query param, OUTSIDE the signed payload, so it
+    # never affects HMAC verification (contract with the external page).
+    query = parse_qs(urlparse(success_url).query)
+    assert query["lang"] == ["en"]
     payload = _verify_signed_redirect(success_url, secret)
+    assert "lang" not in payload
     assert payload["first_name"] == "Matias"
     assert payload["amount_total"] == 240.0
     assert payload["currency"] == "USD"
@@ -765,6 +772,57 @@ def test_signed_redirect_substitutes_locale_placeholder(
     # Request locale ("en") wins over the popup default ("es").
     assert success_url.startswith("https://amanita.example.com/en/gracias")
     assert "{locale}" not in success_url
+    # The same locale is forwarded as the lang query param.
+    assert parse_qs(urlparse(success_url).query)["lang"] == ["en"]
+
+
+def test_signed_redirect_forwards_lang_on_fixed_path_success_url(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Fixed-path external thank-you contract: the checkout language travels
+    as .../gracias?lang=<es|en>&d=...&sig=... — lang outside the signed payload,
+    so signature verification is untouched."""
+    secret = "amanita-secret"
+    popup = _make_popup(db, tenant_a, slug_prefix="lang-fixed-path")
+    popup.open_checkout_success_url = "https://amanita.example.com/gracias"
+    popup.open_checkout_signing_secret = secret
+    db.add(popup)
+    product = _make_product(db, popup, price="120.00")
+    db.commit()
+
+    with patch("app.services.simplefi.get_simplefi_client") as mock_get_client:
+        mock_get_client.return_value.create_payment.return_value = SimpleNamespace(
+            id="sf_lang_1",
+            status="pending",
+            checkout_url="https://simplefi.test/checkout/lang",
+            is_installment_plan=False,
+        )
+        response = client.post(
+            f"/api/v1/checkout/{popup.slug}/purchase",
+            json={
+                "products": [{"product_id": str(product.id), "quantity": 1}],
+                "buyer": {
+                    "email": "buyer@test.com",
+                    "first_name": "Ana",
+                    "last_name": "Diaz",
+                    "form_data": {},
+                },
+                "locale": "es",  # from the entry URL ?lang=es
+            },
+            headers={"X-Tenant-Id": str(tenant_a.id)},
+        )
+
+    assert response.status_code == 200, response.text
+    success_url = mock_get_client.return_value.create_payment.call_args.kwargs[
+        "success_path"
+    ]
+    assert success_url.startswith("https://amanita.example.com/gracias?")
+    query = parse_qs(urlparse(success_url).query)
+    assert query["lang"] == ["es"]
+    payload = _verify_signed_redirect(success_url, secret)
+    assert "lang" not in payload
 
 
 def test_zero_amount_purchase_signs_order_payload_into_redirect_url(
@@ -854,6 +912,9 @@ def test_paid_purchase_injects_order_data_into_portal_thank_you(
 
     assert f"/checkout/{popup.slug}/thank-you" in success_url
     assert "sig=" not in success_url  # portal page is ours — no signature
+    # The internal thank-you also receives lang so the portal keeps the
+    # buyer's checkout language after the provider redirect.
+    assert parse_qs(urlparse(success_url).query)["lang"] == ["en"]
     payload = _decode_data_param(success_url)
     assert payload["first_name"] == "Matias"
     assert payload["amount_total"] == 240.0

--- a/backend/tests/test_simplefi_client_installments.py
+++ b/backend/tests/test_simplefi_client_installments.py
@@ -54,6 +54,8 @@ def test_create_payment_one_shot_hits_payment_requests(monkeypatch) -> None:
     assert "max_installments" not in captured["body"]
     assert "interval" not in captured["body"]
     assert captured["body"]["amount"] == 100.0
+    # Manual is SimpleFi's default and must be sent explicitly unless overridden.
+    assert captured["body"]["redirect_urls"]["success_behavior"] == "manual"
     assert isinstance(result, SimpleFIPaymentResponse)
     assert result.is_installment_plan is False
     assert result.id == "pr-1"
@@ -139,6 +141,7 @@ def test_create_payment_installment_branch_hits_installment_plans(
     assert body["reference"] == {"application_id": "abc"}
     assert "notification_url" in body
     assert "redirect_urls" in body
+    assert body["redirect_urls"]["success_behavior"] == "manual"
 
     assert isinstance(result, SimpleFIPaymentResponse)
     assert result.is_installment_plan is True
@@ -212,3 +215,47 @@ def test_create_payment_passes_through_custom_interval(monkeypatch) -> None:
     body = captured["body"]
     assert body["interval"] == "week"
     assert body["interval_count"] == 2
+
+
+def test_create_payment_passes_through_automatic_success_behavior(
+    monkeypatch,
+) -> None:
+    captured = _install_capture(
+        monkeypatch,
+        {"id": "pr-4", "status": "pending", "checkout_v2_url": "https://pay/x"},
+    )
+    client = SimpleFIClient("fake-key")
+
+    client.create_payment(
+        amount=Decimal("100.00"),
+        popup_slug="popup",
+        tenant_slug="tenant",
+        success_behavior="automatic",
+    )
+
+    assert captured["body"]["redirect_urls"]["success_behavior"] == "automatic"
+
+
+def test_create_payment_installment_branch_passes_success_behavior(
+    monkeypatch,
+) -> None:
+    captured = _install_capture(
+        monkeypatch,
+        {
+            "id": "plan-4",
+            "status": "pending",
+            "checkout_url": "https://pay/plan/plan-4",
+        },
+    )
+    client = SimpleFIClient("fake-key")
+
+    client.create_payment(
+        amount=Decimal("600.00"),
+        popup_slug="popup",
+        tenant_slug="tenant",
+        max_installments=3,
+        user_email="buyer@example.com",
+        success_behavior="automatic",
+    )
+
+    assert captured["body"]["redirect_urls"]["success_behavior"] == "automatic"

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -13166,6 +13166,10 @@ export const PopupAdminSchema = {
             ],
             title: 'Simplefi Api Key'
         },
+        simplefi_success_behavior: {
+            '$ref': '#/components/schemas/SimpleFiSuccessBehavior',
+            default: 'manual'
+        },
         terms_and_conditions_url: {
             anyOf: [
                 {
@@ -13643,6 +13647,10 @@ export const PopupCreateSchema = {
                 }
             ],
             title: 'Simplefi Api Key'
+        },
+        simplefi_success_behavior: {
+            '$ref': '#/components/schemas/SimpleFiSuccessBehavior',
+            default: 'manual'
         },
         terms_and_conditions_url: {
             anyOf: [
@@ -14618,6 +14626,16 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Simplefi Api Key'
+        },
+        simplefi_success_behavior: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/SimpleFiSuccessBehavior'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         terms_and_conditions_url: {
             anyOf: [
@@ -16916,6 +16934,18 @@ export const SendTestRequestSchema = {
     type: 'object',
     required: ['html_content', 'template_type', 'to_email'],
     title: 'SendTestRequest'
+} as const;
+
+export const SimpleFiSuccessBehaviorSchema = {
+    type: 'string',
+    enum: ['manual', 'automatic'],
+    title: 'SimpleFiSuccessBehavior',
+    description: `How SimpleFi redirects the buyer to the success URL after payment.
+
+Mirrors SimpleFi's \`\`redirect_urls.success_behavior\`\`:
+- manual: the buyer clicks a button on SimpleFi's checkout to continue
+  (SimpleFi's default, and ours).
+- automatic: SimpleFi redirects the buyer immediately after approval.`
 } as const;
 
 export const TaskAppSchema = {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -2859,6 +2859,7 @@ export type PopupAdmin = {
     blog_url?: (string | null);
     twitter_url?: (string | null);
     simplefi_api_key?: (string | null);
+    simplefi_success_behavior?: SimpleFiSuccessBehavior;
     terms_and_conditions_url?: (string | null);
     open_checkout_success_url?: (string | null);
     open_checkout_cancel_url?: (string | null);
@@ -2916,6 +2917,7 @@ export type PopupCreate = {
     blog_url?: (string | null);
     twitter_url?: (string | null);
     simplefi_api_key?: (string | null);
+    simplefi_success_behavior?: SimpleFiSuccessBehavior;
     terms_and_conditions_url?: (string | null);
     open_checkout_success_url?: (string | null);
     open_checkout_cancel_url?: (string | null);
@@ -3055,6 +3057,7 @@ export type PopupUpdate = {
     blog_url?: (string | null);
     twitter_url?: (string | null);
     simplefi_api_key?: (string | null);
+    simplefi_success_behavior?: (SimpleFiSuccessBehavior | null);
     terms_and_conditions_url?: (string | null);
     open_checkout_success_url?: (string | null);
     open_checkout_cancel_url?: (string | null);
@@ -3487,6 +3490,16 @@ export type SendTestRequest = {
 } | null);
     popup_id?: (string | null);
 };
+
+/**
+ * How SimpleFi redirects the buyer to the success URL after payment.
+ *
+ * Mirrors SimpleFi's ``redirect_urls.success_behavior``:
+ * - manual: the buyer clicks a button on SimpleFi's checkout to continue
+ * (SimpleFi's default, and ours).
+ * - automatic: SimpleFi redirects the buyer immediately after approval.
+ */
+export type SimpleFiSuccessBehavior = 'manual' | 'automatic';
 
 /**
  * Which surface a task relates to. Optional (NULL = unspecified).

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -35,6 +35,7 @@ import {
   PopupsService,
   type PopupUpdate,
   type SaleType,
+  type SimpleFiSuccessBehavior,
 } from "@/client"
 import { AttendeeCategoriesEditor } from "@/components/attendee-categories/AttendeeCategoriesEditor"
 import { DangerZone } from "@/components/Common/DangerZone"
@@ -221,6 +222,8 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
       open_checkout_signing_secret:
         defaultValues?.open_checkout_signing_secret ?? "",
       simplefi_api_key: defaultValues?.simplefi_api_key ?? "",
+      simplefi_success_behavior: (defaultValues?.simplefi_success_behavior ??
+        "manual") as SimpleFiSuccessBehavior,
       invoice_company_name: defaultValues?.invoice_company_name ?? "",
       invoice_company_address: defaultValues?.invoice_company_address ?? "",
       invoice_company_email: defaultValues?.invoice_company_email ?? "",
@@ -284,6 +287,7 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
         open_checkout_signing_secret:
           value.open_checkout_signing_secret || null,
         simplefi_api_key: value.simplefi_api_key || null,
+        simplefi_success_behavior: value.simplefi_success_behavior,
         invoice_company_name: value.invoice_company_name || null,
         invoice_company_address: value.invoice_company_address || null,
         invoice_company_email: value.invoice_company_email || null,
@@ -1032,6 +1036,34 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                   disabled={readOnly}
                   className="max-w-xs text-sm"
                 />
+              </InlineRow>
+            )}
+          </form.Field>
+          <form.Field name="simplefi_success_behavior">
+            {(field) => (
+              <InlineRow
+                icon={<LinkIcon className="h-4 w-4 text-muted-foreground" />}
+                label="SimpleFi success redirect"
+                description="How the buyer reaches the success URL after paying. Manual keeps them on SimpleFi's checkout until they click through; automatic redirects them immediately."
+              >
+                <Select
+                  value={field.state.value}
+                  onValueChange={(v) =>
+                    field.handleChange(v as SimpleFiSuccessBehavior)
+                  }
+                  disabled={readOnly}
+                >
+                  <SelectTrigger
+                    id="simplefi_success_behavior"
+                    className="w-[140px]"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="manual">Manual</SelectItem>
+                    <SelectItem value="automatic">Automatic</SelectItem>
+                  </SelectContent>
+                </Select>
               </InlineRow>
             )}
           </form.Field>

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -13166,6 +13166,10 @@ export const PopupAdminSchema = {
             ],
             title: 'Simplefi Api Key'
         },
+        simplefi_success_behavior: {
+            '$ref': '#/components/schemas/SimpleFiSuccessBehavior',
+            default: 'manual'
+        },
         terms_and_conditions_url: {
             anyOf: [
                 {
@@ -13643,6 +13647,10 @@ export const PopupCreateSchema = {
                 }
             ],
             title: 'Simplefi Api Key'
+        },
+        simplefi_success_behavior: {
+            '$ref': '#/components/schemas/SimpleFiSuccessBehavior',
+            default: 'manual'
         },
         terms_and_conditions_url: {
             anyOf: [
@@ -14618,6 +14626,16 @@ export const PopupUpdateSchema = {
                 }
             ],
             title: 'Simplefi Api Key'
+        },
+        simplefi_success_behavior: {
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/SimpleFiSuccessBehavior'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         terms_and_conditions_url: {
             anyOf: [
@@ -16916,6 +16934,18 @@ export const SendTestRequestSchema = {
     type: 'object',
     required: ['html_content', 'template_type', 'to_email'],
     title: 'SendTestRequest'
+} as const;
+
+export const SimpleFiSuccessBehaviorSchema = {
+    type: 'string',
+    enum: ['manual', 'automatic'],
+    title: 'SimpleFiSuccessBehavior',
+    description: `How SimpleFi redirects the buyer to the success URL after payment.
+
+Mirrors SimpleFi's \`\`redirect_urls.success_behavior\`\`:
+- manual: the buyer clicks a button on SimpleFi's checkout to continue
+  (SimpleFi's default, and ours).
+- automatic: SimpleFi redirects the buyer immediately after approval.`
 } as const;
 
 export const TaskAppSchema = {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -2859,6 +2859,7 @@ export type PopupAdmin = {
     blog_url?: (string | null);
     twitter_url?: (string | null);
     simplefi_api_key?: (string | null);
+    simplefi_success_behavior?: SimpleFiSuccessBehavior;
     terms_and_conditions_url?: (string | null);
     open_checkout_success_url?: (string | null);
     open_checkout_cancel_url?: (string | null);
@@ -2916,6 +2917,7 @@ export type PopupCreate = {
     blog_url?: (string | null);
     twitter_url?: (string | null);
     simplefi_api_key?: (string | null);
+    simplefi_success_behavior?: SimpleFiSuccessBehavior;
     terms_and_conditions_url?: (string | null);
     open_checkout_success_url?: (string | null);
     open_checkout_cancel_url?: (string | null);
@@ -3055,6 +3057,7 @@ export type PopupUpdate = {
     blog_url?: (string | null);
     twitter_url?: (string | null);
     simplefi_api_key?: (string | null);
+    simplefi_success_behavior?: (SimpleFiSuccessBehavior | null);
     terms_and_conditions_url?: (string | null);
     open_checkout_success_url?: (string | null);
     open_checkout_cancel_url?: (string | null);
@@ -3487,6 +3490,16 @@ export type SendTestRequest = {
 } | null);
     popup_id?: (string | null);
 };
+
+/**
+ * How SimpleFi redirects the buyer to the success URL after payment.
+ *
+ * Mirrors SimpleFi's ``redirect_urls.success_behavior``:
+ * - manual: the buyer clicks a button on SimpleFi's checkout to continue
+ * (SimpleFi's default, and ours).
+ * - automatic: SimpleFi redirects the buyer immediately after approval.
+ */
+export type SimpleFiSuccessBehavior = 'manual' | 'automatic';
 
 /**
  * Which surface a task relates to. Optional (NULL = unspecified).

--- a/portal/src/providers/languageProvider.tsx
+++ b/portal/src/providers/languageProvider.tsx
@@ -103,6 +103,13 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
       searchParams.get("lang"),
       supportedLanguages,
     )
+    // An explicit ?lang= is a user choice made on the referring site (same
+    // class as the manual selector), so persist it: the language must survive
+    // in-session navigations that drop the query param, e.g. returning from
+    // the payment provider after a cancel.
+    if (urlLanguage && typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, urlLanguage)
+    }
     const storedLanguage =
       typeof window === "undefined"
         ? null
@@ -124,8 +131,9 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     }
   }, [searchParams, supportedLanguages, defaultLanguage, currentLanguage])
 
-  // localStorage is written only by setLanguage (manual choice) — not here, to avoid
-  // clobbering the popup default during auto-resolve and bouncing back on next render.
+  // localStorage is written only on explicit signals — setLanguage (manual
+  // choice) and an incoming ?lang= param — never by auto-resolve, to avoid
+  // clobbering the popup default and bouncing back on next render.
   useEffect(() => {
     if (i18n.language !== currentLanguage) {
       i18n.changeLanguage(currentLanguage)


### PR DESCRIPTION
## Summary

Two related SimpleFi checkout changes:

1. SimpleFi added a `success_behavior` field to `redirect_urls` in their payment creation API. This PR adds a per-popup option to configure it, defaulting to `manual` (SimpleFi's default) so existing popups keep the current behavior. `automatic` redirects the buyer to the success URL immediately after approval instead of waiting for a click-through on SimpleFi's checkout.
2. The buyer's checkout language (from the entry URL `?lang=`) is now forwarded to the post-payment success redirect as a `lang` query param, outside the signed payload, matching the external thank-you contract of a fixed path with the language in the query (`/gracias?lang=<es|en>&d=...&sig=...`).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**SimpleFi success behavior**
- New `SimpleFiSuccessBehavior` enum (`manual` | `automatic`) and `simplefi_success_behavior` field on the Popup model, create and update schemas. `PopupAdmin` exposes it; `PopupPublic` intentionally does not.
- Migration `a8e3d7f4c2b9` adds the column with `server_default="manual"`.
- `SimpleFIClient.create_payment` accepts `success_behavior` and includes it in `redirect_urls` for both `payment_requests` and `installment_plans`.
- All three payment creation call sites (open checkout, application fee, pass purchase) forward `popup.simplefi_success_behavior`.
- Backoffice: "SimpleFi success redirect" select in the popup Integrations section.
- Regenerated OpenAPI clients for backoffice and portal.

**Checkout language forwarding**
- `_resolve_open_checkout_success_url` appends `lang=<locale>` to the success redirect in all branches: external signed, external plain, and internal portal thank-you. `lang` travels outside the signed `d` payload, so HMAC verification is untouched.
- The 409 `previous_payment_completed` redirect forwards the new purchase attempt's locale (threaded through `supersede_pending_payments`, falling back to the popup default language) and now also substitutes `{locale}`, which it previously skipped.
- Portal `LanguageProvider` persists an explicit `?lang=` entry param like a manual language choice, so the language survives navigations that drop the query param (e.g. returning from SimpleFi after a cancel).

## Testing

- [x] Backend tests pass (SimpleFi client suite, checkout purchase suite incl. new fixed-path lang contract test, pending-release and signing suites: 83 green)
- [x] Backend linting passes (`bash scripts/lint.sh`)
- [x] Backoffice builds successfully (`pnpm run build`)
- [x] Backoffice linting passes (`pnpm run lint`)
- [x] Portal builds successfully and lints clean

## Checklist

- [x] My code follows the project's coding standards
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed (`pnpm run generate-client`)
- [x] Database migrations are included if schema changed (`alembic heads` shows a single head)