### PR TITLE
feat(api-keys): bind portal API keys to a single popup

### DIFF
--- a/backend/app/alembic/versions/d4f7b2a9c1e6_api_key_popup_scope.py
+++ b/backend/app/alembic/versions/d4f7b2a9c1e6_api_key_popup_scope.py
@@ -1,0 +1,53 @@
+"""Bind human-owned API keys to a single popup.
+
+Adds ``api_keys.popup_id`` (FK popups.id, indexed). Human-owned keys are
+attendee keys (identity = human_id + popup_id); the column is nullable at
+the table level only because admin-owned keys (user_id set) have no popup.
+
+Data migration: revokes every active human-owned key. Legacy keys were
+tenant-wide (no popup binding) and are unsafe under the new popup-scoped
+enforcement, so they are revoked rather than backfilled. Admin-owned keys
+are untouched.
+
+Revision ID: d4f7b2a9c1e6
+Revises: a8e3d7f4c2b9
+Create Date: 2026-07-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d4f7b2a9c1e6"
+down_revision: str | None = "a8e3d7f4c2b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "popup_id",
+            sa.Uuid(),
+            sa.ForeignKey("popups.id"),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_api_keys_popup_id", "api_keys", ["popup_id"])
+
+    # Revoke all legacy human-owned keys: they predate popup scoping and
+    # would otherwise fail closed (403) on every portal route anyway.
+    # DML, so plain SQL through op.execute is fine.
+    op.execute(
+        "UPDATE api_keys SET revoked_at = now() "
+        "WHERE human_id IS NOT NULL AND revoked_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    # NOTE: the revocation of legacy human-owned keys above is irreversible;
+    # downgrading only drops the column and index.
+    op.drop_index("ix_api_keys_popup_id", table_name="api_keys")
+    op.drop_column("api_keys", "popup_id")

--- a/backend/app/api/api_key/crud.py
+++ b/backend/app/api/api_key/crud.py
@@ -83,15 +83,17 @@ def create_for_human(
     *,
     tenant_id: uuid.UUID,
     human_id: uuid.UUID,
+    popup_id: uuid.UUID,
     name: str,
     expires_at: datetime | None,
     scopes: list[str],
 ) -> tuple[ApiKeys, str]:
-    """Mint and persist a new key. Returns (row, raw_token)."""
+    """Mint and persist a new key bound to one popup. Returns (row, raw_token)."""
     raw = generate_raw_key()
     row = ApiKeys(
         tenant_id=tenant_id,
         human_id=human_id,
+        popup_id=popup_id,
         name=name,
         key_hash=hash_key(raw),
         prefix=display_prefix(raw),

--- a/backend/app/api/api_key/models.py
+++ b/backend/app/api/api_key/models.py
@@ -41,6 +41,14 @@ class ApiKeys(SQLModel, table=True):
         foreign_key="users.id",
         index=True,
     )
+    # Popup the key is bound to. Human-owned keys are attendee keys
+    # (identity = human_id + popup_id) and always carry one going forward;
+    # nullable at the table level only because admin-owned keys have no popup.
+    popup_id: uuid.UUID | None = Field(
+        default=None,
+        foreign_key="popups.id",
+        index=True,
+    )
     name: str = Field(max_length=100)
     key_hash: str = Field(max_length=64, unique=True)
     prefix: str = Field(max_length=20)

--- a/backend/app/api/api_key/router.py
+++ b/backend/app/api/api_key/router.py
@@ -106,10 +106,43 @@ async def create_api_key(
                 detail=f"These scopes are not permitted for third-party sessions: {sorted(invalid)}",
             )
 
+    # Popup binding: keys are attendee keys (human + popup). The popup must
+    # exist within the caller's tenant (RLS hides foreign popups → 404).
+    from app.api.application.crud import applications_crud
+    from app.api.popup.crud import popups_crud
+    from app.api.popup.schemas import PopupStatus
+
+    popup = popups_crud.get(db, payload.popup_id)
+    if popup is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Popup not found",
+        )
+
+    # Membership gate: same access ladder as the portal passes/events gates
+    # (accepted application, attendee ticket, payment, or companion access).
+    access = applications_crud.resolve_popup_access(db, current_human.id, popup.id)
+    if not access.allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You need to be an accepted participant of this popup to create an API key for it.",
+        )
+
+    # Ended popups are recap/read-only: keys may still be minted for queries,
+    # but never with write capability.
+    if popup.status == PopupStatus.ended and any(
+        scope.endswith(":write") for scope in payload.scopes
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This popup has ended; API keys can only be created with read-only access.",
+        )
+
     row, raw = crud.create_for_human(
         db,
         tenant_id=current_human.tenant_id,
         human_id=current_human.id,
+        popup_id=popup.id,
         name=payload.name.strip(),
         expires_at=payload.expires_at,
         scopes=payload.scopes,

--- a/backend/app/api/api_key/schemas.py
+++ b/backend/app/api/api_key/schemas.py
@@ -20,6 +20,9 @@ class ApiKeyCreate(BaseModel):
     """Request body for creating a new API key."""
 
     name: str = Field(min_length=1, max_length=100)
+    # Popup the key is bound to. Human-owned keys are attendee keys: the key
+    # only works against this popup's portal routes.
+    popup_id: uuid.UUID
     expires_at: datetime | None = None
     scopes: list[ApiKeyScope] = Field(
         default_factory=lambda: list(DEFAULT_API_KEY_SCOPES)
@@ -74,6 +77,8 @@ class ApiKeyPublic(BaseModel):
     id: uuid.UUID
     name: str
     prefix: str
+    # None only for legacy rows created before popup scoping (all revoked).
+    popup_id: uuid.UUID | None = None
     scopes: list[ApiKeyScope]
     created_at: datetime
     last_used_at: datetime | None = None

--- a/backend/app/api/event/router.py
+++ b/backend/app/api/event/router.py
@@ -48,7 +48,12 @@ from app.api.event.schemas import (
 )
 from app.api.event_audit.crud import build_event_snapshot, record_event_audit
 from app.api.event_audit.schemas import EventAuditAction
-from app.api.popup.guards import ensure_popup_writable
+from app.api.popup.guards import (
+    CallerToken,
+    ensure_api_key_popup,
+    ensure_popup_writable,
+    resolve_api_key_popup_filter,
+)
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import (
@@ -1810,8 +1815,14 @@ async def check_availability_portal(
     payload: EventAvailabilityCheck,
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventAvailabilityResult:
     """Portal-facing variant of /check-availability authenticated as a human."""
+    from app.api.event_venue.models import EventVenues
+
+    # Popup-scoped API keys may only probe venues of their own popup.
+    venue = db.get(EventVenues, payload.venue_id)
+    ensure_api_key_popup(token_payload, venue.popup_id if venue else None)
     return _run_availability_check(db, payload)
 
 
@@ -2271,13 +2282,15 @@ async def list_portal_invitations(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> list[EventInvitationPublic]:
     from sqlmodel import select
 
     from app.api.event.models import EventInvitations
     from app.api.human.models import Humans
 
-    _ensure_portal_event_owner(db, event_id, current_human)
+    event = _ensure_portal_event_owner(db, event_id, current_human)
+    ensure_api_key_popup(token_payload, event.popup_id)
     rows = db.exec(
         select(EventInvitations, Humans)
         .where(EventInvitations.event_id == event_id)
@@ -2477,8 +2490,10 @@ async def bulk_invite_portal(
     payload: EventInvitationBulkCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventInvitationBulkResult:
     event = _ensure_portal_event_owner(db, event_id, current_human)
+    ensure_api_key_popup(token_payload, event.popup_id)
     from app.api.popup.crud import popups_crud
 
     ensure_popup_writable(popups_crud.get(db, event.popup_id))
@@ -2505,8 +2520,10 @@ async def delete_portal_invitation(
     invitation_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> None:
     event = _ensure_portal_event_owner(db, event_id, current_human)
+    ensure_api_key_popup(token_payload, event.popup_id)
     from app.api.popup.crud import popups_crud
 
     ensure_popup_writable(popups_crud.get(db, event.popup_id))
@@ -2669,6 +2686,7 @@ def _filter_rsvped_events(db, events: list, human_id: uuid.UUID) -> list:
 async def list_portal_events(
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID | None = None,
     event_status: EventStatus | None = None,
     kind: str | None = None,
@@ -2683,6 +2701,9 @@ async def list_portal_events(
     managed_only: bool = False,
     include_hidden: bool = False,
 ) -> ListModel[EventPublic]:
+    # Popup-scoped API keys never see tenant-wide data: an omitted popup_id
+    # is forced to the key's popup, a mismatching one raises 403.
+    popup_id = resolve_api_key_popup_filter(token_payload, popup_id)
     if popup_id:
         # The portal list always consumes the full window (it groups by day and
         # sorts globally client-side), so we fetch every matching row in one
@@ -2820,6 +2841,7 @@ async def list_portal_popup_tags(
 async def portal_hidden_events_count(
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID | None = None,
 ) -> dict[str, int]:
     """Return how many events the human has hidden (optionally for a popup).
@@ -2831,6 +2853,8 @@ async def portal_hidden_events_count(
     from sqlmodel import select
 
     from app.api.event.models import EventHiddenByHuman, Events
+
+    popup_id = resolve_api_key_popup_filter(token_payload, popup_id)
 
     # We count by distinct hide targets: each hide row is already unique per
     # (human, event), so a plain count of matching events = number of
@@ -2854,6 +2878,7 @@ async def portal_hidden_events_count(
 async def list_portal_track_event_counts(
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID,
 ) -> list[TrackEventCount]:
     """Distinct published-event count per track for a popup.
@@ -2862,6 +2887,7 @@ async def list_portal_track_event_counts(
     empty tracks without fetching the whole event list to count on the
     client (which also capped at the page limit).
     """
+    ensure_api_key_popup(token_payload, popup_id)
     counts = crud.events_crud.count_published_events_by_track(db, popup_id=popup_id)
     return [
         TrackEventCount(track_id=track_id, event_count=count)
@@ -2873,6 +2899,7 @@ async def list_portal_track_event_counts(
 async def list_portal_venue_event_counts(
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID,
 ) -> list[VenueEventCount]:
     """Distinct published-event count per venue for a popup.
@@ -2881,6 +2908,7 @@ async def list_portal_venue_event_counts(
     no events without fetching the whole event list to count on the client
     (which also capped at the page limit).
     """
+    ensure_api_key_popup(token_payload, popup_id)
     rows = crud.events_crud.count_published_events_by_venue(db, popup_id=popup_id)
     return [
         VenueEventCount(venue_id=venue_id, venue_title=venue_title, event_count=count)
@@ -2892,6 +2920,7 @@ async def list_portal_venue_event_counts(
 async def portal_calendar_summary(
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID,
     start_after: datetime | None = None,
     start_before: datetime | None = None,
@@ -2912,6 +2941,7 @@ async def portal_calendar_summary(
     """
     from app.api.event_venue.router import _resolve_popup_timezone
 
+    ensure_api_key_popup(token_payload, popup_id)
     events = crud.events_crud.find_in_range_expanded(
         db,
         popup_id=popup_id,
@@ -2979,6 +3009,7 @@ async def get_portal_event(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     occurrence_start: datetime | None = None,
 ) -> EventPublic:
     """Fetch a single event for the portal.
@@ -2996,6 +3027,7 @@ async def get_portal_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
 
     if event.visibility == EventVisibility.PRIVATE:
         invited = db.exec(
@@ -3065,6 +3097,7 @@ async def get_portal_event_admin_notes(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     _: CurrentPortalStaff,
+    token_payload: CallerToken,
 ) -> EventAdminNotes:
     """Read an event's staff-only notes from the portal (staff humans only)."""
     event = crud.events_crud.get(db, event_id)
@@ -3072,6 +3105,7 @@ async def get_portal_event_admin_notes(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
     return EventAdminNotes(notes=event.admin_notes)
 
 
@@ -3100,6 +3134,7 @@ async def hide_portal_event(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> None:
     """Hide an event from the current human's portal.
 
@@ -3113,6 +3148,7 @@ async def hide_portal_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
 
     target_id = event.recurrence_master_id or event.id
     crud.hidden_by_human_crud.hide(
@@ -3135,9 +3171,12 @@ async def unhide_portal_event(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> None:
     """Undo a prior hide."""
     event = crud.events_crud.get(db, event_id)
+    # Fail closed for popup-scoped keys when the event can't be resolved.
+    ensure_api_key_popup(token_payload, event.popup_id if event else None)
     target_id = event.recurrence_master_id or event.id if event else event_id
     crud.hidden_by_human_crud.unhide(
         db,
@@ -3161,9 +3200,12 @@ async def create_portal_event(
     event_in: EventCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventPublic:
     from app.api.event.models import Events
     from app.api.event_settings.crud import event_settings_crud
+
+    ensure_api_key_popup(token_payload, event_in.popup_id)
 
     settings = event_settings_crud.get_by_popup_id(db, event_in.popup_id)
     if settings and not settings.event_enabled:
@@ -3301,12 +3343,14 @@ async def update_portal_event(
     event_in: EventUpdate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
     if not _human_manages_event(event, current_human):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -3461,12 +3505,14 @@ async def cancel_portal_event(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventPublic:
     event = crud.events_crud.get(db, event_id)
     if not event:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
     if not _human_manages_event(event, current_human):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -3504,10 +3550,12 @@ async def export_portal_event_ics(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> Response:
     event = crud.events_crud.get(db, event_id)
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
+    ensure_api_key_popup(token_payload, event.popup_id)
     # Re-use the same visibility gate as the detail endpoint.
     if event.visibility == EventVisibility.PRIVATE and not _human_manages_event(
         event, current_human

--- a/backend/app/api/event_participant/router.py
+++ b/backend/app/api/event_participant/router.py
@@ -13,7 +13,11 @@ from app.api.event_participant.schemas import (
     ParticipantStatus,
     RegisterRequest,
 )
-from app.api.popup.guards import ensure_popup_writable
+from app.api.popup.guards import (
+    CallerToken,
+    ensure_api_key_popup,
+    ensure_popup_writable,
+)
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
     AdminOrApiKey_EventsRead,
@@ -203,6 +207,7 @@ def _resolve_occurrence_start(
 async def list_portal_participants(
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
     event_id: uuid.UUID,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
@@ -217,6 +222,11 @@ async def list_portal_participants(
     from app.api.application.crud import applications_crud
     from app.api.event.crud import events_crud
 
+    # Popup-scoped API keys may only list participants of their own popup's
+    # events. Resolved up-front so an unknown event fails closed for keys.
+    event = events_crud.get(db, event_id)
+    ensure_api_key_popup(token_payload, event.popup_id if event else None)
+
     participants, total = crud.event_participants_crud.find_by_event(
         db,
         event_id=event_id,
@@ -229,7 +239,6 @@ async def list_portal_participants(
     # Privacy: drop participants who hid their name (info_not_shared) on their
     # application for this event's popup. Excluding (not masking) keeps the RSVP
     # list from leaking a name the attendee chose to hide.
-    event = events_crud.get(db, event_id)
     if event is not None and participants:
         hidden = applications_crud.human_ids_hiding_name(
             db,
@@ -319,6 +328,7 @@ async def register_for_event(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     body: RegisterRequest | None = None,
 ) -> EventParticipantPublic:
     """Register current human for an event (portal)."""
@@ -335,6 +345,7 @@ async def register_for_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
     ensure_popup_writable(popups_crud.get(db, event.popup_id))
     if event.status != EventStatus.PUBLISHED:
         raise HTTPException(
@@ -477,6 +488,7 @@ async def cancel_registration(
     event_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     body: RegisterRequest | None = None,
 ) -> EventParticipantPublic:
     """Cancel current human's registration (portal).
@@ -492,6 +504,7 @@ async def cancel_registration(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
         )
+    ensure_api_key_popup(token_payload, event.popup_id)
     ensure_popup_writable(popups_crud.get(db, event.popup_id))
     occ_start = _resolve_occurrence_start(
         event, body.occurrence_start if body else None

--- a/backend/app/api/event_settings/router.py
+++ b/backend/app/api/event_settings/router.py
@@ -8,6 +8,7 @@ from app.api.event_settings.schemas import (
     EventSettingsPublic,
     EventSettingsUpdate,
 )
+from app.api.popup.guards import CallerToken, ensure_api_key_popup
 from app.core.dependencies.users import (
     CurrentHuman,
     CurrentUser,
@@ -106,8 +107,10 @@ async def get_portal_event_settings(
     popup_id: uuid.UUID,
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventSettingsPublic | None:
     """Get event settings for a popup (portal). Returns null if not configured."""
+    ensure_api_key_popup(token_payload, popup_id)
     settings = crud.event_settings_crud.get_by_popup_id(db, popup_id)
     if not settings:
         return None

--- a/backend/app/api/event_venue/router.py
+++ b/backend/app/api/event_venue/router.py
@@ -35,7 +35,11 @@ from app.api.event_venue.schemas import (
     VenueStatus,
     VenueWeeklyHoursUpdate,
 )
-from app.api.popup.guards import ensure_popup_writable
+from app.api.popup.guards import (
+    CallerToken,
+    ensure_api_key_popup,
+    ensure_popup_writable,
+)
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.core.dependencies.users import (
     AdminOrApiKey_EventsRead,
@@ -805,6 +809,7 @@ async def get_portal_availability(
     venue_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     start: datetime = Query(...),
     end: datetime = Query(...),
     exclude_event_id: uuid.UUID | None = Query(default=None),
@@ -816,6 +821,7 @@ async def get_portal_availability(
     visible as occupied without leaking what it is.
     """
     venue = _get_venue_or_404(db, venue_id)
+    ensure_api_key_popup(token_payload, venue.popup_id)
     return _compute_availability(
         db,
         venue,
@@ -831,11 +837,13 @@ async def get_portal_availability(
 async def list_portal_venues(
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID,
     search: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[EventVenuePublic]:
+    ensure_api_key_popup(token_payload, popup_id)
     # Hide pending venues from portal listings. Filtering in the query (not in
     # Python) keeps the paging total correct.
     venues, total = crud.event_venues_crud.find_by_popup(
@@ -858,12 +866,14 @@ async def update_portal_venue(
     venue_in: EventVenueUpdate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventVenuePublic:
     """Let a human edit a venue they created from the portal. Admin-only
     fields (``status``) are ignored on this endpoint — re-approval lives in
     the backoffice.
     """
     venue = _get_venue_or_404(db, venue_id)
+    ensure_api_key_popup(token_payload, venue.popup_id)
     if venue.owner_id != current_human.id:
         raise HTTPException(
             status_code=403,
@@ -894,6 +904,7 @@ async def delete_portal_venue(
     venue_id: uuid.UUID,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> None:
     """Let a human delete a venue they created. Blocked if the venue still
     has linked events — those must be removed/reassigned first."""
@@ -901,6 +912,7 @@ async def delete_portal_venue(
     from app.api.event.schemas import EventStatus
 
     venue = _get_venue_or_404(db, venue_id)
+    ensure_api_key_popup(token_payload, venue.popup_id)
     if venue.owner_id != current_human.id:
         raise HTTPException(
             status_code=403,
@@ -934,11 +946,13 @@ async def create_portal_venue(
     venue_in: EventVenueCreate,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
 ) -> EventVenuePublic:
     """Create a venue as a human (portal). Respects popup event settings."""
     from app.api.event_settings.crud import event_settings_crud
     from app.api.popup.crud import popups_crud
 
+    ensure_api_key_popup(token_payload, venue_in.popup_id)
     ensure_popup_writable(popups_crud.get(db, venue_in.popup_id))
 
     settings = event_settings_crud.get_by_popup_id(db, venue_in.popup_id)

--- a/backend/app/api/popup/guards.py
+++ b/backend/app/api/popup/guards.py
@@ -4,10 +4,18 @@ Lives in the popup package (not ``core``) so routers can import it without
 pulling API modules into ``app.core.security``.
 """
 
-from fastapi import HTTPException, status
+import uuid
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
 
 from app.api.popup.models import Popups
 from app.api.popup.schemas import PopupStatus
+from app.core.security import TokenPayload, get_token_payload
+
+# Convenience annotation so portal routes can receive the resolved token
+# payload (JWT or API key) and pass it to the popup guards below.
+CallerToken = Annotated[TokenPayload, Depends(get_token_payload)]
 
 
 def ensure_popup_writable(popup: Popups | None) -> None:
@@ -21,3 +29,58 @@ def ensure_popup_writable(popup: Popups | None) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail="This popup has ended and is read-only.",
         )
+
+
+def is_popup_scoped_api_key(token_payload: TokenPayload) -> bool:
+    """True when the caller authenticated with a human-owned (portal) API key.
+
+    Admin-owned keys (token_type="user") are tenant-scoped, governed by
+    CurrentAdminOrApiKey, and never popup-bound.
+    """
+    return bool(token_payload.via_api_key) and token_payload.token_type == "human"
+
+
+def ensure_api_key_popup(
+    token_payload: TokenPayload, popup_id: uuid.UUID | None
+) -> None:
+    """Reject popup-scoped API-key calls that target a different popup.
+
+    No-op for JWT sessions and admin keys. For human-owned keys the request's
+    popup must match the key's binding; a key without a binding (legacy row)
+    or a request whose popup could not be resolved fails closed.
+    """
+    if not is_popup_scoped_api_key(token_payload):
+        return
+    if (
+        token_payload.popup_id is None
+        or popup_id is None
+        or token_payload.popup_id != popup_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This API key does not have access to this popup.",
+        )
+
+
+def resolve_api_key_popup_filter(
+    token_payload: TokenPayload, popup_id: uuid.UUID | None
+) -> uuid.UUID | None:
+    """Popup filter for list endpoints with an optional ``popup_id`` param.
+
+    JWT sessions keep whatever filter they asked for. Popup-scoped API keys
+    are forced onto their own popup: an explicit mismatching filter raises
+    403, and an omitted filter is replaced by the key's popup so a key can
+    never read tenant-wide data.
+    """
+    if not is_popup_scoped_api_key(token_payload):
+        return popup_id
+    if popup_id is not None:
+        ensure_api_key_popup(token_payload, popup_id)
+        return popup_id
+    if token_payload.popup_id is None:
+        # Legacy key without a popup binding — fail closed.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This API key does not have access to this popup.",
+        )
+    return token_payload.popup_id

--- a/backend/app/api/popup/router.py
+++ b/backend/app/api/popup/router.py
@@ -16,6 +16,11 @@ from app.api.form_section.models import FormSections
 from app.api.payment.crud import payments_crud
 from app.api.payment.schemas import PaymentStatus
 from app.api.popup import crud
+from app.api.popup.guards import (
+    CallerToken,
+    ensure_api_key_popup,
+    is_popup_scoped_api_key,
+)
 from app.api.popup.models import Popups
 from app.api.popup.schemas import (
     PopupAdmin,
@@ -399,6 +404,7 @@ async def delete_popup(
 async def list_portal_popups(
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     accept_language: Annotated[str | None, Header(alias="Accept-Language")] = None,
 ) -> list[PopupPublic]:
     """List popups visible to the current human in the Portal.
@@ -417,6 +423,10 @@ async def list_portal_popups(
         if applications_crud.resolve_popup_access(db, current_human.id, p.id).allowed
     ]
     popups = list(active_popups) + participated_ended
+
+    # Popup-scoped API keys only ever see their own popup.
+    if is_popup_scoped_api_key(token_payload):
+        popups = [p for p in popups if p.id == token_payload.popup_id]
 
     if not accept_language or accept_language == "en":
         return [PopupPublic.model_validate(p) for p in popups]
@@ -440,6 +450,7 @@ async def get_portal_popup(
     slug: str,
     db: HumanTenantSession,
     current_human: CurrentHuman,
+    token_payload: CallerToken,
     accept_language: Annotated[str | None, Header(alias="Accept-Language")] = None,
 ) -> PopupPublic:
     """Get a popup by slug (Portal). Ended popups are served only to participants."""
@@ -452,6 +463,7 @@ async def get_portal_popup(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Event not found",
         )
+    ensure_api_key_popup(token_payload, popup.id)
 
     if popup.status == PopupStatus.ended:
         access = applications_crud.resolve_popup_access(db, current_human.id, popup.id)

--- a/backend/app/api/track/router.py
+++ b/backend/app/api/track/router.py
@@ -3,6 +3,7 @@ import uuid
 from fastapi import APIRouter, HTTPException, status
 
 from app.api.event.schemas import EventPublic
+from app.api.popup.guards import CallerToken, ensure_api_key_popup
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
 from app.api.track import crud
 from app.api.track.schemas import TrackCreate, TrackPublic, TrackUpdate
@@ -170,11 +171,13 @@ async def list_track_events(
 async def list_portal_tracks(
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
     popup_id: uuid.UUID,
     search: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[TrackPublic]:
+    ensure_api_key_popup(token_payload, popup_id)
     tracks, total = crud.tracks_crud.find_by_popup(
         db,
         popup_id=popup_id,
@@ -193,12 +196,14 @@ async def get_portal_track(
     track_id: uuid.UUID,
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
 ) -> TrackPublic:
     track = crud.tracks_crud.get(db, track_id)
     if not track:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Track not found"
         )
+    ensure_api_key_popup(token_payload, track.popup_id)
     return TrackPublic.model_validate(track)
 
 
@@ -210,6 +215,7 @@ async def list_portal_track_events(
     track_id: uuid.UUID,
     db: HumanTenantSession,
     _: CurrentHuman,
+    token_payload: CallerToken,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[EventPublic]:
@@ -221,6 +227,7 @@ async def list_portal_track_events(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Track not found"
         )
+    ensure_api_key_popup(token_payload, track.popup_id)
 
     # Track views are public — hide private events only. Unlisted events are
     # visible in the track view because the track itself acts as a soft share.

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -169,6 +169,11 @@ class TokenPayload(BaseModel):
     # get_admin_or_api_key_tenant_session resolve tenant without going through
     # CurrentUser. NOT serialised into any JWT.
     api_key_tenant_id: uuid.UUID | None = None
+    # Internal — set only by _resolve_api_key for human-owned keys. The popup
+    # the key is bound to; popup-scoped route guards compare it against the
+    # popup targeted by each request. None for JWT and admin-key paths.
+    # NOT serialised into any JWT.
+    popup_id: uuid.UUID | None = None
     # Identifies which ThirdPartyApps row minted this JWT. Drives per-app scope
     # enforcement at api-key minting and self-discovery.
     # None for portal JWTs and for legacy v1 third-party JWTs in flight at
@@ -413,6 +418,9 @@ def _resolve_api_key(token: str) -> TokenPayload:
                 api_key_id=str(row.id),
                 scopes=row.scopes,  # type: ignore[arg-type]
                 via_api_key=True,
+                # Popup binding — enforced per-route by ensure_api_key_popup.
+                # Legacy rows without one fail closed there.
+                popup_id=row.popup_id,
             )
 
         # Admin-owned key (user_id is set).

--- a/backend/tests/api/api_key/test_create_per_app_scopes.py
+++ b/backend/tests/api/api_key/test_create_per_app_scopes.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.api.human.models import Humans
+from app.api.popup.models import Popups
 from app.api.tenant.models import Tenants
 
 CREATE_URL = "/api/v1/api-keys"
@@ -31,6 +32,34 @@ def _make_human(db: Session, *, tenant: Tenants, email: str) -> Humans:
     db.commit()
     db.refresh(h)
     return h
+
+
+def _member_popup(db: Session, *, tenant: Tenants, human: Humans) -> Popups:
+    """Popup with an accepted application for ``human``.
+
+    API keys are popup-bound and require popup membership at creation.
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+
+    popup = Popups(
+        name=f"AK Popup {uuid.uuid4().hex[:6]}",
+        slug=f"ak-{uuid.uuid4().hex[:10]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    db.add(
+        Applications(
+            tenant_id=tenant.id,
+            popup_id=popup.id,
+            human_id=human.id,
+            status=ApplicationStatus.ACCEPTED.value,
+        )
+    )
+    db.commit()
+    return popup
 
 
 def _expiry() -> str:
@@ -67,6 +96,7 @@ class TestPerAppScopeSubset:
 
         email = f"pa-api-ok-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant_a, email=email)
+        popup = _member_popup(db, tenant=tenant_a, human=human)
 
         token = create_access_token(
             subject=human.id,
@@ -78,7 +108,11 @@ class TestPerAppScopeSubset:
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "my-events-key", "scopes": ["events:read"]},
+            json={
+                "name": "my-events-key",
+                "scopes": ["events:read"],
+                "popup_id": str(popup.id),
+            },
         )
         assert resp.status_code == 201, resp.text
 
@@ -127,6 +161,8 @@ class TestPerAppScopeSubset:
                 "name": "rsvp-key",
                 "scopes": ["rsvp:write"],
                 "expires_at": _expiry(),
+                # Scope check fires before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
             },
         )
         assert resp.status_code == 403, resp.text
@@ -181,7 +217,12 @@ class TestPerAppScopeSubset:
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "post-revoke-key", "scopes": ["events:read"]},
+            json={
+                "name": "post-revoke-key",
+                "scopes": ["events:read"],
+                # App revocation check fires before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
+            },
         )
         assert resp.status_code == 401, resp.text
 
@@ -205,6 +246,7 @@ class TestLegacyJwtFallback:
         tenant, _app, _raw = third_party_enabled_tenant
         email = f"legacy-ok-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant, email=email)
+        popup = _member_popup(db, tenant=tenant, human=human)
 
         # Legacy token: issued_via=third_party but NO issued_by_app_id
         token = create_access_token(
@@ -216,7 +258,11 @@ class TestLegacyJwtFallback:
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "legacy-events-key", "scopes": ["events:read"]},
+            json={
+                "name": "legacy-events-key",
+                "scopes": ["events:read"],
+                "popup_id": str(popup.id),
+            },
         )
         assert resp.status_code == 201, resp.text
 
@@ -232,6 +278,7 @@ class TestLegacyJwtFallback:
         tenant, _app, _raw = third_party_enabled_tenant
         email = f"legacy-rsvp-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant, email=email)
+        popup = _member_popup(db, tenant=tenant, human=human)
 
         token = create_access_token(
             subject=human.id,
@@ -246,6 +293,7 @@ class TestLegacyJwtFallback:
                 "name": "legacy-rsvp-key",
                 "scopes": ["rsvp:write"],
                 "expires_at": _expiry(),
+                "popup_id": str(popup.id),
             },
         )
         assert resp.status_code == 201, resp.text
@@ -276,6 +324,8 @@ class TestLegacyJwtFallback:
                 "name": "legacy-venues-key",
                 "scopes": ["venues:write"],
                 "expires_at": _expiry(),
+                # Scope check fires before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
             },
         )
         assert resp.status_code == 403, resp.text

--- a/backend/tests/api/api_key/test_third_party_scope_restriction.py
+++ b/backend/tests/api/api_key/test_third_party_scope_restriction.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.api.human.models import Humans
+from app.api.popup.models import Popups
 from app.api.tenant.models import Tenants
 
 CREATE_URL = "/api/v1/api-keys"
@@ -32,6 +33,34 @@ def _make_human(db: Session, *, tenant: Tenants, email: str) -> Humans:
     return h
 
 
+def _member_popup(db: Session, *, tenant: Tenants, human: Humans) -> Popups:
+    """Popup with an accepted application for ``human``.
+
+    API keys are popup-bound and require popup membership at creation.
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+
+    popup = Popups(
+        name=f"AK Popup {uuid.uuid4().hex[:6]}",
+        slug=f"ak-{uuid.uuid4().hex[:10]}",
+        tenant_id=tenant.id,
+    )
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    db.add(
+        Applications(
+            tenant_id=tenant.id,
+            popup_id=popup.id,
+            human_id=human.id,
+            status=ApplicationStatus.ACCEPTED.value,
+        )
+    )
+    db.commit()
+    return popup
+
+
 class TestThirdPartyJwtApiKeyMintingRestriction:
     """REQ-AK-04."""
 
@@ -46,12 +75,17 @@ class TestThirdPartyJwtApiKeyMintingRestriction:
         tenant, _app, _raw = third_party_enabled_tenant
         email = f"tp-mint-ok-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant, email=email)
+        popup = _member_popup(db, tenant=tenant, human=human)
         token = third_party_jwt_factory(human=human)
 
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "tp-events", "scopes": ["events:read"]},
+            json={
+                "name": "tp-events",
+                "scopes": ["events:read"],
+                "popup_id": str(popup.id),
+            },
         )
         assert resp.status_code == 201, resp.text
 
@@ -82,6 +116,8 @@ class TestThirdPartyJwtApiKeyMintingRestriction:
                 "name": "tp-venues",
                 "scopes": ["venues:write"],
                 "expires_at": expiry,
+                # Scope check fires before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
             },
         )
         assert resp.status_code == 403, resp.text
@@ -113,6 +149,8 @@ class TestThirdPartyJwtApiKeyMintingRestriction:
                 "name": "tp-mixed",
                 "scopes": ["rsvp:write", "venues:write"],
                 "expires_at": expiry,
+                # Scope check fires before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
             },
         )
         assert resp.status_code == 403, resp.text
@@ -133,12 +171,17 @@ class TestPortalJwtApiKeyMintingUnchanged:
         tenant, _app, _raw = third_party_enabled_tenant
         email = f"portal-mint-ok-{uuid.uuid4().hex[:8]}@example.com"
         human = _make_human(db, tenant=tenant, email=email)
+        popup = _member_popup(db, tenant=tenant, human=human)
         # Mint a legacy-style portal JWT (no scopes, no issued_via)
         token = create_access_token(subject=human.id, token_type="human")
 
         resp = client.post(
             CREATE_URL,
             headers=_bearer(token),
-            json={"name": "portal-events", "scopes": ["events:read"]},
+            json={
+                "name": "portal-events",
+                "scopes": ["events:read"],
+                "popup_id": str(popup.id),
+            },
         )
         assert resp.status_code == 201, resp.text

--- a/backend/tests/test_api_key_policy.py
+++ b/backend/tests/test_api_key_policy.py
@@ -133,6 +133,7 @@ def _make_pat(
     db: Session,
     tenant: Tenants,
     human: Humans,
+    popup: Popups,
     *,
     scopes: list[str] | None = None,
 ) -> str:
@@ -140,11 +141,34 @@ def _make_pat(
         db,
         tenant_id=tenant.id,
         human_id=human.id,
+        popup_id=popup.id,
         name="test pat",
         expires_at=None,
         scopes=scopes or ["events:read"],
     )
     return raw
+
+
+def _accept_application(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> None:
+    """Seed an accepted application so the human is a member of the popup.
+
+    API key creation requires popup membership (accepted application,
+    attendee ticket, payment, or companion access).
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+
+    db.add(
+        Applications(
+            tenant_id=tenant.id,
+            popup_id=popup.id,
+            human_id=human.id,
+            status=ApplicationStatus.ACCEPTED.value,
+        )
+    )
+    db.commit()
 
 
 def _event_payload(popup: Popups) -> dict[str, str]:
@@ -168,8 +192,9 @@ class TestApiKeyPolicy:
         db: Session,
         tenant_a: Tenants,
     ) -> None:
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.get(
             "/api/v1/events/portal/events",
@@ -184,8 +209,9 @@ class TestApiKeyPolicy:
         db: Session,
         tenant_a: Tenants,
     ) -> None:
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.get(
             "/api/v1/applications/my/applications",
@@ -209,6 +235,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             human,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -243,6 +270,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             human,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -273,7 +301,7 @@ class TestApiKeyPolicy:
         popup = _make_popup(db, tenant_a)
         _set_event_settings(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.post(
             "/api/v1/events/portal/events",
@@ -308,7 +336,7 @@ class TestApiKeyPolicy:
 
         human = _make_human(db, tenant_a)
         _give_ticket(db, tenant_a, popup, human)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["rsvp:write"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["rsvp:write"])
 
         resp = client.post(
             f"/api/v1/event-participants/portal/register/{event.id}",
@@ -335,7 +363,12 @@ class TestApiKeyPolicy:
         resp = client.post(
             "/api/v1/api-keys",
             headers={"Authorization": f"Bearer {token}"},
-            json={"name": "blocked", "scopes": ["events:read"]},
+            json={
+                "name": "blocked",
+                "scopes": ["events:read"],
+                # The red-flag guard fires before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
+            },
         )
 
         assert resp.status_code == 403, resp.text
@@ -352,13 +385,19 @@ class TestApiKeyPolicy:
         from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
         from app.core.security import create_access_token
 
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
+        _accept_application(db, tenant_a, popup, human)
         token = create_access_token(subject=human.id, token_type="human")
 
         resp = client.post(
             "/api/v1/api-keys",
             headers={"Authorization": f"Bearer {token}"},
-            json={"name": "writer", "scopes": ["events:read", "events:write"]},
+            json={
+                "name": "writer",
+                "scopes": ["events:read", "events:write"],
+                "popup_id": str(popup.id),
+            },
         )
 
         assert resp.status_code == 201, resp.text
@@ -394,6 +433,8 @@ class TestApiKeyPolicy:
                 "name": "writer",
                 "scopes": ["events:read", "events:write"],
                 "expires_at": expires_at,
+                # Validation fails before the popup is resolved.
+                "popup_id": str(uuid.uuid4()),
             },
         )
 
@@ -406,8 +447,9 @@ class TestApiKeyPolicy:
         tenant_a: Tenants,
         admin_token_tenant_a: str,
     ) -> None:
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.post(
             f"/api/v1/humans/{human.id}/api-keys/revoke",
@@ -434,12 +476,14 @@ class TestApiKeyPolicy:
         tenant_a: Tenants,
         admin_token_tenant_a: str,
     ) -> None:
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
-        _make_pat(db, tenant_a, human, scopes=["events:read"])
+        _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
         _make_pat(
             db,
             tenant_a,
             human,
+            popup,
             scopes=["events:read", "rsvp:write"],
         )
 
@@ -481,6 +525,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             human,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -526,6 +571,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             attacker,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -561,7 +607,7 @@ class TestApiKeyPolicy:
         db.commit()
         db.refresh(event)
 
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.patch(
             f"/api/v1/events/portal/events/{event.id}",
@@ -599,6 +645,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             human,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -643,6 +690,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             owner,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -689,7 +737,7 @@ class TestApiKeyPolicy:
         db.commit()
         db.refresh(event)
 
-        raw_key = _make_pat(db, tenant_a, owner, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, owner, popup, scopes=["events:read"])
 
         resp = client.get(
             f"/api/v1/events/portal/events/{event.id}/invitations",
@@ -739,6 +787,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             owner,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -795,6 +844,7 @@ class TestApiKeyPolicy:
             db,
             tenant_a,
             attacker,
+            popup,
             scopes=["events:read", "events:write"],
         )
 
@@ -826,8 +876,9 @@ class TestApiKeyPolicy:
         tenant_a: Tenants,
         admin_token_tenant_a: str,
     ) -> None:
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.patch(
             f"/api/v1/humans/{human.id}",

--- a/backend/tests/test_portal_venue_crud.py
+++ b/backend/tests/test_portal_venue_crud.py
@@ -94,6 +94,7 @@ def _make_pat(
     db: Session,
     tenant: Tenants,
     human: Humans,
+    popup: Popups,
     *,
     scopes: list[str] | None = None,
     expires_at: datetime | None = None,
@@ -102,11 +103,33 @@ def _make_pat(
         db,
         tenant_id=tenant.id,
         human_id=human.id,
+        popup_id=popup.id,
         name=f"venue test pat {uuid.uuid4().hex[:4]}",
         expires_at=expires_at,
         scopes=scopes or ["events:read"],
     )
     return raw
+
+
+def _accept_application(
+    db: Session, tenant: Tenants, popup: Popups, human: Humans
+) -> None:
+    """Seed an accepted application so the human is a member of the popup.
+
+    API key creation requires popup membership.
+    """
+    from app.api.application.models import Applications
+    from app.api.application.schemas import ApplicationStatus
+
+    db.add(
+        Applications(
+            tenant_id=tenant.id,
+            popup_id=popup.id,
+            human_id=human.id,
+            status=ApplicationStatus.ACCEPTED.value,
+        )
+    )
+    db.commit()
 
 
 def _make_venue(
@@ -213,7 +236,7 @@ class TestPortalVenueCrudPat:
         popup = _make_popup(db, tenant_a)
         owner = _make_human(db, tenant_a)
         venue = _make_venue(db, tenant_a, popup, owner)
-        raw_key = _make_pat(db, tenant_a, owner, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, owner, popup, scopes=["events:read"])
 
         resp = client.delete(
             f"/api/v1/event-venues/portal/venues/{venue.id}",
@@ -238,6 +261,7 @@ class TestPortalVenueCrudPat:
             db,
             tenant_a,
             other,
+            popup,
             scopes=["events:read", "venues:write"],
             expires_at=datetime.now(UTC) + timedelta(days=7),
         )
@@ -264,6 +288,7 @@ class TestPortalVenueCrudPat:
             db,
             tenant_a,
             owner,
+            popup,
             scopes=["events:read", "venues:write"],
             expires_at=datetime.now(UTC) + timedelta(days=7),
         )
@@ -360,6 +385,7 @@ class TestPortalVenueCrudPat:
             db,
             tenant_a,
             owner,
+            popup,
             scopes=["events:read", "venues:write"],
             expires_at=datetime.now(UTC) + timedelta(days=7),
         )
@@ -415,6 +441,7 @@ class TestPortalVenueCrudPat:
             db,
             tenant_a,
             human,
+            popup,
             scopes=["events:read", "venues:write"],
             expires_at=datetime.now(UTC) + timedelta(days=7),
         )
@@ -439,7 +466,7 @@ class TestPortalVenueCrudPat:
         popup = _make_popup(db, tenant_a)
         _set_event_settings(db, tenant_a, popup)
         human = _make_human(db, tenant_a)
-        raw_key = _make_pat(db, tenant_a, human, scopes=["events:read"])
+        raw_key = _make_pat(db, tenant_a, human, popup, scopes=["events:read"])
 
         resp = client.post(
             "/api/v1/event-venues/portal/venues",
@@ -463,6 +490,7 @@ class TestPortalVenueCrudPat:
             db,
             tenant_a,
             owner,
+            popup,
             scopes=["events:read", "venues:write"],
             expires_at=datetime.now(UTC) + timedelta(days=7),
         )
@@ -491,6 +519,7 @@ class TestPortalVenueCrudPat:
             db,
             tenant_a,
             other,
+            popup,
             scopes=["events:read", "venues:write"],
             expires_at=datetime.now(UTC) + timedelta(days=7),
         )
@@ -513,13 +542,19 @@ class TestPortalVenueCrudPat:
         from app.api.api_key.schemas import MAX_WRITE_SCOPE_LIFETIME_DAYS
         from app.core.security import create_access_token
 
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
+        _accept_application(db, tenant_a, popup, human)
         token = create_access_token(subject=human.id, token_type="human")
 
         resp = client.post(
             "/api/v1/api-keys",
             headers={"Authorization": f"Bearer {token}"},
-            json={"name": "venue writer", "scopes": ["venues:write"]},
+            json={
+                "name": "venue writer",
+                "scopes": ["venues:write"],
+                "popup_id": str(popup.id),
+            },
         )
 
         assert resp.status_code == 201, resp.text
@@ -537,7 +572,9 @@ class TestPortalVenueCrudPat:
     ) -> None:
         from app.core.security import create_access_token
 
+        popup = _make_popup(db, tenant_a)
         human = _make_human(db, tenant_a)
+        _accept_application(db, tenant_a, popup, human)
         token = create_access_token(subject=human.id, token_type="human")
 
         resp = client.post(
@@ -547,6 +584,7 @@ class TestPortalVenueCrudPat:
                 "name": "venue writer",
                 "scopes": ["events:read", "venues:write"],
                 "expires_at": _future_expiry(),
+                "popup_id": str(popup.id),
             },
         )
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -305,6 +305,11 @@ export const ApiKeyCreateSchema = {
             minLength: 1,
             title: 'Name'
         },
+        popup_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Popup Id'
+        },
         expires_at: {
             anyOf: [
                 {
@@ -327,7 +332,7 @@ export const ApiKeyCreateSchema = {
         }
     },
     type: 'object',
-    required: ['name'],
+    required: ['name', 'popup_id'],
     title: 'ApiKeyCreate',
     description: 'Request body for creating a new API key.'
 } as const;
@@ -346,6 +351,18 @@ export const ApiKeyCreatedSchema = {
         prefix: {
             type: 'string',
             title: 'Prefix'
+        },
+        popup_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Popup Id'
         },
         scopes: {
             items: {
@@ -422,6 +439,18 @@ export const ApiKeyPublicSchema = {
         prefix: {
             type: 'string',
             title: 'Prefix'
+        },
+        popup_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Popup Id'
         },
         scopes: {
             items: {

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -79,6 +79,7 @@ export type AITranslateRequest = {
  */
 export type ApiKeyCreate = {
     name: string;
+    popup_id: string;
     expires_at?: (string | null);
     scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:read' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
 };
@@ -91,6 +92,7 @@ export type ApiKeyCreated = {
     id: string;
     name: string;
     prefix: string;
+    popup_id?: (string | null);
     scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:read' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
@@ -106,6 +108,7 @@ export type ApiKeyPublic = {
     id: string;
     name: string;
     prefix: string;
+    popup_id?: (string | null);
     scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:read' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);

--- a/portal/src/app/portal/agentic-access/page.tsx
+++ b/portal/src/app/portal/agentic-access/page.tsx
@@ -28,6 +28,7 @@ import type {
   ApiKeyPublic,
   ApiKeyScope,
 } from "@/lib/apiKeysService"
+import { useCityProvider } from "@/providers/cityProvider"
 import { CopyAgentBrief } from "./CopyAgentBrief"
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? ""
@@ -116,6 +117,14 @@ export default function AgenticAccessPage() {
 
 function ApiKeysSection() {
   const { t } = useTranslation()
+  const { getCity } = useCityProvider()
+  const city = getCity()
+  // Keys are bound to the current popup. When it has ended (recap mode)
+  // the backend rejects write scopes, so the dialog only offers read access.
+  const isPopupEnded = city?.status === "ended"
+  const scopeOptions = isPopupEnded
+    ? SCOPE_OPTIONS.filter((scope) => !scope.value.endsWith(":write"))
+    : SCOPE_OPTIONS
   const {
     keys,
     isLoading,
@@ -148,14 +157,19 @@ function ApiKeysSection() {
 
   const onCreate = async () => {
     const name = newKeyName.trim()
-    if (!name) return
+    const popupId = city?.id
+    if (!name || !popupId) return
     try {
       // The backend owns the write-scope lifetime: send ``expires_at: null``
       // and let it fill in the policy default. The created key returned in
       // the response already carries the final ``expires_at`` for display.
       const created = await createKey({
         name,
-        scopes: selectedScopes,
+        // Keys are attendee keys: they only work for the current popup.
+        popup_id: popupId,
+        scopes: isPopupEnded
+          ? selectedScopes.filter((scope) => !scope.endsWith(":write"))
+          : selectedScopes,
         expires_at: null,
       })
       setCreatedKey(created)
@@ -360,12 +374,20 @@ function ApiKeysSection() {
                     "New keys start with read-only access. Only enable broader permissions when you really need them.",
                 })}
               </p>
+              {isPopupEnded && (
+                <p className="flex items-center gap-1.5 text-xs font-medium text-amber-700">
+                  <Info className="size-3.5 shrink-0" />
+                  {t("api_keys.ended_read_only_note", {
+                    defaultValue:
+                      "This popup has ended, so new API keys can only have read access.",
+                  })}
+                </p>
+              )}
             </div>
             <div className="space-y-3 rounded-md border p-3">
-              {SCOPE_OPTIONS.map((scope) => {
+              {scopeOptions.map((scope) => {
                 const checked = selectedScopes.includes(scope.value)
                 const checkboxId = `scope-${scope.value}`
-                const isComingSoon = scope.value === "events:write"
                 return (
                   <div key={scope.value} className="flex items-start gap-3">
                     <Checkbox
@@ -393,14 +415,6 @@ function ApiKeysSection() {
                           },
                         )}
                       </p>
-                      {isComingSoon && (
-                        <p className="flex items-center gap-1.5 text-xs font-medium text-green-900">
-                          <Info className="size-3.5 shrink-0" />
-                          {t("api_keys.scope.events_write.coming_soon", {
-                            defaultValue: "Coming to the village in week 2",
-                          })}
-                        </p>
-                      )}
                     </div>
                   </div>
                 )
@@ -414,7 +428,10 @@ function ApiKeysSection() {
             <Button
               onClick={onCreate}
               disabled={
-                !newKeyName.trim() || isCreating || selectedScopes.length === 0
+                !newKeyName.trim() ||
+                !city ||
+                isCreating ||
+                selectedScopes.length === 0
               }
             >
               {isCreating && <Loader2 className="size-4 animate-spin mr-1" />}

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -305,6 +305,11 @@ export const ApiKeyCreateSchema = {
             minLength: 1,
             title: 'Name'
         },
+        popup_id: {
+            type: 'string',
+            format: 'uuid',
+            title: 'Popup Id'
+        },
         expires_at: {
             anyOf: [
                 {
@@ -327,7 +332,7 @@ export const ApiKeyCreateSchema = {
         }
     },
     type: 'object',
-    required: ['name'],
+    required: ['name', 'popup_id'],
     title: 'ApiKeyCreate',
     description: 'Request body for creating a new API key.'
 } as const;
@@ -346,6 +351,18 @@ export const ApiKeyCreatedSchema = {
         prefix: {
             type: 'string',
             title: 'Prefix'
+        },
+        popup_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Popup Id'
         },
         scopes: {
             items: {
@@ -422,6 +439,18 @@ export const ApiKeyPublicSchema = {
         prefix: {
             type: 'string',
             title: 'Prefix'
+        },
+        popup_id: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'uuid'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Popup Id'
         },
         scopes: {
             items: {

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -79,6 +79,7 @@ export type AITranslateRequest = {
  */
 export type ApiKeyCreate = {
     name: string;
+    popup_id: string;
     expires_at?: (string | null);
     scopes?: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:read' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
 };
@@ -91,6 +92,7 @@ export type ApiKeyCreated = {
     id: string;
     name: string;
     prefix: string;
+    popup_id?: (string | null);
     scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:read' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);
@@ -106,6 +108,7 @@ export type ApiKeyPublic = {
     id: string;
     name: string;
     prefix: string;
+    popup_id?: (string | null);
     scopes: Array<('events:read' | 'events:write' | 'rsvp:write' | 'venues:read' | 'venues:write' | 'applications:read' | 'applications:write' | 'attendees:read' | 'attendees:write' | 'humans:read' | 'humans:write' | 'groups:read' | 'groups:write' | 'products:read' | 'products:write' | 'coupons:read' | 'coupons:write' | 'forms:read' | 'forms:write' | 'payments:read' | 'tracks:read' | 'tracks:write' | 'ticketing_steps:read' | 'ticketing_steps:write' | 'translations:read' | 'translations:write')>;
     created_at: string;
     last_used_at?: (string | null);

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -489,6 +489,7 @@
     "revoke_failed": "Failed to revoke API key",
     "scopes_label": "Permissions",
     "scopes_description": "New keys start with read-only access. Only enable broader permissions when you really need them.",
+    "ended_read_only_note": "This popup has ended, so new API keys can only have read access.",
     "scope": {
       "events_read": {
         "label": "Read events",
@@ -501,6 +502,10 @@
       "rsvp_write": {
         "label": "RSVP to events",
         "description": "Register or cancel attendance for events."
+      },
+      "venues_write": {
+        "label": "Manage own venues",
+        "description": "Create, edit, and delete venues you own."
       }
     }
   },

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -487,6 +487,7 @@
     "revoke_failed": "Error al revocar la API key",
     "scopes_label": "Permisos",
     "scopes_description": "Las keys nuevas arrancan solo con acceso de lectura. Activá permisos más amplios solo cuando realmente los necesites.",
+    "ended_read_only_note": "Este popup ha finalizado, por lo que las nuevas API keys solo pueden tener acceso de lectura.",
     "scope": {
       "events_read": {
         "label": "Leer eventos",
@@ -499,6 +500,10 @@
       "rsvp_write": {
         "label": "Registrarse a eventos",
         "description": "Registrar o cancelar la asistencia a eventos."
+      },
+      "venues_write": {
+        "label": "Gestionar tus venues",
+        "description": "Crear, editar y eliminar los venues que te pertenecen."
       }
     }
   },

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -458,6 +458,7 @@
     "revoke_failed": "Mistókst að afturkalla API lykil",
     "scopes_label": "Heimildir",
     "scopes_description": "Nýir lyklar byrja með lesaðgangi eingöngu. Aðeins veita víðtækari heimildir þegar þú þarft þess.",
+    "ended_read_only_note": "Þessum popup viðburði er lokið og því geta nýir API lyklar aðeins haft lesaðgang.",
     "scope": {
       "events_read": {
         "label": "Lesa viðburði",
@@ -470,6 +471,10 @@
       "rsvp_write": {
         "label": "RSVP á viðburði",
         "description": "Skrá eða afturkalla mætingu á viðburði."
+      },
+      "venues_write": {
+        "label": "Sýsla með eigin staði",
+        "description": "Búa til, breyta og eyða stöðum sem þú átt."
       }
     }
   },

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -468,6 +468,7 @@
     "revoke_failed": "撤销 API 密钥失败",
     "scopes_label": "权限",
     "scopes_description": "新密钥默认仅有只读权限。仅在确有需要时才开启更多权限。",
+    "ended_read_only_note": "此 pop-up 已结束，因此新的 API 密钥仅能拥有只读权限。",
     "scope": {
       "events_read": {
         "label": "读取活动",
@@ -480,6 +481,10 @@
       "rsvp_write": {
         "label": "报名活动",
         "description": "为活动报名或取消报名。"
+      },
+      "venues_write": {
+        "label": "管理自己的场地",
+        "description": "创建、编辑和删除你拥有的场地。"
       }
     }
   },


### PR DESCRIPTION
## Summary

- Human-owned API keys (agentic access) are now popup-scoped: each key is bound to the popup it was requested from and acts as an attendee credential (`human_id` + `popup_id`).
- Creating a key requires an accepted application (or accepted companion) in that popup. Keys for ended popups can only carry read scopes, so a finished popup stays query-only through the API as well.
- Every PAT-reachable portal route now verifies the request targets the key's popup, closing cross-popup reads inside the same tenant (events and participants of popups the human never applied to were readable before).

## Behavior

| Surface | Before | After |
|---------|--------|-------|
| Key creation | Any logged-in human, tenant-wide key | Requires accepted application in the popup; key bound to it |
| Key creation on ended popup | Same as active | Read scopes only, write scopes rejected |
| Events / venues / participants / tracks / settings / popups routes (PAT) | Tenant-wide access | 403 outside the key's popup; unscoped list calls are forced to the key's popup |
| Existing keys | Tenant-wide | Revoked by migration (unsafe by design; users re-create from the portal) |

## Changes Made

- `api_keys.popup_id` column (FK + index) via migration `d4f7b2a9c1e6`, which also revokes all pre-existing human-owned keys. Admin keys (`user_id`) are untouched.
- Creation gate in `api_key/router.py`: popup membership check + read-only scopes on ended popups.
- `TokenPayload` carries the key's popup; new `ensure_api_key_popup` guard applied across the PAT route surface (`event`, `event_participant`, `event_venue`, `event_settings`, `track`, `popup` routers).
- Portal: create dialog sends `popup_id`, hides write scopes on ended popups with a read-only note (i18n en/es/zh/is).
- OpenAPI clients regenerated for portal and backoffice.

## Testing

- [x] Targeted backend tests pass (`tests/test_api_key_policy.py`, `tests/api/api_key/`, `tests/test_portal_venue_crud.py`)
- [x] Backend linting passes (`ruff check` + `ruff format --check`)
- [x] Portal and backoffice build successfully
- [x] OpenAPI client regenerated (`bash scripts/generate-client.sh`)
- [x] Database migration included, single alembic head verified