### PR TITLE
feat(i18n): translate the full portal checkout dynamically

### DIFF
--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -23,6 +23,12 @@ from app.api.product.models import Products
 from app.api.shared.enums import SaleType
 from app.api.ticketing_step.models import TicketingSteps
 from app.api.ticketing_step.schemas import TicketingStepPublic
+from app.api.translation.service import (
+    TRANSLATABLE_FIELDS,
+    apply_translation_overlay,
+    get_translations_bulk,
+    get_translations_for_entity,
+)
 
 
 def resolve_active_direct_popup_slug(db: Session, tenant_id: uuid.UUID) -> str | None:
@@ -88,9 +94,15 @@ def get_open_ticketing_popup(
 
 
 def runtime_for_slug(
-    session: Session, slug: str, tenant_id: uuid.UUID
+    session: Session, slug: str, tenant_id: uuid.UUID, lang: str | None = None
 ) -> CheckoutRuntimeResponse:
-    """Load the public runtime data for an open-ticketing checkout page."""
+    """Load the public runtime data for an open-ticketing checkout page.
+
+    When ``lang`` is provided, popup, product, and ticketing-step text is
+    overlaid with the matching translations. The overlay is default-agnostic:
+    if the requested language equals the popup default (no rows exist), the
+    untranslated source is returned unchanged.
+    """
     popup = get_open_ticketing_popup(session, slug, tenant_id)
 
     # Load active products
@@ -127,14 +139,41 @@ def runtime_for_slug(
 
     attendee_categories = attendee_categories_crud.list_by_popup(session, popup.id)
 
+    # Translation overlays. Every branch is a no-op when lang is None or when no
+    # rows match the requested language, so the untranslated source is returned.
+    popup_data = PopupPublic.model_validate(popup).model_dump()
+    product_translations: dict[uuid.UUID, dict] = {}
+    step_translations: dict[uuid.UUID, dict] = {}
+    if lang:
+        popup_data = apply_translation_overlay(
+            popup_data,
+            get_translations_for_entity(session, "popup", popup.id, lang),
+            TRANSLATABLE_FIELDS["popup"],
+        )
+        product_translations = get_translations_bulk(
+            session, "product", [p.id for p in products], lang
+        )
+        step_translations = get_translations_bulk(
+            session, "ticketing_step", [s.id for s in ticketing_steps], lang
+        )
+
+    def _product(p: Products) -> CheckoutRuntimeProduct:
+        data = {**p.model_dump(), "currency": popup.currency}
+        data = apply_translation_overlay(
+            data, product_translations.get(p.id), TRANSLATABLE_FIELDS["product"]
+        )
+        return CheckoutRuntimeProduct.model_validate(data)
+
+    def _step(step: TicketingSteps) -> TicketingStepPublic:
+        data = TicketingStepPublic.model_validate(step).model_dump()
+        data = apply_translation_overlay(
+            data, step_translations.get(step.id), TRANSLATABLE_FIELDS["ticketing_step"]
+        )
+        return TicketingStepPublic.model_validate(data)
+
     return CheckoutRuntimeResponse(
-        popup=PopupPublic.model_validate(popup),
-        products=[
-            CheckoutRuntimeProduct.model_validate(
-                {**p.model_dump(), "currency": popup.currency}
-            )
-            for p in products
-        ],
+        popup=PopupPublic.model_validate(popup_data),
+        products=[_product(p) for p in products],
         buyer_form=[
             CheckoutBuyerSection(
                 id=sec.id,
@@ -149,9 +188,7 @@ def runtime_for_slug(
             )
             for sec in sections
         ],
-        ticketing_steps=[
-            TicketingStepPublic.model_validate(step) for step in ticketing_steps
-        ],
+        ticketing_steps=[_step(step) for step in ticketing_steps],
         attendee_categories=[
             AttendeeCategoryPublic.model_validate(c) for c in attendee_categories
         ],

--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -25,6 +25,7 @@ from app.api.ticketing_step.models import TicketingSteps
 from app.api.ticketing_step.schemas import TicketingStepPublic
 from app.api.translation.service import (
     TRANSLATABLE_FIELDS,
+    apply_ticketing_step_overlay,
     apply_translation_overlay,
     get_translations_bulk,
     get_translations_for_entity,
@@ -166,9 +167,7 @@ def runtime_for_slug(
 
     def _step(step: TicketingSteps) -> TicketingStepPublic:
         data = TicketingStepPublic.model_validate(step).model_dump()
-        data = apply_translation_overlay(
-            data, step_translations.get(step.id), TRANSLATABLE_FIELDS["ticketing_step"]
-        )
+        data = apply_ticketing_step_overlay(data, step_translations.get(step.id))
         return TicketingStepPublic.model_validate(data)
 
     return CheckoutRuntimeResponse(

--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -7,11 +7,13 @@ Endpoints:
 """
 
 import uuid
+from typing import Annotated
 
 from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    Header,
     HTTPException,
     Query,
     Request,
@@ -39,6 +41,7 @@ from app.api.payment.router import (
     _send_payment_confirmed_email,
 )
 from app.api.payment.schemas import PaymentStatus, PendingReleaseResponse
+from app.api.translation.service import parse_accept_language
 from app.core.dependencies.tenants import PublicTenant
 from app.core.dependencies.users import SessionDep
 from app.core.rate_limit import RateLimit
@@ -109,13 +112,14 @@ async def get_runtime(
     slug: str,
     db: SessionDep,
     tenant: PublicTenant,
+    accept_language: Annotated[str | None, Header(alias="Accept-Language")] = None,
 ) -> CheckoutRuntimeResponse:
     """Return popup metadata, products, buyer form, and ticketing steps for anonymous checkout.
 
     Fully public endpoint (no JWT). Only serves sale_type=direct active popups.
     Rate-limited 120/min/IP.
     """
-    return runtime_for_slug(db, slug, tenant.id)
+    return runtime_for_slug(db, slug, tenant.id, parse_accept_language(accept_language))
 
 
 @router.get(

--- a/backend/app/api/popup/router.py
+++ b/backend/app/api/popup/router.py
@@ -38,6 +38,7 @@ from app.api.translation.service import (
     delete_translations_for_entity,
     get_translations_bulk,
     get_translations_for_entity,
+    parse_accept_language,
 )
 from app.core.dependencies.users import (
     CurrentCheckInOperator,
@@ -428,10 +429,10 @@ async def list_portal_popups(
     if is_popup_scoped_api_key(token_payload):
         popups = [p for p in popups if p.id == token_payload.popup_id]
 
-    if not accept_language or accept_language == "en":
+    lang = parse_accept_language(accept_language)
+    if lang is None:
         return [PopupPublic.model_validate(p) for p in popups]
 
-    lang = accept_language.split(",")[0].split("-")[0].strip()
     popup_ids = [p.id for p in popups]
     translations_map = get_translations_bulk(db, "popup", popup_ids, lang)
 
@@ -473,10 +474,10 @@ async def get_portal_popup(
                 detail="Event not found",
             )
 
-    if not accept_language or accept_language == "en":
+    lang = parse_accept_language(accept_language)
+    if lang is None:
         return PopupPublic.model_validate(popup)
 
-    lang = accept_language.split(",")[0].split("-")[0].strip()
     translation = get_translations_for_entity(db, "popup", popup.id, lang)
     data = PopupPublic.model_validate(popup).model_dump()
     data = apply_translation_overlay(data, translation, TRANSLATABLE_FIELDS["popup"])

--- a/backend/app/api/product/router.py
+++ b/backend/app/api/product/router.py
@@ -20,6 +20,7 @@ from app.api.translation.service import (
     apply_translation_overlay,
     delete_translations_for_entity,
     get_translations_bulk,
+    parse_accept_language,
 )
 from app.core.dependencies.users import (
     AdminOrApiKey_ProductsRead,
@@ -416,9 +417,7 @@ async def list_portal_products(
             category=category,
         )
 
-    lang = None
-    if accept_language and accept_language != "en":
-        lang = accept_language.split(",")[0].split("-")[0].strip()
+    lang = parse_accept_language(accept_language)
 
     translations_map: dict[uuid.UUID, Any] = {}
     if lang:

--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -12,8 +12,7 @@ from app.api.ticketing_step.schemas import (
     TicketingStepUpdate,
 )
 from app.api.translation.service import (
-    TRANSLATABLE_FIELDS,
-    apply_translation_overlay,
+    apply_ticketing_step_overlay,
     delete_translations_for_entity,
     get_translations_bulk,
     parse_accept_language,
@@ -49,9 +48,7 @@ async def list_portal_ticketing_steps(
     results = []
     for s in steps:
         data = TicketingStepPublic.model_validate(s).model_dump()
-        data = apply_translation_overlay(
-            data, translations_map.get(s.id), TRANSLATABLE_FIELDS["ticketing_step"]
-        )
+        data = apply_ticketing_step_overlay(data, translations_map.get(s.id))
         results.append(TicketingStepPublic.model_validate(data))
     return ListModel[TicketingStepPublic](
         results=results,

--- a/backend/app/api/ticketing_step/router.py
+++ b/backend/app/api/ticketing_step/router.py
@@ -1,6 +1,7 @@
 import uuid
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Header, HTTPException, status
 
 from app.api.shared.enums import UserRole
 from app.api.shared.response import ListModel, PaginationLimit, PaginationSkip, Paging
@@ -9,6 +10,13 @@ from app.api.ticketing_step.schemas import (
     TicketingStepCreate,
     TicketingStepPublic,
     TicketingStepUpdate,
+)
+from app.api.translation.service import (
+    TRANSLATABLE_FIELDS,
+    apply_translation_overlay,
+    delete_translations_for_entity,
+    get_translations_bulk,
+    parse_accept_language,
 )
 from app.core.dependencies.users import (
     AdminOrApiKey_TicketingStepsRead,
@@ -28,11 +36,25 @@ async def list_portal_ticketing_steps(
     db: HumanTenantSession,
     _: CurrentHuman,
     popup_id: uuid.UUID,
+    accept_language: Annotated[str | None, Header(alias="Accept-Language")] = None,
 ) -> ListModel[TicketingStepPublic]:
     """List enabled ticketing steps for a popup (portal-facing)."""
     steps = crud.ticketing_steps_crud.find_portal_by_popup(db, popup_id=popup_id)
+    lang = parse_accept_language(accept_language)
+    translations_map = (
+        get_translations_bulk(db, "ticketing_step", [s.id for s in steps], lang)
+        if lang
+        else {}
+    )
+    results = []
+    for s in steps:
+        data = TicketingStepPublic.model_validate(s).model_dump()
+        data = apply_translation_overlay(
+            data, translations_map.get(s.id), TRANSLATABLE_FIELDS["ticketing_step"]
+        )
+        results.append(TicketingStepPublic.model_validate(data))
     return ListModel[TicketingStepPublic](
-        results=[TicketingStepPublic.model_validate(s) for s in steps],
+        results=results,
         paging=Paging(offset=0, limit=len(steps), total=len(steps)),
     )
 
@@ -244,4 +266,5 @@ async def delete_ticketing_step(
             detail="Cannot delete a protected step",
         )
 
+    delete_translations_for_entity(db, "ticketing_step", step.id)
     crud.ticketing_steps_crud.delete(db, step)

--- a/backend/app/api/translation/router.py
+++ b/backend/app/api/translation/router.py
@@ -7,7 +7,10 @@ from pydantic import BaseModel
 from app.api.shared.enums import UserRole
 from app.api.translation.crud import translations_crud
 from app.api.translation.schemas import TranslationCreate, TranslationPublic
-from app.api.translation.service import TRANSLATABLE_FIELDS
+from app.api.translation.service import (
+    TRANSLATABLE_FIELDS,
+    extract_translatable_leaves,
+)
 from app.core.dependencies.users import (
     AdminOrApiKey_TranslationsRead,
     AdminOrApiKey_TranslationsWrite,
@@ -91,6 +94,14 @@ async def ai_translate(
         if value and isinstance(value, str):
             source_fields[field] = value
 
+    # Ticketing steps also carry nested template_config copy (section labels,
+    # meal-plan options, insurance card text). Extract those leaves keyed by
+    # path so the AI translates them alongside the flat fields.
+    if request.entity_type == "ticketing_step":
+        source_fields.update(
+            extract_translatable_leaves(getattr(entity, "template_config", None))
+        )
+
     if not source_fields:
         return {}
 
@@ -113,7 +124,8 @@ async def ai_translate(
             detail=f"AI translation failed: {e}",
         )
 
-    return {k: v for k, v in translated.items() if k in translatable}
+    # Return only keys we asked to translate (flat fields + nested leaf paths).
+    return {k: v for k, v in translated.items() if k in source_fields}
 
 
 @router.delete("/{translation_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -142,6 +154,7 @@ def _fetch_entity(db, entity_type: str, entity_id: uuid.UUID):
     from app.api.group.crud import groups_crud
     from app.api.popup.crud import popups_crud
     from app.api.product.crud import products_crud
+    from app.api.ticketing_step.crud import ticketing_steps_crud
 
     cruds = {
         "popup": popups_crud,
@@ -149,6 +162,7 @@ def _fetch_entity(db, entity_type: str, entity_id: uuid.UUID):
         "group": groups_crud,
         "form_field": form_fields_crud,
         "form_section": form_sections_crud,
+        "ticketing_step": ticketing_steps_crud,
     }
     crud = cruds.get(entity_type)
     if not crud:

--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -119,6 +119,10 @@ _TEXT_LEAF_KEYS = frozenset(
         "card_subtitle",
         "toggle_label",
         "footer_text",
+        "question",
+        "answer",
+        "caption",
+        "html",
     }
 )
 _TEXT_LIST_KEYS = frozenset({"benefits"})

--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -10,6 +10,7 @@ TRANSLATABLE_FIELDS: dict[str, list[str]] = {
     "group": ["name", "description", "welcome_message"],
     "form_field": ["label", "placeholder", "help_text", "options"],
     "form_section": ["label", "description"],
+    "ticketing_step": ["title", "description"],
 }
 
 

--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -107,6 +107,52 @@ def deep_merge_translation(source: Any, overlay: Any) -> Any:
     return source
 
 
+# Nested template_config keys whose value is user-visible copy. Kept in sync
+# with the backoffice extractor (components/translations/templateConfigLeaves.ts).
+_TEXT_LEAF_KEYS = frozenset(
+    {
+        "label",
+        "description",
+        "title",
+        "subtitle",
+        "card_title",
+        "card_subtitle",
+        "toggle_label",
+        "footer_text",
+    }
+)
+_TEXT_LIST_KEYS = frozenset({"benefits"})
+
+
+def extract_translatable_leaves(config: Any, prefix: str = "") -> dict[str, str]:
+    """Flatten a nested template_config into path -> source text.
+
+    Mirrors the backoffice leaf extractor: only known text keys are collected,
+    keyed by a dot/index path ("sections.0.label", "insurance.benefits.2"), so
+    the AI translator receives every visible string and nothing structural.
+    """
+    leaves: dict[str, str] = {}
+    if isinstance(config, list):
+        items: Any = enumerate(config)
+    elif isinstance(config, dict):
+        items = config.items()
+    else:
+        return leaves
+
+    for key, value in items:
+        path = f"{prefix}.{key}" if prefix else str(key)
+        if key in _TEXT_LEAF_KEYS and isinstance(value, str):
+            if value.strip():
+                leaves[path] = value
+        elif key in _TEXT_LIST_KEYS and isinstance(value, list):
+            for index, item in enumerate(value):
+                if isinstance(item, str) and item.strip():
+                    leaves[f"{path}.{index}"] = item
+        elif isinstance(value, (dict, list)):
+            leaves.update(extract_translatable_leaves(value, path))
+    return leaves
+
+
 def apply_ticketing_step_overlay(data: dict, translation: dict | None) -> dict:
     """Overlay a ticketing step's translated flat fields and nested config.
 

--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -13,6 +13,21 @@ TRANSLATABLE_FIELDS: dict[str, list[str]] = {
 }
 
 
+def parse_accept_language(accept_language: str | None) -> str | None:
+    """Extract the primary language subtag from an Accept-Language header.
+
+    Returns the base subtag ("es-AR" -> "es") of the first listed language,
+    or None when the header is absent or empty. This is default-agnostic on
+    purpose: it never special-cases English. When the requested language
+    matches the entity's default, the overlay lookup simply finds no rows and
+    the untranslated source is returned.
+    """
+    if not accept_language:
+        return None
+    lang = accept_language.split(",")[0].split("-")[0].strip()
+    return lang or None
+
+
 def get_translations_for_entity(
     session: Session,
     entity_type: str,

--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from sqlmodel import Session, select
 
@@ -76,6 +77,55 @@ def apply_translation_overlay(
     for field in translatable_fields:
         if field in translation:
             result[field] = translation[field]
+    return result
+
+
+def deep_merge_translation(source: Any, overlay: Any) -> Any:
+    """Recursively overlay translated text over a source structure.
+
+    Used for nested config such as a ticketing step's ``template_config``: the
+    translation stores a partial mirror holding only the translated text
+    leaves, and everything it omits (ids, prices, flags, icons) is preserved
+    from the source. Dicts merge key-wise, lists merge element-wise by index,
+    and a non-empty string leaf in the overlay replaces the source value.
+    """
+    if isinstance(source, dict) and isinstance(overlay, dict):
+        merged = dict(source)
+        for key, ov in overlay.items():
+            merged[key] = deep_merge_translation(source.get(key), ov)
+        return merged
+    if isinstance(source, list) and isinstance(overlay, list):
+        merged = list(source)
+        for index, ov in enumerate(overlay):
+            if index < len(merged):
+                merged[index] = deep_merge_translation(merged[index], ov)
+            else:
+                merged.append(ov)
+        return merged
+    if isinstance(overlay, str):
+        return overlay if overlay.strip() else source
+    return source
+
+
+def apply_ticketing_step_overlay(data: dict, translation: dict | None) -> dict:
+    """Overlay a ticketing step's translated flat fields and nested config.
+
+    Title/description use the flat overlay; ``template_config`` is deep-merged
+    so translated labels replace their source text while non-text config is
+    preserved. A no-op when ``translation`` is None.
+    """
+    if not translation:
+        return data
+    result = apply_translation_overlay(
+        data, translation, TRANSLATABLE_FIELDS["ticketing_step"]
+    )
+    config_overlay = translation.get("template_config")
+    source_config = result.get("template_config")
+    if isinstance(config_overlay, dict) and isinstance(source_config, dict):
+        result = dict(result)
+        result["template_config"] = deep_merge_translation(
+            source_config, config_overlay
+        )
     return result
 
 

--- a/backend/app/services/ai_translation.py
+++ b/backend/app/services/ai_translation.py
@@ -13,31 +13,54 @@ LANGUAGE_NAMES: dict[str, str] = {
 }
 
 
+def _map_translation_response(
+    raw_map: dict, real_by_token: dict[str, str]
+) -> dict[str, str]:
+    """Map opaque-token keys from the model response back to real field keys.
+
+    Only string values for known tokens are kept, so a malformed or partial
+    response degrades gracefully instead of leaking tokens or nested objects.
+    """
+    return {
+        real_by_token[token]: value
+        for token, value in raw_map.items()
+        if token in real_by_token and isinstance(value, str)
+    }
+
+
 async def translate_fields(
     fields: dict[str, str],
     target_language: str,
     entity_type: str,
 ) -> dict[str, str]:
-    """Translate entity fields using Gemini. Returns a dict of field_name→translated_value."""
+    """Translate entity fields using Gemini. Returns a dict of field_name→translated_value.
+
+    Field keys can be nested config paths ("sections.0.label"). Those are mapped
+    to opaque tokens ("t0", "t1", ...) before hitting the model so it cannot
+    "helpfully" restructure a dotted key into nested JSON, which would otherwise
+    drop the field on the way back. Tokens are mapped back to real keys after.
+    """
     if not settings.GEMINI_API_KEY:
         raise HTTPException(status_code=400, detail="GEMINI_API_KEY is not configured")
 
     lang_name = LANGUAGE_NAMES.get(target_language, target_language)
 
-    fields_text = "\n".join(
-        f"- {key}: {value}" for key, value in fields.items() if value
-    )
-    if not fields_text:
+    ordered = [(key, value) for key, value in fields.items() if value and value.strip()]
+    if not ordered:
         return {}
+
+    real_by_token = {f"t{i}": key for i, (key, _) in enumerate(ordered)}
+    fields_text = "\n".join(f"- t{i}: {value}" for i, (_, value) in enumerate(ordered))
 
     prompt = (
         f"You are a professional translator for an event management platform. "
-        f"Translate the following {entity_type} fields to {lang_name}.\n\n"
+        f"Translate the following {entity_type} field values to {lang_name}.\n\n"
         f"Fields to translate:\n{fields_text}\n\n"
         f"Rules:\n"
-        f"- Return ONLY a valid JSON object mapping field names to translated values.\n"
-        f"- Keep the same field names (keys) in English.\n"
-        f"- Preserve any HTML tags, URLs, or special formatting.\n"
+        f"- Return ONLY a valid JSON object mapping each key to its translated value.\n"
+        f"- Use the exact same keys (t0, t1, ...) as given. Do NOT nest or rename them.\n"
+        f"- Translate only the values, never the keys.\n"
+        f"- Preserve any HTML tags, URLs, emojis, or special formatting.\n"
         f"- Use natural, culturally appropriate language (not literal word-for-word).\n"
         f"- Do NOT add any explanation or markdown formatting.\n"
     )
@@ -57,4 +80,4 @@ async def translate_fields(
         if raw.endswith("```"):
             raw = raw[:-3].strip()
 
-    return json.loads(raw)
+    return _map_translation_response(json.loads(raw), real_by_token)

--- a/backend/app/services/ai_translation.py
+++ b/backend/app/services/ai_translation.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 # Stable (GA) flash model: production rate limits, unlike the preview variants
 # whose separate, tighter quotas were causing 429s. Swap to a *-flash-lite id
 # for higher throughput at a small quality cost.
-TRANSLATION_MODEL = "gemini-3.5-flash"
+TRANSLATION_MODEL = "gemini-2.5-flash"
 
 LANGUAGE_NAMES: dict[str, str] = {
     "en": "English",

--- a/backend/app/services/ai_translation.py
+++ b/backend/app/services/ai_translation.py
@@ -9,6 +9,7 @@ LANGUAGE_NAMES: dict[str, str] = {
     "en": "English",
     "es": "Spanish (Latin America)",
     "zh": "Simplified Chinese",
+    "is": "Icelandic",
 }
 
 

--- a/backend/app/services/ai_translation.py
+++ b/backend/app/services/ai_translation.py
@@ -5,6 +5,11 @@ from google import genai
 
 from app.core.config import settings
 
+# Stable (GA) flash model: production rate limits, unlike the preview variants
+# whose separate, tighter quotas were causing 429s. Swap to a *-flash-lite id
+# for higher throughput at a small quality cost.
+TRANSLATION_MODEL = "gemini-3.5-flash"
+
 LANGUAGE_NAMES: dict[str, str] = {
     "en": "English",
     "es": "Spanish (Latin America)",
@@ -84,7 +89,7 @@ async def translate_fields(
 
     client = genai.Client(api_key=settings.GEMINI_API_KEY)
     response = await client.aio.models.generate_content(
-        model="gemini-3-flash-preview",
+        model=TRANSLATION_MODEL,
         contents=prompt,
     )
     if not response.text:

--- a/backend/app/services/ai_translation.py
+++ b/backend/app/services/ai_translation.py
@@ -28,6 +28,17 @@ def _map_translation_response(
     }
 
 
+def _field_hint(key: str) -> str:
+    """Human-readable context for a field key, used to guide the model.
+
+    Numeric path indices are dropped ("sections.0.label" -> "sections label",
+    "insurance.card_title" -> "insurance card title"), giving tone/register
+    context without exposing the opaque-token scheme.
+    """
+    segments = [seg for seg in key.split(".") if not seg.isdigit()]
+    return " ".join(segments).replace("_", " ")
+
+
 async def translate_fields(
     fields: dict[str, str],
     target_language: str,
@@ -50,16 +61,22 @@ async def translate_fields(
         return {}
 
     real_by_token = {f"t{i}": key for i, (key, _) in enumerate(ordered)}
-    fields_text = "\n".join(f"- t{i}: {value}" for i, (_, value) in enumerate(ordered))
+    fields_text = "\n".join(
+        f"- t{i} ({_field_hint(key)}): {value}"
+        for i, (key, value) in enumerate(ordered)
+    )
 
     prompt = (
         f"You are a professional translator for an event management platform. "
         f"Translate the following {entity_type} field values to {lang_name}.\n\n"
+        f"Each line has the form `- <key> (<field context>): <text to translate>`. "
+        f"The context in parentheses tells you what the field is, to help you "
+        f"choose the right tone and register; it is not part of the text.\n\n"
         f"Fields to translate:\n{fields_text}\n\n"
         f"Rules:\n"
         f"- Return ONLY a valid JSON object mapping each key to its translated value.\n"
         f"- Use the exact same keys (t0, t1, ...) as given. Do NOT nest or rename them.\n"
-        f"- Translate only the values, never the keys.\n"
+        f"- Translate only the text values, never the keys or the context hints.\n"
         f"- Preserve any HTML tags, URLs, emojis, or special formatting.\n"
         f"- Use natural, culturally appropriate language (not literal word-for-word).\n"
         f"- Do NOT add any explanation or markdown formatting.\n"

--- a/backend/tests/api/translation/test_translation_service.py
+++ b/backend/tests/api/translation/test_translation_service.py
@@ -88,6 +88,18 @@ class TestExtractTranslatableLeaves:
             "footer_text": "Términos y condiciones",
         }
 
+    def test_faq_items_question_and_answer(self):
+        config = {
+            "variant": "accordion",
+            "items": [
+                {"id": "a", "question": "¿Otra duda?", "answer": "Escribinos"},
+            ],
+        }
+        assert extract_translatable_leaves(config) == {
+            "items.0.question": "¿Otra duda?",
+            "items.0.answer": "Escribinos",
+        }
+
     def test_ignores_non_text_and_blank_values(self):
         config = {"presets": [10, 20], "label": "  ", "minimum": 5}
         assert extract_translatable_leaves(config) == {}

--- a/backend/tests/api/translation/test_translation_service.py
+++ b/backend/tests/api/translation/test_translation_service.py
@@ -1,0 +1,126 @@
+"""Unit tests for the pure translation-overlay helpers.
+
+These cover the default-agnostic language parsing, the nested deep-merge used
+for ticketing-step template_config, the leaf extractor shared with the
+backoffice, and the combined step overlay. No database is required.
+"""
+
+from app.api.translation.service import (
+    apply_ticketing_step_overlay,
+    deep_merge_translation,
+    extract_translatable_leaves,
+    parse_accept_language,
+)
+
+
+class TestParseAcceptLanguage:
+    def test_none_and_empty_return_none(self):
+        assert parse_accept_language(None) is None
+        assert parse_accept_language("") is None
+        assert parse_accept_language("   ") is None
+
+    def test_english_is_not_special_cased(self):
+        # Default-agnostic: "en" is parsed like any other language.
+        assert parse_accept_language("en") == "en"
+
+    def test_base_subtag_is_extracted(self):
+        assert parse_accept_language("es-AR") == "es"
+        assert parse_accept_language("zh-Hant") == "zh"
+
+    def test_first_language_of_a_list_wins(self):
+        assert parse_accept_language("es-AR,es;q=0.9,en;q=0.8") == "es"
+
+
+class TestDeepMergeTranslation:
+    def test_non_empty_string_overlay_replaces_source(self):
+        assert deep_merge_translation("Hola", "Hello") == "Hello"
+
+    def test_empty_or_missing_overlay_keeps_source(self):
+        assert deep_merge_translation("Hola", "") == "Hola"
+        assert deep_merge_translation("Hola", "   ") == "Hola"
+        assert deep_merge_translation("Hola", None) == "Hola"
+
+    def test_non_text_source_is_preserved(self):
+        source = {"price": 100, "label": "Precio"}
+        overlay = {"label": "Price"}
+        assert deep_merge_translation(source, overlay) == {
+            "price": 100,
+            "label": "Price",
+        }
+
+    def test_nested_dict_merge(self):
+        source = {"insurance": {"card_title": "Seguro", "enabled": True}}
+        overlay = {"insurance": {"card_title": "Insurance"}}
+        assert deep_merge_translation(source, overlay) == {
+            "insurance": {"card_title": "Insurance", "enabled": True}
+        }
+
+    def test_lists_merge_element_wise_with_holes(self):
+        source = ["a", "b", "c"]
+        overlay = [None, None, "translated-c"]
+        assert deep_merge_translation(source, overlay) == ["a", "b", "translated-c"]
+
+    def test_source_is_not_mutated(self):
+        source = {"label": "Precio", "nested": {"title": "Titulo"}}
+        deep_merge_translation(source, {"nested": {"title": "Title"}})
+        assert source == {"label": "Precio", "nested": {"title": "Titulo"}}
+
+
+class TestExtractTranslatableLeaves:
+    def test_flat_and_nested_text_leaves(self):
+        config = {
+            "sections": [
+                {"key": "passes", "label": "Elegí tu pase", "order": 1},
+            ],
+            "insurance": {
+                "card_title": "Seguro",
+                "benefits": ["Cobertura total", "Reembolso"],
+                "enabled": True,
+            },
+            "footer_text": "Términos y condiciones",
+        }
+        assert extract_translatable_leaves(config) == {
+            "sections.0.label": "Elegí tu pase",
+            "insurance.card_title": "Seguro",
+            "insurance.benefits.0": "Cobertura total",
+            "insurance.benefits.1": "Reembolso",
+            "footer_text": "Términos y condiciones",
+        }
+
+    def test_ignores_non_text_and_blank_values(self):
+        config = {"presets": [10, 20], "label": "  ", "minimum": 5}
+        assert extract_translatable_leaves(config) == {}
+
+    def test_non_dict_input_is_safe(self):
+        assert extract_translatable_leaves(None) == {}
+        assert extract_translatable_leaves("string") == {}
+
+
+class TestApplyTicketingStepOverlay:
+    def test_none_translation_is_noop(self):
+        data = {"title": "Titulo", "template_config": {"footer_text": "Pie"}}
+        assert apply_ticketing_step_overlay(data, None) == data
+
+    def test_flat_and_nested_overlay_combined(self):
+        data = {
+            "title": "Titulo",
+            "description": "Desc",
+            "template_config": {
+                "sections": [{"key": "passes", "label": "Pases"}],
+                "footer_text": "Pie",
+            },
+        }
+        translation = {
+            "title": "Title",
+            "template_config": {
+                "sections": [{"label": "Passes"}],
+            },
+        }
+        result = apply_ticketing_step_overlay(data, translation)
+        assert result["title"] == "Title"
+        assert result["description"] == "Desc"
+        assert result["template_config"]["sections"][0] == {
+            "key": "passes",
+            "label": "Passes",
+        }
+        assert result["template_config"]["footer_text"] == "Pie"

--- a/backend/tests/api/translation/test_translation_service.py
+++ b/backend/tests/api/translation/test_translation_service.py
@@ -11,7 +11,7 @@ from app.api.translation.service import (
     extract_translatable_leaves,
     parse_accept_language,
 )
-from app.services.ai_translation import _map_translation_response
+from app.services.ai_translation import _field_hint, _map_translation_response
 
 
 class TestParseAcceptLanguage:
@@ -137,6 +137,17 @@ class TestApplyTicketingStepOverlay:
             "label": "Passes",
         }
         assert result["template_config"]["footer_text"] == "Pie"
+
+
+class TestFieldHint:
+    def test_flat_key(self):
+        assert _field_hint("name") == "name"
+        assert _field_hint("help_text") == "help text"
+
+    def test_nested_key_drops_indices(self):
+        assert _field_hint("sections.0.label") == "sections label"
+        assert _field_hint("insurance.card_title") == "insurance card title"
+        assert _field_hint("items.3.question") == "items question"
 
 
 class TestMapTranslationResponse:

--- a/backend/tests/api/translation/test_translation_service.py
+++ b/backend/tests/api/translation/test_translation_service.py
@@ -11,6 +11,7 @@ from app.api.translation.service import (
     extract_translatable_leaves,
     parse_accept_language,
 )
+from app.services.ai_translation import _map_translation_response
 
 
 class TestParseAcceptLanguage:
@@ -124,3 +125,23 @@ class TestApplyTicketingStepOverlay:
             "label": "Passes",
         }
         assert result["template_config"]["footer_text"] == "Pie"
+
+
+class TestMapTranslationResponse:
+    def test_tokens_map_back_to_real_keys(self):
+        real_by_token = {"t0": "title", "t1": "sections.0.label"}
+        raw = {"t0": "Accommodation", "t1": "Camping right"}
+        assert _map_translation_response(raw, real_by_token) == {
+            "title": "Accommodation",
+            "sections.0.label": "Camping right",
+        }
+
+    def test_unknown_tokens_are_dropped(self):
+        assert _map_translation_response({"t9": "x"}, {"t0": "title"}) == {}
+
+    def test_nested_or_non_string_values_are_dropped(self):
+        # A model that ignored the opaque keys and nested its output must not
+        # leak structural objects back as translations.
+        raw = {"t0": {"sections": [{"label": "x"}]}, "t1": "Ok"}
+        real_by_token = {"t0": "sections.0.label", "t1": "title"}
+        assert _map_translation_response(raw, real_by_token) == {"title": "Ok"}

--- a/backoffice/src/components/translations/AITranslateButton.tsx
+++ b/backoffice/src/components/translations/AITranslateButton.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react"
+import { Loader2, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import useCustomToast from "@/hooks/useCustomToast"
 import { useAITranslate } from "@/hooks/useTranslations"
@@ -18,32 +18,48 @@ export function AITranslateButton({
 }: AITranslateButtonProps) {
   const aiTranslate = useAITranslate()
   const { showErrorToast } = useCustomToast()
+  const isPending = aiTranslate.isPending
 
   return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={aiTranslate.isPending}
-      onClick={() => {
-        aiTranslate.mutate(
-          {
-            entity_type: entityType,
-            entity_id: entityId,
-            target_language: targetLanguage,
-          },
-          {
-            onSuccess: (data) => onTranslated(data),
-            onError: (err) =>
-              showErrorToast(
-                err instanceof Error ? err.message : "AI translation failed",
-              ),
-          },
-        )
-      }}
-    >
-      <Sparkles className="mr-2 h-4 w-4" />
-      {aiTranslate.isPending ? "Translating..." : "AI Translate"}
-    </Button>
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={isPending}
+        onClick={() => {
+          aiTranslate.mutate(
+            {
+              entity_type: entityType,
+              entity_id: entityId,
+              target_language: targetLanguage,
+            },
+            {
+              onSuccess: (data) => onTranslated(data),
+              onError: (err) =>
+                showErrorToast(
+                  err instanceof Error ? err.message : "AI translation failed",
+                ),
+            },
+          )
+        }}
+      >
+        {isPending ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="mr-2 h-4 w-4" />
+        )}
+        {isPending ? "Translating..." : "AI Translate"}
+      </Button>
+      {isPending && (
+        <span
+          aria-live="polite"
+          className="text-xs text-muted-foreground animate-pulse"
+        >
+          Translating with AI, this can take a few seconds. Please keep this
+          page open.
+        </span>
+      )}
+    </div>
   )
 }

--- a/backoffice/src/components/translations/TranslationManager.tsx
+++ b/backoffice/src/components/translations/TranslationManager.tsx
@@ -174,7 +174,22 @@ function LanguageTab({
   }
 
   const handleAITranslated = (data: Record<string, string>) => {
-    setDraft((prev) => ({ ...prev, ...data }))
+    // The AI response mixes flat fields (title, description) with nested config
+    // leaf paths (sections.0.label). Route each key to its own draft.
+    const leafPaths = new Set(leaves.map((l) => l.path))
+    const flat: Record<string, string> = {}
+    const nested: Record<string, string> = {}
+    for (const [key, value] of Object.entries(data)) {
+      if (leafPaths.has(key)) {
+        nested[key] = value
+      } else {
+        flat[key] = value
+      }
+    }
+    setDraft((prev) => ({ ...prev, ...flat }))
+    if (Object.keys(nested).length > 0) {
+      setNestedDraft((prev) => ({ ...prev, ...nested }))
+    }
   }
 
   const formatFieldLabel = (field: string) =>

--- a/backoffice/src/components/translations/TranslationManager.tsx
+++ b/backoffice/src/components/translations/TranslationManager.tsx
@@ -10,6 +10,12 @@ import {
 } from "@/hooks/useTranslations"
 import { AITranslateButton } from "./AITranslateButton"
 import { TranslationFieldEditor } from "./TranslationFieldEditor"
+import {
+  buildPartialConfig,
+  type ConfigLeaf,
+  extractTranslatableLeaves,
+  flattenConfigValues,
+} from "./templateConfigLeaves"
 
 const LANGUAGE_NAMES: Record<string, string> = {
   en: "English",
@@ -31,6 +37,11 @@ interface TranslationManagerProps {
   sourceData: Record<string, string | null | undefined>
   supportedLanguages: string[]
   defaultLanguage?: string
+  // Optional nested-config translation (e.g. a ticketing step's
+  // template_config): text leaves are auto-extracted and saved as a partial
+  // mirror under `nestedField` in the same translation row.
+  nestedField?: string
+  nestedSource?: unknown
 }
 
 export function TranslationManager({
@@ -40,6 +51,8 @@ export function TranslationManager({
   sourceData,
   supportedLanguages,
   defaultLanguage = "en",
+  nestedField,
+  nestedSource,
 }: TranslationManagerProps) {
   const nonDefaultLanguages = supportedLanguages.filter(
     (l) => l !== defaultLanguage,
@@ -67,6 +80,8 @@ export function TranslationManager({
                 language={lang}
                 translatableFields={translatableFields}
                 sourceData={sourceData}
+                nestedField={nestedField}
+                nestedSource={nestedSource}
               />
             </TabsContent>
           ))}
@@ -82,12 +97,16 @@ function LanguageTab({
   language,
   translatableFields,
   sourceData,
+  nestedField,
+  nestedSource,
 }: {
   entityType: string
   entityId: string
   language: string
   translatableFields: string[]
   sourceData: Record<string, string | null | undefined>
+  nestedField?: string
+  nestedSource?: unknown
 }) {
   const { data: translations = [] } = useTranslationsQuery(entityType, entityId)
   const upsertMutation = useUpsertTranslation()
@@ -95,30 +114,46 @@ function LanguageTab({
 
   const existingTranslation = translations.find((t) => t.language === language)
 
+  const leaves: ConfigLeaf[] = nestedField
+    ? extractTranslatableLeaves(nestedSource)
+    : []
+
   const [draft, setDraft] = useState<Record<string, string>>(() => {
     const initial: Record<string, string> = {}
     for (const field of translatableFields) {
-      initial[field] = existingTranslation?.data[field] ?? ""
+      initial[field] = (existingTranslation?.data[field] as string) ?? ""
     }
     return initial
   })
 
-  // Sync draft when data loads
-  const translationData = existingTranslation?.data
+  const [nestedDraft, setNestedDraft] = useState<Record<string, string>>(() =>
+    nestedField
+      ? flattenConfigValues(existingTranslation?.data[nestedField])
+      : {},
+  )
+
+  // Sync drafts when the persisted translation loads or changes identity.
   const [syncedId, setSyncedId] = useState<string | null>(null)
   if (existingTranslation && existingTranslation.id !== syncedId) {
     const updated: Record<string, string> = {}
     for (const field of translatableFields) {
-      updated[field] = translationData?.[field] ?? ""
+      updated[field] = (existingTranslation.data[field] as string) ?? ""
     }
     setDraft(updated)
+    if (nestedField) {
+      setNestedDraft(flattenConfigValues(existingTranslation.data[nestedField]))
+    }
     setSyncedId(existingTranslation.id)
   }
 
   const handleSave = () => {
-    const data: Record<string, string> = {}
+    const data: Record<string, unknown> = {}
     for (const [key, value] of Object.entries(draft)) {
       if (value.trim()) data[key] = value
+    }
+    if (nestedField) {
+      const partial = buildPartialConfig(nestedDraft)
+      if (partial) data[nestedField] = partial
     }
 
     upsertMutation.mutate(
@@ -160,6 +195,27 @@ function LanguageTab({
           multiline={MULTILINE_FIELDS.has(field)}
         />
       ))}
+
+      {leaves.length > 0 && (
+        <div className="space-y-4 border-t pt-4">
+          <p className="text-sm font-medium text-muted-foreground">
+            Step content
+          </p>
+          {leaves.map((leaf) => (
+            <TranslationFieldEditor
+              key={leaf.path}
+              fieldName={leaf.path}
+              label={leaf.label}
+              originalValue={leaf.value}
+              translatedValue={nestedDraft[leaf.path] ?? ""}
+              onChange={(value) =>
+                setNestedDraft((prev) => ({ ...prev, [leaf.path]: value }))
+              }
+              multiline={leaf.multiline}
+            />
+          ))}
+        </div>
+      )}
 
       <div className="flex items-center gap-2 pt-2">
         <Button

--- a/backoffice/src/components/translations/TranslationManager.tsx
+++ b/backoffice/src/components/translations/TranslationManager.tsx
@@ -175,7 +175,9 @@ function LanguageTab({
 
   const handleAITranslated = (data: Record<string, string>) => {
     // The AI response mixes flat fields (title, description) with nested config
-    // leaf paths (sections.0.label). Route each key to its own draft.
+    // leaf paths (sections.0.label). Route each key to its own draft, and only
+    // fill blanks: a value the user already typed is never overwritten, so AI
+    // Translate completes what is missing instead of replacing manual work.
     const leafPaths = new Set(leaves.map((l) => l.path))
     const flat: Record<string, string> = {}
     const nested: Record<string, string> = {}
@@ -186,9 +188,22 @@ function LanguageTab({
         flat[key] = value
       }
     }
-    setDraft((prev) => ({ ...prev, ...flat }))
+
+    const fillBlanks =
+      (incoming: Record<string, string>) =>
+      (prev: Record<string, string>): Record<string, string> => {
+        const next = { ...prev }
+        for (const [key, value] of Object.entries(incoming)) {
+          if (!next[key]?.trim()) {
+            next[key] = value
+          }
+        }
+        return next
+      }
+
+    setDraft(fillBlanks(flat))
     if (Object.keys(nested).length > 0) {
-      setNestedDraft((prev) => ({ ...prev, ...nested }))
+      setNestedDraft(fillBlanks(nested))
     }
   }
 

--- a/backoffice/src/components/translations/templateConfigLeaves.ts
+++ b/backoffice/src/components/translations/templateConfigLeaves.ts
@@ -14,6 +14,10 @@ const TEXT_LEAF_KEYS = new Set([
   "card_subtitle",
   "toggle_label",
   "footer_text",
+  "question",
+  "answer",
+  "caption",
+  "html",
 ])
 
 // Keys holding an array of user-visible strings (each item is a leaf).
@@ -23,6 +27,8 @@ const MULTILINE_LEAF_KEYS = new Set([
   "description",
   "subtitle",
   "card_subtitle",
+  "answer",
+  "html",
 ])
 
 export interface ConfigLeaf {

--- a/backoffice/src/components/translations/templateConfigLeaves.ts
+++ b/backoffice/src/components/translations/templateConfigLeaves.ts
@@ -1,0 +1,162 @@
+// Auto-extraction of translatable text leaves from a ticketing step's nested
+// `template_config`. The organizer never edits JSON: we walk the config, list
+// every user-visible text leaf as a flat field, and on save rebuild a partial
+// config mirror holding only the translated leaves. The backend deep-merges
+// that partial over the source, preserving ids, prices, flags and icons.
+
+// Object keys whose string value is user-visible copy.
+const TEXT_LEAF_KEYS = new Set([
+  "label",
+  "description",
+  "title",
+  "subtitle",
+  "card_title",
+  "card_subtitle",
+  "toggle_label",
+  "footer_text",
+])
+
+// Keys holding an array of user-visible strings (each item is a leaf).
+const TEXT_LIST_KEYS = new Set(["benefits"])
+
+const MULTILINE_LEAF_KEYS = new Set([
+  "description",
+  "subtitle",
+  "card_subtitle",
+])
+
+export interface ConfigLeaf {
+  /** Dot/index path into the config, e.g. "sections.0.label". */
+  path: string
+  /** Human label shown next to the editor. */
+  label: string
+  /** Source (default-language) text. */
+  value: string
+  multiline: boolean
+}
+
+function humanizeKey(key: string): string {
+  return key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+/**
+ * Walk a template_config and return every translatable text leaf, in a stable
+ * document order. Only known text keys are collected; structural and numeric
+ * values are ignored so they can never be accidentally translated.
+ */
+export function extractTranslatableLeaves(
+  config: unknown,
+  prefix = "",
+): ConfigLeaf[] {
+  if (!config || typeof config !== "object") return []
+
+  const leaves: ConfigLeaf[] = []
+  const entries = Array.isArray(config)
+    ? config.map((v, i) => [String(i), v] as const)
+    : Object.entries(config as Record<string, unknown>)
+
+  for (const [key, value] of entries) {
+    const path = prefix ? `${prefix}.${key}` : key
+
+    if (TEXT_LEAF_KEYS.has(key) && typeof value === "string") {
+      if (value.trim()) {
+        leaves.push({
+          path,
+          label: humanizeKey(key),
+          value,
+          multiline: MULTILINE_LEAF_KEYS.has(key),
+        })
+      }
+      continue
+    }
+
+    if (TEXT_LIST_KEYS.has(key) && Array.isArray(value)) {
+      value.forEach((item, index) => {
+        if (typeof item === "string" && item.trim()) {
+          leaves.push({
+            path: `${path}.${index}`,
+            label: `${humanizeKey(key)} ${index + 1}`,
+            value: item,
+            multiline: false,
+          })
+        }
+      })
+      continue
+    }
+
+    if (value && typeof value === "object") {
+      leaves.push(...extractTranslatableLeaves(value, path))
+    }
+  }
+
+  return leaves
+}
+
+/** Set a value at a dot/index path, creating objects/arrays as needed. */
+function setByPath(
+  target: Record<string, unknown>,
+  path: string,
+  value: string,
+): void {
+  const segments = path.split(".")
+  let cursor: Record<string, unknown> | unknown[] = target
+
+  segments.forEach((segment, i) => {
+    const isLast = i === segments.length - 1
+    const nextIsIndex = !isLast && /^\d+$/.test(segments[i + 1])
+    const key = /^\d+$/.test(segment) ? Number(segment) : segment
+
+    if (isLast) {
+      ;(cursor as Record<string | number, unknown>)[key] = value
+      return
+    }
+
+    const container = cursor as Record<string | number, unknown>
+    if (container[key] === undefined) {
+      container[key] = nextIsIndex ? [] : {}
+    }
+    cursor = container[key] as Record<string, unknown> | unknown[]
+  })
+}
+
+/**
+ * Rebuild a partial template_config mirror from path->translation entries.
+ * Empty translations are skipped so untranslated leaves fall back to source
+ * via the backend deep-merge. Returns null when nothing was translated.
+ */
+export function buildPartialConfig(
+  drafts: Record<string, string>,
+): Record<string, unknown> | null {
+  const partial: Record<string, unknown> = {}
+  let hasAny = false
+  for (const [path, value] of Object.entries(drafts)) {
+    if (value.trim()) {
+      setByPath(partial, path, value)
+      hasAny = true
+    }
+  }
+  return hasAny ? partial : null
+}
+
+/** Flatten a stored partial config back to path->value for editing. */
+export function flattenConfigValues(
+  config: unknown,
+  prefix = "",
+): Record<string, string> {
+  if (!config || typeof config !== "object") return {}
+
+  const flat: Record<string, string> = {}
+  const entries = Array.isArray(config)
+    ? config.map((v, i) => [String(i), v] as const)
+    : Object.entries(config as Record<string, unknown>)
+
+  for (const [key, value] of entries) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (typeof value === "string") {
+      flat[path] = value
+    } else if (value && typeof value === "object") {
+      Object.assign(flat, flattenConfigValues(value, path))
+    }
+  }
+  return flat
+}

--- a/backoffice/src/hooks/useTranslations.ts
+++ b/backoffice/src/hooks/useTranslations.ts
@@ -7,7 +7,7 @@ interface TranslationPublic {
   entity_type: string
   entity_id: string
   language: string
-  data: Record<string, string>
+  data: Record<string, unknown>
   created_at: string | null
   updated_at: string | null
 }
@@ -16,7 +16,7 @@ interface TranslationCreate {
   entity_type: string
   entity_id: string
   language: string
-  data: Record<string, string>
+  data: Record<string, unknown>
 }
 
 async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -22,6 +22,7 @@ import {
   TEMPLATE_DEFINITIONS,
 } from "@/components/ticketing-step-builder/constants"
 import { TEMPLATE_CONFIG_REGISTRY } from "@/components/ticketing-step-builder/template-configs"
+import { TranslationManager } from "@/components/translations/TranslationManager"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import {
@@ -155,11 +156,12 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     step.emoji,
   ])
 
-  // Popup data (needed for insurance_enabled gate on confirm step)
+  // Popup data: needed for the insurance_enabled gate on the confirm step and
+  // for the supported/default languages that drive the translations editor.
   const { data: popup } = useQuery({
     queryKey: ["popups", "detail", step.popup_id],
     queryFn: () => PopupsService.getPopup({ popupId: step.popup_id }),
-    enabled: step.step_type === "confirm",
+    enabled: !!step.popup_id,
   })
 
   // Product categories for select
@@ -625,6 +627,23 @@ function StepConfigContent({ stepId }: { stepId: string }) {
               </CardContent>
             </Card>
           )}
+        </>
+      )}
+
+      {(popup?.supported_languages?.length ?? 0) > 1 && (
+        <>
+          <Separator />
+          <TranslationManager
+            entityType="ticketing_step"
+            entityId={step.id}
+            translatableFields={["title", "description"]}
+            sourceData={{
+              title: step.title,
+              description: step.description,
+            }}
+            supportedLanguages={popup!.supported_languages!}
+            defaultLanguage={popup!.default_language!}
+          />
         </>
       )}
 

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -641,6 +641,8 @@ function StepConfigContent({ stepId }: { stepId: string }) {
               title: step.title,
               description: step.description,
             }}
+            nestedField="template_config"
+            nestedSource={step.template_config}
             supportedLanguages={popup!.supported_languages!}
             defaultLanguage={popup!.default_language!}
           />

--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -6,17 +6,24 @@ import CheckoutPageClient from "./CheckoutPageClient"
 
 export default async function OpenTicketingCheckoutPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ popupSlug: string }>
+  searchParams: Promise<{ lang?: string; locale?: string }>
 }) {
   const { popupSlug } = await params
+  const { lang, locale } = await searchParams
 
   const tenant = await resolveTenantForMetadata()
   if (!tenant) {
     return <CheckoutPageClient popupSlug={popupSlug} />
   }
 
-  const runtime = await fetchCheckoutRuntime(popupSlug, tenant.id)
+  const runtime = await fetchCheckoutRuntime(
+    popupSlug,
+    tenant.id,
+    lang ?? locale,
+  )
   if (!runtime) {
     return <CheckoutPageClient popupSlug={popupSlug} />
   }

--- a/portal/src/lib/api-client.ts
+++ b/portal/src/lib/api-client.ts
@@ -1,4 +1,5 @@
 import { OpenAPI } from "@/client"
+import { LANGUAGE_STORAGE_KEY } from "@/lib/language-storage"
 
 if (!process.env.NEXT_PUBLIC_API_URL) {
   throw new Error("NEXT_PUBLIC_API_URL is not configured")
@@ -24,8 +25,12 @@ OpenAPI.interceptors.request.use((config) => {
   if (tenantId) {
     config.headers = { ...config.headers, "X-Tenant-Id": tenantId }
   }
-  const language = localStorage.getItem("portal_language")
-  if (language && language !== "en") {
+  // Send the selected language whenever one is stored, regardless of which
+  // language it is. The backend overlay is default-agnostic: if the requested
+  // language matches the popup default it simply finds no translation rows and
+  // returns the source. Special-casing "en" here broke Spanish-default popups.
+  const language = localStorage.getItem(LANGUAGE_STORAGE_KEY)
+  if (language) {
     config.headers = { ...config.headers, "Accept-Language": language }
   }
   return config

--- a/portal/src/lib/checkout-runtime.ts
+++ b/portal/src/lib/checkout-runtime.ts
@@ -19,19 +19,27 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL
 export async function fetchCheckoutRuntime(
   slug: string,
   tenantId: string,
+  lang?: string,
 ): Promise<CheckoutRuntimeResponse | null> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 1500)
 
   try {
+    // Forward an explicit ?lang= deep link as Accept-Language so the SSR render
+    // is already translated. localStorage is not available server-side; the
+    // in-session switch path is covered by the client refetch on language change.
+    const headers: Record<string, string> = {
+      "X-Tenant-Id": tenantId,
+      Accept: "application/json",
+    }
+    if (lang) {
+      headers["Accept-Language"] = lang
+    }
     const res = await fetch(
       `${API_BASE}/api/v1/checkout/${encodeURIComponent(slug)}/runtime`,
       {
         cache: "no-store",
-        headers: {
-          "X-Tenant-Id": tenantId,
-          Accept: "application/json",
-        },
+        headers,
         signal: controller.signal,
       },
     )

--- a/portal/src/lib/language-storage.ts
+++ b/portal/src/lib/language-storage.ts
@@ -1,0 +1,5 @@
+// Single source of truth for the portal language localStorage key. Shared by
+// the language provider (writer) and the API client interceptor (reader) so the
+// two can never drift apart and silently stop sending the Accept-Language
+// header, which is what previously broke dynamic translations end to end.
+export const LANGUAGE_STORAGE_KEY = "portal_language_v2"

--- a/portal/src/providers/languageProvider.tsx
+++ b/portal/src/providers/languageProvider.tsx
@@ -12,11 +12,12 @@ import {
 } from "react"
 import { useTranslation } from "react-i18next"
 import { SUPPORTED_LANGUAGES } from "@/i18n/config"
+import { LANGUAGE_STORAGE_KEY } from "@/lib/language-storage"
 import { CityContext } from "./cityProvider"
 
 // Bumped from "portal_language": prior versions auto-wrote on every render,
 // leaving stale "en" values that override the popup default_language.
-const STORAGE_KEY = "portal_language_v2"
+const STORAGE_KEY = LANGUAGE_STORAGE_KEY
 const PORTAL_LANGUAGES = Object.keys(SUPPORTED_LANGUAGES)
 const DEFAULT_LANGUAGE = "en"
 


### PR DESCRIPTION
## Summary

- Make the portal checkout fully translatable: selecting a second language now retranslates the whole checkout (popup, products, and ticketing steps including nested `template_config` content), not just the static UI chrome.
- Fix the root cause that kept dynamic translations from ever showing, and make the overlay default-language-agnostic (works with a Spanish or English default).
- Extend AI Translate to cover ticketing steps and their nested content, only fill blank fields, and add clearer progress feedback.

## Related Issue

No tracking issue — direct request.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- **Default-agnostic overlay fix**: the portal never sent `Accept-Language` (the API client read `portal_language` while the provider wrote `portal_language_v2`); shared the key via `lib/language-storage.ts`. Dropped the hardcoded `"en"` baseline in portal and backend (`parse_accept_language`) so requesting the default language just returns the source.
- **Open-checkout runtime + steps**: overlay popup, products and ticketing steps in `/checkout/{slug}/runtime` and `/ticketing-steps/portal`; forward `?lang=` to the SSR runtime fetch; cascade-delete step translations. Registered `ticketing_step` in `TRANSLATABLE_FIELDS`.
- **Nested `template_config`**: `deep_merge_translation` + `apply_ticketing_step_overlay` preserve ids/prices/flags while overlaying translated copy. Backoffice auto-extracts every text leaf (section labels, meal-plan options, insurance card copy, FAQ question/answer, gallery caption, rich-text html) into flat editors and rebuilds a partial mirror on save.
- **AI Translate**: covers ticketing steps and nested leaves; opaque-token round-trip so the model can't nest the JSON response; per-field context hints for tone; fills only blank fields (never overwrites manual work); spinner + "keep this page open" notice; added Icelandic; uses the stable `gemini-2.5-flash`.
- Unit tests for the pure overlay/translation helpers.

## Testing

- [x] Backend tests pass (`uv run pytest` — 1934 passed, 4 skipped)
- [x] Backend linting passes (`uv run ruff check .`)
- [x] Backoffice builds / typechecks (`tsc`) and Biome CI pass
- [x] Portal typechecks (`tsc`) and Biome CI pass
- [ ] Manual testing performed (end-to-end verification with a real popup pending)

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed (n/a)
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed — not needed: the only API-surface change is optional `Accept-Language` request headers consumed via the client interceptor; no response schemas changed
- [x] Database migrations are included if schema changed — n/a, no schema change (uses the existing `Translations` table)
