### PR TITLE
feat: make ended popups read-only in the portal

### DIFF
--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -847,6 +847,10 @@ async def detach_companion(
     (money decisions handled by support, not by a checkout button).
     """
     from app.api.attendee.crud import attendees_crud
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, body.popup_id))
 
     companion = attendees_crud.find_companion_for_popup(
         db, human_id=current_human.id, popup_id=body.popup_id
@@ -890,6 +894,11 @@ async def create_my_application(
     current_human: CurrentHuman,
 ) -> ApplicationPublic:
     """Create an application for the current human (Portal)."""
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, app_in.popup_id))
+
     # Check for existing application
     existing = crud.applications_crud.get_by_human_popup(
         db, human_id=current_human.id, popup_id=app_in.popup_id
@@ -914,8 +923,6 @@ async def create_my_application(
 
     # Validate scholarship request against popup settings
     if app_in.scholarship_request is True:
-        from app.api.popup.crud import popups_crud
-
         popup = popups_crud.get(db, app_in.popup_id)
         if not popup or not popup.allows_scholarship:
             raise HTTPException(
@@ -950,6 +957,11 @@ async def update_my_application(
     current_human: CurrentHuman,
 ) -> ApplicationPublic:
     """Update current human's application (Portal)."""
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     application = crud.applications_crud.get_by_human_popup(
         db, human_id=current_human.id, popup_id=popup_id
     )
@@ -1321,6 +1333,11 @@ async def add_my_attendee(
             detail="Application not found",
         )
 
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     crud.applications_crud.create_attendee(
         db,
         application=application,
@@ -1367,6 +1384,11 @@ async def update_my_attendee(
             detail="Attendee not found",
         )
 
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     # Check for duplicate email
     if attendee_in.email:
         existing_emails = [
@@ -1406,6 +1428,11 @@ async def delete_my_attendee(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Application not found",
         )
+
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
 
     crud.applications_crud.delete_attendee(db, application, attendee_id)
 

--- a/backend/app/api/attendee/router.py
+++ b/backend/app/api/attendee/router.py
@@ -269,6 +269,7 @@ async def create_my_attendee_for_popup(
     popup is not an application popup.
     """
     from app.api.application.crud import applications_crud
+    from app.api.popup.guards import ensure_popup_writable
     from app.api.popup.models import Popups
     from app.api.shared.enums import SaleType
 
@@ -284,6 +285,8 @@ async def create_my_attendee_for_popup(
                 }
             ],
         )
+
+    ensure_popup_writable(popup)
 
     # Validate application exists for this human + popup
     application = applications_crud.get_by_human_popup(db, current_human.id, popup_id)
@@ -420,6 +423,11 @@ async def update_my_attendee_for_popup(
             status_code=status.HTTP_404_NOT_FOUND, detail="Attendee not found"
         )
 
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     # Validate category change (blocked if attendee has products)
     update_dict = attendee_in.model_dump(exclude_unset=True)
     if "category" in update_dict and attendee.has_products():
@@ -485,6 +493,11 @@ async def update_my_meal_plan_ticket(
             status_code=status.HTTP_404_NOT_FOUND, detail="Attendee not found"
         )
 
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     crud.attendees_crud.update_ticket_metadata(
         db,
         attendee_id=attendee_id,
@@ -531,6 +544,11 @@ async def delete_my_attendee_for_popup(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Attendee not found"
         )
+
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
 
     # delete_attendee raises 400 if attendee has products
     crud.attendees_crud.delete_attendee(db, attendee)

--- a/backend/app/api/cart/router.py
+++ b/backend/app/api/cart/router.py
@@ -134,6 +134,11 @@ async def update_my_cart(
     current_human: CurrentHuman,
 ) -> CartPublic:
     """Replace cart items for current human and popup (Portal)."""
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     cart = carts_crud.get_or_create(
         db,
         human_id=current_human.id,
@@ -161,6 +166,11 @@ async def delete_my_cart(
     current_human: CurrentHuman,
 ) -> None:
     """Clear cart for current human and popup (Portal)."""
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, popup_id))
+
     carts_crud.delete_by_human_popup(
         db,
         human_id=current_human.id,

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -48,6 +48,7 @@ from app.api.event.schemas import (
 )
 from app.api.event_audit.crud import build_event_snapshot, record_event_audit
 from app.api.event_audit.schemas import EventAuditAction
+from app.api.popup.guards import ensure_popup_writable
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
@@ -2478,6 +2479,9 @@ async def bulk_invite_portal(
     current_human: CurrentHuman,
 ) -> EventInvitationBulkResult:
     event = _ensure_portal_event_owner(db, event_id, current_human)
+    from app.api.popup.crud import popups_crud
+
+    ensure_popup_writable(popups_crud.get(db, event.popup_id))
     result = _run_bulk_invite(db, event, payload.emails, current_human.id)
     await _send_event_invitation_emails(db, event, result.invited)
     invite_snapshot = build_event_snapshot(db, event)
@@ -2503,6 +2507,9 @@ async def delete_portal_invitation(
     current_human: CurrentHuman,
 ) -> None:
     event = _ensure_portal_event_owner(db, event_id, current_human)
+    from app.api.popup.crud import popups_crud
+
+    ensure_popup_writable(popups_crud.get(db, event.popup_id))
     inv = crud.invitations_crud.get(db, invitation_id)
     if not inv or inv.event_id != event_id:
         raise HTTPException(status_code=404, detail="Invitation not found")
@@ -3173,6 +3180,7 @@ async def create_portal_event(
     from app.api.popup.crud import popups_crud
 
     popup = popups_crud.get(db, event_in.popup_id)
+    ensure_popup_writable(popup)
     _check_event_within_popup_window(
         popup, start_time=event_in.start_time, end_time=event_in.end_time
     )
@@ -3305,6 +3313,11 @@ async def update_portal_event(
             detail="Only the event owner or host can edit",
         )
 
+    from app.api.popup.crud import popups_crud
+
+    popup = popups_crud.get(db, event.popup_id)
+    ensure_popup_writable(popup)
+
     audit_before = build_event_snapshot(db, event)
 
     new_venue_id = (
@@ -3318,9 +3331,6 @@ async def update_portal_event(
         or event_in.end_time is not None
     )
     if event_in.start_time is not None or event_in.end_time is not None:
-        from app.api.popup.crud import popups_crud
-
-        popup = popups_crud.get(db, event.popup_id)
         _check_event_within_popup_window(popup, start_time=new_start, end_time=new_end)
     if new_venue_id is not None and timing_or_venue_changed:
         _check_recurrence_conflicts(
@@ -3462,6 +3472,9 @@ async def cancel_portal_event(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only the event owner or host can cancel",
         )
+    from app.api.popup.crud import popups_crud
+
+    ensure_popup_writable(popups_crud.get(db, event.popup_id))
     if event.status == EventStatus.CANCELLED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -13,6 +13,7 @@ from app.api.event_participant.schemas import (
     ParticipantStatus,
     RegisterRequest,
 )
+from app.api.popup.guards import ensure_popup_writable
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
     AdminOrApiKey_EventsRead,
@@ -327,12 +328,14 @@ async def register_for_event(
     from app.api.event.crud import events_crud
     from app.api.event.schemas import EventStatus
     from app.api.event_participant.models import EventParticipants
+    from app.api.popup.crud import popups_crud
 
     event = events_crud.get(db, event_id)
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_popup_writable(popups_crud.get(db, event.popup_id))
     if event.status != EventStatus.PUBLISHED:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Event is not published"
@@ -482,12 +485,14 @@ async def cancel_registration(
     field; ``role``/``message`` are ignored on cancel.
     """
     from app.api.event.crud import events_crud
+    from app.api.popup.crud import popups_crud
 
     event = events_crud.get(db, event_id)
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_popup_writable(popups_crud.get(db, event.popup_id))
     occ_start = _resolve_occurrence_start(
         event, body.occurrence_start if body else None
     )
@@ -521,12 +526,14 @@ async def check_in(
 ) -> EventParticipantPublic:
     """Check in current human for an event (portal)."""
     from app.api.event.crud import events_crud
+    from app.api.popup.crud import popups_crud
 
     event = events_crud.get(db, event_id)
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_popup_writable(popups_crud.get(db, event.popup_id))
     occ_start = _resolve_occurrence_start(
         event, body.occurrence_start if body else None
     )

--- a/backend/app/api/event_venue/router.py
+++ b/backend/app/api/event_venue/router.py
@@ -35,6 +35,7 @@ from app.api.event_venue.schemas import (
     VenueStatus,
     VenueWeeklyHoursUpdate,
 )
+from app.api.popup.guards import ensure_popup_writable
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
     AdminOrApiKey_EventsRead,
@@ -868,6 +869,9 @@ async def update_portal_venue(
             status_code=403,
             detail="Only the venue's owner can edit it from the portal",
         )
+    from app.api.popup.crud import popups_crud
+
+    ensure_popup_writable(popups_crud.get(db, venue.popup_id))
 
     update_data = venue_in.model_dump(
         exclude_unset=True, exclude={"property_type_ids", "status"}
@@ -902,6 +906,9 @@ async def delete_portal_venue(
             status_code=403,
             detail="Only the venue's owner can delete it from the portal",
         )
+    from app.api.popup.crud import popups_crud
+
+    ensure_popup_writable(popups_crud.get(db, venue.popup_id))
 
     active_event = db.exec(
         select(Events)
@@ -930,6 +937,9 @@ async def create_portal_venue(
 ) -> EventVenuePublic:
     """Create a venue as a human (portal). Respects popup event settings."""
     from app.api.event_settings.crud import event_settings_crud
+    from app.api.popup.crud import popups_crud
+
+    ensure_popup_writable(popups_crud.get(db, venue_in.popup_id))
 
     settings = event_settings_crud.get_by_popup_id(db, venue_in.popup_id)
     if not settings or not settings.humans_can_create_venues:
@@ -951,7 +961,6 @@ async def create_portal_venue(
     db.refresh(venue)
 
     if pending:
-        from app.api.popup.crud import popups_crud
         from app.services.approval_notify import notify_venue_pending_approval
 
         popup = popups_crud.get(db, venue.popup_id)

--- a/backend/app/api/group/router.py
+++ b/backend/app/api/group/router.py
@@ -286,6 +286,11 @@ async def update_my_group(
 
     _check_leader_permission(group, current_human.id)
 
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, group.popup_id))
+
     updated = crud.groups_crud.update(db, group, group_in)
     return GroupPublic.model_validate(updated)
 
@@ -314,6 +319,11 @@ async def add_group_member(
         )
 
     _check_leader_permission(group, current_human.id)
+
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, group.popup_id))
 
     # Get or create human (Human stores identity only, profile goes in Application)
     human = humans_crud.get_by_email(db, member_in.email, group.tenant_id)
@@ -425,6 +435,11 @@ async def add_group_members_batch(
 
     _check_leader_permission(group, current_human.id)
 
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, group.popup_id))
+
     results = []
     for member in batch.members:
         try:
@@ -479,6 +494,11 @@ async def update_group_member(
         )
 
     _check_leader_permission(group, current_human.id)
+
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, group.popup_id))
 
     # Check if human is a member
     if not crud.groups_crud.is_member(db, group.id, human_id):
@@ -555,6 +575,11 @@ async def remove_group_member(
         )
 
     _check_leader_permission(group, current_human.id)
+
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(popups_crud.get(db, group.popup_id))
 
     # Check if human is a member
     if not crud.groups_crud.is_member(db, group.id, human_id):

--- a/backend/app/api/payment/router.py
+++ b/backend/app/api/payment/router.py
@@ -540,7 +540,10 @@ async def create_my_application_fee(
             detail="Application not found",
         )
 
+    from app.api.popup.guards import ensure_popup_writable
+
     popup = application.popup
+    ensure_popup_writable(popup)
     payment = payments_crud.create_fee_payment(db, application, popup)
     return PaymentPublic.model_validate(payment)
 
@@ -850,6 +853,10 @@ async def create_my_payment(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Application not found",
         )
+
+    from app.api.popup.guards import ensure_popup_writable
+
+    ensure_popup_writable(application.popup)
 
     payment, _preview = payments_crud.create_payment(
         db,

--- a/backend/app/api/popup/guards.py
+++ b/backend/app/api/popup/guards.py
@@ -1,0 +1,23 @@
+"""Write guards shared by popup-scoped portal endpoints.
+
+Lives in the popup package (not ``core``) so routers can import it without
+pulling API modules into ``app.core.security``.
+"""
+
+from fastapi import HTTPException, status
+
+from app.api.popup.models import Popups
+from app.api.popup.schemas import PopupStatus
+
+
+def ensure_popup_writable(popup: Popups | None) -> None:
+    """Reject portal mutations on ended popups (recap mode is read-only).
+
+    Applies to both portal JWT humans and API-key callers, which share the
+    same ``/portal`` endpoints. Backoffice/admin endpoints stay writable.
+    """
+    if popup is not None and popup.status == PopupStatus.ended:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This popup has ended and is read-only.",
+        )

--- a/backend/app/api/product/crud.py
+++ b/backend/app/api/product/crud.py
@@ -112,6 +112,58 @@ class ProductsCRUD(BaseCRUD[Products, ProductCreate, ProductUpdate]):
         results = list(session.exec(statement).all())
         return results, total
 
+    def find_excluding_ended_popups(
+        self,
+        session: Session,
+        skip: int = 0,
+        limit: int = 100,
+        search: str | None = None,
+        search_fields: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_order: str = "desc",
+        **filters: object,
+    ) -> tuple[list[Products], int]:
+        """Find live products, excluding those of ended (read-only) popups.
+
+        Mirrors :meth:`find` (filters, search, sorting) with an extra join
+        that hides products belonging to ended popups.
+        """
+        from sqlalchemy import or_
+        from sqlmodel import func
+
+        from app.api.popup.models import Popups
+        from app.api.popup.schemas import PopupStatus
+
+        statement = (
+            select(Products)
+            .join(Popups, Products.popup_id == Popups.id)  # type: ignore[arg-type]
+            .where(
+                col(Products.deleted_at).is_(None),
+                Popups.status != PopupStatus.ended,
+            )
+        )
+        for field, value in filters.items():
+            if value is not None:
+                statement = statement.where(getattr(Products, field) == value)
+
+        if search and search_fields:
+            search_term = f"%{search}%"
+            search_conditions = [
+                getattr(Products, field).ilike(search_term)
+                for field in search_fields
+                if hasattr(Products, field)
+            ]
+            if search_conditions:
+                statement = statement.where(or_(*search_conditions))
+
+        count_statement = select(func.count()).select_from(statement.subquery())
+        total = session.exec(count_statement).one()
+
+        statement = self._apply_sorting(statement, sort_by, sort_order)
+        statement = statement.offset(skip).limit(limit)
+        results = list(session.exec(statement).all())
+        return results, total
+
     def get_by_slug(
         self, session: Session, slug: str, popup_id: uuid.UUID
     ) -> Products | None:

--- a/backend/app/api/product/router.py
+++ b/backend/app/api/product/router.py
@@ -394,6 +394,9 @@ async def list_portal_products(
 ) -> ListModel[ProductPublic]:
     """List products visible to the current human (Portal)."""
     if popup_id:
+        # Ended popups keep their products visible here: the portal recap
+        # views still need them, and purchasing is blocked at the payment,
+        # cart, and application layers.
         products, total = crud.products_crud.find_by_popup(
             db,
             popup_id=popup_id,
@@ -403,10 +406,14 @@ async def list_portal_products(
             category=category,
         )
     else:
-        products, total = crud.products_crud.find(
+        # Same read-only contract without popup_id: ended-popup products are
+        # excluded so they cannot be enumerated through the unscoped listing.
+        products, total = crud.products_crud.find_excluding_ended_popups(
             db,
             skip=skip,
             limit=limit,
+            is_active=is_active,
+            category=category,
         )
 
     lang = None

--- a/backend/tests/api/event/test_ended_popup_read_only.py
+++ b/backend/tests/api/event/test_ended_popup_read_only.py
@@ -1,0 +1,327 @@
+"""HTTP integration tests for the ended-popup read-only guard.
+
+Popups with status ``ended`` (recap mode) must reject every portal-side
+mutation with 403 via ``ensure_popup_writable``, while the same calls keep
+working on active popups. Backoffice/admin endpoints are not gated and are
+not covered here.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.event.models import Events
+from app.api.event.schemas import EventStatus
+from app.api.event_settings.models import EventSettings
+from app.api.event_settings.schemas import PublishPermission
+from app.api.event_venue.models import EventVenues
+from app.api.event_venue.schemas import VenueBookingMode, VenueStatus
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+READ_ONLY_DETAIL = "This popup has ended and is read-only."
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_popup(
+    db: Session, tenant: Tenants, *, suffix: str, status: str = "ended"
+) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name=f"Ended RO Popup {suffix} {uuid.uuid4().hex[:6]}",
+        slug=f"ended-ro-{suffix}-{uuid.uuid4().hex[:6]}",
+        status=status,
+    )
+    db.add(popup)
+    db.flush()
+    db.add(
+        EventSettings(
+            tenant_id=tenant.id,
+            popup_id=popup.id,
+            event_enabled=True,
+            can_publish_event=PublishPermission.EVERYONE,
+            humans_can_create_venues=True,
+            events_require_approval=False,
+        )
+    )
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants, *, suffix: str) -> Humans:
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        email=f"ended-ro-{suffix}-{uuid.uuid4().hex[:8]}@test.com",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _make_event(db: Session, tenant: Tenants, popup: Popups, owner: Humans) -> Events:
+    start = datetime(2999, 1, 1, 13, 0, tzinfo=UTC)
+    event = Events(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        owner_id=owner.id,
+        title=f"Ended RO Event {uuid.uuid4().hex[:6]}",
+        start_time=start,
+        end_time=start + timedelta(hours=1),
+        custom_location_name="Test Hall",
+        custom_location_url="https://maps.test/hall",
+        status=EventStatus.PUBLISHED,
+    )
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return event
+
+
+def _make_venue(
+    db: Session, tenant: Tenants, popup: Popups, owner: Humans
+) -> EventVenues:
+    venue = EventVenues(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        owner_id=owner.id,
+        title=f"Ended RO Venue {uuid.uuid4().hex[:6]}",
+        status=VenueStatus.ACTIVE,
+        booking_mode=VenueBookingMode.FREE,
+    )
+    db.add(venue)
+    db.commit()
+    db.refresh(venue)
+    return venue
+
+
+def _auth(human: Humans) -> dict[str, str]:
+    token = create_access_token(subject=human.id, token_type="human")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _event_payload(popup: Popups) -> dict:
+    return {
+        "popup_id": str(popup.id),
+        "title": f"Ended RO Create {uuid.uuid4().hex[:6]}",
+        "start_time": "2999-01-02T13:00:00+00:00",
+        "end_time": "2999-01-02T14:00:00+00:00",
+        "timezone": "UTC",
+        "custom_location_name": "Test Hall",
+        "custom_location_url": "https://maps.test/hall",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: portal mutations blocked on ended popups
+# ---------------------------------------------------------------------------
+
+
+class TestEndedPopupPortalWritesBlocked:
+    def test_event_create_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="event-create")
+        human = _make_human(db, tenant_a, suffix="event-create")
+
+        response = client.post(
+            "/api/v1/events/portal/events",
+            headers=_auth(human),
+            json=_event_payload(popup),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_event_update_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="event-update")
+        human = _make_human(db, tenant_a, suffix="event-update")
+        event = _make_event(db, tenant_a, popup, human)
+
+        response = client.patch(
+            f"/api/v1/events/portal/events/{event.id}",
+            headers=_auth(human),
+            json={"title": "New title"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_event_cancel_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="event-cancel")
+        human = _make_human(db, tenant_a, suffix="event-cancel")
+        event = _make_event(db, tenant_a, popup, human)
+
+        response = client.post(
+            f"/api/v1/events/portal/events/{event.id}/cancel",
+            headers=_auth(human),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_rsvp_register_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="rsvp")
+        owner = _make_human(db, tenant_a, suffix="rsvp-owner")
+        attendee = _make_human(db, tenant_a, suffix="rsvp-attendee")
+        event = _make_event(db, tenant_a, popup, owner)
+
+        response = client.post(
+            f"/api/v1/event-participants/portal/register/{event.id}",
+            headers=_auth(attendee),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_check_in_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="check-in")
+        owner = _make_human(db, tenant_a, suffix="check-in-owner")
+        attendee = _make_human(db, tenant_a, suffix="check-in-attendee")
+        event = _make_event(db, tenant_a, popup, owner)
+
+        response = client.post(
+            f"/api/v1/event-participants/portal/check-in/{event.id}",
+            headers=_auth(attendee),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_venue_create_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="venue-create")
+        human = _make_human(db, tenant_a, suffix="venue-create")
+
+        response = client.post(
+            "/api/v1/event-venues/portal/venues",
+            headers=_auth(human),
+            json={"popup_id": str(popup.id), "title": "Ended RO Venue"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_bulk_invite_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="bulk-invite")
+        owner = _make_human(db, tenant_a, suffix="bulk-invite-owner")
+        invitee = _make_human(db, tenant_a, suffix="bulk-invite-invitee")
+        event = _make_event(db, tenant_a, popup, owner)
+
+        response = client.post(
+            f"/api/v1/events/portal/events/{event.id}/invitations",
+            headers=_auth(owner),
+            json={"emails": [invitee.email]},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_invitation_delete_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="invitation-delete")
+        owner = _make_human(db, tenant_a, suffix="invitation-delete-owner")
+        event = _make_event(db, tenant_a, popup, owner)
+
+        # The guard fires after the owner check but before the invitation
+        # lookup, so a nonexistent invitation id still hits the 403.
+        response = client.delete(
+            f"/api/v1/events/portal/events/{event.id}/invitations/{uuid.uuid4()}",
+            headers=_auth(owner),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_venue_update_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="venue-update")
+        human = _make_human(db, tenant_a, suffix="venue-update")
+        venue = _make_venue(db, tenant_a, popup, human)
+
+        response = client.patch(
+            f"/api/v1/event-venues/portal/venues/{venue.id}",
+            headers=_auth(human),
+            json={"title": "New venue title"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_venue_delete_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="venue-delete")
+        human = _make_human(db, tenant_a, suffix="venue-delete")
+        venue = _make_venue(db, tenant_a, popup, human)
+
+        response = client.delete(
+            f"/api/v1/event-venues/portal/venues/{venue.id}",
+            headers=_auth(human),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_cancel_registration_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="cancel-reg")
+        owner = _make_human(db, tenant_a, suffix="cancel-reg-owner")
+        attendee = _make_human(db, tenant_a, suffix="cancel-reg-attendee")
+        event = _make_event(db, tenant_a, popup, owner)
+
+        # The guard fires right after the event lookup and before the
+        # registration lookup, so no participant row is needed.
+        response = client.post(
+            f"/api/v1/event-participants/portal/cancel-registration/{event.id}",
+            headers=_auth(attendee),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+
+# ---------------------------------------------------------------------------
+# Tests: same calls stay writable on active popups
+# ---------------------------------------------------------------------------
+
+
+class TestActivePopupPortalWritesAllowed:
+    def test_event_create_succeeds_on_active_popup(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="active-create", status="active")
+        human = _make_human(db, tenant_a, suffix="active-create")
+
+        response = client.post(
+            "/api/v1/events/portal/events",
+            headers=_auth(human),
+            json=_event_payload(popup),
+        )
+
+        assert response.status_code == 201, response.text
+        assert response.json()["popup_id"] == str(popup.id)

--- a/backend/tests/api/popup/test_ended_popup_read_only_extended.py
+++ b/backend/tests/api/popup/test_ended_popup_read_only_extended.py
@@ -1,0 +1,572 @@
+"""HTTP integration tests for the ended-popup read-only guard on the
+application/purchase surface (applications, attendees, groups, payments,
+carts, portal products).
+
+Complements ``tests/api/event/test_ended_popup_read_only.py``, which covers
+the event/RSVP/venue surface. Backoffice/admin endpoints are not gated and
+are not covered here.
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.group.models import GroupLeaders, Groups
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.product.models import Products
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+READ_ONLY_DETAIL = "This popup has ended and is read-only."
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_popup(
+    db: Session, tenant: Tenants, *, suffix: str, status: str = "ended"
+) -> Popups:
+    popup = Popups(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        name=f"Ended RO Ext Popup {suffix} {uuid.uuid4().hex[:6]}",
+        slug=f"ended-ro-ext-{suffix}-{uuid.uuid4().hex[:6]}",
+        status=status,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_human(db: Session, tenant: Tenants, *, suffix: str) -> Humans:
+    human = Humans(
+        id=uuid.uuid4(),
+        tenant_id=tenant.id,
+        email=f"ended-ro-ext-{suffix}-{uuid.uuid4().hex[:8]}@test.com",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human
+
+
+def _make_application(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> Applications:
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=ApplicationStatus.ACCEPTED.value,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _make_group_with_leader(
+    db: Session, tenant: Tenants, popup: Popups, leader: Humans
+) -> Groups:
+    group = Groups(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Ended RO Ext Group {uuid.uuid4().hex[:6]}",
+        slug=f"ended-ro-ext-group-{uuid.uuid4().hex[:6]}",
+    )
+    db.add(group)
+    db.flush()
+    db.add(GroupLeaders(tenant_id=tenant.id, group_id=group.id, human_id=leader.id))
+    db.commit()
+    db.refresh(group)
+    return group
+
+
+def _make_product(
+    db: Session, tenant: Tenants, popup: Popups, *, is_active: bool = True
+) -> Products:
+    product = Products(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        name=f"Ended RO Ext Product {uuid.uuid4().hex[:6]}",
+        slug=f"ended-ro-ext-product-{uuid.uuid4().hex[:6]}",
+        price=100,
+        is_active=is_active,
+    )
+    db.add(product)
+    db.commit()
+    db.refresh(product)
+    return product
+
+
+def _auth(human: Humans) -> dict[str, str]:
+    token = create_access_token(subject=human.id, token_type="human")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _member_payload() -> dict:
+    return {
+        "first_name": "Ended",
+        "last_name": "Member",
+        "email": f"ended-ro-ext-member-{uuid.uuid4().hex[:8]}@test.com",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: portal mutations blocked on ended popups
+# ---------------------------------------------------------------------------
+
+
+class TestEndedPopupPortalWritesBlocked:
+    def test_application_create_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="app-create")
+        human = _make_human(db, tenant_a, suffix="app-create")
+
+        response = client.post(
+            "/api/v1/applications/my",
+            headers=_auth(human),
+            json={
+                "popup_id": str(popup.id),
+                "first_name": "Ended",
+                "last_name": "Applicant",
+            },
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_application_update_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="app-update")
+        human = _make_human(db, tenant_a, suffix="app-update")
+        _make_application(db, tenant_a, popup, human)
+
+        response = client.patch(
+            f"/api/v1/applications/my/{popup.id}",
+            headers=_auth(human),
+            json={"first_name": "New Name"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_detach_companion_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="detach")
+        human = _make_human(db, tenant_a, suffix="detach")
+
+        # The guard fires before the companion lookup, so no companion row is
+        # needed to reach it.
+        response = client.post(
+            "/api/v1/applications/my/detach-companion",
+            headers=_auth(human),
+            json={"popup_id": str(popup.id)},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_application_attendee_add_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="app-att-add")
+        human = _make_human(db, tenant_a, suffix="app-att-add")
+        _make_application(db, tenant_a, popup, human)
+
+        response = client.post(
+            f"/api/v1/applications/my/{popup.id}/attendees",
+            headers=_auth(human),
+            json={"name": "Ended Companion", "category": "spouse"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_application_attendee_update_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="app-att-update")
+        human = _make_human(db, tenant_a, suffix="app-att-update")
+        application = _make_application(db, tenant_a, popup, human)
+
+        from app.api.attendee.crud import attendees_crud
+
+        attendee = attendees_crud.create_internal(
+            session=db,
+            tenant_id=tenant_a.id,
+            application_id=application.id,
+            popup_id=popup.id,
+            name="Ended Companion",
+            category="spouse",
+        )
+
+        response = client.patch(
+            f"/api/v1/applications/my/{popup.id}/attendees/{attendee.id}",
+            headers=_auth(human),
+            json={"name": "Renamed Companion"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_application_attendee_delete_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="app-att-delete")
+        human = _make_human(db, tenant_a, suffix="app-att-delete")
+        application = _make_application(db, tenant_a, popup, human)
+
+        from app.api.attendee.crud import attendees_crud
+
+        attendee = attendees_crud.create_internal(
+            session=db,
+            tenant_id=tenant_a.id,
+            application_id=application.id,
+            popup_id=popup.id,
+            name="Ended Companion",
+            category="spouse",
+        )
+
+        response = client.delete(
+            f"/api/v1/applications/my/{popup.id}/attendees/{attendee.id}",
+            headers=_auth(human),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_attendee_create_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="att-create")
+        human = _make_human(db, tenant_a, suffix="att-create")
+        _make_application(db, tenant_a, popup, human)
+
+        response = client.post(
+            f"/api/v1/attendees/my/popup/{popup.id}",
+            headers=_auth(human),
+            json={"name": "Ended Companion", "category": "spouse"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_attendee_delete_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="att-delete")
+        human = _make_human(db, tenant_a, suffix="att-delete")
+        application = _make_application(db, tenant_a, popup, human)
+
+        from app.api.attendee.crud import attendees_crud
+
+        attendee = attendees_crud.create_internal(
+            session=db,
+            tenant_id=tenant_a.id,
+            application_id=application.id,
+            popup_id=popup.id,
+            name="Ended Companion",
+            category="spouse",
+        )
+
+        response = client.delete(
+            f"/api/v1/attendees/my/popup/{popup.id}/{attendee.id}",
+            headers=_auth(human),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_group_update_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="group-update")
+        leader = _make_human(db, tenant_a, suffix="group-update-leader")
+        group = _make_group_with_leader(db, tenant_a, popup, leader)
+
+        response = client.patch(
+            f"/api/v1/groups/my/{group.id}",
+            headers=_auth(leader),
+            json={"description": "Updated description"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_group_add_member_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="group-add")
+        leader = _make_human(db, tenant_a, suffix="group-add-leader")
+        group = _make_group_with_leader(db, tenant_a, popup, leader)
+
+        response = client.post(
+            f"/api/v1/groups/my/{group.id}/members",
+            headers=_auth(leader),
+            json=_member_payload(),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_group_add_members_batch_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="group-batch")
+        leader = _make_human(db, tenant_a, suffix="group-batch-leader")
+        group = _make_group_with_leader(db, tenant_a, popup, leader)
+
+        # The entry guard rejects the whole request with 403 instead of a 207
+        # multi-status with per-member failures.
+        response = client.post(
+            f"/api/v1/groups/my/{group.id}/members/batch",
+            headers=_auth(leader),
+            json={"members": [_member_payload()]},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_group_remove_member_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="group-remove")
+        leader = _make_human(db, tenant_a, suffix="group-remove-leader")
+        group = _make_group_with_leader(db, tenant_a, popup, leader)
+
+        # The guard fires before the membership lookup, so a nonexistent
+        # member id still hits the 403.
+        response = client.delete(
+            f"/api/v1/groups/my/{group.id}/members/{uuid.uuid4()}",
+            headers=_auth(leader),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_payment_application_fee_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="pay-fee")
+        human = _make_human(db, tenant_a, suffix="pay-fee")
+        application = _make_application(db, tenant_a, popup, human)
+
+        response = client.post(
+            "/api/v1/payments/my/application-fee",
+            headers=_auth(human),
+            json={"application_id": str(application.id)},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_payment_create_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="pay-create")
+        human = _make_human(db, tenant_a, suffix="pay-create")
+        application = _make_application(db, tenant_a, popup, human)
+
+        # The guard fires before product resolution, so placeholder ids are
+        # enough to reach it.
+        response = client.post(
+            "/api/v1/payments/my",
+            headers=_auth(human),
+            json={
+                "application_id": str(application.id),
+                "products": [
+                    {
+                        "product_id": str(uuid.uuid4()),
+                        "attendee_id": str(uuid.uuid4()),
+                    }
+                ],
+            },
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_cart_update_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="cart-update")
+        human = _make_human(db, tenant_a, suffix="cart-update")
+
+        response = client.put(
+            f"/api/v1/carts/my/{popup.id}",
+            headers=_auth(human),
+            json={"items": {}},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+    def test_cart_delete_blocked(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="cart-delete")
+        human = _make_human(db, tenant_a, suffix="cart-delete")
+
+        response = client.delete(
+            f"/api/v1/carts/my/{popup.id}",
+            headers=_auth(human),
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == READ_ONLY_DETAIL
+
+
+# ---------------------------------------------------------------------------
+# Tests: portal products listing (recap keeps scoped visibility, unscoped
+# listing hides ended-popup products)
+# ---------------------------------------------------------------------------
+
+
+class TestEndedPopupPortalProductsHidden:
+    def test_products_list_returns_products_for_ended_popup(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        # Scoped listing keeps returning ended-popup products: the portal
+        # recap views (e.g. groups via PassesProvider) still need them, and
+        # purchasing is blocked at the payment/cart/application layers.
+        popup = _make_popup(db, tenant_a, suffix="products-ended")
+        human = _make_human(db, tenant_a, suffix="products-ended")
+        product = _make_product(db, tenant_a, popup)
+
+        response = client.get(
+            "/api/v1/products/portal/products",
+            headers=_auth(human),
+            params={"popup_id": str(popup.id)},
+        )
+
+        assert response.status_code == 200, response.text
+        ids = [p["id"] for p in response.json()["results"]]
+        assert str(product.id) in ids
+
+    def test_products_list_returns_products_for_active_popup(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="products-active", status="active")
+        human = _make_human(db, tenant_a, suffix="products-active")
+        product = _make_product(db, tenant_a, popup)
+
+        response = client.get(
+            "/api/v1/products/portal/products",
+            headers=_auth(human),
+            params={"popup_id": str(popup.id)},
+        )
+
+        assert response.status_code == 200, response.text
+        ids = [p["id"] for p in response.json()["results"]]
+        assert str(product.id) in ids
+
+    def test_unscoped_products_list_excludes_ended_popup_products(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        ended_popup = _make_popup(db, tenant_a, suffix="products-unscoped-ended")
+        active_popup = _make_popup(
+            db, tenant_a, suffix="products-unscoped-active", status="active"
+        )
+        human = _make_human(db, tenant_a, suffix="products-unscoped")
+        ended_product = _make_product(db, tenant_a, ended_popup)
+        active_product = _make_product(db, tenant_a, active_popup)
+
+        # Paginate through the full unscoped listing so the assertions stay
+        # deterministic when the shared test DB already has other products.
+        ids: list[str] = []
+        skip = 0
+        while True:
+            response = client.get(
+                "/api/v1/products/portal/products",
+                headers=_auth(human),
+                params={"skip": skip, "limit": 100},
+            )
+            assert response.status_code == 200, response.text
+            results = response.json()["results"]
+            ids.extend(p["id"] for p in results)
+            if len(results) < 100:
+                break
+            skip += 100
+
+        assert str(ended_product.id) not in ids
+        assert str(active_product.id) in ids
+
+    def test_unscoped_products_list_honors_is_active_filter(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="products-is-active", status="active")
+        human = _make_human(db, tenant_a, suffix="products-is-active")
+        active_product = _make_product(db, tenant_a, popup, is_active=True)
+        inactive_product = _make_product(db, tenant_a, popup, is_active=False)
+
+        # Paginate through the full unscoped listing so the assertions stay
+        # deterministic when the shared test DB already has other products.
+        ids: list[str] = []
+        skip = 0
+        while True:
+            response = client.get(
+                "/api/v1/products/portal/products",
+                headers=_auth(human),
+                params={"is_active": True, "skip": skip, "limit": 100},
+            )
+            assert response.status_code == 200, response.text
+            results = response.json()["results"]
+            assert all(p["is_active"] is True for p in results)
+            ids.extend(p["id"] for p in results)
+            if len(results) < 100:
+                break
+            skip += 100
+
+        assert str(active_product.id) in ids
+        assert str(inactive_product.id) not in ids
+
+
+# ---------------------------------------------------------------------------
+# Tests: same calls stay writable on active popups
+# ---------------------------------------------------------------------------
+
+
+class TestActivePopupPortalWritesAllowed:
+    def test_application_create_succeeds_on_active_popup(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="active-app-create", status="active")
+        human = _make_human(db, tenant_a, suffix="active-app-create")
+
+        response = client.post(
+            "/api/v1/applications/my",
+            headers=_auth(human),
+            json={
+                "popup_id": str(popup.id),
+                "first_name": "Active",
+                "last_name": "Applicant",
+            },
+        )
+
+        assert response.status_code == 201, response.text
+        assert response.json()["popup_id"] == str(popup.id)
+
+    def test_cart_update_succeeds_on_active_popup(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a, suffix="active-cart", status="active")
+        human = _make_human(db, tenant_a, suffix="active-cart")
+
+        response = client.put(
+            f"/api/v1/carts/my/{popup.id}",
+            headers=_auth(human),
+            json={"items": {}},
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["popup_id"] == str(popup.id)

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/edit/page.tsx
@@ -48,6 +48,26 @@ export default function EditPortalEventPage() {
     )
   }
 
+  // Ended popups are read-only: events can no longer be edited.
+  if (city.status === "ended") {
+    return (
+      <div className="max-w-2xl mx-auto p-4 sm:p-6 text-center py-20">
+        <h1 className="text-xl font-semibold">
+          {t("events.form.popup_ended_heading")}
+        </h1>
+        <p className="text-sm text-muted-foreground mt-2">
+          {t("events.form.popup_ended_message")}
+        </p>
+        <Link
+          href={`/portal/${city.slug}/events/${params.eventId}`}
+          className="mt-4 inline-block text-sm underline"
+        >
+          {t("events.form.back_to_event")}
+        </Link>
+      </div>
+    )
+  }
+
   const canManage = canManageEvent(event, currentHuman?.id)
   if (!canManage) {
     return (

--- a/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/[eventId]/page.tsx
@@ -230,6 +230,11 @@ export default function EventDetailPage() {
 
   const canManage = !!event && canManageEvent(event, currentHuman?.id)
 
+  // Ended popups are read-only in the portal: every write affordance (RSVP,
+  // check-in, edit, cancel, invitations) is hidden. Mirrors the backend
+  // ensure_popup_writable guard.
+  const isEnded = city?.status === "ended"
+
   // RSVP state is sourced from the event's own `my_rsvp_status` field so
   // this page agrees with the list/day/calendar views (which read the
   // same field). The participants list above is still used for the
@@ -276,6 +281,18 @@ export default function EventDetailPage() {
     queryClient.invalidateQueries({ queryKey: ["portal-events-calendar"] })
   }
 
+  // Surface backend rejections (e.g. ended popups answering 403) instead of
+  // failing silently. Mirrors toastRsvpError in ../lib/useEventRsvp.ts.
+  const toastRsvpError = (err: unknown) => {
+    const fallback = t("events.rsvp.action_error") as string
+    let detail = fallback
+    if (err instanceof ApiError && err.body && typeof err.body === "object") {
+      const body = err.body as { detail?: unknown }
+      if (typeof body.detail === "string") detail = body.detail
+    }
+    toast.error(detail)
+  }
+
   const registerMutation = useMutation({
     mutationFn: () =>
       EventParticipantsService.registerForEvent({
@@ -283,6 +300,7 @@ export default function EventDetailPage() {
         requestBody: rsvpBody,
       }),
     onSuccess: invalidateRsvpQueries,
+    onError: toastRsvpError,
   })
 
   const cancelMutation = useMutation({
@@ -292,6 +310,7 @@ export default function EventDetailPage() {
         requestBody: rsvpBody,
       }),
     onSuccess: invalidateRsvpQueries,
+    onError: toastRsvpError,
   })
 
   const [cancelEventOpen, setCancelEventOpen] = useState(false)
@@ -328,6 +347,7 @@ export default function EventDetailPage() {
         requestBody: rsvpBody,
       }),
     onSuccess: invalidateRsvpQueries,
+    onError: toastRsvpError,
   })
 
   const { data: invitations = [] } = useQuery<EventInvitationPublic[]>({
@@ -530,7 +550,7 @@ export default function EventDetailPage() {
           <ArrowLeft className="h-4 w-4" /> {t("events.common.back_to_events")}
         </Link>
         <div className="flex items-center gap-2 shrink-0">
-          {canManage && event.status !== "cancelled" && (
+          {canManage && !isEnded && event.status !== "cancelled" && (
             <Dialog open={cancelEventOpen} onOpenChange={setCancelEventOpen}>
               <DialogTrigger asChild>
                 <Button
@@ -574,7 +594,7 @@ export default function EventDetailPage() {
               </DialogContent>
             </Dialog>
           )}
-          {canManage && (
+          {canManage && !isEnded && (
             <Button asChild variant="outline" size="sm">
               <Link
                 href={`/portal/${city?.slug}/events/${event.id}/edit`}
@@ -724,17 +744,19 @@ export default function EventDetailPage() {
                       ? t("events.rsvp.checked_in")
                       : t("events.rsvp.going")}
                   </div>
-                  {myRsvpStatus === "registered" && eventStarted && (
-                    <Button
-                      size="sm"
-                      onClick={() => checkInMutation.mutate()}
-                      disabled={isPending}
-                    >
-                      {t("events.rsvp.check_in")}
-                    </Button>
-                  )}
+                  {!isEnded &&
+                    myRsvpStatus === "registered" &&
+                    eventStarted && (
+                      <Button
+                        size="sm"
+                        onClick={() => checkInMutation.mutate()}
+                        disabled={isPending}
+                      >
+                        {t("events.rsvp.check_in")}
+                      </Button>
+                    )}
                 </>
-              ) : isFull ? (
+              ) : isEnded ? null : isFull ? (
                 <Button
                   disabled
                   variant="secondary"
@@ -999,30 +1021,32 @@ export default function EventDetailPage() {
 
       {/* Below-card RSVP utilities: hint on the left, Cancel RSVP on the right.
           Separated by justify-between so they don't visually crowd each other. */}
-      {event.status === "published" && myRsvpStatus === "registered" && (
-        <div className="flex items-center justify-between gap-4">
-          {!eventStarted ? (
-            <span className="text-xs text-muted-foreground">
-              {t("events.rsvp.check_in_opens_at_start")}
-            </span>
-          ) : (
-            <span />
-          )}
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => cancelMutation.mutate()}
-            disabled={isPending}
-            className="border-destructive/30 bg-destructive/10 text-destructive shadow-none hover:border-destructive/50 hover:bg-destructive/20 hover:text-destructive dark:border-destructive/40 dark:bg-destructive/20 dark:hover:bg-destructive/30"
-          >
-            <X className="h-3.5 w-3.5" />
-            {t("events.rsvp.cancel")}
-          </Button>
-        </div>
-      )}
+      {!isEnded &&
+        event.status === "published" &&
+        myRsvpStatus === "registered" && (
+          <div className="flex items-center justify-between gap-4">
+            {!eventStarted ? (
+              <span className="text-xs text-muted-foreground">
+                {t("events.rsvp.check_in_opens_at_start")}
+              </span>
+            ) : (
+              <span />
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => cancelMutation.mutate()}
+              disabled={isPending}
+              className="border-destructive/30 bg-destructive/10 text-destructive shadow-none hover:border-destructive/50 hover:bg-destructive/20 hover:text-destructive dark:border-destructive/40 dark:bg-destructive/20 dark:hover:bg-destructive/30"
+            >
+              <X className="h-3.5 w-3.5" />
+              {t("events.rsvp.cancel")}
+            </Button>
+          </div>
+        )}
 
       {/* Managers only (owner / host / collaborators): paste attendees to invite */}
-      {canManage && (
+      {canManage && !isEnded && (
         <div className="rounded-xl border bg-card p-4 space-y-3">
           <div className="flex items-center gap-2">
             <Mail className="h-4 w-4 text-primary" />

--- a/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/CalendarBody.tsx
@@ -99,6 +99,11 @@ interface CalendarBodyProps {
   canRsvp?: boolean
   /** Tooltip text shown on the disabled RSVP button explaining why. */
   rsvpDisabledReason?: string
+  /**
+   * When false, the RSVP and "Going"/cancel buttons are hidden entirely —
+   * used for ended (read-only) popups. Defaults to true.
+   */
+  showRsvp?: boolean
 }
 
 /**
@@ -124,6 +129,7 @@ export function CalendarBody({
   placeholderUrl,
   canRsvp = true,
   rsvpDisabledReason,
+  showRsvp = true,
 }: CalendarBodyProps) {
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
@@ -589,6 +595,7 @@ export function CalendarBody({
                         </div>
                       </Link>
                       {isAuthed &&
+                        showRsvp &&
                         event.status === "published" &&
                         (() => {
                           const rsvpKey = `${event.id}:${event.start_time}`

--- a/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/DayBody.tsx
@@ -100,6 +100,11 @@ interface DayBodyProps {
   canRsvp?: boolean
   /** Tooltip text shown on the disabled RSVP button explaining why. */
   rsvpDisabledReason?: string
+  /**
+   * When false, the RSVP and "Going"/cancel buttons are hidden entirely —
+   * used for ended (read-only) popups. Defaults to true.
+   */
+  showRsvp?: boolean
 }
 
 const HOUR_PX = 56
@@ -165,6 +170,7 @@ export function DayBody({
   timezoneOverride,
   canRsvp = true,
   rsvpDisabledReason,
+  showRsvp = true,
 }: DayBodyProps) {
   const isAuthed = mode === "authed"
   const useOverride = eventsOverride !== undefined
@@ -801,6 +807,7 @@ export function DayBody({
                                 </div>
                               )}
                             {isAuthed &&
+                              showRsvp &&
                               !isShort &&
                               event.status === "published" &&
                               (() => {

--- a/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/lib/ListBody.tsx
@@ -118,6 +118,11 @@ interface ListBodyProps {
   canRsvp?: boolean
   /** Tooltip text shown on the disabled RSVP button explaining why. */
   rsvpDisabledReason?: string
+  /**
+   * When false, the RSVP and "Going"/cancel buttons are hidden entirely —
+   * used for ended (read-only) popups. Defaults to true.
+   */
+  showRsvp?: boolean
   onHide?: (eventId: string) => void
   onUnhide?: (eventId: string) => void
   /** Popup-scoped fallback image when an event has no cover/venue image. */
@@ -160,6 +165,7 @@ export function ListBody({
   pendingRsvpKey,
   canRsvp = true,
   rsvpDisabledReason,
+  showRsvp = true,
   onHide,
   onUnhide,
   placeholderUrl,
@@ -508,7 +514,8 @@ export function ListBody({
                         </Link>
                         {isAuthed && (
                           <div className="absolute bottom-2 right-2 flex items-center gap-1.5">
-                            {event.status === "published" &&
+                            {showRsvp &&
+                              event.status === "published" &&
                               (() => {
                                 const rsvpKey = `${event.id}:${event.start_time}`
                                 const isRsvpPending = pendingRsvpKey === rsvpKey

--- a/portal/src/app/portal/[popupSlug]/events/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/new/page.tsx
@@ -99,6 +99,15 @@ export default function NewPortalEventPage() {
       />
     )
   }
+  // Ended popups are read-only: no new events, whatever the settings say.
+  if (city?.status === "ended") {
+    return (
+      <GatedMessage
+        title={t("events.form.popup_ended_heading")}
+        message={t("events.form.popup_ended_message")}
+      />
+    )
+  }
   if (!canCreate) {
     return (
       <GatedMessage

--- a/portal/src/app/portal/[popupSlug]/events/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/page.tsx
@@ -364,6 +364,10 @@ export default function EventsPage() {
   // event_settings.event_enabled gates creation only; existing events
   // stay browsable so users can review what's already published.
   const creationEnabled = eventSettings?.event_enabled ?? true
+  // Ended popups are read-only in the portal: creation and RSVP affordances
+  // are hidden while the list stays browsable (recap mode). Mirrors the
+  // backend ensure_popup_writable guard.
+  const isEnded = city?.status === "ended"
 
   // Only surface tracks that actually have events in the window — the
   // curated track list often contains tracks no published event uses yet,
@@ -725,7 +729,8 @@ export default function EventsPage() {
           </h1>
           <div className="flex shrink-0 items-center gap-2">
             {city?.id && <SubscribeCalendarButton popupId={city.id} />}
-            {creationEnabled &&
+            {!isEnded &&
+              creationEnabled &&
               (eventSettings?.can_publish_event ?? "everyone") ===
                 "everyone" && (
                 <Button asChild size="sm" className="shrink-0 px-2 sm:px-3">
@@ -806,6 +811,7 @@ export default function EventsPage() {
             placeholderUrl={eventSettings?.placeholder_url}
             canRsvp={canRsvp}
             rsvpDisabledReason={rsvpDisabledReason}
+            showRsvp={!isEnded}
           />
         ) : view === "day" ? (
           isDayFullscreen ? null : (
@@ -826,6 +832,7 @@ export default function EventsPage() {
               onToggleFullscreen={toggleDayFullscreen}
               canRsvp={canRsvp}
               rsvpDisabledReason={rsvpDisabledReason}
+              showRsvp={!isEnded}
             />
           )
         ) : (
@@ -844,6 +851,7 @@ export default function EventsPage() {
             pendingRsvpKey={pendingRsvpKey}
             canRsvp={canRsvp}
             rsvpDisabledReason={rsvpDisabledReason}
+            showRsvp={!isEnded}
             onHide={(id) => hideMutation.mutate(id)}
             onUnhide={(id) => unhideMutation.mutate(id)}
             placeholderUrl={eventSettings?.placeholder_url}
@@ -903,6 +911,7 @@ export default function EventsPage() {
               onToggleFullscreen={toggleDayFullscreen}
               canRsvp={canRsvp}
               rsvpDisabledReason={rsvpDisabledReason}
+              showRsvp={!isEnded}
             />
           </div>,
           document.body,

--- a/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/edit/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/edit/page.tsx
@@ -190,6 +190,28 @@ export default function EditPortalVenuePage() {
     )
   }
 
+  // Ended popups are read-only: venues can no longer be edited.
+  if (city?.status === "ended") {
+    return (
+      <div className="max-w-xl mx-auto p-6 text-center">
+        <CircleAlert className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
+        <h1 className="text-lg font-semibold">
+          {t("events.form.popup_ended_heading")}
+        </h1>
+        <p className="text-sm text-muted-foreground mt-2">
+          {t("events.form.popup_ended_message")}
+        </p>
+        <Link
+          href={`/portal/${popupSlug}/events/venues/${venue.id}`}
+          className="inline-flex items-center gap-1 text-sm text-primary mt-6"
+        >
+          <ArrowLeft className="h-4 w-4" />{" "}
+          {t("events.venues.edit.back_to_venue")}
+        </Link>
+      </div>
+    )
+  }
+
   const isOwner = currentHuman != null && venue.owner_id === currentHuman.id
 
   if (!isOwner) {

--- a/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/[venueId]/page.tsx
@@ -64,8 +64,12 @@ export default function PortalVenueDetailPage() {
   const venue: EventVenuePublic | undefined = data?.results.find(
     (v) => v.id === params.venueId,
   )
+  // Ended popups are read-only: the owner's edit affordance is hidden.
   const isOwner =
-    venue != null && currentHuman != null && venue.owner_id === currentHuman.id
+    venue != null &&
+    currentHuman != null &&
+    venue.owner_id === currentHuman.id &&
+    city?.status !== "ended"
 
   if (isLoading) {
     return (

--- a/portal/src/app/portal/[popupSlug]/events/venues/new/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/new/page.tsx
@@ -60,7 +60,9 @@ export default function NewPortalVenuePage() {
 
   const { data: settings, isLoading: settingsLoading } =
     usePortalEventSettings(popupId)
-  const canCreate = settings?.humans_can_create_venues === true
+  // Ended popups are read-only: venue creation is blocked in recap mode.
+  const isEnded = city?.status === "ended"
+  const canCreate = settings?.humans_can_create_venues === true && !isEnded
   const requiresApproval = settings?.venues_require_approval === true
 
   const { data: propertyTypes } = useQuery({
@@ -177,12 +179,16 @@ export default function NewPortalVenuePage() {
       <div className="max-w-xl mx-auto p-6 text-center">
         <CircleAlert className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
         <h1 className="text-lg font-semibold">
-          {t("events.venues.new.venue_not_available")}
+          {isEnded
+            ? t("events.form.popup_ended_heading")
+            : t("events.venues.new.venue_not_available")}
         </h1>
         <p className="text-sm text-muted-foreground mt-2">
-          {t("events.venues.new.venue_not_available_message", {
-            cityName: city?.name,
-          })}
+          {isEnded
+            ? t("events.form.popup_ended_message")
+            : t("events.venues.new.venue_not_available_message", {
+                cityName: city?.name,
+              })}
         </p>
         <Link
           href={`/portal/${popupSlug}/events/venues`}

--- a/portal/src/app/portal/[popupSlug]/events/venues/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/events/venues/page.tsx
@@ -24,7 +24,9 @@ export default function PortalVenuesPage() {
     enabled: !!city?.id,
   })
   const { data: settings } = usePortalEventSettings(city?.id)
-  const canCreateVenue = settings?.humans_can_create_venues === true
+  // Ended popups are read-only: venue creation is hidden in recap mode.
+  const canCreateVenue =
+    settings?.humans_can_create_venues === true && city?.status !== "ended"
 
   const venues: EventVenuePublic[] = data?.results ?? []
 

--- a/portal/src/hooks/checkout/errorDispatch.ts
+++ b/portal/src/hooks/checkout/errorDispatch.ts
@@ -10,6 +10,14 @@ export type CartMeta = {
   restoreToken: string | null
 }
 
+/**
+ * Exact string detail returned by the backend's ended-popup write guard
+ * (`ensure_popup_writable`, HTTP 403). Matched verbatim so the checkout can
+ * surface a specific message instead of the generic payment error.
+ */
+export const POPUP_ENDED_READ_ONLY_DETAIL =
+  "This popup has ended and is read-only."
+
 export type NavigateAction =
   | { type: "href"; url: string }
   | { type: "router-push"; path: string }

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -22,7 +22,11 @@ import type {
   SelectedPatronItem,
 } from "@/types/checkout"
 import { buildPaymentProducts } from "./buildPaymentProducts"
-import { dispatchPaymentError, extractCartMeta } from "./errorDispatch"
+import {
+  dispatchPaymentError,
+  extractCartMeta,
+  POPUP_ENDED_READ_ONLY_DETAIL,
+} from "./errorDispatch"
 
 interface UsePaymentSubmitParams {
   applicationId: string | undefined
@@ -387,6 +391,13 @@ export function usePaymentSubmit({
         apiBody !== null && typeof apiBody?.detail === "string"
           ? (apiBody.detail as string)
           : null
+      if (apiDetailStr === POPUP_ENDED_READ_ONLY_DETAIL) {
+        const errorMsg = t("checkout.popup_ended_error")
+        setPromoError(errorMsg)
+        toast.error(errorMsg)
+        setIsSubmitting(false)
+        return { success: false, error: errorMsg }
+      }
       const isCouponError = apiDetailStr?.startsWith("Coupon code")
       if (isCouponError) {
         clearPromoCode()

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -820,6 +820,8 @@
       "required_start": "Pick a start time",
       "creation_restricted_heading": "Event creation is restricted",
       "creation_restricted_message": "Only admins can create events for this pop-up.",
+      "popup_ended_heading": "This pop-up has ended",
+      "popup_ended_message": "It is now read-only, so creating or editing content is no longer available.",
       "no_popup_error": "No popup",
       "no_timezone_error": "No timezone configured for this popup",
       "no_venue_option": "Virtual meeting",

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -278,6 +278,7 @@
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
     "payment_error": "Something went wrong with your payment. Please try again.",
+    "popup_ended_error": "This popup has ended. Purchases are no longer available.",
     "no_products": "No products available for this step.",
     "no_images": "No images available for this step.",
     "no_video": "No video available for this step.",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -809,6 +809,8 @@
       "required_start": "Elegí una hora de inicio",
       "creation_restricted_heading": "La creación de eventos está restringida",
       "creation_restricted_message": "Solo los admins pueden crear eventos para este pop-up.",
+      "popup_ended_heading": "Este pop-up finalizó",
+      "popup_ended_message": "Ahora es de solo lectura, por lo que ya no es posible crear ni editar contenido.",
       "no_popup_error": "Sin popup",
       "no_timezone_error": "El popup no tiene zona horaria configurada",
       "no_venue_option": "Reunión virtual",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -278,6 +278,7 @@
     },
     "coupon_no_longer_valid": "This coupon is no longer available. Your total has been updated. Please review and try again.",
     "payment_error": "Something went wrong with your payment. Please try again.",
+    "popup_ended_error": "Este popup ha finalizado. Las compras ya no están disponibles.",
     "no_products": "No hay productos disponibles para este paso.",
     "no_images": "No hay imágenes disponibles para este paso.",
     "no_video": "No hay video disponible para este paso.",


### PR DESCRIPTION
## Summary

- Popups with status "ended" become read-only in the portal: every portal-side mutation scoped to an ended popup returns 403 with the message "This popup has ended and is read-only."
- Enforcement lives at the endpoint level (shared guard `ensure_popup_writable`), so it covers the portal UI, existing API keys and any future keys in one place. Backoffice/admin endpoints stay fully writable.
- Portal UI hides write affordances on ended popups and surfaces a specific error if a stale tab races the transition mid-checkout.

## Blocked on ended popups (portal)

| Surface | Endpoints |
|---------|-----------|
| Events | create, update, cancel, invitations add/delete |
| Participation | RSVP register, cancel-registration, check-in |
| Venues | create, update, delete |
| Applications | create, update, attendee add/update/delete, detach-companion |
| Attendees | create, update, meal-plan, delete |
| Groups | update, member add/batch/update/remove |
| Purchase | payment create, application-fee, cart update/delete |

Left writable by design: event hide/unhide (personal metadata), admin notes (staff), all backoffice endpoints. Open checkout already requires an active popup upstream.

## Products

Popup-scoped product listing stays visible for ended popups: the recap views (PassesProvider, group passes) need product data, and purchasing is blocked at the payment/cart/application level. The unscoped portal listing excludes ended-popup products so API keys cannot enumerate them, and now honors the `is_active`/`category` filters it previously dropped.

## Portal UI

- Create-event button, RSVP buttons, edit/cancel/invitations/check-in controls and venue creation hidden when the popup is ended; direct URL access to create/edit pages shows a read-only notice (i18n en/es).
- Event detail RSVP/cancel/check-in mutations now surface backend errors via toast instead of failing silently.
- Checkout payment submit recognizes the ended-popup 403 and shows a specific message instead of a generic payment error.

## Test plan

- [x] 34 dedicated guard tests (`tests/api/event/test_ended_popup_read_only.py`, `tests/api/popup/test_ended_popup_read_only_extended.py`)
- [x] Full backend suite: 1906 passed, 8 skipped
- [x] `bash scripts/lint.sh` clean
- [x] `pnpm --filter portal run build` passes
- [x] No schema changes, no migrations, no client regeneration needed

## Follow-ups (non-blocking)

- Application submit / attendee edit / group flows show generic error toasts on the ended 403 (UI already hides those flows; only stale tabs hit it)
- Cart background sync fails silently on a just-ended popup (state preserved locally)
- Pre-existing: `checkout.payment_error` in `es.json` is in English