### PR TITLE
fix(carts): match anonymous cart email case-insensitively

### DIFF
--- a/backend/app/api/cart/crud.py
+++ b/backend/app/api/cart/crud.py
@@ -122,9 +122,14 @@ class CartsCRUD:
         email: str,
         popup_id: uuid.UUID,
     ) -> Carts | None:
-        """Find an anonymous cart by email and popup (read-only)."""
+        """Find an anonymous cart by email and popup (read-only).
+
+        Email match is case-insensitive so the payment-approval cleanup finds
+        the cart regardless of how the buyer typed the address here versus at
+        checkout — the rest of the open-checkout flow normalizes to lowercase.
+        """
         statement = select(Carts).where(
-            Carts.email == email,
+            func.lower(Carts.email) == email.lower(),
             Carts.popup_id == popup_id,
             col(Carts.human_id).is_(None),
         )
@@ -160,7 +165,9 @@ class CartsCRUD:
                 tenant_id=tenant_id,
                 human_id=None,
                 popup_id=popup_id,
-                email=email,
+                # Store normalized so the unique (tenant, popup, email) index and
+                # later case-insensitive lookups stay consistent.
+                email=email.lower(),
                 items=items.model_dump(),
             )
             session.add(cart)

--- a/backend/tests/api/checkout/test_open_cart.py
+++ b/backend/tests/api/checkout/test_open_cart.py
@@ -158,6 +158,43 @@ def test_upsert_open_cart_is_idempotent_per_email(
     assert len(carts) == 1
 
 
+def test_upsert_open_cart_email_is_case_insensitive(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """A different email casing resolves to the same cart, stored lowercased.
+
+    Guards the payment-approval cleanup: it looks the cart up by the buyer
+    email, so a casing mismatch must never leave an already-paid cart behind.
+    """
+    popup = _make_popup(db, tenant_a, slug_prefix="case", signing_secret="s3cr3t")
+    product = _make_product(db, popup)
+    db.commit()
+
+    first = client.put(
+        f"/api/v1/checkout/{popup.slug}/cart",
+        json={"email": "Buyer@Test.com", "items": _items(product, promo_code="A")},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+    second = client.put(
+        f"/api/v1/checkout/{popup.slug}/cart",
+        json={"email": "BUYER@test.com", "items": _items(product, promo_code="B")},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert first.status_code == 200 and second.status_code == 200
+    assert first.json()["id"] == second.json()["id"]
+
+    carts = list(
+        db.exec(
+            select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_(None))
+        ).all()
+    )
+    assert len(carts) == 1
+    assert carts[0].email == "buyer@test.com"
+
+
 def test_restore_open_cart_with_valid_signature_returns_items(
     client: TestClient,
     db: Session,


### PR DESCRIPTION
## Problem

`approve_payment` deletes the anonymous open-checkout cart on payment approval by looking it up via the buyer email (`_direct_buyer_email` → `delete_anonymous_by_email_popup` → `find_anonymous_by_email_popup`).

That lookup compared `Carts.email == email` **exactly**, while the rest of the open-checkout flow normalizes to lowercase (`buyer_snapshot['buyer_email'] = email.lower()`, lock keys, and an explicit `cart_email.lower() == buyer_email.lower()` helper).

A casing difference in the email between the cart-save request and the checkout request left an **already-paid cart behind**, restorable after payment.

## Changes

| File | Change |
|------|--------|
| `backend/app/api/cart/crud.py` | `find_anonymous_by_email_popup` compares with `func.lower(Carts.email) == email.lower()`; `upsert_anonymous` stores the email lowercased on create (consistent with the unique `(tenant, popup, email)` index) |
| `backend/tests/api/checkout/test_open_cart.py` | New `test_upsert_open_cart_email_is_case_insensitive` — mixed-case upserts resolve to one lowercased cart |

## Verification

- `pytest tests/api/checkout/test_open_cart.py` — 8 passed
- `scripts/lint.sh` (ruff) — pass
- Backend only, no schema/client change