### PR TITLE
Release v1.34.0: dev to main

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -78,3 +78,6 @@ services:
       dockerfile: portal/Dockerfile
       args:
         - NEXT_PUBLIC_API_URL=${BACKEND_URL?Variable not set}
+        # CDN for /_next/static (e.g. https://static.edgeos.world). Optional:
+        # unset serves assets same-origin, as before.
+        - ASSET_PREFIX=${ASSET_PREFIX-}

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -17,6 +17,7 @@ COPY ./packages/shared-form-ui /app/packages/shared-form-ui
 COPY ./packages/shared-events /app/packages/shared-events
 COPY ./portal /app/portal
 ARG NEXT_PUBLIC_API_URL
+ARG ASSET_PREFIX
 ENV NODE_ENV=production
 
 RUN pnpm --filter portal run build

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -5,6 +5,10 @@ import { OPTIMIZED_IMAGE_HOSTS } from "./src/lib/image-optimization"
 const nextConfig: NextConfig = {
   output: "standalone",
   outputFileTracingRoot: path.resolve(__dirname, ".."),
+  // CDN for /_next/static chunks (e.g. https://static.edgeos.world). One
+  // static domain serves every tenant custom domain, so immutable assets get
+  // edge caching without per-tenant certificates or DNS. Unset = same-origin.
+  assetPrefix: process.env.ASSET_PREFIX || undefined,
   transpilePackages: ["@edgeos/shared-form-ui", "@edgeos/shared-events"],
   env: {
     NEXT_PUBLIC_API_URL:


### PR DESCRIPTION
## Release v1.34.0

Brings dev into main. Content delta vs main is exactly one feature:

- **feat(portal): support ASSET_PREFIX for CDN-served static chunks** (#457) — opt-in `assetPrefix` via the `ASSET_PREFIX` build arg, backed by the already-live `static.edgeos.world` CloudFront distribution. Unset = same-origin (no behavior change until the prod build sets it).

Also back-merges main's release history into dev lineage (24 history-only commits; content diff vs dev is empty).

## Post-release activation

Set `ASSET_PREFIX=https://static.edgeos.world` in the prod portal image build to serve `/_next/static` from the CDN, then re-measure cold-load LCP on portal.solgathering.org.

## Checks

- [x] Content parity with dev verified (`git diff origin/dev` empty)
- [x] No new backend migrations in this delta
- [x] No squash (merge commit flow preserved)