### PR TITLE
release: dev to main v1.35.0

### DIFF
--- a/backend/app/api/cart/crud.py
+++ b/backend/app/api/cart/crud.py
@@ -122,9 +122,14 @@ class CartsCRUD:
         email: str,
         popup_id: uuid.UUID,
     ) -> Carts | None:
-        """Find an anonymous cart by email and popup (read-only)."""
+        """Find an anonymous cart by email and popup (read-only).
+
+        Email match is case-insensitive so the payment-approval cleanup finds
+        the cart regardless of how the buyer typed the address here versus at
+        checkout — the rest of the open-checkout flow normalizes to lowercase.
+        """
         statement = select(Carts).where(
-            Carts.email == email,
+            func.lower(Carts.email) == email.lower(),
             Carts.popup_id == popup_id,
             col(Carts.human_id).is_(None),
         )
@@ -160,7 +165,9 @@ class CartsCRUD:
                 tenant_id=tenant_id,
                 human_id=None,
                 popup_id=popup_id,
-                email=email,
+                # Store normalized so the unique (tenant, popup, email) index and
+                # later case-insensitive lookups stay consistent.
+                email=email.lower(),
                 items=items.model_dump(),
             )
             session.add(cart)

--- a/backend/app/api/cart/router.py
+++ b/backend/app/api/cart/router.py
@@ -32,35 +32,63 @@ async def list_abandoned_carts(
     limit: PaginationLimit = 100,
 ) -> ListModel[AbandonedCartPublic]:
     """List all abandoned carts with human, popup and payment info (BO only)."""
+    from sqlalchemy import text
+    from sqlmodel import select
+
     from app.api.application.models import Applications
     from app.api.payment.models import Payments
     from app.api.payment.schemas import PaymentStatus
 
     carts, total = carts_crud.find_all(db, popup_id=popup_id, skip=skip, limit=limit)
 
+    pending_statuses = [PaymentStatus.PENDING.value, PaymentStatus.EXPIRED.value]
+
     results = []
     for cart in carts:
         human = cart.human
         popup = cart.popup
 
-        # Find pending/expired payments for this human+popup
-        from sqlmodel import select
-
-        payment_stmt = (
-            select(Payments)
-            .join(Applications, Payments.application_id == Applications.id)  # type: ignore[arg-type]
-            .where(
-                Applications.human_id == cart.human_id,
-                Applications.popup_id == cart.popup_id,
-                Payments.status.in_(  # type: ignore[attr-defined]
-                    [PaymentStatus.PENDING.value, PaymentStatus.EXPIRED.value]
-                ),
+        # Find pending/expired payments for this cart. Authenticated carts link
+        # payments through the human's applications; anonymous open-checkout
+        # carts have no application, so correlate by the buyer email stored in
+        # the payment's buyer_snapshot.
+        if cart.human_id is not None:
+            payment_stmt = (
+                select(Payments)
+                .join(Applications, Payments.application_id == Applications.id)  # type: ignore[arg-type]
+                .where(
+                    Applications.human_id == cart.human_id,
+                    Applications.popup_id == cart.popup_id,
+                    Payments.status.in_(pending_statuses),  # type: ignore[attr-defined]
+                )
+                .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
             )
-            .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
-        )
+        else:
+            payment_stmt = (
+                select(Payments)
+                .where(
+                    Payments.application_id.is_(None),  # type: ignore[union-attr]
+                    Payments.popup_id == cart.popup_id,
+                    Payments.status.in_(pending_statuses),  # type: ignore[attr-defined]
+                    text("buyer_snapshot->>'buyer_email' = :buyer_email"),
+                )
+                .params(buyer_email=(cart.email or "").lower())
+                .order_by(Payments.created_at.desc())  # type: ignore[union-attr]
+            )
         payments = list(db.exec(payment_stmt).all())
 
         items = CartState.model_validate(cart.items) if cart.items else CartState()
+
+        human_info = (
+            CartHumanInfo(
+                id=human.id,
+                email=human.email,
+                first_name=human.first_name,
+                last_name=human.last_name,
+            )
+            if human is not None
+            else None
+        )
 
         results.append(
             AbandonedCartPublic(
@@ -68,12 +96,8 @@ async def list_abandoned_carts(
                 items=items,
                 created_at=cart.created_at,
                 updated_at=cart.updated_at,
-                human=CartHumanInfo(
-                    id=human.id,
-                    email=human.email,
-                    first_name=human.first_name,
-                    last_name=human.last_name,
-                ),
+                email=human.email if human is not None else cart.email,
+                human=human_info,
                 popup=CartPopupInfo(
                     id=popup.id,
                     name=popup.name,

--- a/backend/app/api/cart/schemas.py
+++ b/backend/app/api/cart/schemas.py
@@ -169,7 +169,11 @@ class AbandonedCartPublic(BaseModel):
     items: CartState
     created_at: datetime | None = None
     updated_at: datetime | None = None
-    human: CartHumanInfo
+    # Buyer email. Taken from the human for authenticated carts, or from the
+    # cart row for anonymous open-checkout carts (which have no human).
+    email: str | None = None
+    # Null for anonymous open-checkout carts (no logged-in human).
+    human: CartHumanInfo | None = None
     popup: CartPopupInfo
     payments: list[CartPaymentInfo] = []
 

--- a/backend/tests/api/checkout/test_open_cart.py
+++ b/backend/tests/api/checkout/test_open_cart.py
@@ -158,6 +158,43 @@ def test_upsert_open_cart_is_idempotent_per_email(
     assert len(carts) == 1
 
 
+def test_upsert_open_cart_email_is_case_insensitive(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """A different email casing resolves to the same cart, stored lowercased.
+
+    Guards the payment-approval cleanup: it looks the cart up by the buyer
+    email, so a casing mismatch must never leave an already-paid cart behind.
+    """
+    popup = _make_popup(db, tenant_a, slug_prefix="case", signing_secret="s3cr3t")
+    product = _make_product(db, popup)
+    db.commit()
+
+    first = client.put(
+        f"/api/v1/checkout/{popup.slug}/cart",
+        json={"email": "Buyer@Test.com", "items": _items(product, promo_code="A")},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+    second = client.put(
+        f"/api/v1/checkout/{popup.slug}/cart",
+        json={"email": "BUYER@test.com", "items": _items(product, promo_code="B")},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert first.status_code == 200 and second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+
+    carts = list(
+        db.exec(
+            select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_(None))
+        ).all()
+    )
+    assert len(carts) == 1
+    assert carts[0].email == "buyer@test.com"
+
+
 def test_restore_open_cart_with_valid_signature_returns_items(
     client: TestClient,
     db: Session,

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -55,8 +55,26 @@ export const AbandonedCartPublicSchema = {
             ],
             title: 'Updated At'
         },
+        email: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
+        },
         human: {
-            '$ref': '#/components/schemas/CartHumanInfo'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/CartHumanInfo'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         popup: {
             '$ref': '#/components/schemas/CartPopupInfo'
@@ -71,7 +89,7 @@ export const AbandonedCartPublicSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'items', 'human', 'popup'],
+    required: ['id', 'items', 'popup'],
     title: 'AbandonedCartPublic',
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -2035,6 +2035,7 @@ export class CheckoutService {
      * Rate-limited 120/min/IP.
      * @param data The data for the request.
      * @param data.slug
+     * @param data.acceptLanguage
      * @param data.xTenantId
      * @returns CheckoutRuntimeResponse Successful Response
      * @throws ApiError
@@ -2047,6 +2048,7 @@ export class CheckoutService {
                 slug: data.slug
             },
             headers: {
+                'Accept-Language': data.acceptLanguage,
                 'X-Tenant-Id': data.xTenantId
             },
             errors: {
@@ -7988,6 +7990,7 @@ export class TicketingStepsService {
      * List enabled ticketing steps for a popup (portal-facing).
      * @param data The data for the request.
      * @param data.popupId
+     * @param data.acceptLanguage
      * @returns ListModel_TicketingStepPublic_ Successful Response
      * @throws ApiError
      */
@@ -7995,6 +7998,9 @@ export class TicketingStepsService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/ticketing-steps/portal',
+            headers: {
+                'Accept-Language': data.acceptLanguage
+            },
             query: {
                 popup_id: data.popupId
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -8,7 +8,8 @@ export type AbandonedCartPublic = {
     items: CartState;
     created_at?: (string | null);
     updated_at?: (string | null);
-    human: CartHumanInfo;
+    email?: (string | null);
+    human?: (CartHumanInfo | null);
     popup: CartPopupInfo;
     payments?: Array<CartPaymentInfo>;
 };
@@ -4858,6 +4859,7 @@ export type CheckInListCheckInsData = {
 export type CheckInListCheckInsResponse = (ListModel_CheckInListItem_);
 
 export type CheckoutGetRuntimeData = {
+    acceptLanguage?: (string | null);
     slug: string;
     xTenantId?: (string | null);
 };
@@ -6640,6 +6642,7 @@ export type ThirdPartyDiscoveryGetThirdPartyOpenapiResponse = ({
 });
 
 export type TicketingStepsListPortalTicketingStepsData = {
+    acceptLanguage?: (string | null);
     popupId: string;
 };
 

--- a/backoffice/src/components/forms/PopupForm.tsx
+++ b/backoffice/src/components/forms/PopupForm.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
@@ -346,880 +347,270 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
 
   return (
     <div className="space-y-6">
-      <form
-        noValidate
-        onSubmit={(e) => {
-          e.preventDefault()
-          if (!readOnly) {
-            form.handleSubmit()
-          }
-        }}
-        className="mx-auto max-w-2xl space-y-6"
-      >
-        <FormErrorSummary
-          form={form}
-          fieldLabels={{
-            name: "Pop-up Name",
-            tagline: "Tagline",
-            location: "Location",
-            slug: "Slug",
-            start_date: "Start Date",
-            end_date: "End Date",
-          }}
-        />
-
-        {/* Hero: Name + Status */}
-        <div className="space-y-3">
-          <form.Field
-            name="name"
-            validators={{
-              onBlur: ({ value }) =>
-                !readOnly && !value ? "Name is required" : undefined,
+      <Tabs defaultValue="general" className="mx-auto max-w-2xl space-y-6">
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="translations">Translations</TabsTrigger>
+        </TabsList>
+        <TabsContent value="general" className="space-y-6">
+          <form
+            noValidate
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (!readOnly) {
+                form.handleSubmit()
+              }
             }}
+            className="mx-auto max-w-2xl space-y-6"
           >
-            {(field) => (
-              <div>
-                <HeroInput
-                  placeholder="Pop-up Name"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                />
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="tagline">
-            {(field) => (
-              <div className="space-y-2">
-                <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Tagline
-                </Label>
-                <Input
-                  placeholder="Short description or slogan"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="text-sm"
-                />
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="location">
-            {(field) => (
-              <div className="space-y-2">
-                <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Location
-                </Label>
-                <Input
-                  placeholder="Pop-up location or venue"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="text-sm"
-                />
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="status">
-            {(field) => (
-              <div className="flex items-center gap-2">
-                <Select
-                  value={field.state.value}
-                  onValueChange={(value) =>
-                    field.handleChange(value as typeof field.state.value)
-                  }
-                  disabled={readOnly}
-                >
-                  <SelectTrigger className="w-auto border-0 bg-transparent p-0 shadow-none focus:ring-0">
-                    <Badge
-                      variant={
-                        field.state.value === "active" ? "default" : "secondary"
-                      }
-                    >
-                      <SelectValue />
-                    </Badge>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {POPUP_STATUSES.map((status) => (
-                      <SelectItem key={status.value} value={status.value}>
-                        {status.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </form.Field>
-        </div>
-
-        {/* Popup Details - right after identity (edit only) */}
-        {isEdit && (
-          <div className="flex gap-6 text-sm text-muted-foreground">
-            <div>
-              <span className="text-xs uppercase tracking-wider">Slug</span>
-              <p className="font-mono">{defaultValues.slug}</p>
-            </div>
-          </div>
-        )}
-
-        <Separator />
-
-        {/* Sale Model — keep commerce decisions near the event identity,
-            like the previous implementation. */}
-        <div className="space-y-3">
-          <div className="space-y-1 px-1">
-            <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Commerce setup
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              Decide how people will access this event. This is the primary
-              identity of the popup. Checkout mode is always derived from this
-              choice by the backend.
-            </p>
-          </div>
-
-          <InlineSection title="How this event sells">
-            <form.Field name="sale_type">
-              {(field) => (
-                <InlineRow
-                  icon={
-                    isEdit ? (
-                      <Lock className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <ShoppingCart className="h-4 w-4 text-muted-foreground" />
-                    )
-                  }
-                  label="Sale Type"
-                  description={
-                    isEdit
-                      ? "Change sale type only if this popup has no approved payments yet"
-                      : "Choose whether people apply first or buy tickets directly"
-                  }
-                >
-                  <Select
-                    value={field.state.value}
-                    onValueChange={(value) =>
-                      field.handleChange(value as SaleType)
-                    }
-                    disabled={readOnly}
-                  >
-                    <SelectTrigger className="w-[220px] text-sm" size="sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="application">
-                        {SALE_TYPE_COPY.application.label}
-                      </SelectItem>
-                      <SelectItem value="direct">
-                        {SALE_TYPE_COPY.direct.label}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                </InlineRow>
-              )}
-            </form.Field>
-          </InlineSection>
-
-          <form.Subscribe selector={(state) => state.values.sale_type}>
-            {(saleType) => {
-              const copy = SALE_TYPE_COPY[saleType]
-              const guidance = getSaleTypeGuidance(saleType)
-              return (
-                <div className="rounded-xl border bg-muted/30 p-4">
-                  <p className="text-sm font-semibold">{copy.label}</p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {copy.description}
-                  </p>
-                  <div className="mt-3 border-t pt-3">
-                    <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      {guidance.title}
-                    </p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {guidance.description}
-                    </p>
-                  </div>
-                </div>
-              )
-            }}
-          </form.Subscribe>
-
-          <InlineSection>
-            <form.Field name="currency">
-              {(field) => (
-                <InlineRow
-                  icon={
-                    <DollarSign className="h-4 w-4 text-muted-foreground" />
-                  }
-                  label="Currency"
-                  description="Currency used for products, fees, invoices, and checkout totals"
-                >
-                  <Select
-                    value={field.state.value}
-                    onValueChange={(value) => field.handleChange(value)}
-                    disabled={readOnly}
-                  >
-                    <SelectTrigger className="w-[220px] text-sm" size="sm">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {CURRENCIES.map((currency) => (
-                        <SelectItem key={currency.value} value={currency.value}>
-                          {currency.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </InlineRow>
-              )}
-            </form.Field>
-          </InlineSection>
-        </div>
-
-        <Separator />
-
-        {/* Event Details */}
-        <InlineSection title="Pop-up Details">
-          <form.Field
-            name="start_date"
-            validators={{
-              onChange: ({ value }) => {
-                if (readOnly || !value || isEdit) return undefined
-                const today = new Date()
-                today.setHours(0, 0, 0, 0)
-                const startDate = new Date(value)
-                startDate.setHours(0, 0, 0, 0)
-                if (startDate < today) {
-                  return "Start date must be today or in the future"
-                }
-                return undefined
-              },
-            }}
-          >
-            {(field) => (
-              <div>
-                <InlineRow
-                  icon={<Calendar className="h-4 w-4 text-muted-foreground" />}
-                  label="Start Date"
-                >
-                  <DatePicker
-                    id="start_date"
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                    disabled={readOnly}
-                    placeholder="Select date"
-                    className="w-auto"
-                  />
-                </InlineRow>
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Subscribe selector={(state) => state.values.start_date}>
-            {(startDate) => {
-              const startDateAsDate = startDate
-                ? (() => {
-                    const [y, m, d] = startDate
-                      .slice(0, 10)
-                      .split("-")
-                      .map(Number)
-                    return new Date(y, m - 1, d)
-                  })()
-                : undefined
-              return (
-                <form.Field
-                  name="end_date"
-                  validators={{
-                    onChange: ({ value, fieldApi }) => {
-                      if (readOnly || !value) return undefined
-                      const startDateValue =
-                        fieldApi.form.getFieldValue("start_date")
-                      if (!startDateValue) return undefined
-                      const sd = new Date(startDateValue)
-                      const endDate = new Date(value)
-                      if (endDate < sd) {
-                        return "End date cannot be before start date"
-                      }
-                      return undefined
-                    },
-                  }}
-                >
-                  {(field) => (
-                    <div>
-                      <InlineRow
-                        icon={
-                          <Calendar className="h-4 w-4 text-muted-foreground" />
-                        }
-                        label="End Date"
-                      >
-                        <DatePicker
-                          id="end_date"
-                          value={field.state.value}
-                          onChange={field.handleChange}
-                          disabled={readOnly}
-                          placeholder="Select date"
-                          defaultMonth={startDateAsDate}
-                          className="w-auto"
-                        />
-                      </InlineRow>
-                      <FieldError errors={field.state.meta.errors} />
-                    </div>
-                  )}
-                </form.Field>
-              )
-            }}
-          </form.Subscribe>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Event Options */}
-        <InlineSection title="Pop-up Options">
-          <form.Field name="allows_coupons">
-            {(field) => (
-              <InlineRow
-                icon={<Ticket className="h-4 w-4 text-muted-foreground" />}
-                label="Discount Coupons"
-                description="Enable discount coupons for this pop-up"
-              >
-                <Switch
-                  id="allows_coupons"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="allows_scholarship">
-            {(field) => (
-              <InlineRow
-                icon={
-                  <GraduationCap className="h-4 w-4 text-muted-foreground" />
-                }
-                label="Scholarship Requests"
-                description="Allow applicants to request financial assistance"
-              >
-                <Switch
-                  id="allows_scholarship"
-                  checked={!!field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Subscribe selector={(state) => state.values.allows_scholarship}>
-            {(allowsScholarship) =>
-              allowsScholarship ? (
-                <form.Field name="allows_incentive">
-                  {(field) => (
-                    <InlineRow
-                      icon={
-                        <DollarSign className="h-4 w-4 text-muted-foreground" />
-                      }
-                      label="Cash Incentives"
-                      description="Allow assigning a cash grant alongside scholarship approval"
-                    >
-                      <Switch
-                        id="allows_incentive"
-                        checked={!!field.state.value}
-                        onCheckedChange={(checked) =>
-                          field.handleChange(checked)
-                        }
-                        disabled={readOnly}
-                      />
-                    </InlineRow>
-                  )}
-                </form.Field>
-              ) : null
-            }
-          </form.Subscribe>
-
-          <form.Field name="requires_application_fee">
-            {(field) => (
-              <InlineRow
-                icon={<DollarSign className="h-4 w-4 text-muted-foreground" />}
-                label="Require Application Fee"
-                description="Applicants must pay a refundable fee before their application is reviewed"
-              >
-                <Switch
-                  id="requires_application_fee"
-                  checked={!!field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Subscribe
-            selector={(state) => ({
-              requiresFee: state.values.requires_application_fee,
-              currency: state.values.currency,
-            })}
-          >
-            {({ requiresFee, currency }) =>
-              requiresFee ? (
-                <form.Field name="application_fee_amount">
-                  {(field) => (
-                    <InlineRow
-                      icon={
-                        <DollarSign className="h-4 w-4 text-muted-foreground" />
-                      }
-                      label={`Fee Amount (${currency})`}
-                      description={`Amount in ${currency} that applicants must pay`}
-                    >
-                      <Input
-                        id="application_fee_amount"
-                        type="number"
-                        min="0"
-                        step="0.01"
-                        placeholder="0.00"
-                        value={field.state.value}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        disabled={readOnly}
-                        className="max-w-[120px] text-sm"
-                      />
-                    </InlineRow>
-                  )}
-                </form.Field>
-              ) : null
-            }
-          </form.Subscribe>
-
-          <form.Field name="checkin_pass_lead_days">
-            {(field) => (
-              <InlineRow
-                icon={<QrCode className="h-4 w-4 text-muted-foreground" />}
-                label="Check-in Pass Email"
-                description="Days before the event start to email attendees their check-in QR code. Leave empty to disable."
-              >
-                <Input
-                  id="checkin_pass_lead_days"
-                  type="number"
-                  min="1"
-                  step="1"
-                  placeholder="e.g. 3"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-[120px] text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Companion Types — only available when editing an existing popup */}
-        {isEdit && defaultValues && (
-          <>
-            <AttendeeCategoriesEditor
-              popupId={defaultValues.id}
-              readOnly={readOnly}
+            <FormErrorSummary
+              form={form}
+              fieldLabels={{
+                name: "Pop-up Name",
+                tagline: "Tagline",
+                location: "Location",
+                slug: "Slug",
+                start_date: "Start Date",
+                end_date: "End Date",
+              }}
             />
-            <Separator />
-          </>
-        )}
 
-        {/* Branding */}
-        <InlineSection title="Branding">
-          <form.Field name="image_url">
-            {(field) => (
-              <div className="space-y-2 py-3">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                    <Image className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium">Cover Image</p>
-                    <p className="text-xs text-muted-foreground">
-                      Main event image used in cards, tickets, application
-                      headers, invoices, and emails
-                    </p>
-                  </div>
-                </div>
-                <ImageUpload
-                  value={field.state.value || null}
-                  onChange={(url) => field.handleChange(url ?? "")}
-                  disabled={readOnly}
-                />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="icon_url">
-            {(field) => (
-              <div className="space-y-2 py-3">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                    <Image className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium">Icon</p>
-                    <p className="text-xs text-muted-foreground">
-                      Small icon shown in the portal sidebar popup menu
-                    </p>
-                  </div>
-                </div>
-                <ImageUpload
-                  value={field.state.value || null}
-                  onChange={(url) => field.handleChange(url ?? "")}
-                  disabled={readOnly}
-                />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="favicon_url">
-            {(field) => (
-              <div className="space-y-2 py-3">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                    <Image className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium">Favicon</p>
-                    <p className="text-xs text-muted-foreground">
-                      Browser tab icon shown on the public checkout for this
-                      popup. Overrides the tenant default.
-                    </p>
-                  </div>
-                </div>
-                <ImageUpload
-                  value={field.state.value || null}
-                  onChange={(url) => field.handleChange(url ?? "")}
-                  disabled={readOnly}
-                />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="express_checkout_background">
-            {(field) => (
-              <div className="space-y-2 py-3">
-                <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-                    <Image className="h-4 w-4 text-muted-foreground" />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium">Checkout Background</p>
-                    <p className="text-xs text-muted-foreground">
-                      Full-screen background for checkout, invite, and success
-                      pages. Image or MP4 video (autoplay + audio toggle). Falls
-                      back to Cover Image, then tenant background.
-                    </p>
-                  </div>
-                </div>
-                <ImageUpload
-                  value={field.state.value || null}
-                  onChange={(url) => field.handleChange(url ?? "")}
-                  disabled={readOnly}
-                  accept="image+video"
-                />
-              </div>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Links */}
-        <InlineSection title="Links">
-          <form.Field name="web_url">
-            {(field) => (
-              <InlineRow
-                icon={<Globe className="h-4 w-4 text-muted-foreground" />}
-                label="Website"
-              >
-                <Input
-                  id="web_url"
-                  type="url"
-                  placeholder="https://example.com"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="blog_url">
-            {(field) => (
-              <InlineRow
-                icon={<FileText className="h-4 w-4 text-muted-foreground" />}
-                label="Blog"
-              >
-                <Input
-                  id="blog_url"
-                  type="url"
-                  placeholder="https://example.com/blog"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="twitter_url">
-            {(field) => (
-              <InlineRow
-                icon={<LinkIcon className="h-4 w-4 text-muted-foreground" />}
-                label="Twitter"
-              >
-                <Input
-                  id="twitter_url"
-                  type="url"
-                  placeholder="https://twitter.com/example"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="terms_and_conditions_url">
-            {(field) => (
-              <InlineRow
-                icon={<Scale className="h-4 w-4 text-muted-foreground" />}
-                label="Terms & Conditions"
-              >
-                <Input
-                  id="terms_and_conditions_url"
-                  type="url"
-                  placeholder="https://example.com/terms"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Integrations */}
-        <InlineSection title="Integrations">
-          <form.Field name="simplefi_api_key">
-            {(field) => (
-              <InlineRow
-                icon={<Key className="h-4 w-4 text-muted-foreground" />}
-                label="SimpleFi"
-                description="Payment integration API key"
-              >
-                <Input
-                  id="simplefi_api_key"
-                  type="password"
-                  placeholder="Enter API key"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-          <form.Field name="simplefi_success_behavior">
-            {(field) => (
-              <InlineRow
-                icon={<LinkIcon className="h-4 w-4 text-muted-foreground" />}
-                label="SimpleFi success redirect"
-                description="How the buyer reaches the success URL after paying. Manual keeps them on SimpleFi's checkout until they click through; automatic redirects them immediately."
-              >
-                <Select
-                  value={field.state.value}
-                  onValueChange={(v) =>
-                    field.handleChange(v as SimpleFiSuccessBehavior)
-                  }
-                  disabled={readOnly}
-                >
-                  <SelectTrigger
-                    id="simplefi_success_behavior"
-                    className="w-[140px]"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="manual">Manual</SelectItem>
-                    <SelectItem value="automatic">Automatic</SelectItem>
-                  </SelectContent>
-                </Select>
-              </InlineRow>
-            )}
-          </form.Field>
-          <form.Field name="open_checkout_success_url">
-            {(field) => (
-              <InlineRow
-                icon={<LinkIcon className="h-4 w-4 text-muted-foreground" />}
-                label="Open checkout success URL"
-                description="Where the buyer is redirected after a successful open-checkout payment. Defaults to the portal thank-you page."
-              >
-                <Input
-                  id="open_checkout_success_url"
-                  type="url"
-                  placeholder="https://example.com/thank-you"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-          <form.Field name="open_checkout_cancel_url">
-            {(field) => (
-              <InlineRow
-                icon={<LinkIcon className="h-4 w-4 text-muted-foreground" />}
-                label="Open checkout cancel URL"
-                description="Where the buyer is redirected after a cancelled open-checkout payment. Defaults to the portal checkout page."
-              >
-                <Input
-                  id="open_checkout_cancel_url"
-                  type="url"
-                  placeholder="https://example.com/checkout"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-          <form.Field name="open_checkout_signing_secret">
-            {(field) => (
-              <InlineRow
-                icon={<Key className="h-4 w-4 text-muted-foreground" />}
-                label="Open checkout signing secret"
-                description="Shared secret to HMAC-sign the order data sent to the success URL. Set the same value on the external thank-you page to verify it. Leave empty to send the redirect without a signed payload."
-              >
-                <Input
-                  id="open_checkout_signing_secret"
-                  type="password"
-                  placeholder="Enter signing secret"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Invoice Settings */}
-        <InlineSection title="Invoice Settings">
-          <form.Field name="invoice_company_name">
-            {(field) => (
-              <InlineRow
-                icon={<Building2 className="h-4 w-4 text-muted-foreground" />}
-                label="Company Name"
-              >
-                <Input
-                  id="invoice_company_name"
-                  placeholder="Acme Inc"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="invoice_company_address">
-            {(field) => (
-              <InlineRow
-                icon={<MapPin className="h-4 w-4 text-muted-foreground" />}
-                label="Address"
-              >
-                <Input
-                  id="invoice_company_address"
-                  placeholder="123 Main St, City, Country"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="invoice_company_email">
-            {(field) => (
-              <InlineRow
-                icon={<Mail className="h-4 w-4 text-muted-foreground" />}
-                label="Email"
-              >
-                <Input
-                  id="invoice_company_email"
-                  type="email"
-                  placeholder="billing@example.com"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-xs text-sm"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Insurance */}
-        <InlineSection title="Insurance">
-          <form.Field name="insurance_enabled">
-            {(field) => (
-              <InlineRow
-                icon={<ShieldCheck className="h-4 w-4 text-muted-foreground" />}
-                label="Enable Insurance"
-                description="Offer insurance for eligible products during checkout"
-              >
-                <Switch
-                  id="insurance_enabled"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Subscribe selector={(state) => state.values.insurance_enabled}>
-            {(insuranceEnabled) => (
+            {/* Hero: Name + Status */}
+            <div className="space-y-3">
               <form.Field
-                name="insurance_percentage"
+                name="name"
                 validators={{
-                  onBlur: ({ value }) => {
-                    if (readOnly || !insuranceEnabled) return undefined
-                    const num = Number.parseFloat(value)
-                    if (!value || Number.isNaN(num) || num <= 0) {
-                      return "Insurance percentage must be greater than 0 when insurance is enabled"
-                    }
-                    if (num > 100) {
-                      return "Insurance percentage cannot exceed 100"
+                  onBlur: ({ value }) =>
+                    !readOnly && !value ? "Name is required" : undefined,
+                }}
+              >
+                {(field) => (
+                  <div>
+                    <HeroInput
+                      placeholder="Pop-up Name"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                    />
+                    <FieldError errors={field.state.meta.errors} />
+                  </div>
+                )}
+              </form.Field>
+
+              <form.Field name="tagline">
+                {(field) => (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Tagline
+                    </Label>
+                    <Input
+                      placeholder="Short description or slogan"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="text-sm"
+                    />
+                    <FieldError errors={field.state.meta.errors} />
+                  </div>
+                )}
+              </form.Field>
+
+              <form.Field name="location">
+                {(field) => (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Location
+                    </Label>
+                    <Input
+                      placeholder="Pop-up location or venue"
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="text-sm"
+                    />
+                    <FieldError errors={field.state.meta.errors} />
+                  </div>
+                )}
+              </form.Field>
+
+              <form.Field name="status">
+                {(field) => (
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={field.state.value}
+                      onValueChange={(value) =>
+                        field.handleChange(value as typeof field.state.value)
+                      }
+                      disabled={readOnly}
+                    >
+                      <SelectTrigger className="w-auto border-0 bg-transparent p-0 shadow-none focus:ring-0">
+                        <Badge
+                          variant={
+                            field.state.value === "active"
+                              ? "default"
+                              : "secondary"
+                          }
+                        >
+                          <SelectValue />
+                        </Badge>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {POPUP_STATUSES.map((status) => (
+                          <SelectItem key={status.value} value={status.value}>
+                            {status.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+              </form.Field>
+            </div>
+
+            {/* Popup Details - right after identity (edit only) */}
+            {isEdit && (
+              <div className="flex gap-6 text-sm text-muted-foreground">
+                <div>
+                  <span className="text-xs uppercase tracking-wider">Slug</span>
+                  <p className="font-mono">{defaultValues.slug}</p>
+                </div>
+              </div>
+            )}
+
+            <Separator />
+
+            {/* Sale Model — keep commerce decisions near the event identity,
+            like the previous implementation. */}
+            <div className="space-y-3">
+              <div className="space-y-1 px-1">
+                <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Commerce setup
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Decide how people will access this event. This is the primary
+                  identity of the popup. Checkout mode is always derived from
+                  this choice by the backend.
+                </p>
+              </div>
+
+              <InlineSection title="How this event sells">
+                <form.Field name="sale_type">
+                  {(field) => (
+                    <InlineRow
+                      icon={
+                        isEdit ? (
+                          <Lock className="h-4 w-4 text-muted-foreground" />
+                        ) : (
+                          <ShoppingCart className="h-4 w-4 text-muted-foreground" />
+                        )
+                      }
+                      label="Sale Type"
+                      description={
+                        isEdit
+                          ? "Change sale type only if this popup has no approved payments yet"
+                          : "Choose whether people apply first or buy tickets directly"
+                      }
+                    >
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value as SaleType)
+                        }
+                        disabled={readOnly}
+                      >
+                        <SelectTrigger className="w-[220px] text-sm" size="sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="application">
+                            {SALE_TYPE_COPY.application.label}
+                          </SelectItem>
+                          <SelectItem value="direct">
+                            {SALE_TYPE_COPY.direct.label}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </InlineRow>
+                  )}
+                </form.Field>
+              </InlineSection>
+
+              <form.Subscribe selector={(state) => state.values.sale_type}>
+                {(saleType) => {
+                  const copy = SALE_TYPE_COPY[saleType]
+                  const guidance = getSaleTypeGuidance(saleType)
+                  return (
+                    <div className="rounded-xl border bg-muted/30 p-4">
+                      <p className="text-sm font-semibold">{copy.label}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {copy.description}
+                      </p>
+                      <div className="mt-3 border-t pt-3">
+                        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          {guidance.title}
+                        </p>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {guidance.description}
+                        </p>
+                      </div>
+                    </div>
+                  )
+                }}
+              </form.Subscribe>
+
+              <InlineSection>
+                <form.Field name="currency">
+                  {(field) => (
+                    <InlineRow
+                      icon={
+                        <DollarSign className="h-4 w-4 text-muted-foreground" />
+                      }
+                      label="Currency"
+                      description="Currency used for products, fees, invoices, and checkout totals"
+                    >
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) => field.handleChange(value)}
+                        disabled={readOnly}
+                      >
+                        <SelectTrigger className="w-[220px] text-sm" size="sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {CURRENCIES.map((currency) => (
+                            <SelectItem
+                              key={currency.value}
+                              value={currency.value}
+                            >
+                              {currency.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </InlineRow>
+                  )}
+                </form.Field>
+              </InlineSection>
+            </div>
+
+            <Separator />
+
+            {/* Event Details */}
+            <InlineSection title="Pop-up Details">
+              <form.Field
+                name="start_date"
+                validators={{
+                  onChange: ({ value }) => {
+                    if (readOnly || !value || isEdit) return undefined
+                    const today = new Date()
+                    today.setHours(0, 0, 0, 0)
+                    const startDate = new Date(value)
+                    startDate.setHours(0, 0, 0, 0)
+                    if (startDate < today) {
+                      return "Start date must be today or in the future"
                     }
                     return undefined
                   },
@@ -1229,589 +620,1270 @@ export function PopupForm({ defaultValues, onSuccess }: PopupFormProps) {
                   <div>
                     <InlineRow
                       icon={
-                        <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                        <Calendar className="h-4 w-4 text-muted-foreground" />
                       }
-                      label="Insurance Rate (%)"
-                      description="Percentage of eligible product price applied as insurance fee"
+                      label="Start Date"
                     >
-                      <Input
-                        id="insurance_percentage"
-                        type="number"
-                        min="0.01"
-                        max="100"
-                        step="0.01"
-                        placeholder="e.g. 5.00"
+                      <DatePicker
+                        id="start_date"
                         value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        disabled={readOnly || !insuranceEnabled}
-                        className="max-w-[120px] text-sm"
+                        onChange={field.handleChange}
+                        disabled={readOnly}
+                        placeholder="Select date"
+                        className="w-auto"
                       />
                     </InlineRow>
                     <FieldError errors={field.state.meta.errors} />
                   </div>
                 )}
               </form.Field>
-            )}
-          </form.Subscribe>
-        </InlineSection>
 
-        <Separator />
-
-        {/* Contribution fee */}
-        <InlineSection title="Contribution">
-          <form.Field name="contribution_enabled">
-            {(field) => (
-              <InlineRow
-                icon={<HandCoins className="h-4 w-4 text-muted-foreground" />}
-                label="Enable Contribution"
-                description="Add an optional contribution fee to orders at checkout"
-              >
-                <Switch
-                  id="contribution_enabled"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Subscribe
-            selector={(state) => state.values.contribution_enabled}
-          >
-            {(contributionEnabled) => (
-              <>
-                <form.Field
-                  name="contribution_percentage"
-                  validators={{
-                    onBlur: ({ value }) => {
-                      if (readOnly || !contributionEnabled) return undefined
-                      const num = Number.parseFloat(value)
-                      if (!value || Number.isNaN(num) || num < 0) {
-                        return "Contribution percentage must be 0 or greater when contribution is enabled"
-                      }
-                      if (num > 100) {
-                        return "Contribution percentage cannot exceed 100"
-                      }
-                      return undefined
-                    },
-                  }}
-                >
-                  {(field) => (
-                    <div>
-                      <InlineRow
-                        icon={
-                          <HandCoins className="h-4 w-4 text-muted-foreground" />
-                        }
-                        label="Contribution Rate (%)"
-                        description="Percentage of the total order applied as a contribution fee"
-                      >
-                        <Input
-                          id="contribution_percentage"
-                          type="number"
-                          min="0"
-                          max="100"
-                          step="0.01"
-                          placeholder="e.g. 2.50"
-                          value={field.state.value}
-                          onBlur={field.handleBlur}
-                          onChange={(e) => field.handleChange(e.target.value)}
-                          disabled={readOnly || !contributionEnabled}
-                          className="max-w-[120px] text-sm"
-                        />
-                      </InlineRow>
-                      <FieldError errors={field.state.meta.errors} />
-                    </div>
-                  )}
-                </form.Field>
-
-                <form.Field name="contribution_label">
-                  {(field) => (
-                    <InlineRow
-                      icon={
-                        <HandCoins className="h-4 w-4 text-muted-foreground" />
-                      }
-                      label="Contribution Label"
-                      description="Short name shown as the line item in the checkout summary"
+              <form.Subscribe selector={(state) => state.values.start_date}>
+                {(startDate) => {
+                  const startDateAsDate = startDate
+                    ? (() => {
+                        const [y, m, d] = startDate
+                          .slice(0, 10)
+                          .split("-")
+                          .map(Number)
+                        return new Date(y, m - 1, d)
+                      })()
+                    : undefined
+                  return (
+                    <form.Field
+                      name="end_date"
+                      validators={{
+                        onChange: ({ value, fieldApi }) => {
+                          if (readOnly || !value) return undefined
+                          const startDateValue =
+                            fieldApi.form.getFieldValue("start_date")
+                          if (!startDateValue) return undefined
+                          const sd = new Date(startDateValue)
+                          const endDate = new Date(value)
+                          if (endDate < sd) {
+                            return "End date cannot be before start date"
+                          }
+                          return undefined
+                        },
+                      }}
                     >
-                      <Input
-                        id="contribution_label"
-                        type="text"
-                        placeholder="e.g. Event support contribution"
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        disabled={readOnly || !contributionEnabled}
-                        className="max-w-xs text-sm"
-                      />
-                    </InlineRow>
-                  )}
-                </form.Field>
-
-                <form.Field name="contribution_description">
-                  {(field) => (
-                    <InlineRow
-                      icon={
-                        <HandCoins className="h-4 w-4 text-muted-foreground" />
-                      }
-                      label="Contribution Description"
-                      description="Longer explanation shown under the line item in the portal order summary"
-                    >
-                      <Textarea
-                        id="contribution_description"
-                        placeholder="e.g. This contribution helps fund scholarships and community programs."
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        disabled={readOnly || !contributionEnabled}
-                        className="w-80 max-w-xs text-sm field-sizing-fixed"
-                        rows={3}
-                      />
-                    </InlineRow>
-                  )}
-                </form.Field>
-              </>
-            )}
-          </form.Subscribe>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Installment plans (SimpleFi) */}
-        <InlineSection title="Installment plans">
-          <form.Field name="installments_enabled">
-            {(field) => (
-              <InlineRow
-                icon={<CreditCard className="h-4 w-4 text-muted-foreground" />}
-                label="Enable installment plans"
-                description="Offer buyers the option to pay in scheduled installments. SimpleFi renders the per-cycle selector at checkout."
-              >
-                <Switch
-                  id="installments_enabled"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Subscribe
-            selector={(state) => state.values.installments_enabled}
-          >
-            {(installmentsEnabled) =>
-              installmentsEnabled ? (
-                <>
-                  <form.Field
-                    name="installments_deadline"
-                    validators={{
-                      onBlur: ({ value }) => {
-                        if (readOnly) return undefined
-                        if (!value) {
-                          return "Deadline is required when installments are enabled"
-                        }
-                        return undefined
-                      },
-                    }}
-                  >
-                    {(field) => (
-                      <div>
-                        <InlineRow
-                          icon={
-                            <Calendar className="h-4 w-4 text-muted-foreground" />
-                          }
-                          label="Deadline"
-                          description="All installments must be paid by this date. New plans created after the deadline fall back to one-shot payment."
-                        >
-                          <DatePicker
-                            id="installments_deadline"
-                            value={field.state.value}
-                            onChange={field.handleChange}
-                            disabled={readOnly}
-                            placeholder="Select date"
-                            className="w-auto"
-                          />
-                        </InlineRow>
-                        <FieldError errors={field.state.meta.errors} />
-                      </div>
-                    )}
-                  </form.Field>
-
-                  <form.Field
-                    name="installments_max"
-                    validators={{
-                      onBlur: ({ value }) => {
-                        if (readOnly) return undefined
-                        if (!value) {
-                          return "Max installments is required when installments are enabled"
-                        }
-                        const num = Number.parseInt(value, 10)
-                        if (Number.isNaN(num) || num < 2 || num > 12) {
-                          return "Max installments must be between 2 and 12 (SimpleFi limit)"
-                        }
-                        return undefined
-                      },
-                    }}
-                  >
-                    {(field) => (
-                      <div>
-                        <InlineRow
-                          icon={
-                            <Ticket className="h-4 w-4 text-muted-foreground" />
-                          }
-                          label="Max installments"
-                          description="Ceiling shown to buyers. SimpleFi accepts 2–12; the actual number is picked by the buyer at checkout."
-                        >
-                          <Input
-                            id="installments_max"
-                            type="number"
-                            min="2"
-                            max="12"
-                            step="1"
-                            placeholder="e.g. 6"
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) => field.handleChange(e.target.value)}
-                            disabled={readOnly}
-                            className="max-w-[120px] text-sm"
-                          />
-                        </InlineRow>
-                        <FieldError errors={field.state.meta.errors} />
-                      </div>
-                    )}
-                  </form.Field>
-
-                  <form.Field name="installments_interval">
-                    {(field) => (
-                      <InlineRow
-                        icon={
-                          <CalendarDays className="h-4 w-4 text-muted-foreground" />
-                        }
-                        label="Billing interval"
-                        description="Cadence between installments."
-                      >
-                        <Select
-                          value={field.state.value}
-                          onValueChange={(v) =>
-                            field.handleChange(v as InstallmentInterval)
-                          }
-                          disabled={readOnly}
-                        >
-                          <SelectTrigger
-                            id="installments_interval"
-                            className="w-[140px]"
+                      {(field) => (
+                        <div>
+                          <InlineRow
+                            icon={
+                              <Calendar className="h-4 w-4 text-muted-foreground" />
+                            }
+                            label="End Date"
                           >
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="day">Day</SelectItem>
-                            <SelectItem value="week">Week</SelectItem>
-                            <SelectItem value="month">Month</SelectItem>
-                            <SelectItem value="year">Year</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </InlineRow>
-                    )}
-                  </form.Field>
+                            <DatePicker
+                              id="end_date"
+                              value={field.state.value}
+                              onChange={field.handleChange}
+                              disabled={readOnly}
+                              placeholder="Select date"
+                              defaultMonth={startDateAsDate}
+                              className="w-auto"
+                            />
+                          </InlineRow>
+                          <FieldError errors={field.state.meta.errors} />
+                        </div>
+                      )}
+                    </form.Field>
+                  )
+                }}
+              </form.Subscribe>
+            </InlineSection>
 
-                  <form.Field
-                    name="installments_interval_count"
-                    validators={{
-                      onBlur: ({ value }) => {
-                        if (readOnly) return undefined
-                        const num = Number.parseInt(value, 10)
-                        if (!value || Number.isNaN(num) || num < 1) {
-                          return "Interval count must be at least 1"
-                        }
-                        return undefined
-                      },
-                    }}
+            <Separator />
+
+            {/* Event Options */}
+            <InlineSection title="Pop-up Options">
+              <form.Field name="allows_coupons">
+                {(field) => (
+                  <InlineRow
+                    icon={<Ticket className="h-4 w-4 text-muted-foreground" />}
+                    label="Discount Coupons"
+                    description="Enable discount coupons for this pop-up"
                   >
-                    {(field) => (
-                      <div>
+                    <Switch
+                      id="allows_coupons"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="allows_scholarship">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <GraduationCap className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Scholarship Requests"
+                    description="Allow applicants to request financial assistance"
+                  >
+                    <Switch
+                      id="allows_scholarship"
+                      checked={!!field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Subscribe
+                selector={(state) => state.values.allows_scholarship}
+              >
+                {(allowsScholarship) =>
+                  allowsScholarship ? (
+                    <form.Field name="allows_incentive">
+                      {(field) => (
                         <InlineRow
                           icon={
-                            <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                            <DollarSign className="h-4 w-4 text-muted-foreground" />
                           }
-                          label="Interval count"
-                          description="Multiplier on the interval (e.g. interval = week + count = 2 → bi-weekly)."
+                          label="Cash Incentives"
+                          description="Allow assigning a cash grant alongside scholarship approval"
+                        >
+                          <Switch
+                            id="allows_incentive"
+                            checked={!!field.state.value}
+                            onCheckedChange={(checked) =>
+                              field.handleChange(checked)
+                            }
+                            disabled={readOnly}
+                          />
+                        </InlineRow>
+                      )}
+                    </form.Field>
+                  ) : null
+                }
+              </form.Subscribe>
+
+              <form.Field name="requires_application_fee">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <DollarSign className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Require Application Fee"
+                    description="Applicants must pay a refundable fee before their application is reviewed"
+                  >
+                    <Switch
+                      id="requires_application_fee"
+                      checked={!!field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Subscribe
+                selector={(state) => ({
+                  requiresFee: state.values.requires_application_fee,
+                  currency: state.values.currency,
+                })}
+              >
+                {({ requiresFee, currency }) =>
+                  requiresFee ? (
+                    <form.Field name="application_fee_amount">
+                      {(field) => (
+                        <InlineRow
+                          icon={
+                            <DollarSign className="h-4 w-4 text-muted-foreground" />
+                          }
+                          label={`Fee Amount (${currency})`}
+                          description={`Amount in ${currency} that applicants must pay`}
                         >
                           <Input
-                            id="installments_interval_count"
+                            id="application_fee_amount"
                             type="number"
-                            min="1"
-                            step="1"
+                            min="0"
+                            step="0.01"
+                            placeholder="0.00"
                             value={field.state.value}
-                            onBlur={field.handleBlur}
                             onChange={(e) => field.handleChange(e.target.value)}
                             disabled={readOnly}
                             className="max-w-[120px] text-sm"
                           />
                         </InlineRow>
-                        <FieldError errors={field.state.meta.errors} />
-                      </div>
-                    )}
-                  </form.Field>
-                </>
-              ) : null
-            }
-          </form.Subscribe>
-        </InlineSection>
+                      )}
+                    </form.Field>
+                  ) : null
+                }
+              </form.Subscribe>
 
-        <Separator />
+              <form.Field name="checkin_pass_lead_days">
+                {(field) => (
+                  <InlineRow
+                    icon={<QrCode className="h-4 w-4 text-muted-foreground" />}
+                    label="Check-in Pass Email"
+                    description="Days before the event start to email attendees their check-in QR code. Leave empty to disable."
+                  >
+                    <Input
+                      id="checkin_pass_lead_days"
+                      type="number"
+                      min="1"
+                      step="1"
+                      placeholder="e.g. 3"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-[120px] text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
 
-        {/* Self-service check-in feature flag */}
-        <InlineSection title="Self-service check-in">
-          <form.Field name="self_check_in_enabled">
-            {(field) => (
-              <InlineRow
-                icon={<QrCode className="h-4 w-4 text-muted-foreground" />}
-                label="Enable attendee self check-in"
-                description="Allow authenticated attendees to check themselves in from the hidden QR-code portal page."
-              >
-                <Switch
-                  id="self_check_in_enabled"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
+            <Separator />
 
-        <Separator />
-
-        {/* Attendee directory feature flag */}
-        <form.Subscribe selector={(state) => state.values.sale_type}>
-          {(saleType) =>
-            saleType === "application" ? (
+            {/* Companion Types — only available when editing an existing popup */}
+            {isEdit && defaultValues && (
               <>
-                <InlineSection title="Attendee directory">
-                  <form.Field name="show_attendee_directory">
-                    {(field) => (
-                      <InlineRow
-                        icon={
-                          <Users className="h-4 w-4 text-muted-foreground" />
-                        }
-                        label="Show attendee directory"
-                        description="Show the directory in the portal for accepted applicants."
-                      >
-                        <Switch
-                          id="show_attendee_directory"
-                          checked={field.state.value}
-                          onCheckedChange={(checked) =>
-                            field.handleChange(checked)
-                          }
-                          disabled={readOnly}
-                        />
-                      </InlineRow>
-                    )}
-                  </form.Field>
-                </InlineSection>
-
+                <AttendeeCategoriesEditor
+                  popupId={defaultValues.id}
+                  readOnly={readOnly}
+                />
                 <Separator />
               </>
-            ) : null
-          }
-        </form.Subscribe>
-
-        {/* Events module feature flag */}
-        <InlineSection title="Events module">
-          <form.Field name="events_enabled">
-            {(field) => (
-              <InlineRow
-                icon={
-                  <CalendarDays className="h-4 w-4 text-muted-foreground" />
-                }
-                label="Enable events module"
-                description="Show the Events section in the portal (calendar, venues, RSVPs). When off, the entire section is hidden — to only block creating new events without hiding existing ones, use the Event Settings page instead."
-              >
-                <Switch
-                  id="events_enabled"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
             )}
-          </form.Field>
-        </InlineSection>
 
-        <Separator />
-
-        {/* Pass editing feature flag */}
-        <InlineSection title="Pass Editing">
-          <form.Field name="edit_passes_enabled">
-            {(field) => (
-              <InlineRow
-                icon={<Coins className="h-4 w-4 text-muted-foreground" />}
-                label="Enable pass editing"
-                description="Allow attendees to edit their already-purchased passes during checkout. Giving up a pass returns its value as credit toward a new one."
-              >
-                <Switch
-                  id="edit_passes_enabled"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        <Separator />
-
-        {/* Languages */}
-        <InlineSection title="Languages">
-          <form.Field name="default_language">
-            {(field) => (
-              <InlineRow
-                icon={<Languages className="h-4 w-4 text-muted-foreground" />}
-                label="Default Language"
-                description="The primary language for this event"
-              >
-                <Select
-                  value={field.state.value}
-                  onValueChange={(value) => field.handleChange(value)}
-                  disabled={readOnly}
-                >
-                  <SelectTrigger className="w-auto">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {AVAILABLE_LANGUAGES.map((lang) => (
-                      <SelectItem key={lang.value} value={lang.value}>
-                        {lang.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="supported_languages">
-            {(field) => (
-              <InlineRow
-                icon={<Globe className="h-4 w-4 text-muted-foreground" />}
-                label="Supported Languages"
-                description="Languages available in the portal"
-              >
-                <div className="flex flex-col gap-2">
-                  {AVAILABLE_LANGUAGES.map((lang) => (
-                    <div
-                      key={lang.value}
-                      className="flex items-center gap-2 text-sm"
-                    >
-                      <Checkbox
-                        id={`lang-${lang.value}`}
-                        checked={field.state.value.includes(lang.value)}
-                        disabled={readOnly}
-                        onCheckedChange={(checked) => {
-                          const current = field.state.value
-                          if (checked) {
-                            field.handleChange([...current, lang.value])
-                          } else {
-                            const defaultLang =
-                              form.getFieldValue("default_language")
-                            if (lang.value === defaultLang) return
-                            field.handleChange(
-                              current.filter((l: string) => l !== lang.value),
-                            )
-                          }
-                        }}
-                      />
-                      <Label htmlFor={`lang-${lang.value}`}>{lang.label}</Label>
+            {/* Branding */}
+            <InlineSection title="Branding">
+              <form.Field name="image_url">
+                {(field) => (
+                  <div className="space-y-2 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                        <Image className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">Cover Image</p>
+                        <p className="text-xs text-muted-foreground">
+                          Main event image used in cards, tickets, application
+                          headers, invoices, and emails
+                        </p>
+                      </div>
                     </div>
-                  ))}
-                </div>
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
+                    <ImageUpload
+                      value={field.state.value || null}
+                      onChange={(url) => field.handleChange(url ?? "")}
+                      disabled={readOnly}
+                    />
+                  </div>
+                )}
+              </form.Field>
 
-        <Separator />
+              <form.Field name="icon_url">
+                {(field) => (
+                  <div className="space-y-2 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                        <Image className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">Icon</p>
+                        <p className="text-xs text-muted-foreground">
+                          Small icon shown in the portal sidebar popup menu
+                        </p>
+                      </div>
+                    </div>
+                    <ImageUpload
+                      value={field.state.value || null}
+                      onChange={(url) => field.handleChange(url ?? "")}
+                      disabled={readOnly}
+                    />
+                  </div>
+                )}
+              </form.Field>
 
-        {/* Approval strategy + Reviewers (edit only, application sale_type only —
-            direct-sale popups have no application flow, so these are meaningless) */}
-        {isEdit && (
-          <form.Subscribe selector={(state) => state.values.sale_type}>
-            {(saleType) =>
-              saleType === "application" ? (
-                <>
-                  <Separator />
+              <form.Field name="favicon_url">
+                {(field) => (
+                  <div className="space-y-2 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                        <Image className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">Favicon</p>
+                        <p className="text-xs text-muted-foreground">
+                          Browser tab icon shown on the public checkout for this
+                          popup. Overrides the tenant default.
+                        </p>
+                      </div>
+                    </div>
+                    <ImageUpload
+                      value={field.state.value || null}
+                      onChange={(url) => field.handleChange(url ?? "")}
+                      disabled={readOnly}
+                    />
+                  </div>
+                )}
+              </form.Field>
 
-                  <ApprovalStrategyForm
-                    popupId={defaultValues!.id}
-                    readOnly={readOnly}
-                    variant="inline"
-                  />
+              <form.Field name="express_checkout_background">
+                {(field) => (
+                  <div className="space-y-2 py-3">
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+                        <Image className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium">
+                          Checkout Background
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Full-screen background for checkout, invite, and
+                          success pages. Image or MP4 video (autoplay + audio
+                          toggle). Falls back to Cover Image, then tenant
+                          background.
+                        </p>
+                      </div>
+                    </div>
+                    <ImageUpload
+                      value={field.state.value || null}
+                      onChange={(url) => field.handleChange(url ?? "")}
+                      disabled={readOnly}
+                      accept="image+video"
+                    />
+                  </div>
+                )}
+              </form.Field>
+            </InlineSection>
 
-                  <Separator />
-
-                  <ConditionalReviewersManager
-                    popupId={defaultValues!.id}
-                    tenantId={defaultValues!.tenant_id}
-                    readOnly={readOnly}
-                    variant="inline"
-                  />
-                </>
-              ) : null
-            }
-          </form.Subscribe>
-        )}
-
-        {isEdit && (defaultValues?.supported_languages?.length ?? 0) > 1 && (
-          <>
             <Separator />
-            <TranslationManager
-              entityType="popup"
-              entityId={defaultValues!.id}
-              translatableFields={["name", "tagline", "location"]}
-              sourceData={{
-                name: defaultValues!.name,
-                tagline: defaultValues!.tagline,
-                location: defaultValues!.location,
-              }}
-              supportedLanguages={defaultValues!.supported_languages!}
-              defaultLanguage={defaultValues!.default_language!}
-            />
-          </>
-        )}
 
-        <Separator />
+            {/* Links */}
+            <InlineSection title="Links">
+              <form.Field name="web_url">
+                {(field) => (
+                  <InlineRow
+                    icon={<Globe className="h-4 w-4 text-muted-foreground" />}
+                    label="Website"
+                  >
+                    <Input
+                      id="web_url"
+                      type="url"
+                      placeholder="https://example.com"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
 
-        {/* Form Actions */}
-        <div className="flex gap-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigate({ to: "/popups" })}
-          >
-            {readOnly ? "Back" : "Cancel"}
-          </Button>
-          {!readOnly && (
-            <LoadingButton type="submit" loading={isPending}>
-              {isEdit ? "Save Changes" : "Create Event"}
-            </LoadingButton>
+              <form.Field name="blog_url">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <FileText className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Blog"
+                  >
+                    <Input
+                      id="blog_url"
+                      type="url"
+                      placeholder="https://example.com/blog"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="twitter_url">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <LinkIcon className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Twitter"
+                  >
+                    <Input
+                      id="twitter_url"
+                      type="url"
+                      placeholder="https://twitter.com/example"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="terms_and_conditions_url">
+                {(field) => (
+                  <InlineRow
+                    icon={<Scale className="h-4 w-4 text-muted-foreground" />}
+                    label="Terms & Conditions"
+                  >
+                    <Input
+                      id="terms_and_conditions_url"
+                      type="url"
+                      placeholder="https://example.com/terms"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Integrations */}
+            <InlineSection title="Integrations">
+              <form.Field name="simplefi_api_key">
+                {(field) => (
+                  <InlineRow
+                    icon={<Key className="h-4 w-4 text-muted-foreground" />}
+                    label="SimpleFi"
+                    description="Payment integration API key"
+                  >
+                    <Input
+                      id="simplefi_api_key"
+                      type="password"
+                      placeholder="Enter API key"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+              <form.Field name="simplefi_success_behavior">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <LinkIcon className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="SimpleFi success redirect"
+                    description="How the buyer reaches the success URL after paying. Manual keeps them on SimpleFi's checkout until they click through; automatic redirects them immediately."
+                  >
+                    <Select
+                      value={field.state.value}
+                      onValueChange={(v) =>
+                        field.handleChange(v as SimpleFiSuccessBehavior)
+                      }
+                      disabled={readOnly}
+                    >
+                      <SelectTrigger
+                        id="simplefi_success_behavior"
+                        className="w-[140px]"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="manual">Manual</SelectItem>
+                        <SelectItem value="automatic">Automatic</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </InlineRow>
+                )}
+              </form.Field>
+              <form.Field name="open_checkout_success_url">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <LinkIcon className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Open checkout success URL"
+                    description="Where the buyer is redirected after a successful open-checkout payment. Defaults to the portal thank-you page."
+                  >
+                    <Input
+                      id="open_checkout_success_url"
+                      type="url"
+                      placeholder="https://example.com/thank-you"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+              <form.Field name="open_checkout_cancel_url">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <LinkIcon className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Open checkout cancel URL"
+                    description="Where the buyer is redirected after a cancelled open-checkout payment. Defaults to the portal checkout page."
+                  >
+                    <Input
+                      id="open_checkout_cancel_url"
+                      type="url"
+                      placeholder="https://example.com/checkout"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+              <form.Field name="open_checkout_signing_secret">
+                {(field) => (
+                  <InlineRow
+                    icon={<Key className="h-4 w-4 text-muted-foreground" />}
+                    label="Open checkout signing secret"
+                    description="Shared secret to HMAC-sign the order data sent to the success URL. Set the same value on the external thank-you page to verify it. Leave empty to send the redirect without a signed payload."
+                  >
+                    <Input
+                      id="open_checkout_signing_secret"
+                      type="password"
+                      placeholder="Enter signing secret"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Invoice Settings */}
+            <InlineSection title="Invoice Settings">
+              <form.Field name="invoice_company_name">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <Building2 className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Company Name"
+                  >
+                    <Input
+                      id="invoice_company_name"
+                      placeholder="Acme Inc"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="invoice_company_address">
+                {(field) => (
+                  <InlineRow
+                    icon={<MapPin className="h-4 w-4 text-muted-foreground" />}
+                    label="Address"
+                  >
+                    <Input
+                      id="invoice_company_address"
+                      placeholder="123 Main St, City, Country"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="invoice_company_email">
+                {(field) => (
+                  <InlineRow
+                    icon={<Mail className="h-4 w-4 text-muted-foreground" />}
+                    label="Email"
+                  >
+                    <Input
+                      id="invoice_company_email"
+                      type="email"
+                      placeholder="billing@example.com"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-xs text-sm"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Insurance */}
+            <InlineSection title="Insurance">
+              <form.Field name="insurance_enabled">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Enable Insurance"
+                    description="Offer insurance for eligible products during checkout"
+                  >
+                    <Switch
+                      id="insurance_enabled"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Subscribe
+                selector={(state) => state.values.insurance_enabled}
+              >
+                {(insuranceEnabled) => (
+                  <form.Field
+                    name="insurance_percentage"
+                    validators={{
+                      onBlur: ({ value }) => {
+                        if (readOnly || !insuranceEnabled) return undefined
+                        const num = Number.parseFloat(value)
+                        if (!value || Number.isNaN(num) || num <= 0) {
+                          return "Insurance percentage must be greater than 0 when insurance is enabled"
+                        }
+                        if (num > 100) {
+                          return "Insurance percentage cannot exceed 100"
+                        }
+                        return undefined
+                      },
+                    }}
+                  >
+                    {(field) => (
+                      <div>
+                        <InlineRow
+                          icon={
+                            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                          }
+                          label="Insurance Rate (%)"
+                          description="Percentage of eligible product price applied as insurance fee"
+                        >
+                          <Input
+                            id="insurance_percentage"
+                            type="number"
+                            min="0.01"
+                            max="100"
+                            step="0.01"
+                            placeholder="e.g. 5.00"
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            disabled={readOnly || !insuranceEnabled}
+                            className="max-w-[120px] text-sm"
+                          />
+                        </InlineRow>
+                        <FieldError errors={field.state.meta.errors} />
+                      </div>
+                    )}
+                  </form.Field>
+                )}
+              </form.Subscribe>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Contribution fee */}
+            <InlineSection title="Contribution">
+              <form.Field name="contribution_enabled">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <HandCoins className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Enable Contribution"
+                    description="Add an optional contribution fee to orders at checkout"
+                  >
+                    <Switch
+                      id="contribution_enabled"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Subscribe
+                selector={(state) => state.values.contribution_enabled}
+              >
+                {(contributionEnabled) => (
+                  <>
+                    <form.Field
+                      name="contribution_percentage"
+                      validators={{
+                        onBlur: ({ value }) => {
+                          if (readOnly || !contributionEnabled) return undefined
+                          const num = Number.parseFloat(value)
+                          if (!value || Number.isNaN(num) || num < 0) {
+                            return "Contribution percentage must be 0 or greater when contribution is enabled"
+                          }
+                          if (num > 100) {
+                            return "Contribution percentage cannot exceed 100"
+                          }
+                          return undefined
+                        },
+                      }}
+                    >
+                      {(field) => (
+                        <div>
+                          <InlineRow
+                            icon={
+                              <HandCoins className="h-4 w-4 text-muted-foreground" />
+                            }
+                            label="Contribution Rate (%)"
+                            description="Percentage of the total order applied as a contribution fee"
+                          >
+                            <Input
+                              id="contribution_percentage"
+                              type="number"
+                              min="0"
+                              max="100"
+                              step="0.01"
+                              placeholder="e.g. 2.50"
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(e) =>
+                                field.handleChange(e.target.value)
+                              }
+                              disabled={readOnly || !contributionEnabled}
+                              className="max-w-[120px] text-sm"
+                            />
+                          </InlineRow>
+                          <FieldError errors={field.state.meta.errors} />
+                        </div>
+                      )}
+                    </form.Field>
+
+                    <form.Field name="contribution_label">
+                      {(field) => (
+                        <InlineRow
+                          icon={
+                            <HandCoins className="h-4 w-4 text-muted-foreground" />
+                          }
+                          label="Contribution Label"
+                          description="Short name shown as the line item in the checkout summary"
+                        >
+                          <Input
+                            id="contribution_label"
+                            type="text"
+                            placeholder="e.g. Event support contribution"
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            disabled={readOnly || !contributionEnabled}
+                            className="max-w-xs text-sm"
+                          />
+                        </InlineRow>
+                      )}
+                    </form.Field>
+
+                    <form.Field name="contribution_description">
+                      {(field) => (
+                        <InlineRow
+                          icon={
+                            <HandCoins className="h-4 w-4 text-muted-foreground" />
+                          }
+                          label="Contribution Description"
+                          description="Longer explanation shown under the line item in the portal order summary"
+                        >
+                          <Textarea
+                            id="contribution_description"
+                            placeholder="e.g. This contribution helps fund scholarships and community programs."
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            disabled={readOnly || !contributionEnabled}
+                            className="w-80 max-w-xs text-sm field-sizing-fixed"
+                            rows={3}
+                          />
+                        </InlineRow>
+                      )}
+                    </form.Field>
+                  </>
+                )}
+              </form.Subscribe>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Installment plans (SimpleFi) */}
+            <InlineSection title="Installment plans">
+              <form.Field name="installments_enabled">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <CreditCard className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Enable installment plans"
+                    description="Offer buyers the option to pay in scheduled installments. SimpleFi renders the per-cycle selector at checkout."
+                  >
+                    <Switch
+                      id="installments_enabled"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Subscribe
+                selector={(state) => state.values.installments_enabled}
+              >
+                {(installmentsEnabled) =>
+                  installmentsEnabled ? (
+                    <>
+                      <form.Field
+                        name="installments_deadline"
+                        validators={{
+                          onBlur: ({ value }) => {
+                            if (readOnly) return undefined
+                            if (!value) {
+                              return "Deadline is required when installments are enabled"
+                            }
+                            return undefined
+                          },
+                        }}
+                      >
+                        {(field) => (
+                          <div>
+                            <InlineRow
+                              icon={
+                                <Calendar className="h-4 w-4 text-muted-foreground" />
+                              }
+                              label="Deadline"
+                              description="All installments must be paid by this date. New plans created after the deadline fall back to one-shot payment."
+                            >
+                              <DatePicker
+                                id="installments_deadline"
+                                value={field.state.value}
+                                onChange={field.handleChange}
+                                disabled={readOnly}
+                                placeholder="Select date"
+                                className="w-auto"
+                              />
+                            </InlineRow>
+                            <FieldError errors={field.state.meta.errors} />
+                          </div>
+                        )}
+                      </form.Field>
+
+                      <form.Field
+                        name="installments_max"
+                        validators={{
+                          onBlur: ({ value }) => {
+                            if (readOnly) return undefined
+                            if (!value) {
+                              return "Max installments is required when installments are enabled"
+                            }
+                            const num = Number.parseInt(value, 10)
+                            if (Number.isNaN(num) || num < 2 || num > 12) {
+                              return "Max installments must be between 2 and 12 (SimpleFi limit)"
+                            }
+                            return undefined
+                          },
+                        }}
+                      >
+                        {(field) => (
+                          <div>
+                            <InlineRow
+                              icon={
+                                <Ticket className="h-4 w-4 text-muted-foreground" />
+                              }
+                              label="Max installments"
+                              description="Ceiling shown to buyers. SimpleFi accepts 2–12; the actual number is picked by the buyer at checkout."
+                            >
+                              <Input
+                                id="installments_max"
+                                type="number"
+                                min="2"
+                                max="12"
+                                step="1"
+                                placeholder="e.g. 6"
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(e) =>
+                                  field.handleChange(e.target.value)
+                                }
+                                disabled={readOnly}
+                                className="max-w-[120px] text-sm"
+                              />
+                            </InlineRow>
+                            <FieldError errors={field.state.meta.errors} />
+                          </div>
+                        )}
+                      </form.Field>
+
+                      <form.Field name="installments_interval">
+                        {(field) => (
+                          <InlineRow
+                            icon={
+                              <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                            }
+                            label="Billing interval"
+                            description="Cadence between installments."
+                          >
+                            <Select
+                              value={field.state.value}
+                              onValueChange={(v) =>
+                                field.handleChange(v as InstallmentInterval)
+                              }
+                              disabled={readOnly}
+                            >
+                              <SelectTrigger
+                                id="installments_interval"
+                                className="w-[140px]"
+                              >
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="day">Day</SelectItem>
+                                <SelectItem value="week">Week</SelectItem>
+                                <SelectItem value="month">Month</SelectItem>
+                                <SelectItem value="year">Year</SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </InlineRow>
+                        )}
+                      </form.Field>
+
+                      <form.Field
+                        name="installments_interval_count"
+                        validators={{
+                          onBlur: ({ value }) => {
+                            if (readOnly) return undefined
+                            const num = Number.parseInt(value, 10)
+                            if (!value || Number.isNaN(num) || num < 1) {
+                              return "Interval count must be at least 1"
+                            }
+                            return undefined
+                          },
+                        }}
+                      >
+                        {(field) => (
+                          <div>
+                            <InlineRow
+                              icon={
+                                <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                              }
+                              label="Interval count"
+                              description="Multiplier on the interval (e.g. interval = week + count = 2 → bi-weekly)."
+                            >
+                              <Input
+                                id="installments_interval_count"
+                                type="number"
+                                min="1"
+                                step="1"
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(e) =>
+                                  field.handleChange(e.target.value)
+                                }
+                                disabled={readOnly}
+                                className="max-w-[120px] text-sm"
+                              />
+                            </InlineRow>
+                            <FieldError errors={field.state.meta.errors} />
+                          </div>
+                        )}
+                      </form.Field>
+                    </>
+                  ) : null
+                }
+              </form.Subscribe>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Self-service check-in feature flag */}
+            <InlineSection title="Self-service check-in">
+              <form.Field name="self_check_in_enabled">
+                {(field) => (
+                  <InlineRow
+                    icon={<QrCode className="h-4 w-4 text-muted-foreground" />}
+                    label="Enable attendee self check-in"
+                    description="Allow authenticated attendees to check themselves in from the hidden QR-code portal page."
+                  >
+                    <Switch
+                      id="self_check_in_enabled"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Attendee directory feature flag */}
+            <form.Subscribe selector={(state) => state.values.sale_type}>
+              {(saleType) =>
+                saleType === "application" ? (
+                  <>
+                    <InlineSection title="Attendee directory">
+                      <form.Field name="show_attendee_directory">
+                        {(field) => (
+                          <InlineRow
+                            icon={
+                              <Users className="h-4 w-4 text-muted-foreground" />
+                            }
+                            label="Show attendee directory"
+                            description="Show the directory in the portal for accepted applicants."
+                          >
+                            <Switch
+                              id="show_attendee_directory"
+                              checked={field.state.value}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked)
+                              }
+                              disabled={readOnly}
+                            />
+                          </InlineRow>
+                        )}
+                      </form.Field>
+                    </InlineSection>
+
+                    <Separator />
+                  </>
+                ) : null
+              }
+            </form.Subscribe>
+
+            {/* Events module feature flag */}
+            <InlineSection title="Events module">
+              <form.Field name="events_enabled">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <CalendarDays className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Enable events module"
+                    description="Show the Events section in the portal (calendar, venues, RSVPs). When off, the entire section is hidden — to only block creating new events without hiding existing ones, use the Event Settings page instead."
+                  >
+                    <Switch
+                      id="events_enabled"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Pass editing feature flag */}
+            <InlineSection title="Pass Editing">
+              <form.Field name="edit_passes_enabled">
+                {(field) => (
+                  <InlineRow
+                    icon={<Coins className="h-4 w-4 text-muted-foreground" />}
+                    label="Enable pass editing"
+                    description="Allow attendees to edit their already-purchased passes during checkout. Giving up a pass returns its value as credit toward a new one."
+                  >
+                    <Switch
+                      id="edit_passes_enabled"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Languages */}
+            <InlineSection title="Languages">
+              <form.Field name="default_language">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <Languages className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Default Language"
+                    description="The primary language for this event"
+                  >
+                    <Select
+                      value={field.state.value}
+                      onValueChange={(value) => field.handleChange(value)}
+                      disabled={readOnly}
+                    >
+                      <SelectTrigger className="w-auto">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {AVAILABLE_LANGUAGES.map((lang) => (
+                          <SelectItem key={lang.value} value={lang.value}>
+                            {lang.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="supported_languages">
+                {(field) => (
+                  <InlineRow
+                    icon={<Globe className="h-4 w-4 text-muted-foreground" />}
+                    label="Supported Languages"
+                    description="Languages available in the portal"
+                  >
+                    <div className="flex flex-col gap-2">
+                      {AVAILABLE_LANGUAGES.map((lang) => (
+                        <div
+                          key={lang.value}
+                          className="flex items-center gap-2 text-sm"
+                        >
+                          <Checkbox
+                            id={`lang-${lang.value}`}
+                            checked={field.state.value.includes(lang.value)}
+                            disabled={readOnly}
+                            onCheckedChange={(checked) => {
+                              const current = field.state.value
+                              if (checked) {
+                                field.handleChange([...current, lang.value])
+                              } else {
+                                const defaultLang =
+                                  form.getFieldValue("default_language")
+                                if (lang.value === defaultLang) return
+                                field.handleChange(
+                                  current.filter(
+                                    (l: string) => l !== lang.value,
+                                  ),
+                                )
+                              }
+                            }}
+                          />
+                          <Label htmlFor={`lang-${lang.value}`}>
+                            {lang.label}
+                          </Label>
+                        </div>
+                      ))}
+                    </div>
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            <Separator />
+
+            {/* Approval strategy + Reviewers (edit only, application sale_type only —
+            direct-sale popups have no application flow, so these are meaningless) */}
+            {isEdit && (
+              <form.Subscribe selector={(state) => state.values.sale_type}>
+                {(saleType) =>
+                  saleType === "application" ? (
+                    <>
+                      <Separator />
+
+                      <ApprovalStrategyForm
+                        popupId={defaultValues!.id}
+                        readOnly={readOnly}
+                        variant="inline"
+                      />
+
+                      <Separator />
+
+                      <ConditionalReviewersManager
+                        popupId={defaultValues!.id}
+                        tenantId={defaultValues!.tenant_id}
+                        readOnly={readOnly}
+                        variant="inline"
+                      />
+                    </>
+                  ) : null
+                }
+              </form.Subscribe>
+            )}
+
+            <Separator />
+
+            {/* Form Actions */}
+            <div className="flex gap-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => navigate({ to: "/popups" })}
+              >
+                {readOnly ? "Back" : "Cancel"}
+              </Button>
+              {!readOnly && (
+                <LoadingButton type="submit" loading={isPending}>
+                  {isEdit ? "Save Changes" : "Create Event"}
+                </LoadingButton>
+              )}
+            </div>
+          </form>
+
+          {isEdit && !readOnly && (
+            <div className="mx-auto max-w-2xl">
+              <DangerZone
+                description="Once you delete this event, all associated products, groups, coupons, and attendee data will be permanently removed. This action cannot be undone."
+                onDelete={() => deleteMutation.mutate()}
+                isDeleting={deleteMutation.isPending}
+                confirmText="Delete Event"
+                resourceName={defaultValues.name}
+                variant="inline"
+              />
+            </div>
           )}
-        </div>
-      </form>
+        </TabsContent>
 
-      {isEdit && !readOnly && (
-        <div className="mx-auto max-w-2xl">
-          <DangerZone
-            description="Once you delete this event, all associated products, groups, coupons, and attendee data will be permanently removed. This action cannot be undone."
-            onDelete={() => deleteMutation.mutate()}
-            isDeleting={deleteMutation.isPending}
-            confirmText="Delete Event"
-            resourceName={defaultValues.name}
-            variant="inline"
-          />
-        </div>
-      )}
+        <TabsContent value="translations">
+          {!isEdit ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Save the event first to add translations.
+            </div>
+          ) : (defaultValues?.supported_languages?.length ?? 0) <= 1 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Enable a second language to translate this event.
+            </div>
+          ) : (
+            <form.Subscribe selector={(state) => state.isDirty}>
+              {(isDirty) =>
+                isDirty ? (
+                  <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                    Save your changes first to translate the latest content.
+                  </div>
+                ) : (
+                  <TranslationManager
+                    entityType="popup"
+                    entityId={defaultValues!.id}
+                    translatableFields={["name", "tagline", "location"]}
+                    sourceData={{
+                      name: defaultValues!.name,
+                      tagline: defaultValues!.tagline,
+                      location: defaultValues!.location,
+                    }}
+                    supportedLanguages={defaultValues!.supported_languages!}
+                    defaultLanguage={defaultValues!.default_language!}
+                  />
+                )
+              }
+            </form.Subscribe>
+          )}
+        </TabsContent>
+      </Tabs>
 
       <UnsavedChangesDialog blocker={blocker} />
     </div>

--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
@@ -327,595 +328,639 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
 
   return (
     <div className="space-y-6">
-      <form
-        noValidate
-        onSubmit={(e) => {
-          e.preventDefault()
-          if (!readOnly) {
-            form.handleSubmit()
-          }
-        }}
-        className="mx-auto max-w-2xl space-y-6"
-      >
-        {/* Hero: Name + Category Badge */}
-        <div className="space-y-3">
-          <form.Field
-            name="name"
-            validators={{
-              onBlur: ({ value }) =>
-                !readOnly && !value ? "Name is required" : undefined,
+      <Tabs defaultValue="general" className="mx-auto max-w-2xl space-y-6">
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="translations">Translations</TabsTrigger>
+        </TabsList>
+        <TabsContent value="general" className="space-y-6">
+          <form
+            noValidate
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (!readOnly) {
+                form.handleSubmit()
+              }
             }}
+            className="mx-auto max-w-2xl space-y-6"
           >
-            {(field) => (
-              <div>
-                <HeroInput
-                  placeholder="Product Name"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                />
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="category">
-            {(field) => (
-              <div className="flex items-center gap-2">
-                <Select
-                  value={field.state.value}
-                  onValueChange={(val) => {
-                    if (val === "__add_new__") {
-                      setNewCategoryName("")
-                      setAddCategoryOpen(true)
-                      return
-                    }
-                    field.handleChange(val as ProductCategory)
-                  }}
-                  disabled={readOnly}
-                >
-                  <SelectTrigger className="w-auto border-0 bg-transparent p-0 shadow-none focus:ring-0">
-                    <Badge variant="secondary">
-                      <SelectValue />
-                    </Badge>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {allCategories.map((cat) => {
-                      const known = PRODUCT_CATEGORIES.find(
-                        (c) => c.value === cat,
-                      )
-                      const isDisabled =
-                        cat === "patreon" && hasActivePatreonProduct
-                      return (
-                        <SelectItem
-                          key={cat}
-                          value={cat}
-                          disabled={isDisabled}
-                          title={
-                            isDisabled
-                              ? "This popup already has a Patron product"
-                              : undefined
-                          }
-                        >
-                          {known?.label ?? cat}
-                        </SelectItem>
-                      )
-                    })}
-                    <SelectItem value="__add_new__" className="text-primary">
-                      <span className="flex items-center gap-1.5">
-                        <Plus className="h-3.5 w-3.5" />
-                        Add category
-                      </span>
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </form.Field>
-        </div>
-
-        {/* Product Details metadata (edit only) */}
-        {isEdit && (
-          <div className="flex gap-6 text-sm text-muted-foreground">
-            <div>
-              <span className="text-xs uppercase tracking-wider">Slug</span>
-              <p className="font-mono">{defaultValues.slug}</p>
-            </div>
-          </div>
-        )}
-
-        <Separator />
-
-        {/* Description */}
-        <form.Field name="description">
-          {(field) => (
-            <div className="space-y-2">
-              <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Description
-              </p>
-              <Textarea
-                placeholder="Product description..."
-                rows={2}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(e) => field.handleChange(e.target.value)}
-                disabled={readOnly}
-              />
-            </div>
-          )}
-        </form.Field>
-
-        {/* Image */}
-        <form.Field name="image_url">
-          {(field) => (
-            <div className="space-y-2">
-              <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Image
-              </p>
-              <ImageUpload
-                value={field.state.value || null}
-                onChange={(url) => field.handleChange(url ?? "")}
-                disabled={readOnly}
-              />
-            </div>
-          )}
-        </form.Field>
-
-        {/* Additional images — housing-only, rendered as a carousel in the
-            grid/showcase checkout variants. The cover above is image #1. */}
-        <form.Subscribe selector={(state) => state.values.category}>
-          {(category) =>
-            category === "housing" ? (
-              <form.Field name="images">
+            {/* Hero: Name + Category Badge */}
+            <div className="space-y-3">
+              <form.Field
+                name="name"
+                validators={{
+                  onBlur: ({ value }) =>
+                    !readOnly && !value ? "Name is required" : undefined,
+                }}
+              >
                 {(field) => (
-                  <div className="space-y-2">
-                    <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Additional images
-                    </p>
-                    <p className="px-1 text-xs text-muted-foreground">
-                      Shown after the cover in the grid/showcase carousel. Tap
-                      enlarges to a lightbox.
-                    </p>
-                    <MultiImageUpload
+                  <div>
+                    <HeroInput
+                      placeholder="Product Name"
                       value={field.state.value}
-                      onChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => field.handleChange(e.target.value)}
                       disabled={readOnly}
                     />
+                    <FieldError errors={field.state.meta.errors} />
                   </div>
                 )}
               </form.Field>
-            ) : null
-          }
-        </form.Subscribe>
 
-        <Separator />
-
-        {/* Pricing & Inventory */}
-        <InlineSection title="Pricing & Inventory">
-          <form.Subscribe selector={(state) => state.values.category}>
-            {(category) =>
-              category !== "patreon" && (
-                <>
-                  <form.Field
-                    name="price"
-                    validators={{
-                      onBlur: ({ value }) =>
-                        !readOnly && !value ? "Price is required" : undefined,
-                    }}
-                  >
-                    {(field) => (
-                      <div>
-                        <InlineRow
-                          icon={
-                            <DollarSign className="h-4 w-4 text-muted-foreground" />
-                          }
-                          label="Price"
-                        >
-                          <Input
-                            placeholder="100.00"
-                            type="text"
-                            inputMode="decimal"
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) => field.handleChange(e.target.value)}
-                            disabled={readOnly}
-                            className="max-w-32 text-sm"
-                          />
-                        </InlineRow>
-                        <FieldError errors={field.state.meta.errors} />
-                      </div>
-                    )}
-                  </form.Field>
-
-                  <form.Field
-                    name="compare_price"
-                    validators={{
-                      onBlur: ({ value, fieldApi }) => {
-                        if (readOnly || !value) return undefined
-                        const num = Number(value)
-                        if (Number.isNaN(num) || num < 0) {
-                          return "Compare-at price must be a positive number."
+              <form.Field name="category">
+                {(field) => (
+                  <div className="flex items-center gap-2">
+                    <Select
+                      value={field.state.value}
+                      onValueChange={(val) => {
+                        if (val === "__add_new__") {
+                          setNewCategoryName("")
+                          setAddCategoryOpen(true)
+                          return
                         }
-                        const rawPrice = fieldApi.form.getFieldValue("price")
-                        if (rawPrice) {
-                          const price = Number(rawPrice)
-                          if (!Number.isNaN(price) && num <= price) {
-                            return "Compare-at price must be higher than price."
-                          }
-                        }
-                        return undefined
-                      },
-                    }}
-                  >
-                    {(field) => (
-                      <div>
-                        <InlineRow
-                          icon={
-                            <DollarSign className="h-4 w-4 text-muted-foreground" />
-                          }
-                          label="Compare-at price"
-                          description="Crossed-out original price shown next to the current price. Leave empty for no discount."
-                        >
-                          <Input
-                            placeholder="120.00"
-                            type="text"
-                            inputMode="decimal"
-                            value={field.state.value}
-                            onBlur={field.handleBlur}
-                            onChange={(e) => field.handleChange(e.target.value)}
-                            disabled={readOnly}
-                            className="max-w-32 text-sm"
-                          />
-                        </InlineRow>
-                        <FieldError errors={field.state.meta.errors} />
-                      </div>
-                    )}
-                  </form.Field>
-                </>
-              )
-            }
-          </form.Subscribe>
-
-          <form.Field
-            name="total_stock_cap"
-            validators={{
-              onBlur: ({ value }) => {
-                if (readOnly || !value) return undefined
-                const num = Number.parseInt(value, 10)
-                if (Number.isNaN(num) || num < 1) {
-                  return "Total stock must be a positive number. Leave empty for unlimited."
-                }
-                return undefined
-              },
-            }}
-          >
-            {(field) => (
-              <div>
-                <InlineRow
-                  icon={<Hash className="h-4 w-4 text-muted-foreground" />}
-                  label="Total stock"
-                  description="Maximum units available. Leave empty for unlimited."
-                >
-                  <Input
-                    id="total_stock_cap"
-                    aria-label="Total stock"
-                    placeholder="Unlimited"
-                    type="number"
-                    min="1"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    disabled={readOnly}
-                    className="max-w-32 text-sm"
-                  />
-                </InlineRow>
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field
-            name="max_per_order"
-            validators={{
-              onBlur: ({ value, fieldApi }) => {
-                if (readOnly || !value) return undefined
-                const num = Number.parseInt(value, 10)
-                if (Number.isNaN(num) || num < 1) {
-                  return "Max per order must be a positive number. Leave empty for unlimited."
-                }
-                const rawCap = fieldApi.form.getFieldValue("total_stock_cap")
-                if (rawCap) {
-                  const cap = Number.parseInt(rawCap, 10)
-                  if (!Number.isNaN(cap) && num > cap) {
-                    return `Cannot exceed total stock cap (${cap})`
-                  }
-                }
-                return undefined
-              },
-            }}
-          >
-            {(field) => (
-              <div>
-                <InlineRow
-                  icon={<Hash className="h-4 w-4 text-muted-foreground" />}
-                  label="Max per order"
-                  description="Per-cart cap. Leave empty for unlimited."
-                >
-                  <Input
-                    id="max_per_order"
-                    aria-label="Max per order"
-                    placeholder="Unlimited"
-                    type="number"
-                    min="1"
-                    value={field.state.value}
-                    onBlur={field.handleBlur}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                    disabled={readOnly}
-                    className="max-w-32 text-sm"
-                  />
-                </InlineRow>
-                <FieldError errors={field.state.meta.errors} />
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="insurance_eligible">
-            {(field) => (
-              <InlineRow
-                icon={<ShieldCheck className="h-4 w-4 text-muted-foreground" />}
-                label="Insurance Eligible"
-                description="Include this product in the insurance calculation when popup insurance is enabled"
-              >
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="insurance_eligible"
-                    checked={field.state.value}
-                    onCheckedChange={(checked) =>
-                      field.handleChange(checked === true)
-                    }
-                    disabled={readOnly}
-                  />
-                  <Label htmlFor="insurance_eligible" className="text-sm">
-                    Eligible
-                  </Label>
-                </div>
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Subscribe selector={(state) => state.values.category}>
-            {(category) => (
-              <form.Field name="discountable">
-                {(field) => {
-                  // Patreon donations are never discountable by policy — the
-                  // backend coerces the field on write, so mirror that in the
-                  // form: force value=false, disable the checkbox, and show
-                  // why.
-                  const isPatreon = category === "patreon"
-                  const isDisabled = readOnly || isPatreon
-                  const effectiveChecked = isPatreon ? false : field.state.value
-
-                  return (
-                    <InlineRow
-                      icon={
-                        <TicketPercent className="h-4 w-4 text-muted-foreground" />
-                      }
-                      label="Discountable"
-                      description={
-                        isPatreon
-                          ? "Patreon donations are never discountable"
-                          : "When off, coupons and group/scholarship discounts never reduce this product's price (e.g. mandatory meal plans)"
-                      }
+                        field.handleChange(val as ProductCategory)
+                      }}
+                      disabled={readOnly}
                     >
-                      <div className="flex items-center gap-2">
-                        <Checkbox
-                          id="discountable"
-                          checked={effectiveChecked}
-                          onCheckedChange={(checked) =>
-                            field.handleChange(checked === true)
+                      <SelectTrigger className="w-auto border-0 bg-transparent p-0 shadow-none focus:ring-0">
+                        <Badge variant="secondary">
+                          <SelectValue />
+                        </Badge>
+                      </SelectTrigger>
+                      <SelectContent>
+                        {allCategories.map((cat) => {
+                          const known = PRODUCT_CATEGORIES.find(
+                            (c) => c.value === cat,
+                          )
+                          const isDisabled =
+                            cat === "patreon" && hasActivePatreonProduct
+                          return (
+                            <SelectItem
+                              key={cat}
+                              value={cat}
+                              disabled={isDisabled}
+                              title={
+                                isDisabled
+                                  ? "This popup already has a Patron product"
+                                  : undefined
+                              }
+                            >
+                              {known?.label ?? cat}
+                            </SelectItem>
+                          )
+                        })}
+                        <SelectItem
+                          value="__add_new__"
+                          className="text-primary"
+                        >
+                          <span className="flex items-center gap-1.5">
+                            <Plus className="h-3.5 w-3.5" />
+                            Add category
+                          </span>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+              </form.Field>
+            </div>
+
+            {/* Product Details metadata (edit only) */}
+            {isEdit && (
+              <div className="flex gap-6 text-sm text-muted-foreground">
+                <div>
+                  <span className="text-xs uppercase tracking-wider">Slug</span>
+                  <p className="font-mono">{defaultValues.slug}</p>
+                </div>
+              </div>
+            )}
+
+            <Separator />
+
+            {/* Description */}
+            <form.Field name="description">
+              {(field) => (
+                <div className="space-y-2">
+                  <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Description
+                  </p>
+                  <Textarea
+                    placeholder="Product description..."
+                    rows={2}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    disabled={readOnly}
+                  />
+                </div>
+              )}
+            </form.Field>
+
+            {/* Image */}
+            <form.Field name="image_url">
+              {(field) => (
+                <div className="space-y-2">
+                  <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Image
+                  </p>
+                  <ImageUpload
+                    value={field.state.value || null}
+                    onChange={(url) => field.handleChange(url ?? "")}
+                    disabled={readOnly}
+                  />
+                </div>
+              )}
+            </form.Field>
+
+            {/* Additional images — housing-only, rendered as a carousel in the
+            grid/showcase checkout variants. The cover above is image #1. */}
+            <form.Subscribe selector={(state) => state.values.category}>
+              {(category) =>
+                category === "housing" ? (
+                  <form.Field name="images">
+                    {(field) => (
+                      <div className="space-y-2">
+                        <p className="px-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          Additional images
+                        </p>
+                        <p className="px-1 text-xs text-muted-foreground">
+                          Shown after the cover in the grid/showcase carousel.
+                          Tap enlarges to a lightbox.
+                        </p>
+                        <MultiImageUpload
+                          value={field.state.value}
+                          onChange={field.handleChange}
+                          disabled={readOnly}
+                        />
+                      </div>
+                    )}
+                  </form.Field>
+                ) : null
+              }
+            </form.Subscribe>
+
+            <Separator />
+
+            {/* Pricing & Inventory */}
+            <InlineSection title="Pricing & Inventory">
+              <form.Subscribe selector={(state) => state.values.category}>
+                {(category) =>
+                  category !== "patreon" && (
+                    <>
+                      <form.Field
+                        name="price"
+                        validators={{
+                          onBlur: ({ value }) =>
+                            !readOnly && !value
+                              ? "Price is required"
+                              : undefined,
+                        }}
+                      >
+                        {(field) => (
+                          <div>
+                            <InlineRow
+                              icon={
+                                <DollarSign className="h-4 w-4 text-muted-foreground" />
+                              }
+                              label="Price"
+                            >
+                              <Input
+                                placeholder="100.00"
+                                type="text"
+                                inputMode="decimal"
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(e) =>
+                                  field.handleChange(e.target.value)
+                                }
+                                disabled={readOnly}
+                                className="max-w-32 text-sm"
+                              />
+                            </InlineRow>
+                            <FieldError errors={field.state.meta.errors} />
+                          </div>
+                        )}
+                      </form.Field>
+
+                      <form.Field
+                        name="compare_price"
+                        validators={{
+                          onBlur: ({ value, fieldApi }) => {
+                            if (readOnly || !value) return undefined
+                            const num = Number(value)
+                            if (Number.isNaN(num) || num < 0) {
+                              return "Compare-at price must be a positive number."
+                            }
+                            const rawPrice =
+                              fieldApi.form.getFieldValue("price")
+                            if (rawPrice) {
+                              const price = Number(rawPrice)
+                              if (!Number.isNaN(price) && num <= price) {
+                                return "Compare-at price must be higher than price."
+                              }
+                            }
+                            return undefined
+                          },
+                        }}
+                      >
+                        {(field) => (
+                          <div>
+                            <InlineRow
+                              icon={
+                                <DollarSign className="h-4 w-4 text-muted-foreground" />
+                              }
+                              label="Compare-at price"
+                              description="Crossed-out original price shown next to the current price. Leave empty for no discount."
+                            >
+                              <Input
+                                placeholder="120.00"
+                                type="text"
+                                inputMode="decimal"
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(e) =>
+                                  field.handleChange(e.target.value)
+                                }
+                                disabled={readOnly}
+                                className="max-w-32 text-sm"
+                              />
+                            </InlineRow>
+                            <FieldError errors={field.state.meta.errors} />
+                          </div>
+                        )}
+                      </form.Field>
+                    </>
+                  )
+                }
+              </form.Subscribe>
+
+              <form.Field
+                name="total_stock_cap"
+                validators={{
+                  onBlur: ({ value }) => {
+                    if (readOnly || !value) return undefined
+                    const num = Number.parseInt(value, 10)
+                    if (Number.isNaN(num) || num < 1) {
+                      return "Total stock must be a positive number. Leave empty for unlimited."
+                    }
+                    return undefined
+                  },
+                }}
+              >
+                {(field) => (
+                  <div>
+                    <InlineRow
+                      icon={<Hash className="h-4 w-4 text-muted-foreground" />}
+                      label="Total stock"
+                      description="Maximum units available. Leave empty for unlimited."
+                    >
+                      <Input
+                        id="total_stock_cap"
+                        aria-label="Total stock"
+                        placeholder="Unlimited"
+                        type="number"
+                        min="1"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        disabled={readOnly}
+                        className="max-w-32 text-sm"
+                      />
+                    </InlineRow>
+                    <FieldError errors={field.state.meta.errors} />
+                  </div>
+                )}
+              </form.Field>
+
+              <form.Field
+                name="max_per_order"
+                validators={{
+                  onBlur: ({ value, fieldApi }) => {
+                    if (readOnly || !value) return undefined
+                    const num = Number.parseInt(value, 10)
+                    if (Number.isNaN(num) || num < 1) {
+                      return "Max per order must be a positive number. Leave empty for unlimited."
+                    }
+                    const rawCap =
+                      fieldApi.form.getFieldValue("total_stock_cap")
+                    if (rawCap) {
+                      const cap = Number.parseInt(rawCap, 10)
+                      if (!Number.isNaN(cap) && num > cap) {
+                        return `Cannot exceed total stock cap (${cap})`
+                      }
+                    }
+                    return undefined
+                  },
+                }}
+              >
+                {(field) => (
+                  <div>
+                    <InlineRow
+                      icon={<Hash className="h-4 w-4 text-muted-foreground" />}
+                      label="Max per order"
+                      description="Per-cart cap. Leave empty for unlimited."
+                    >
+                      <Input
+                        id="max_per_order"
+                        aria-label="Max per order"
+                        placeholder="Unlimited"
+                        type="number"
+                        min="1"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        disabled={readOnly}
+                        className="max-w-32 text-sm"
+                      />
+                    </InlineRow>
+                    <FieldError errors={field.state.meta.errors} />
+                  </div>
+                )}
+              </form.Field>
+
+              <form.Field name="insurance_eligible">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Insurance Eligible"
+                    description="Include this product in the insurance calculation when popup insurance is enabled"
+                  >
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id="insurance_eligible"
+                        checked={field.state.value}
+                        onCheckedChange={(checked) =>
+                          field.handleChange(checked === true)
+                        }
+                        disabled={readOnly}
+                      />
+                      <Label htmlFor="insurance_eligible" className="text-sm">
+                        Eligible
+                      </Label>
+                    </div>
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Subscribe selector={(state) => state.values.category}>
+                {(category) => (
+                  <form.Field name="discountable">
+                    {(field) => {
+                      // Patreon donations are never discountable by policy — the
+                      // backend coerces the field on write, so mirror that in the
+                      // form: force value=false, disable the checkbox, and show
+                      // why.
+                      const isPatreon = category === "patreon"
+                      const isDisabled = readOnly || isPatreon
+                      const effectiveChecked = isPatreon
+                        ? false
+                        : field.state.value
+
+                      return (
+                        <InlineRow
+                          icon={
+                            <TicketPercent className="h-4 w-4 text-muted-foreground" />
                           }
-                          disabled={isDisabled}
-                          title={
+                          label="Discountable"
+                          description={
                             isPatreon
                               ? "Patreon donations are never discountable"
-                              : undefined
+                              : "When off, coupons and group/scholarship discounts never reduce this product's price (e.g. mandatory meal plans)"
                           }
-                        />
-                        <Label htmlFor="discountable" className="text-sm">
-                          Eligible for discounts
-                        </Label>
-                      </div>
-                    </InlineRow>
-                  )
-                }}
-              </form.Field>
-            )}
-          </form.Subscribe>
-
-          <form.Field name="requires_check_in">
-            {(field) => (
-              <InlineRow
-                icon={<QrCode className="h-4 w-4 text-muted-foreground" />}
-                label="Requires Check-in"
-                description="Enable for products that need scanning at the venue"
-              >
-                <Switch
-                  id="requires_check_in"
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="is_active">
-            {(field) => (
-              <InlineRow
-                icon={<Power className="h-4 w-4 text-muted-foreground" />}
-                label="Active"
-                description="Product is available for purchase"
-              >
-                <Switch
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="exclusive">
-            {(field) => (
-              <InlineRow
-                icon={<Shield className="h-4 w-4 text-muted-foreground" />}
-                label="Exclusive"
-                description="Only one exclusive product can be selected at a time"
-              >
-                <Switch
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                  disabled={readOnly}
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        {/* Ticket Options (conditional) */}
-        <form.Subscribe selector={(state) => state.values.category}>
-          {(category) =>
-            category === "ticket" && (
-              <>
-                <Separator />
-                <InlineSection title="Ticket Options">
-                  <form.Field name="duration_type">
-                    {(field) => (
-                      <InlineRow
-                        icon={
-                          <Clock className="h-4 w-4 text-muted-foreground" />
-                        }
-                        label="Duration"
-                        description="How long the ticket is valid"
-                      >
-                        <Select
-                          value={field.state.value}
-                          onValueChange={(val) =>
-                            field.handleChange(val as TicketDuration)
-                          }
-                          disabled={readOnly}
                         >
-                          <SelectTrigger className="w-auto text-sm">
-                            <SelectValue placeholder="Select duration" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {TICKET_DURATIONS.map((dur) => (
-                              <SelectItem key={dur.value} value={dur.value}>
-                                {dur.label}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </InlineRow>
-                    )}
+                          <div className="flex items-center gap-2">
+                            <Checkbox
+                              id="discountable"
+                              checked={effectiveChecked}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                              disabled={isDisabled}
+                              title={
+                                isPatreon
+                                  ? "Patreon donations are never discountable"
+                                  : undefined
+                              }
+                            />
+                            <Label htmlFor="discountable" className="text-sm">
+                              Eligible for discounts
+                            </Label>
+                          </div>
+                        </InlineRow>
+                      )
+                    }}
                   </form.Field>
-                </InlineSection>
-              </>
-            )
-          }
-        </form.Subscribe>
+                )}
+              </form.Subscribe>
 
-        {/* Sale Window — applies to every product category. Times are entered
+              <form.Field name="requires_check_in">
+                {(field) => (
+                  <InlineRow
+                    icon={<QrCode className="h-4 w-4 text-muted-foreground" />}
+                    label="Requires Check-in"
+                    description="Enable for products that need scanning at the venue"
+                  >
+                    <Switch
+                      id="requires_check_in"
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="is_active">
+                {(field) => (
+                  <InlineRow
+                    icon={<Power className="h-4 w-4 text-muted-foreground" />}
+                    label="Active"
+                    description="Product is available for purchase"
+                  >
+                    <Switch
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+
+              <form.Field name="exclusive">
+                {(field) => (
+                  <InlineRow
+                    icon={<Shield className="h-4 w-4 text-muted-foreground" />}
+                    label="Exclusive"
+                    description="Only one exclusive product can be selected at a time"
+                  >
+                    <Switch
+                      checked={field.state.value}
+                      onCheckedChange={(checked) => field.handleChange(checked)}
+                      disabled={readOnly}
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
+
+            {/* Ticket Options (conditional) */}
+            <form.Subscribe selector={(state) => state.values.category}>
+              {(category) =>
+                category === "ticket" && (
+                  <>
+                    <Separator />
+                    <InlineSection title="Ticket Options">
+                      <form.Field name="duration_type">
+                        {(field) => (
+                          <InlineRow
+                            icon={
+                              <Clock className="h-4 w-4 text-muted-foreground" />
+                            }
+                            label="Duration"
+                            description="How long the ticket is valid"
+                          >
+                            <Select
+                              value={field.state.value}
+                              onValueChange={(val) =>
+                                field.handleChange(val as TicketDuration)
+                              }
+                              disabled={readOnly}
+                            >
+                              <SelectTrigger className="w-auto text-sm">
+                                <SelectValue placeholder="Select duration" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {TICKET_DURATIONS.map((dur) => (
+                                  <SelectItem key={dur.value} value={dur.value}>
+                                    {dur.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </InlineRow>
+                        )}
+                      </form.Field>
+                    </InlineSection>
+                  </>
+                )
+              }
+            </form.Subscribe>
+
+            {/* Sale Window — applies to every product category. Times are entered
             in the popup's timezone and stored as precise instants, so a cutoff
             like a meal-plan "Friday 11:59 PM" deadline is enforced exactly. */}
-        <Separator />
-        <InlineSection title="Sale Window">
-          <form.Field name="sale_starts_at">
-            {(field) => (
-              <InlineRow
-                icon={<Calendar className="h-4 w-4 text-muted-foreground" />}
-                label="Sale Starts At"
-                description={`When the product goes on sale (${popupTimezone}). Blank = no limit.`}
-              >
-                <Input
-                  type="datetime-local"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-60"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-
-          <form.Field name="sale_ends_at">
-            {(field) => (
-              <InlineRow
-                icon={<Calendar className="h-4 w-4 text-muted-foreground" />}
-                label="Sale Ends At"
-                description={`Order cutoff — sales close at this exact time (${popupTimezone}).`}
-              >
-                <Input
-                  type="datetime-local"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  disabled={readOnly}
-                  className="max-w-60"
-                />
-              </InlineRow>
-            )}
-          </form.Field>
-        </InlineSection>
-
-        {isEdit && (popupData?.supported_languages?.length ?? 0) > 1 && (
-          <>
             <Separator />
-            <TranslationManager
-              entityType="product"
-              entityId={defaultValues!.id}
-              translatableFields={["name", "description"]}
-              sourceData={{
-                name: defaultValues!.name,
-                description: defaultValues!.description,
-              }}
-              supportedLanguages={popupData!.supported_languages!}
-              defaultLanguage={popupData!.default_language!}
-            />
-          </>
-        )}
+            <InlineSection title="Sale Window">
+              <form.Field name="sale_starts_at">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <Calendar className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Sale Starts At"
+                    description={`When the product goes on sale (${popupTimezone}). Blank = no limit.`}
+                  >
+                    <Input
+                      type="datetime-local"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-60"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
 
-        <Separator />
+              <form.Field name="sale_ends_at">
+                {(field) => (
+                  <InlineRow
+                    icon={
+                      <Calendar className="h-4 w-4 text-muted-foreground" />
+                    }
+                    label="Sale Ends At"
+                    description={`Order cutoff — sales close at this exact time (${popupTimezone}).`}
+                  >
+                    <Input
+                      type="datetime-local"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      disabled={readOnly}
+                      className="max-w-60"
+                    />
+                  </InlineRow>
+                )}
+              </form.Field>
+            </InlineSection>
 
-        {/* Form Actions */}
-        <div className="flex gap-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => navigate({ to: "/products" })}
-          >
-            {readOnly ? "Back" : "Cancel"}
-          </Button>
-          {!readOnly && (
-            <LoadingButton type="submit" loading={isPending}>
-              {isEdit ? "Save Changes" : "Create Product"}
-            </LoadingButton>
+            <Separator />
+
+            {/* Form Actions */}
+            <div className="flex gap-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => navigate({ to: "/products" })}
+              >
+                {readOnly ? "Back" : "Cancel"}
+              </Button>
+              {!readOnly && (
+                <LoadingButton type="submit" loading={isPending}>
+                  {isEdit ? "Save Changes" : "Create Product"}
+                </LoadingButton>
+              )}
+            </div>
+          </form>
+
+          {isEdit && !readOnly && (
+            <div className="mx-auto max-w-2xl">
+              <DangerZone
+                description="Once you delete this product, it will be permanently removed. Existing purchases will not be affected."
+                onDelete={() => deleteMutation.mutate()}
+                isDeleting={deleteMutation.isPending}
+                confirmText="Delete Product"
+                resourceName={defaultValues.name}
+                variant="inline"
+              />
+            </div>
           )}
-        </div>
-      </form>
+        </TabsContent>
 
-      {isEdit && !readOnly && (
-        <div className="mx-auto max-w-2xl">
-          <DangerZone
-            description="Once you delete this product, it will be permanently removed. Existing purchases will not be affected."
-            onDelete={() => deleteMutation.mutate()}
-            isDeleting={deleteMutation.isPending}
-            confirmText="Delete Product"
-            resourceName={defaultValues.name}
-            variant="inline"
-          />
-        </div>
-      )}
+        <TabsContent value="translations">
+          {!isEdit ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Save the product first to add translations.
+            </div>
+          ) : (popupData?.supported_languages?.length ?? 0) <= 1 ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Enable a second language on the event to translate this product.
+            </div>
+          ) : (
+            <form.Subscribe selector={(state) => state.isDirty}>
+              {(isDirty) =>
+                isDirty ? (
+                  <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                    Save your changes first to translate the latest content.
+                  </div>
+                ) : (
+                  <TranslationManager
+                    entityType="product"
+                    entityId={defaultValues!.id}
+                    translatableFields={["name", "description"]}
+                    sourceData={{
+                      name: defaultValues!.name,
+                      description: defaultValues!.description,
+                    }}
+                    supportedLanguages={popupData!.supported_languages!}
+                    defaultLanguage={popupData!.default_language!}
+                  />
+                )
+              }
+            </form.Subscribe>
+          )}
+        </TabsContent>
+      </Tabs>
       <UnsavedChangesDialog blocker={blocker} />
 
       <Dialog open={addCategoryOpen} onOpenChange={setAddCategoryOpen}>

--- a/backoffice/src/components/translations/TranslationManager.tsx
+++ b/backoffice/src/components/translations/TranslationManager.tsx
@@ -211,8 +211,31 @@ function LanguageTab({
   const formatFieldLabel = (field: string) =>
     field.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
 
+  const nestedGroups = groupLeaves(leaves)
+  const totalCount = translatableFields.length + leaves.length
+  const doneCount =
+    translatableFields.filter((f) => draft[f]?.trim()).length +
+    leaves.filter((l) => nestedDraft[l.path]?.trim()).length
+  const isComplete = totalCount > 0 && doneCount === totalCount
+
   return (
     <div className="space-y-4 pt-4">
+      <div className="flex items-center gap-3">
+        <span className="text-xs font-medium text-muted-foreground">
+          {doneCount}/{totalCount} translated
+        </span>
+        <div className="h-1.5 max-w-[160px] flex-1 overflow-hidden rounded-full bg-muted">
+          <div
+            className={`h-full rounded-full transition-all ${
+              isComplete ? "bg-green-600" : "bg-primary"
+            }`}
+            style={{
+              width: `${totalCount ? (doneCount / totalCount) * 100 : 0}%`,
+            }}
+          />
+        </div>
+      </div>
+
       {translatableFields.map((field) => (
         <TranslationFieldEditor
           key={field}
@@ -232,24 +255,37 @@ function LanguageTab({
           <p className="text-sm font-medium text-muted-foreground">
             Step content
           </p>
-          {groupLeaves(leaves).map((group) => (
-            <div key={group.key} className="space-y-3 rounded-lg border p-4">
-              <p className="text-sm font-semibold">{group.label}</p>
-              {group.leaves.map((leaf) => (
-                <TranslationFieldEditor
-                  key={leaf.path}
-                  fieldName={leaf.path}
-                  label={leaf.label}
-                  originalValue={leaf.value}
-                  translatedValue={nestedDraft[leaf.path] ?? ""}
-                  onChange={(value) =>
-                    setNestedDraft((prev) => ({ ...prev, [leaf.path]: value }))
-                  }
-                  multiline={leaf.multiline}
-                />
-              ))}
-            </div>
-          ))}
+          {nestedGroups.map((group) => {
+            const groupDone = group.leaves.filter((l) =>
+              nestedDraft[l.path]?.trim(),
+            ).length
+            return (
+              <div key={group.key} className="space-y-3 rounded-lg border p-4">
+                <p className="text-sm font-semibold">
+                  {group.label}
+                  <span className="ml-2 text-xs font-normal text-muted-foreground">
+                    {groupDone}/{group.leaves.length}
+                  </span>
+                </p>
+                {group.leaves.map((leaf) => (
+                  <TranslationFieldEditor
+                    key={leaf.path}
+                    fieldName={leaf.path}
+                    label={leaf.label}
+                    originalValue={leaf.value}
+                    translatedValue={nestedDraft[leaf.path] ?? ""}
+                    onChange={(value) =>
+                      setNestedDraft((prev) => ({
+                        ...prev,
+                        [leaf.path]: value,
+                      }))
+                    }
+                    multiline={leaf.multiline}
+                  />
+                ))}
+              </div>
+            )
+          })}
         </div>
       )}
 

--- a/backoffice/src/components/translations/TranslationManager.tsx
+++ b/backoffice/src/components/translations/TranslationManager.tsx
@@ -15,6 +15,7 @@ import {
   type ConfigLeaf,
   extractTranslatableLeaves,
   flattenConfigValues,
+  groupLeaves,
 } from "./templateConfigLeaves"
 
 const LANGUAGE_NAMES: Record<string, string> = {
@@ -231,18 +232,23 @@ function LanguageTab({
           <p className="text-sm font-medium text-muted-foreground">
             Step content
           </p>
-          {leaves.map((leaf) => (
-            <TranslationFieldEditor
-              key={leaf.path}
-              fieldName={leaf.path}
-              label={leaf.label}
-              originalValue={leaf.value}
-              translatedValue={nestedDraft[leaf.path] ?? ""}
-              onChange={(value) =>
-                setNestedDraft((prev) => ({ ...prev, [leaf.path]: value }))
-              }
-              multiline={leaf.multiline}
-            />
+          {groupLeaves(leaves).map((group) => (
+            <div key={group.key} className="space-y-3 rounded-lg border p-4">
+              <p className="text-sm font-semibold">{group.label}</p>
+              {group.leaves.map((leaf) => (
+                <TranslationFieldEditor
+                  key={leaf.path}
+                  fieldName={leaf.path}
+                  label={leaf.label}
+                  originalValue={leaf.value}
+                  translatedValue={nestedDraft[leaf.path] ?? ""}
+                  onChange={(value) =>
+                    setNestedDraft((prev) => ({ ...prev, [leaf.path]: value }))
+                  }
+                  multiline={leaf.multiline}
+                />
+              ))}
+            </div>
           ))}
         </div>
       )}

--- a/backoffice/src/components/translations/templateConfigLeaves.ts
+++ b/backoffice/src/components/translations/templateConfigLeaves.ts
@@ -154,11 +154,24 @@ function singularize(word: string): string {
   return word.endsWith("s") ? word.slice(0, -1) : word
 }
 
+// Friendly group headers per config key. Array-record keys get the item number
+// appended ("FAQ 1"); named-object keys are used as-is. Anything not listed
+// falls back to the humanized (and, for records, singularized) key.
+const GROUP_ALIASES: Record<string, string> = {
+  items: "FAQ",
+  sections: "Section",
+  menu_options: "Meal option",
+  products: "Product",
+  insurance: "Insurance",
+  chef_choice_option: "Chef's choice",
+  benefits: "Benefits",
+}
+
 /**
  * Derive the group a leaf belongs to from its path. Array records group under
- * "<Singular> <n>" ("items.0.question" -> "Item 1"); named objects group under
- * their humanized key ("insurance.card_title" -> "Insurance"); top-level leaves
- * fall under "General".
+ * "<Name> <n>" ("items.0.question" -> "FAQ 1"); named objects group under their
+ * friendly key ("insurance.card_title" -> "Insurance"); top-level leaves fall
+ * under "General".
  */
 function deriveGroup(path: string): { key: string; label: string } {
   const parent = path.split(".").slice(0, -1)
@@ -168,12 +181,13 @@ function deriveGroup(path: string): { key: string; label: string } {
   const last = parent[parent.length - 1]
   if (/^\d+$/.test(last)) {
     const name = parent[parent.length - 2] ?? "item"
-    return {
-      key: parent.join("."),
-      label: `${singularize(humanizeKey(name))} ${Number(last) + 1}`,
-    }
+    const alias = GROUP_ALIASES[name] ?? singularize(humanizeKey(name))
+    return { key: parent.join("."), label: `${alias} ${Number(last) + 1}` }
   }
-  return { key: parent.join("."), label: humanizeKey(last) }
+  return {
+    key: parent.join("."),
+    label: GROUP_ALIASES[last] ?? humanizeKey(last),
+  }
 }
 
 /**

--- a/backoffice/src/components/translations/templateConfigLeaves.ts
+++ b/backoffice/src/components/translations/templateConfigLeaves.ts
@@ -144,6 +144,56 @@ export function buildPartialConfig(
   return hasAny ? partial : null
 }
 
+export interface LeafGroup {
+  key: string
+  label: string
+  leaves: ConfigLeaf[]
+}
+
+function singularize(word: string): string {
+  return word.endsWith("s") ? word.slice(0, -1) : word
+}
+
+/**
+ * Derive the group a leaf belongs to from its path. Array records group under
+ * "<Singular> <n>" ("items.0.question" -> "Item 1"); named objects group under
+ * their humanized key ("insurance.card_title" -> "Insurance"); top-level leaves
+ * fall under "General".
+ */
+function deriveGroup(path: string): { key: string; label: string } {
+  const parent = path.split(".").slice(0, -1)
+  if (parent.length === 0) {
+    return { key: "__general", label: "General" }
+  }
+  const last = parent[parent.length - 1]
+  if (/^\d+$/.test(last)) {
+    const name = parent[parent.length - 2] ?? "item"
+    return {
+      key: parent.join("."),
+      label: `${singularize(humanizeKey(name))} ${Number(last) + 1}`,
+    }
+  }
+  return { key: parent.join("."), label: humanizeKey(last) }
+}
+
+/**
+ * Group flat leaves back into their parent records so the editor can render a
+ * card per FAQ item, section, insurance block, etc., in document order.
+ */
+export function groupLeaves(leaves: ConfigLeaf[]): LeafGroup[] {
+  const groups = new Map<string, LeafGroup>()
+  for (const leaf of leaves) {
+    const { key, label } = deriveGroup(leaf.path)
+    const existing = groups.get(key)
+    if (existing) {
+      existing.leaves.push(leaf)
+    } else {
+      groups.set(key, { key, label, leaves: [leaf] })
+    }
+  }
+  return Array.from(groups.values())
+}
+
 /** Flatten a stored partial config back to path->value for editing. */
 export function flattenConfigValues(
   config: unknown,

--- a/backoffice/src/routes/_layout/abandoned-carts.tsx
+++ b/backoffice/src/routes/_layout/abandoned-carts.tsx
@@ -67,8 +67,8 @@ const columns: ColumnDef<AbandonedCartPublic>[] = [
     cell: ({ row }) => (
       <span className="font-medium">
         {formatName(
-          row.original.human.first_name,
-          row.original.human.last_name,
+          row.original.human?.first_name,
+          row.original.human?.last_name,
         )}
       </span>
     ),
@@ -77,7 +77,7 @@ const columns: ColumnDef<AbandonedCartPublic>[] = [
     id: "human_email",
     header: ({ column }) => <SortableHeader label="Email" column={column} />,
     cell: ({ row }) => (
-      <span className="text-muted-foreground">{row.original.human.email}</span>
+      <span className="text-muted-foreground">{row.original.email ?? "—"}</span>
     ),
   },
   {
@@ -187,9 +187,9 @@ function AbandonedCartsTableContent() {
     ? carts.results.filter((c) => {
         const term = search.toLowerCase()
         return (
-          c.human.email.toLowerCase().includes(term) ||
-          (c.human.first_name ?? "").toLowerCase().includes(term) ||
-          (c.human.last_name ?? "").toLowerCase().includes(term) ||
+          (c.email ?? "").toLowerCase().includes(term) ||
+          (c.human?.first_name ?? "").toLowerCase().includes(term) ||
+          (c.human?.last_name ?? "").toLowerCase().includes(term) ||
           c.popup.name.toLowerCase().includes(term)
         )
       })
@@ -246,8 +246,8 @@ function AbandonedCarts() {
       exportToCsv(
         "abandoned-carts",
         results.map((c) => ({
-          name: formatName(c.human.first_name, c.human.last_name),
-          email: c.human.email,
+          name: formatName(c.human?.first_name, c.human?.last_name),
+          email: c.email ?? "",
           event: c.popup.name,
           items: getCartItemCount(c.items),
           payment_attempts: (c.payments ?? []).length,

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -45,6 +45,7 @@ import {
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Switch } from "@/components/ui/switch"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import useCustomToast from "@/hooks/useCustomToast"
 import { useGoBack } from "@/hooks/useGoBack"
@@ -238,442 +239,470 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     ? TEMPLATE_CONFIG_REGISTRY[template]
     : undefined
 
+  const hasTranslations = (popup?.supported_languages?.length ?? 0) > 1
+
   return (
     <div className="flex flex-col gap-6 max-w-2xl">
-      {/* General Settings */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">General</CardTitle>
-          <CardDescription>Basic step configuration</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="step-title">Title</Label>
-            <div className="flex gap-1.5">
-              <div className="relative w-16">
-                <Input
-                  id="step-emoji"
-                  aria-label="Step emoji"
-                  value={emoji}
-                  onChange={(e) => setEmoji(e.target.value.slice(0, 8))}
-                  className="w-full text-center text-lg"
-                />
-                {/* When the operator hasn't picked a custom emoji, render the
+      <Tabs defaultValue="general" className="flex flex-col gap-6">
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="translations">Translations</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="general" className="flex flex-col gap-6">
+          {/* General Settings */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">General</CardTitle>
+              <CardDescription>Basic step configuration</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="step-title">Title</Label>
+                <div className="flex gap-1.5">
+                  <div className="relative w-16">
+                    <Input
+                      id="step-emoji"
+                      aria-label="Step emoji"
+                      value={emoji}
+                      onChange={(e) => setEmoji(e.target.value.slice(0, 8))}
+                      className="w-full text-center text-lg"
+                    />
+                    {/* When the operator hasn't picked a custom emoji, render the
                     step-type's resolved default icon inside the input so the
                     preview matches what the checkout nav will actually show.
                     Replaces the legacy hardcoded "🎟️" placeholder which made
                     every step look like Tickets by default. */}
-                {!emoji &&
-                  (() => {
-                    const DefaultIcon = getStepTypeDefinition(
-                      step.step_type,
-                    )?.icon
-                    return DefaultIcon ? (
-                      <DefaultIcon
-                        className="absolute inset-0 m-auto h-4 w-4 text-muted-foreground pointer-events-none"
-                        aria-hidden="true"
-                      />
-                    ) : null
-                  })()}
-              </div>
-              <Input
-                id="step-title"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                className="flex-1"
-              />
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Optional emoji replaces the default icon in the checkout step nav.
-              Leave blank to keep the built-in icon (shown faded above).
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="step-description">Description</Label>
-            <Textarea
-              id="step-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description shown to customers"
-              rows={3}
-            />
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="step-watermark">Watermark Text</Label>
-            <Input
-              id="step-watermark"
-              value={watermark}
-              onChange={(e) => setWatermark(e.target.value)}
-              placeholder="Short text shown as background watermark (e.g., Passes)"
-            />
-            <p className="text-xs text-muted-foreground">
-              Large decorative text shown behind the section header in snap
-              layout.
-            </p>
-          </div>
-
-          <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
-            <div className="flex flex-col gap-0.5">
-              <Label>Show Title</Label>
-              <p className="text-xs text-muted-foreground">
-                Display the section title in the checkout
-              </p>
-            </div>
-            <Switch
-              checked={showTitle}
-              onCheckedChange={setShowTitle}
-              aria-label="Toggle title visibility"
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
-            <div className="flex flex-col gap-0.5">
-              <Label>Show Watermark</Label>
-              <p className="text-xs text-muted-foreground">
-                Display the decorative watermark text behind the header
-              </p>
-            </div>
-            <Switch
-              checked={showWatermark}
-              onCheckedChange={setShowWatermark}
-              aria-label="Toggle watermark visibility"
-            />
-          </div>
-
-          <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
-            <div className="flex flex-col gap-0.5">
-              <Label>Show in Navbar</Label>
-              <p className="text-xs text-muted-foreground">
-                Whether the step appears in the top section nav. Hidden steps
-                still render and are reachable by scroll — useful for
-                informational sections that shouldn't clutter the nav.
-              </p>
-            </div>
-            <Switch
-              checked={showInNavbar}
-              onCheckedChange={setShowInNavbar}
-              aria-label="Toggle navbar visibility"
-            />
-          </div>
-
-          {!CONTENT_ONLY_TEMPLATES.has(template) &&
-            step.step_type !== "confirm" && (
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="step-product-category">Product Category</Label>
-                <Select
-                  value={productCategory}
-                  onValueChange={(val) => setProductCategory(val)}
-                >
-                  <SelectTrigger id="step-product-category">
-                    <SelectValue placeholder="None" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {productCategory &&
-                      !(categorySuggestions ?? []).includes(
-                        productCategory,
-                      ) && (
-                        <SelectItem value={productCategory}>
-                          {productCategory}
-                        </SelectItem>
-                      )}
-                    {(categorySuggestions ?? []).map((cat) => (
-                      <SelectItem key={cat} value={cat}>
-                        {cat}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                    {!emoji &&
+                      (() => {
+                        const DefaultIcon = getStepTypeDefinition(
+                          step.step_type,
+                        )?.icon
+                        return DefaultIcon ? (
+                          <DefaultIcon
+                            className="absolute inset-0 m-auto h-4 w-4 text-muted-foreground pointer-events-none"
+                            aria-hidden="true"
+                          />
+                        ) : null
+                      })()}
+                  </div>
+                  <Input
+                    id="step-title"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    className="flex-1"
+                  />
+                </div>
                 <p className="text-xs text-muted-foreground">
-                  Which product category this step displays. Must match a
-                  product's category field.
+                  Optional emoji replaces the default icon in the checkout step
+                  nav. Leave blank to keep the built-in icon (shown faded
+                  above).
                 </p>
               </div>
-            )}
 
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="step-footer">Footer Note</Label>
-            <Textarea
-              id="step-footer"
-              value={(templateConfig?.footer_text as string) ?? ""}
-              onChange={(e) =>
-                setTemplateConfig({
-                  ...templateConfig,
-                  footer_text: e.target.value || undefined,
-                })
-              }
-              placeholder="Optional note shown below this step's content (e.g., pricing clarifications, terms)"
-              rows={2}
-            />
-            <p className="text-xs text-muted-foreground">
-              Small text displayed at the bottom of this section in the
-              checkout.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Insurance Card Content (only for confirm step) */}
-      {step.step_type === "confirm" &&
-        (popup?.insurance_enabled ? (
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Insurance Card</CardTitle>
-              <CardDescription>
-                Text displayed inside the insurance toggle card in this step
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="flex flex-col gap-4">
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="insurance-card-title">Card Title</Label>
-                <Input
-                  id="insurance-card-title"
-                  value={
-                    ((templateConfig?.insurance as Record<string, unknown>)
-                      ?.card_title as string) ?? ""
-                  }
-                  onChange={(e) =>
-                    setTemplateConfig({
-                      ...templateConfig,
-                      insurance: {
-                        ...(templateConfig?.insurance as Record<
-                          string,
-                          unknown
-                        >),
-                        card_title: e.target.value || undefined,
-                      },
-                    })
-                  }
-                  placeholder="Insurance"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="insurance-card-subtitle">Card Subtitle</Label>
-                <Input
-                  id="insurance-card-subtitle"
-                  value={
-                    ((templateConfig?.insurance as Record<string, unknown>)
-                      ?.card_subtitle as string) ?? ""
-                  }
-                  onChange={(e) =>
-                    setTemplateConfig({
-                      ...templateConfig,
-                      insurance: {
-                        ...(templateConfig?.insurance as Record<
-                          string,
-                          unknown
-                        >),
-                        card_subtitle: e.target.value || undefined,
-                      },
-                    })
-                  }
-                  placeholder="Change of plans coverage"
-                />
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="insurance-toggle-label">Toggle Label</Label>
-                <Input
-                  id="insurance-toggle-label"
-                  value={
-                    ((templateConfig?.insurance as Record<string, unknown>)
-                      ?.toggle_label as string) ?? ""
-                  }
-                  onChange={(e) =>
-                    setTemplateConfig({
-                      ...templateConfig,
-                      insurance: {
-                        ...(templateConfig?.insurance as Record<
-                          string,
-                          unknown
-                        >),
-                        toggle_label: e.target.value || undefined,
-                      },
-                    })
-                  }
-                  placeholder="Add insurance"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Accessible label for the insurance toggle button.
-                </p>
-              </div>
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="insurance-benefits">
-                  Benefits (one per line)
-                </Label>
+                <Label htmlFor="step-description">Description</Label>
                 <Textarea
-                  id="insurance-benefits"
-                  value={
-                    Array.isArray(
-                      (templateConfig?.insurance as Record<string, unknown>)
-                        ?.benefits,
-                    )
-                      ? (
-                          (templateConfig?.insurance as Record<string, unknown>)
-                            ?.benefits as string[]
-                        ).join("\n")
-                      : ""
-                  }
+                  id="step-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Optional description shown to customers"
+                  rows={3}
+                />
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="step-watermark">Watermark Text</Label>
+                <Input
+                  id="step-watermark"
+                  value={watermark}
+                  onChange={(e) => setWatermark(e.target.value)}
+                  placeholder="Short text shown as background watermark (e.g., Passes)"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Large decorative text shown behind the section header in snap
+                  layout.
+                </p>
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
+                <div className="flex flex-col gap-0.5">
+                  <Label>Show Title</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Display the section title in the checkout
+                  </p>
+                </div>
+                <Switch
+                  checked={showTitle}
+                  onCheckedChange={setShowTitle}
+                  aria-label="Toggle title visibility"
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
+                <div className="flex flex-col gap-0.5">
+                  <Label>Show Watermark</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Display the decorative watermark text behind the header
+                  </p>
+                </div>
+                <Switch
+                  checked={showWatermark}
+                  onCheckedChange={setShowWatermark}
+                  aria-label="Toggle watermark visibility"
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border p-3">
+                <div className="flex flex-col gap-0.5">
+                  <Label>Show in Navbar</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Whether the step appears in the top section nav. Hidden
+                    steps still render and are reachable by scroll — useful for
+                    informational sections that shouldn't clutter the nav.
+                  </p>
+                </div>
+                <Switch
+                  checked={showInNavbar}
+                  onCheckedChange={setShowInNavbar}
+                  aria-label="Toggle navbar visibility"
+                />
+              </div>
+
+              {!CONTENT_ONLY_TEMPLATES.has(template) &&
+                step.step_type !== "confirm" && (
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="step-product-category">
+                      Product Category
+                    </Label>
+                    <Select
+                      value={productCategory}
+                      onValueChange={(val) => setProductCategory(val)}
+                    >
+                      <SelectTrigger id="step-product-category">
+                        <SelectValue placeholder="None" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {productCategory &&
+                          !(categorySuggestions ?? []).includes(
+                            productCategory,
+                          ) && (
+                            <SelectItem value={productCategory}>
+                              {productCategory}
+                            </SelectItem>
+                          )}
+                        {(categorySuggestions ?? []).map((cat) => (
+                          <SelectItem key={cat} value={cat}>
+                            {cat}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Which product category this step displays. Must match a
+                      product's category field.
+                    </p>
+                  </div>
+                )}
+
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="step-footer">Footer Note</Label>
+                <Textarea
+                  id="step-footer"
+                  value={(templateConfig?.footer_text as string) ?? ""}
                   onChange={(e) =>
                     setTemplateConfig({
                       ...templateConfig,
-                      insurance: {
-                        ...(templateConfig?.insurance as Record<
-                          string,
-                          unknown
-                        >),
-                        benefits: e.target.value
-                          ? e.target.value
-                              .split("\n")
-                              .map((l) => l.trim())
-                              .filter(Boolean)
-                          : [],
-                      },
+                      footer_text: e.target.value || undefined,
                     })
                   }
-                  placeholder={
-                    "Full refund up to 14 days before the event\n50% refund up to 7 days before\nFree date change at no extra cost"
-                  }
-                  rows={4}
+                  placeholder="Optional note shown below this step's content (e.g., pricing clarifications, terms)"
+                  rows={2}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Each line becomes a benefit bullet in the card.
+                  Small text displayed at the bottom of this section in the
+                  checkout.
                 </p>
               </div>
             </CardContent>
           </Card>
-        ) : (
-          <Alert>
-            <Info className="h-4 w-4" />
-            <AlertDescription>
-              Enable insurance in popup settings to configure the card content.{" "}
-              <Link
-                to="/popups/$id/edit"
-                params={{ id: step.popup_id }}
-                className="underline font-medium"
-              >
-                Go to Popup Settings
-              </Link>
-            </AlertDescription>
-          </Alert>
-        ))}
 
-      {/* Template Selection & Configuration (hidden for confirm step) */}
-      {step.step_type !== "confirm" && (
-        <>
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Template</CardTitle>
-              <CardDescription>
-                Choose how products are displayed in the checkout
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 gap-2">
-                {TEMPLATE_DEFINITIONS.map((def) => {
-                  const Icon = def.icon
-                  const isSelected = template === def.key
-                  return (
-                    <button
-                      key={def.key}
-                      type="button"
-                      onClick={() => {
-                        setTemplate(isSelected ? "" : def.key)
-                        if (isSelected) setTemplateConfig(null)
-                      }}
-                      className={cn(
-                        "relative flex flex-col gap-1 rounded-lg border p-3 text-left text-sm transition-all",
-                        isSelected
-                          ? "border-primary bg-primary/5 ring-1 ring-primary"
-                          : "border-border hover:border-primary/50 hover:bg-accent/50",
-                      )}
-                    >
-                      {isSelected && (
-                        <Check className="absolute top-2 right-2 h-3.5 w-3.5 text-primary" />
-                      )}
-                      <Icon className="h-4 w-4 text-muted-foreground" />
-                      <span className="font-medium leading-tight">
-                        {def.label}
-                      </span>
-                      <span className="text-xs text-muted-foreground leading-tight">
-                        {def.description}
-                      </span>
-                    </button>
-                  )
-                })}
-              </div>
-            </CardContent>
-          </Card>
+          {/* Insurance Card Content (only for confirm step) */}
+          {step.step_type === "confirm" &&
+            (popup?.insurance_enabled ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg">Insurance Card</CardTitle>
+                  <CardDescription>
+                    Text displayed inside the insurance toggle card in this step
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="insurance-card-title">Card Title</Label>
+                    <Input
+                      id="insurance-card-title"
+                      value={
+                        ((templateConfig?.insurance as Record<string, unknown>)
+                          ?.card_title as string) ?? ""
+                      }
+                      onChange={(e) =>
+                        setTemplateConfig({
+                          ...templateConfig,
+                          insurance: {
+                            ...(templateConfig?.insurance as Record<
+                              string,
+                              unknown
+                            >),
+                            card_title: e.target.value || undefined,
+                          },
+                        })
+                      }
+                      placeholder="Insurance"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="insurance-card-subtitle">
+                      Card Subtitle
+                    </Label>
+                    <Input
+                      id="insurance-card-subtitle"
+                      value={
+                        ((templateConfig?.insurance as Record<string, unknown>)
+                          ?.card_subtitle as string) ?? ""
+                      }
+                      onChange={(e) =>
+                        setTemplateConfig({
+                          ...templateConfig,
+                          insurance: {
+                            ...(templateConfig?.insurance as Record<
+                              string,
+                              unknown
+                            >),
+                            card_subtitle: e.target.value || undefined,
+                          },
+                        })
+                      }
+                      placeholder="Change of plans coverage"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="insurance-toggle-label">Toggle Label</Label>
+                    <Input
+                      id="insurance-toggle-label"
+                      value={
+                        ((templateConfig?.insurance as Record<string, unknown>)
+                          ?.toggle_label as string) ?? ""
+                      }
+                      onChange={(e) =>
+                        setTemplateConfig({
+                          ...templateConfig,
+                          insurance: {
+                            ...(templateConfig?.insurance as Record<
+                              string,
+                              unknown
+                            >),
+                            toggle_label: e.target.value || undefined,
+                          },
+                        })
+                      }
+                      placeholder="Add insurance"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Accessible label for the insurance toggle button.
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="insurance-benefits">
+                      Benefits (one per line)
+                    </Label>
+                    <Textarea
+                      id="insurance-benefits"
+                      value={
+                        Array.isArray(
+                          (templateConfig?.insurance as Record<string, unknown>)
+                            ?.benefits,
+                        )
+                          ? (
+                              (
+                                templateConfig?.insurance as Record<
+                                  string,
+                                  unknown
+                                >
+                              )?.benefits as string[]
+                            ).join("\n")
+                          : ""
+                      }
+                      onChange={(e) =>
+                        setTemplateConfig({
+                          ...templateConfig,
+                          insurance: {
+                            ...(templateConfig?.insurance as Record<
+                              string,
+                              unknown
+                            >),
+                            benefits: e.target.value
+                              ? e.target.value
+                                  .split("\n")
+                                  .map((l) => l.trim())
+                                  .filter(Boolean)
+                              : [],
+                          },
+                        })
+                      }
+                      placeholder={
+                        "Full refund up to 14 days before the event\n50% refund up to 7 days before\nFree date change at no extra cost"
+                      }
+                      rows={4}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Each line becomes a benefit bullet in the card.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertDescription>
+                  Enable insurance in popup settings to configure the card
+                  content.{" "}
+                  <Link
+                    to="/popups/$id/edit"
+                    params={{ id: step.popup_id }}
+                    className="underline font-medium"
+                  >
+                    Go to Popup Settings
+                  </Link>
+                </AlertDescription>
+              </Alert>
+            ))}
 
-          {TemplateConfigComponent && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg">
-                  Template Configuration
-                </CardTitle>
-                <CardDescription>
-                  Settings specific to the{" "}
-                  {TEMPLATE_DEFINITIONS.find((d) => d.key === template)?.label}{" "}
-                  template
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <TemplateConfigComponent
-                  config={templateConfig}
-                  onChange={setTemplateConfig}
-                  popupId={step.popup_id}
-                  productCategory={productCategory || null}
-                />
-              </CardContent>
-            </Card>
+          {/* Template Selection & Configuration (hidden for confirm step) */}
+          {step.step_type !== "confirm" && (
+            <>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-lg">Template</CardTitle>
+                  <CardDescription>
+                    Choose how products are displayed in the checkout
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid grid-cols-2 gap-2">
+                    {TEMPLATE_DEFINITIONS.map((def) => {
+                      const Icon = def.icon
+                      const isSelected = template === def.key
+                      return (
+                        <button
+                          key={def.key}
+                          type="button"
+                          onClick={() => {
+                            setTemplate(isSelected ? "" : def.key)
+                            if (isSelected) setTemplateConfig(null)
+                          }}
+                          className={cn(
+                            "relative flex flex-col gap-1 rounded-lg border p-3 text-left text-sm transition-all",
+                            isSelected
+                              ? "border-primary bg-primary/5 ring-1 ring-primary"
+                              : "border-border hover:border-primary/50 hover:bg-accent/50",
+                          )}
+                        >
+                          {isSelected && (
+                            <Check className="absolute top-2 right-2 h-3.5 w-3.5 text-primary" />
+                          )}
+                          <Icon className="h-4 w-4 text-muted-foreground" />
+                          <span className="font-medium leading-tight">
+                            {def.label}
+                          </span>
+                          <span className="text-xs text-muted-foreground leading-tight">
+                            {def.description}
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </CardContent>
+              </Card>
+
+              {TemplateConfigComponent && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-lg">
+                      Template Configuration
+                    </CardTitle>
+                    <CardDescription>
+                      Settings specific to the{" "}
+                      {
+                        TEMPLATE_DEFINITIONS.find((d) => d.key === template)
+                          ?.label
+                      }{" "}
+                      template
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <TemplateConfigComponent
+                      config={templateConfig}
+                      onChange={setTemplateConfig}
+                      popupId={step.popup_id}
+                      productCategory={productCategory || null}
+                    />
+                  </CardContent>
+                </Card>
+              )}
+            </>
           )}
-        </>
-      )}
 
-      {(popup?.supported_languages?.length ?? 0) > 1 && (
-        <>
+          {/* Actions */}
           <Separator />
-          <TranslationManager
-            entityType="ticketing_step"
-            entityId={step.id}
-            translatableFields={["title", "description"]}
-            sourceData={{
-              title: step.title,
-              description: step.description,
-            }}
-            nestedField="template_config"
-            nestedSource={step.template_config}
-            supportedLanguages={popup!.supported_languages!}
-            defaultLanguage={popup!.default_language!}
-          />
-        </>
-      )}
+          <div className="flex items-center gap-2">
+            {!step.protected && (
+              <LoadingButton
+                variant="destructive"
+                size="icon"
+                loading={deleteMutation.isPending}
+                onClick={() => deleteMutation.mutate()}
+                className="h-9 w-9 shrink-0"
+              >
+                <Trash2 className="h-4 w-4" />
+              </LoadingButton>
+            )}
+            <div className="flex-1" />
+            <Button variant="outline" onClick={goBack}>
+              Cancel
+            </Button>
+            <LoadingButton
+              loading={updateMutation.isPending}
+              onClick={() => updateMutation.mutate()}
+            >
+              Save
+            </LoadingButton>
+          </div>
+        </TabsContent>
 
-      {/* Actions */}
-      <Separator />
-      <div className="flex items-center gap-2">
-        {!step.protected && (
-          <LoadingButton
-            variant="destructive"
-            size="icon"
-            loading={deleteMutation.isPending}
-            onClick={() => deleteMutation.mutate()}
-            className="h-9 w-9 shrink-0"
-          >
-            <Trash2 className="h-4 w-4" />
-          </LoadingButton>
-        )}
-        <div className="flex-1" />
-        <Button variant="outline" onClick={goBack}>
-          Cancel
-        </Button>
-        <LoadingButton
-          loading={updateMutation.isPending}
-          onClick={() => updateMutation.mutate()}
-        >
-          Save
-        </LoadingButton>
-      </div>
+        <TabsContent value="translations" className="flex flex-col gap-4">
+          {!hasTranslations ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Enable a second language on the event to translate this step.
+            </div>
+          ) : isDirty ? (
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+              Save your changes first to translate the latest content.
+            </div>
+          ) : (
+            <TranslationManager
+              entityType="ticketing_step"
+              entityId={step.id}
+              translatableFields={["title", "description"]}
+              sourceData={{ title: step.title, description: step.description }}
+              nestedField="template_config"
+              nestedSource={step.template_config}
+              supportedLanguages={popup!.supported_languages!}
+              defaultLanguage={popup!.default_language!}
+            />
+          )}
+        </TabsContent>
+      </Tabs>
 
       <UnsavedChangesDialog blocker={blocker} />
     </div>

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -55,8 +55,26 @@ export const AbandonedCartPublicSchema = {
             ],
             title: 'Updated At'
         },
+        email: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Email'
+        },
         human: {
-            '$ref': '#/components/schemas/CartHumanInfo'
+            anyOf: [
+                {
+                    '$ref': '#/components/schemas/CartHumanInfo'
+                },
+                {
+                    type: 'null'
+                }
+            ]
         },
         popup: {
             '$ref': '#/components/schemas/CartPopupInfo'
@@ -71,7 +89,7 @@ export const AbandonedCartPublicSchema = {
         }
     },
     type: 'object',
-    required: ['id', 'items', 'human', 'popup'],
+    required: ['id', 'items', 'popup'],
     title: 'AbandonedCartPublic',
     description: 'Abandoned cart with enriched info for backoffice.'
 } as const;

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -2035,6 +2035,7 @@ export class CheckoutService {
      * Rate-limited 120/min/IP.
      * @param data The data for the request.
      * @param data.slug
+     * @param data.acceptLanguage
      * @param data.xTenantId
      * @returns CheckoutRuntimeResponse Successful Response
      * @throws ApiError
@@ -2047,6 +2048,7 @@ export class CheckoutService {
                 slug: data.slug
             },
             headers: {
+                'Accept-Language': data.acceptLanguage,
                 'X-Tenant-Id': data.xTenantId
             },
             errors: {
@@ -7988,6 +7990,7 @@ export class TicketingStepsService {
      * List enabled ticketing steps for a popup (portal-facing).
      * @param data The data for the request.
      * @param data.popupId
+     * @param data.acceptLanguage
      * @returns ListModel_TicketingStepPublic_ Successful Response
      * @throws ApiError
      */
@@ -7995,6 +7998,9 @@ export class TicketingStepsService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/v1/ticketing-steps/portal',
+            headers: {
+                'Accept-Language': data.acceptLanguage
+            },
             query: {
                 popup_id: data.popupId
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -8,7 +8,8 @@ export type AbandonedCartPublic = {
     items: CartState;
     created_at?: (string | null);
     updated_at?: (string | null);
-    human: CartHumanInfo;
+    email?: (string | null);
+    human?: (CartHumanInfo | null);
     popup: CartPopupInfo;
     payments?: Array<CartPaymentInfo>;
 };
@@ -4858,6 +4859,7 @@ export type CheckInListCheckInsData = {
 export type CheckInListCheckInsResponse = (ListModel_CheckInListItem_);
 
 export type CheckoutGetRuntimeData = {
+    acceptLanguage?: (string | null);
     slug: string;
     xTenantId?: (string | null);
 };
@@ -6640,6 +6642,7 @@ export type ThirdPartyDiscoveryGetThirdPartyOpenapiResponse = ({
 });
 
 export type TicketingStepsListPortalTicketingStepsData = {
+    acceptLanguage?: (string | null);
     popupId: string;
 };
 

--- a/portal/src/lib/api-client.ts
+++ b/portal/src/lib/api-client.ts
@@ -25,11 +25,19 @@ OpenAPI.interceptors.request.use((config) => {
   if (tenantId) {
     config.headers = { ...config.headers, "X-Tenant-Id": tenantId }
   }
-  // Send the selected language whenever one is stored, regardless of which
-  // language it is. The backend overlay is default-agnostic: if the requested
-  // language matches the popup default it simply finds no translation rows and
-  // returns the source. Special-casing "en" here broke Spanish-default popups.
-  const language = localStorage.getItem(LANGUAGE_STORAGE_KEY)
+  // Prefer the ?lang (or ?locale) URL param, then the stored language. The URL
+  // is available synchronously on the first render, before the language
+  // provider persists the choice to localStorage in an effect. Reading only
+  // localStorage raced that write: the first runtime request went out without
+  // Accept-Language and returned the popup default, so a ?lang=en deep link
+  // showed the source language until a later refetch (e.g. on window focus).
+  // The backend overlay is default-agnostic, so sending the default (or an
+  // unsupported value) simply finds no translations and returns the source.
+  const params = new URLSearchParams(window.location.search)
+  const language =
+    params.get("lang") ||
+    params.get("locale") ||
+    localStorage.getItem(LANGUAGE_STORAGE_KEY)
   if (language) {
     config.headers = { ...config.headers, "Accept-Language": language }
   }

--- a/portal/src/providers/languageProvider.tsx
+++ b/portal/src/providers/languageProvider.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useQueryClient } from "@tanstack/react-query"
-import { useSearchParams } from "next/navigation"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import {
   createContext,
   type ReactNode,
@@ -86,6 +86,8 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const { i18n } = useTranslation()
   const cityContext = useContext(CityContext)
   const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
   const queryClient = useQueryClient()
   const prevLanguageRef = useRef<string | null>(null)
   const popup = cityContext?.getCity() ?? null
@@ -153,12 +155,17 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
   const setLanguage = (lang: string) => {
     const resolvedLanguage = resolveLanguageCandidate(lang, supportedLanguages)
-    if (resolvedLanguage) {
-      if (typeof window !== "undefined") {
-        localStorage.setItem(STORAGE_KEY, resolvedLanguage)
-      }
-      setCurrentLanguage(resolvedLanguage)
+    if (!resolvedLanguage) return
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, resolvedLanguage)
     }
+    // The URL is the single source of truth: write ?lang and let the resolver
+    // effect apply it. Setting state here too would let the effect briefly
+    // revert to the stale ?lang before the navigation lands. This also keeps
+    // the selected language forwardable in the URL.
+    const params = new URLSearchParams(searchParams.toString())
+    params.set("lang", resolvedLanguage)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
   }
 
   return (


### PR DESCRIPTION
Release **v1.35.0** (previous tag: v1.34.1). Merges `dev` into `main`.

> ⚠️ Merge with a **merge commit**, never squash — squashing dev↔main erases ancestry and causes phantom add/add conflicts on the next release.

## Features
- **i18n translations editor**: dedicated tabs for step, product and event translations, grouped by parent record, with friendly group headers and a completeness indicator.

## Fixes
- **i18n**: portal language now driven by `?lang` so the switch forwards and sticks; `Accept-Language` sent from `?lang` so the first request isn't stale.
- **carts**: abandoned-carts list no longer 500s on anonymous open-checkout carts; payments correlated by buyer email for anonymous carts.

## Release notes
- No new database migrations (single Alembic head: `d4f7b2a9c1e6`).
- Included PRs: #465, #466, #467, #468.

## Verification
- Backend `scripts/lint.sh` (ruff) — pass
- `pnpm --filter backoffice run build` — pass
- `pnpm --filter portal run build` — pass