### PR TITLE
feat(portal): forward locale to SimpleFi checkout redirects

### DIFF
--- a/portal/src/app/checkout/[popupSlug]/hooks/useOpenTicketingPurchase.ts
+++ b/portal/src/app/checkout/[popupSlug]/hooks/useOpenTicketingPurchase.ts
@@ -1,10 +1,13 @@
 "use client"
 
 import { useMutation } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
 import { CheckoutService, type OpenTicketingPurchaseCreate } from "@/client"
+import { withCheckoutLocale } from "@/helpers/checkout"
 import { getMetaAttribution } from "@/lib/meta-pixel"
 
 export function useOpenTicketingPurchase(slug: string) {
+  const { i18n } = useTranslation()
   return useMutation({
     mutationFn: (requestBody: OpenTicketingPurchaseCreate) =>
       CheckoutService.purchaseOpenTicketing({
@@ -15,7 +18,10 @@ export function useOpenTicketingPurchase(slug: string) {
         },
       }),
     onSuccess: (response) => {
-      window.location.href = response.checkout_url
+      window.location.href = withCheckoutLocale(
+        response.checkout_url,
+        i18n.language,
+      )
     },
   })
 }

--- a/portal/src/app/portal/[popupSlug]/application/hooks/use-submit-application.ts
+++ b/portal/src/app/portal/[popupSlug]/application/hooks/use-submit-application.ts
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import type { ApplicationPublic, PopupPublic } from "@/client"
 import { ApplicationsService } from "@/client"
+import { withCheckoutLocale } from "@/helpers/checkout"
 import { useApplicationFee } from "@/hooks/useApplicationFee"
 import { splitForCreate, splitForUpdate } from "@/lib/form-data-splitter"
 import { queryKeys } from "@/lib/query-keys"
@@ -58,7 +59,7 @@ export function useSubmitApplication({
   application,
   validate,
 }: UseSubmitApplicationArgs) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const router = useRouter()
   const queryClient = useQueryClient()
   const { updateApplication } = useApplication()
@@ -133,7 +134,10 @@ export function useSubmitApplication({
           throw new Error(t("application.fee.missing_checkout_url"))
         }
 
-        window.location.href = feePayment.checkoutUrl
+        window.location.href = withCheckoutLocale(
+          feePayment.checkoutUrl,
+          i18n.language,
+        )
         return
       }
 

--- a/portal/src/helpers/checkout.ts
+++ b/portal/src/helpers/checkout.ts
@@ -1,0 +1,15 @@
+/** SimpleFi's checkout page localizes from a "locale" query param ("lang" is
+ * an EdgeOS-internal entry param it ignores), so every portal redirect to a
+ * checkout URL forwards the buyer's current language through it. */
+export function withCheckoutLocale(
+  checkoutUrl: string,
+  locale: string,
+): string {
+  try {
+    const url = new URL(checkoutUrl)
+    url.searchParams.set("locale", locale)
+    return url.toString()
+  } catch {
+    return checkoutUrl
+  }
+}

--- a/portal/src/hooks/checkout/usePaymentSubmit.ts
+++ b/portal/src/hooks/checkout/usePaymentSubmit.ts
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import type { CheckoutMode } from "@/checkout/popupCheckoutPolicy"
 import { ApiError, CheckoutService, PaymentsService } from "@/client"
+import { withCheckoutLocale } from "@/helpers/checkout"
 import { getAttribution } from "@/lib/attribution"
 import { trackGAPurchase } from "@/lib/google-analytics"
 import { getMetaAttribution, trackMetaPurchase } from "@/lib/meta-pixel"
@@ -262,7 +263,10 @@ export function usePaymentSubmit({
       }
 
       if (data.status === "pending" && data.checkout_url) {
-        window.location.href = data.checkout_url
+        window.location.href = withCheckoutLocale(
+          data.checkout_url,
+          i18n.language,
+        )
         return { success: true }
       }
 


### PR DESCRIPTION
## Summary

- SimpleFi localizes its checkout page from a `locale` query param, but the portal navigated to `checkout_url` verbatim, so the checkout always rendered without a language hint.
- Adds a `withCheckoutLocale` helper that appends `locale=<current i18n language>` to the checkout URL and applies it to every portal redirect to SimpleFi.
- Backend contracts are untouched: success/thank-you URLs keep their internal `lang` param.

## Changes

| File | Change |
|------|--------|
| `portal/src/helpers/checkout.ts` | New `withCheckoutLocale(url, locale)` helper (safe no-op on malformed URLs) |
| `portal/src/hooks/checkout/usePaymentSubmit.ts` | Pass purchase and open-ticketing redirect now carries `locale` |
| `portal/src/app/checkout/[popupSlug]/hooks/useOpenTicketingPurchase.ts` | Open checkout redirect now carries `locale` |
| `portal/src/app/portal/[popupSlug]/application/hooks/use-submit-application.ts` | Application fee redirect now carries `locale` |

## Test plan

- [x] `pnpm --filter portal run lint` (Biome) passes
- [x] `pnpm --filter portal run build` (TypeScript + Next.js) passes