### PR TITLE
test(products): de-flake concurrent stock decrement race

### DIFF
--- a/backend/tests/api/product/test_enforcement_wiring.py
+++ b/backend/tests/api/product/test_enforcement_wiring.py
@@ -535,7 +535,13 @@ class TestOpenTicketingPaymentEnforcement:
         tenant_a: Tenants,
         test_engine,
     ) -> None:
-        """Concurrent calls on remaining=1: exactly one succeeds, one 409."""
+        """Concurrent calls on remaining=1: exactly one succeeds, one loses.
+
+        The loser's status depends on thread timing: 409 when both threads pass
+        the on-sale pre-check and race the atomic decrement, or 422 when it reads
+        the already sold-out state after the winner committed. Both are valid
+        "lost the race" outcomes, so accept either to keep the test deterministic.
+        """
         from types import SimpleNamespace
         from unittest.mock import patch
 
@@ -550,7 +556,7 @@ class TestOpenTicketingPaymentEnforcement:
         )
 
         successes: list[bool] = []
-        conflicts: list[bool] = []
+        losses: list[int] = []
         lock = threading.Lock()
 
         def one_purchase() -> None:
@@ -575,9 +581,9 @@ class TestOpenTicketingPaymentEnforcement:
                         with lock:
                             successes.append(True)
                     except HTTPException as exc:
-                        if exc.status_code == 409:
+                        if exc.status_code in (409, 422):
                             with lock:
-                                conflicts.append(True)
+                                losses.append(exc.status_code)
                         else:
                             raise
 
@@ -589,7 +595,7 @@ class TestOpenTicketingPaymentEnforcement:
         t2.join()
 
         assert len(successes) == 1, f"Expected 1 success, got {successes}"
-        assert len(conflicts) == 1, f"Expected 1 conflict, got {conflicts}"
+        assert len(losses) == 1, f"Expected 1 lost-race (409/422), got {losses}"
 
         db.expire_all()
         refreshed = db.get(Products, product.id)


### PR DESCRIPTION
## Problem

`test_concurrent_decrements_exactly_one_wins` failed intermittently in CI (green on rerun, 5/5 locally). It asserted the losing thread **always** got `409`.

But the loser's status is timing-dependent:
- **409** — both threads pass the on-sale pre-check, then race the atomic `UPDATE ... WHERE total_stock_remaining >= :qty`; the loser's UPDATE matches no row.
- **422** — the threads serialize; the loser reads the already `sold_out` state (`remaining=0`) and is rejected by the on-sale pre-check **before** the decrement.

Both are valid "lost the race" outcomes. Under CI thread scheduling the loser hit `422`, fell into the `else: raise` branch, and left the conflict list empty → intermittent failure.

## Change

| File | Change |
|------|--------|
| `backend/tests/api/product/test_enforcement_wiring.py` | Accept `409` **or** `422` as a valid lost-race outcome for the losing thread; assert exactly one winner and one loser |

No production code changed — the oversell guard already behaves correctly; only the test's assumption was too strict.

## Verification

- Hardened test — 3/3 passes locally (was flaky)
- `scripts/lint.sh` (ruff) — pass