### PR TITLE
fix(carts): handle anonymous open-checkout carts in abandoned list

### DIFF
--- a/backend/app/api/cart/router.py
+++ b/backend/app/api/cart/router.py
@@ -32,35 +32,63 @@ async def list_abandoned_carts(
     limit: PaginationLimit = 100,
 ) -> ListModel[AbandonedCartPublic]:
     """List all abandoned carts with human, popup and payment info (BO only)."""
+    from sqlalchemy import text
+    from sqlmodel import select
+
     from app.api.application.models import Applications
     from app.api.payment.models import Payments
     from app.api.payment.schemas import PaymentStatus
 
     carts, total = carts_crud.find_all(db, popup_id=popup_id, skip=skip, limit=limit)
 
+    pending_statuses = [PaymentStatus.PENDING.value, PaymentStatus.EXPIRED.value]
+
     results = []
     for cart in carts:
         human = cart.human
         popup = cart.popup
 
-        # Find pending/expired payments for this human+popup
-        from sqlmodel import select
-
-        payment_stmt = (
-            select(Payments)
-            .join(Applications, Payments.application_id == Applications.id)  # type: ignore[arg-type]
-            .where(
-                Applications.human_id == cart.human_id,
-                Applications.popup_id == cart.popup_id,
-                Payments.status.in_(  # type: ignore[attr-defined]
-                    [PaymentStatus.PENDING.value, PaymentStatus.EXPIRED.value]
-                ),
+        # Find pending/expired payments for this cart. Authenticated carts link
+        # payments through the human's applications; anonymous open-checkout
+        # carts have no application, so correlate by the buyer email stored in
+        # the payment's buyer_snapshot.
+        if cart.human_id is not None:
+            payment_stmt = (
+                select(Payments)
+                .join(Applications, Payments.application_id == Applications.id)  # type: ignore[arg-type]
+                .where(
+                    Applications.human_id == cart.human_id,
+                    Applications.popup_id == cart.popup_id,
+                    Payments.status.in_(pending_statuses),  # type: ignore[attr-defined]
+                )
+                .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
             )
-            .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
-        )
+        else:
+            payment_stmt = (
+                select(Payments)
+                .where(
+                    Payments.application_id.is_(None),  # type: ignore[union-attr]
+                    Payments.popup_id == cart.popup_id,
+                    Payments.status.in_(pending_statuses),  # type: ignore[attr-defined]
+                    text("buyer_snapshot->>'buyer_email' = :buyer_email"),
+                )
+                .params(buyer_email=(cart.email or "").lower())
+                .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
+            )
         payments = list(db.exec(payment_stmt).all())
 
         items = CartState.model_validate(cart.items) if cart.items else CartState()
+
+        human_info = (
+            CartHumanInfo(
+                id=human.id,
+                email=human.email,
+                first_name=human.first_name,
+                last_name=human.last_name,
+            )
+            if human is not None
+            else None
+        )
 
         results.append(
             AbandonedCartPublic(
@@ -68,12 +96,8 @@ async def list_abandoned_carts(
                 items=items,
                 created_at=cart.created_at,
                 updated_at=cart.updated_at,
-                human=CartHumanInfo(
-                    id=human.id,
-                    email=human.email,
-                    first_name=human.first_name,
-                    last_name=human.last_name,
-                ),
+                email=human.email if human is not None else cart.email,
+                human=human_info,
                 popup=CartPopupInfo(
                     id=popup.id,
                     name=popup.name,

--- a/backend/app/api/cart/schemas.py
+++ b/backend/app/api/cart/schemas.py
@@ -169,7 +169,11 @@ class AbandonedCartPublic(BaseModel):
     items: CartState
     created_at: datetime | None = None
     updated_at: datetime | None = None
-    human: CartHumanInfo
+    # Buyer email. Taken from the human for authenticated carts, or from the
+    # cart row for anonymous open-checkout carts (which have no human).
+    email: str | None = None
+    # Null for anonymous open-checkout carts (no logged-in human).
+    human: CartHumanInfo | None = None
     popup: CartPopupInfo
     payments: list[CartPaymentInfo] = []
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -55,8 +55,26 @@ export const AbandonedCartPublicSchema = {
             ],
             title: 'Updated At'
         },
+        email: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
+        },
         human: {
-            '$ref': '#/components/schemas/CartHumanInfo'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/CartHumanInfo'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         popup: {
             '$ref': '#/components/schemas/CartPopupInfo'
@@ -71,7 +89,7 @@ export const AbandonedCartPublicSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'items', 'human', 'popup'],
+    required: ['id', 'items', 'popup'],
     title: 'AbandonedCartPublic',
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2035,6 +2035,7 @@ export class CheckoutService {
      * Rate-limited 120/min/IP.
      * @param data The data for the request.
      * @param data.slug
+     * @param data.acceptLanguage
      * @param data.xTenantId
      * @returns CheckoutRuntimeResponse Successful Response
      * @throws ApiError
@@ -2047,6 +2048,7 @@ export class CheckoutService {
                 slug: data.slug
             },
             headers: {
+                'Accept-Language': data.acceptLanguage,
                 'X-Tenant-Id': data.xTenantId
             },
             errors: {
@@ -7988,6 +7990,7 @@ export class TicketingStepsService {
      * List enabled ticketing steps for a popup (portal-facing).
      * @param data The data for the request.
      * @param data.popupId
+     * @param data.acceptLanguage
      * @returns ListModel_TicketingStepPublic_ Successful Response
      * @throws ApiError
      */
@@ -7995,6 +7998,9 @@ export class TicketingStepsService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/ticketing-steps/portal',
+            headers: {
+                'Accept-Language': data.acceptLanguage
+            },
             query: {
                 popup_id: data.popupId
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -8,7 +8,8 @@ export type AbandonedCartPublic = {
     items: CartState;
     created_at?: (string | null);
     updated_at?: (string | null);
-    human: CartHumanInfo;
+    email?: (string | null);
+    human?: (CartHumanInfo | null);
     popup: CartPopupInfo;
     payments?: Array<CartPaymentInfo>;
 };
@@ -4858,6 +4859,7 @@ export type CheckInListCheckInsData = {
 export type CheckInListCheckInsResponse = (ListModel_CheckInListItem_);
 
 export type CheckoutGetRuntimeData = {
+    acceptLanguage?: (string | null);
     slug: string;
     xTenantId?: (string | null);
 };
@@ -6640,6 +6642,7 @@ export type ThirdPartyDiscoveryGetThirdPartyOpenapiResponse = ({
 });
 
 export type TicketingStepsListPortalTicketingStepsData = {
+    acceptLanguage?: (string | null);
     popupId: string;
 };
 

--- a/backoffice/src/routes/_layout/abandoned-carts.tsx
+++ b/backoffice/src/routes/_layout/abandoned-carts.tsx
@@ -67,8 +67,8 @@ const columns: ColumnDef<AbandonedCartPublic>[] = [
     cell: ({ row }) => (
       <span className="font-medium">
         {formatName(
-          row.original.human.first_name,
-          row.original.human.last_name,
+          row.original.human?.first_name,
+          row.original.human?.last_name,
         )}
       </span>
     ),
@@ -77,7 +77,7 @@ const columns: ColumnDef<AbandonedCartPublic>[] = [
     id: "human_email",
     header: ({ column }) => <SortableHeader label="Email" column={column} />,
     cell: ({ row }) => (
-      <span className="text-muted-foreground">{row.original.human.email}</span>
+      <span className="text-muted-foreground">{row.original.email ?? "—"}</span>
     ),
   },
   {
@@ -187,9 +187,9 @@ function AbandonedCartsTableContent() {
     ? carts.results.filter((c) => {
         const term = search.toLowerCase()
         return (
-          c.human.email.toLowerCase().includes(term) ||
-          (c.human.first_name ?? "").toLowerCase().includes(term) ||
-          (c.human.last_name ?? "").toLowerCase().includes(term) ||
+          (c.email ?? "").toLowerCase().includes(term) ||
+          (c.human?.first_name ?? "").toLowerCase().includes(term) ||
+          (c.human?.last_name ?? "").toLowerCase().includes(term) ||
           c.popup.name.toLowerCase().includes(term)
         )
       })
@@ -246,8 +246,8 @@ function AbandonedCarts() {
       exportToCsv(
         "abandoned-carts",
         results.map((c) => ({
-          name: formatName(c.human.first_name, c.human.last_name),
-          email: c.human.email,
+          name: formatName(c.human?.first_name, c.human?.last_name),
+          email: c.email ?? "",
           event: c.popup.name,
           items: getCartItemCount(c.items),
           payment_attempts: (c.payments ?? []).length,

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -55,8 +55,26 @@ export const AbandonedCartPublicSchema = {
             ],
             title: 'Updated At'
         },
+        email: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
+        },
         human: {
-            '$ref': '#/components/schemas/CartHumanInfo'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/CartHumanInfo'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         popup: {
             '$ref': '#/components/schemas/CartPopupInfo'
@@ -71,7 +89,7 @@ export const AbandonedCartPublicSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'items', 'human', 'popup'],
+    required: ['id', 'items', 'popup'],
     title: 'AbandonedCartPublic',
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2035,6 +2035,7 @@ export class CheckoutService {
      * Rate-limited 120/min/IP.
      * @param data The data for the request.
      * @param data.slug
+     * @param data.acceptLanguage
      * @param data.xTenantId
      * @returns CheckoutRuntimeResponse Successful Response
      * @throws ApiError
@@ -2047,6 +2048,7 @@ export class CheckoutService {
                 slug: data.slug
             },
             headers: {
+                'Accept-Language': data.acceptLanguage,
                 'X-Tenant-Id': data.xTenantId
             },
             errors: {
@@ -7988,6 +7990,7 @@ export class TicketingStepsService {
      * List enabled ticketing steps for a popup (portal-facing).
      * @param data The data for the request.
      * @param data.popupId
+     * @param data.acceptLanguage
      * @returns ListModel_TicketingStepPublic_ Successful Response
      * @throws ApiError
      */
@@ -7995,6 +7998,9 @@ export class TicketingStepsService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/ticketing-steps/portal',
+            headers: {
+                'Accept-Language': data.acceptLanguage
+            },
             query: {
                 popup_id: data.popupId
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -8,7 +8,8 @@ export type AbandonedCartPublic = {
     items: CartState;
     created_at?: (string | null);
     updated_at?: (string | null);
-    human: CartHumanInfo;
+    email?: (string | null);
+    human?: (CartHumanInfo | null);
     popup: CartPopupInfo;
     payments?: Array<CartPaymentInfo>;
 };
@@ -4858,6 +4859,7 @@ export type CheckInListCheckInsData = {
 export type CheckInListCheckInsResponse = (ListModel_CheckInListItem_);
 
 export type CheckoutGetRuntimeData = {
+    acceptLanguage?: (string | null);
     slug: string;
     xTenantId?: (string | null);
 };
@@ -6640,6 +6642,7 @@ export type ThirdPartyDiscoveryGetThirdPartyOpenapiResponse = ({
 });
 
 export type TicketingStepsListPortalTicketingStepsData = {
+    acceptLanguage?: (string | null);
     popupId: string;
 };
 


### PR DESCRIPTION
## Problem

`GET /api/v1/carts` (backoffice abandoned-carts list) returned **HTTP 500** with `AttributeError: 'NoneType' object has no attribute 'id'`.

The endpoint was built when every cart had a logged-in human. Anonymous open-checkout carts have `human_id NULL` (email lives on `carts.email`), so `cart.human` is `None` and building `CartHumanInfo` crashed.

## Root cause on payments too

Anonymous open-checkout **never creates an Application**. It creates a `Payment` with `application_id NULL` and stores the buyer email in `buyer_snapshot->>'buyer_email'`. The old query joined `Payments -> Applications` by `human_id`, so it never correlated anonymous payments correctly.

## Changes

| File | Change |
|------|--------|
| `backend/app/api/cart/schemas.py` | `AbandonedCartPublic.human` now optional; added top-level `email` |
| `backend/app/api/cart/router.py` | Two payment-correlation branches (authenticated join vs. anonymous by `buyer_snapshot` email); build `human` only when present |
| `backoffice/src/routes/_layout/abandoned-carts.tsx` | Null-safe name/email columns, search filter and CSV export; fall back to top-level `email` |
| `*/src/client/*` | Regenerated OpenAPI client (both frontends) |

## Verification

- Backend `scripts/lint.sh` (ruff) — pass
- `pnpm --filter backoffice run build` — pass
- `pnpm --filter portal run build` — pass