### PR TITLE
fix(i18n): forward and stick the checkout language via ?lang

### DIFF
--- a/portal/src/lib/api-client.ts
+++ b/portal/src/lib/api-client.ts
@@ -25,11 +25,19 @@ OpenAPI.interceptors.request.use((config) => {
   if (tenantId) {
     config.headers = { ...config.headers, "X-Tenant-Id": tenantId }
   }
-  // Send the selected language whenever one is stored, regardless of which
-  // language it is. The backend overlay is default-agnostic: if the requested
-  // language matches the popup default it simply finds no translation rows and
-  // returns the source. Special-casing "en" here broke Spanish-default popups.
-  const language = localStorage.getItem(LANGUAGE_STORAGE_KEY)
+  // Prefer the ?lang (or ?locale) URL param, then the stored language. The URL
+  // is available synchronously on the first render, before the language
+  // provider persists the choice to localStorage in an effect. Reading only
+  // localStorage raced that write: the first runtime request went out without
+  // Accept-Language and returned the popup default, so a ?lang=en deep link
+  // showed the source language until a later refetch (e.g. on window focus).
+  // The backend overlay is default-agnostic, so sending the default (or an
+  // unsupported value) simply finds no translations and returns the source.
+  const params = new URLSearchParams(window.location.search)
+  const language =
+    params.get("lang") ||
+    params.get("locale") ||
+    localStorage.getItem(LANGUAGE_STORAGE_KEY)
   if (language) {
     config.headers = { ...config.headers, "Accept-Language": language }
   }

--- a/portal/src/providers/languageProvider.tsx
+++ b/portal/src/providers/languageProvider.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import { useSearchParams } from "next/navigation"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import {
   createContext,
   type ReactNode,
@@ -86,6 +86,8 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const { i18n } = useTranslation()
   const cityContext = useContext(CityContext)
   const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
   const queryClient = useQueryClient()
   const prevLanguageRef = useRef<string | null>(null)
   const popup = cityContext?.getCity() ?? null
@@ -153,12 +155,17 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
   const setLanguage = (lang: string) => {
     const resolvedLanguage = resolveLanguageCandidate(lang, supportedLanguages)
-    if (resolvedLanguage) {
-      if (typeof window !== "undefined") {
-        localStorage.setItem(STORAGE_KEY, resolvedLanguage)
-      }
-      setCurrentLanguage(resolvedLanguage)
+    if (!resolvedLanguage) return
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, resolvedLanguage)
     }
+    // The URL is the single source of truth: write ?lang and let the resolver
+    // effect apply it. Setting state here too would let the effect briefly
+    // revert to the stale ?lang before the navigation lands. This also keeps
+    // the selected language forwardable in the URL.
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("lang", resolvedLanguage)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
   }
 
   return (


### PR DESCRIPTION
## Summary

- Keep the checkout language in sync with the URL so a language chosen from the switch sticks (instead of being reverted by the `?lang` param) and is always forwardable in the link.
- Fix a race where a `?lang=en` deep link showed the source language until a later refetch (e.g. on window focus).

## Related Issue

No tracking issue — reported while testing dynamic checkout translations.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- **Switch → URL (`languageProvider.tsx`)**: `setLanguage` now writes `?lang` via `router.replace` and lets the resolver apply it, instead of setting state directly. The resolver treats `?lang` as authoritative and re-runs on every language change, so setting state directly was immediately reverted to the URL value. The URL is now the single source of truth, so the selection sticks and is forwardable.
- **First-request race (`api-client.ts`)**: the interceptor read the language only from `localStorage`, which the provider writes in an effect that runs *after* the child runtime query fires its first fetch — so the first request went out without `Accept-Language` and returned the popup default, showing a default-then-translated flash. It now reads `?lang` (or `?locale`) from the URL first (available synchronously), falling back to `localStorage`.

## Testing

- [ ] Backend tests pass — n/a, no backend changes
- [ ] Backend linting passes — n/a, no backend changes
- [x] Portal typechecks (`tsc`) and Biome CI pass
- [x] Manually verified: `?lang=en` deep link renders translated content on first paint; switching language updates the URL and sticks

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have updated documentation if needed (n/a)
- [ ] I have added tests for new functionality (n/a — provider/interceptor behavior)
- [x] All new and existing tests pass
- [ ] I have regenerated the OpenAPI client if backend API changed — n/a, no backend changes
- [x] Database migrations are included if schema changed — n/a, no schema change
