### PR TITLE
feat(portal): support ASSET_PREFIX for CDN-served static chunks

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -78,3 +78,6 @@ services:
       dockerfile: portal/Dockerfile
       args:
         - NEXT_PUBLIC_API_URL=${BACKEND_URL?Variable not set}
+        # CDN for /_next/static (e.g. https://static.edgeos.world). Optional:
+        # unset serves assets same-origin, as before.
+        - ASSET_PREFIX=${ASSET_PREFIX-}

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -17,6 +17,7 @@ COPY ./packages/shared-form-ui /app/packages/shared-form-ui
 COPY ./packages/shared-events /app/packages/shared-events
 COPY ./portal /app/portal
 ARG NEXT_PUBLIC_API_URL
+ARG ASSET_PREFIX
 ENV NODE_ENV=production
 
 RUN pnpm --filter portal run build

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -5,6 +5,10 @@ import { OPTIMIZED_IMAGE_HOSTS } from "./src/lib/image-optimization"
 const nextConfig: NextConfig = {
   output: "standalone",
   outputFileTracingRoot: path.resolve(__dirname, ".."),
+  // CDN for /_next/static chunks (e.g. https://static.edgeos.world). One
+  // static domain serves every tenant custom domain, so immutable assets get
+  // edge caching without per-tenant certificates or DNS. Unset = same-origin.
+  assetPrefix: process.env.ASSET_PREFIX || undefined,
   transpilePackages: ["@edgeos/shared-form-ui", "@edgeos/shared-events"],
   env: {
     NEXT_PUBLIC_API_URL:


### PR DESCRIPTION
## Summary

Prod portal serves every `/_next/static` chunk straight from the ALB (no CDN): ~650ms TTFB per asset, 32 assets (~880 KB) on a cold visit, measured 14.75s LCP on a hard refresh of the real checkout. First-time buyers arriving through shared links pay exactly this path.

This PR adds opt-in support for serving static chunks from a CDN domain:

- `next.config.ts`: `assetPrefix` read from the `ASSET_PREFIX` env var (unset = same-origin, behavior unchanged).
- `portal/Dockerfile`: new `ASSET_PREFIX` build arg.
- `compose.yaml`: optional `ASSET_PREFIX` build arg passthrough.

## Verified

- [x] Local standalone build with `ASSET_PREFIX=https://static.edgeos.world`: SSR pages emit fully-prefixed chunk URLs; `required-server-files.json` carries the prefix
- [x] Real prod chunk through the CDN: Miss then `Hit from cloudfront`, `access-control-allow-origin: *`, immutable cache-control passthrough
- [x] Warm edge TTFB: 22-25ms (vs 651ms from the ALB, ~30x)
- [x] Root document passes through uncached (`no-store` respected; SSR stock freshness unaffected)
- [x] Lint + build clean

## Activation

After merge + release, set `ASSET_PREFIX=https://static.edgeos.world` in the prod portal image build. Rollback = unset the variable (assets revert to same-origin; the distribution can stay).

## Known quirk

Next 16 Turbopack prerenders `_global-error.html` with a mangled prefix (`https://l/...`) - only that artifact; real SSR pages are correct. Tracked for Next upgrades.