### PR TITLE
fix(portal): serve /_next/static with CORS header at the origin

### DIFF
--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -9,6 +9,18 @@ const nextConfig: NextConfig = {
   // static domain serves every tenant custom domain, so immutable assets get
   // edge caching without per-tenant certificates or DNS. Unset = same-origin.
   assetPrefix: process.env.ASSET_PREFIX || undefined,
+  // Fonts fetched through the assetPrefix CDN are cross-origin and require
+  // CORS. Baking the header into the origin response means the CDN caches it
+  // inside the object, instead of depending on per-request edge policy
+  // evaluation.
+  async headers() {
+    return [
+      {
+        source: "/_next/static/:path*",
+        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+      },
+    ]
+  },
   transpilePackages: ["@edgeos/shared-form-ui", "@edgeos/shared-events"],
   env: {
     NEXT_PUBLIC_API_URL:


### PR DESCRIPTION
## Summary

Fonts loaded through the `ASSET_PREFIX` CDN (`static.edgeos.world`) are cross-origin and were intermittently blocked by CORS in production: some CloudFront POPs returned the font without `Access-Control-Allow-Origin` even though the distribution has the SimpleCORS response headers policy attached (policy evaluation is conditional on the viewer `Origin` header, and cacheable no-header variants proved unreliable across POPs).

Fix: bake the header into the origin response. `next.config.ts` now declares `headers()` for `/_next/static/:path*` with `Access-Control-Allow-Origin: *`, so the CDN caches the header inside the object and stops depending on per-request edge policy evaluation. Static chunks/fonts are public and immutable; `*` is the correct scope.

## Verified

- [x] Standalone production build (`ASSET_PREFIX` set): both a JS chunk and a `.woff2` font respond with `Access-Control-Allow-Origin: *` and `Cache-Control: public, max-age=31536000, immutable`
- [x] Biome lint clean