### PR TITLE
feat(carts): key open-checkout carts by human, one per email

### DIFF
--- a/backend/app/alembic/versions/e266b8601d0c_drop_unused_anonymous_cart_email_index.py
+++ b/backend/app/alembic/versions/e266b8601d0c_drop_unused_anonymous_cart_email_index.py
@@ -1,0 +1,34 @@
+"""drop unused anonymous cart email index
+
+Open-checkout carts are now keyed by (human, popup) like authenticated carts,
+so no cart has human_id NULL and the partial unique index on (tenant, popup,
+email) matches nothing. Drop it; uq_cart_human_popup enforces uniqueness.
+
+Revision ID: e266b8601d0c
+Revises: d4f7b2a9c1e6
+Create Date: 2026-07-16 09:59:23.254711
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e266b8601d0c'
+down_revision = 'd4f7b2a9c1e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index("uq_cart_tenant_popup_email", table_name="carts")
+
+
+def downgrade():
+    op.create_index(
+        "uq_cart_tenant_popup_email",
+        "carts",
+        ["tenant_id", "popup_id", "email"],
+        unique=True,
+        postgresql_where=sa.text("human_id IS NULL"),
+    )

--- a/backend/app/api/cart/crud.py
+++ b/backend/app/api/cart/crud.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy.orm import selectinload
-from sqlmodel import Session, col, func, select
+from sqlmodel import Session, func, select
 
 from app.api.cart.models import Carts
 from app.api.cart.schemas import CartState
@@ -113,60 +113,33 @@ class CartsCRUD:
             session.flush()
 
     # ------------------------------------------------------------------
-    # Anonymous open-checkout carts (keyed by email, no human, human_id NULL)
+    # Open-checkout carts. Keyed by human (resolved from the buyer email) just
+    # like authenticated portal carts, so a buyer has a single cart per popup
+    # across both flows.
     # ------------------------------------------------------------------
 
-    def find_anonymous_by_email_popup(
-        self,
-        session: Session,
-        email: str,
-        popup_id: uuid.UUID,
-    ) -> Carts | None:
-        """Find an anonymous cart by email and popup (read-only).
-
-        Email match is case-insensitive so the payment-approval cleanup finds
-        the cart regardless of how the buyer typed the address here versus at
-        checkout — the rest of the open-checkout flow normalizes to lowercase.
-        """
-        statement = select(Carts).where(
-            func.lower(Carts.email) == email.lower(),
-            Carts.popup_id == popup_id,
-            col(Carts.human_id).is_(None),
-        )
-        return session.exec(statement).first()
-
-    def find_anonymous_by_id_popup(
-        self,
-        session: Session,
-        cart_id: uuid.UUID,
-        popup_id: uuid.UUID,
-    ) -> Carts | None:
-        """Find an anonymous cart by id, scoped to a popup (read-only)."""
-        statement = select(Carts).where(
-            Carts.id == cart_id,
-            Carts.popup_id == popup_id,
-            col(Carts.human_id).is_(None),
-        )
-        return session.exec(statement).first()
-
-    def upsert_anonymous(
+    def upsert_open_cart(
         self,
         session: Session,
         *,
         tenant_id: uuid.UUID,
         popup_id: uuid.UUID,
+        human_id: uuid.UUID,
         email: str,
         items: CartState,
     ) -> Carts:
-        """Create or update the anonymous cart for (popup, email)."""
-        cart = self.find_anonymous_by_email_popup(session, email, popup_id)
+        """Create or update the open-checkout cart for (human, popup).
+
+        Shares the uq_cart_human_popup key with the authenticated portal cart,
+        so the two flows converge on one row. Email is stored for display and
+        restore-link continuity only, not as a key.
+        """
+        cart = self.find_by_human_popup(session, human_id, popup_id)
         if cart is None:
             cart = Carts(
                 tenant_id=tenant_id,
-                human_id=None,
+                human_id=human_id,
                 popup_id=popup_id,
-                # Store normalized so the unique (tenant, popup, email) index and
-                # later case-insensitive lookups stay consistent.
                 email=email.lower(),
                 items=items.model_dump(),
             )
@@ -176,23 +149,28 @@ class CartsCRUD:
             return cart
 
         cart.items = items.model_dump()
+        cart.email = email.lower()
         cart.updated_at = datetime.now(UTC)
         session.add(cart)
         session.commit()
         session.refresh(cart)
         return cart
 
-    def delete_anonymous_by_email_popup(
+    def find_by_id_popup(
         self,
         session: Session,
-        email: str,
+        cart_id: uuid.UUID,
         popup_id: uuid.UUID,
-    ) -> None:
-        """Delete the anonymous cart for (popup, email) — e.g. after payment."""
-        cart = self.find_anonymous_by_email_popup(session, email, popup_id)
-        if cart:
-            session.delete(cart)
-            session.flush()
+    ) -> Carts | None:
+        """Find a cart by id, scoped to a popup (read-only).
+
+        Backs the open-checkout restore link and cart-continuity proof.
+        """
+        statement = select(Carts).where(
+            Carts.id == cart_id,
+            Carts.popup_id == popup_id,
+        )
+        return session.exec(statement).first()
 
 
 carts_crud = CartsCRUD()

--- a/backend/app/api/cart/models.py
+++ b/backend/app/api/cart/models.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Index, UniqueConstraint, text
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlmodel import Column, DateTime, Field, Relationship, func
 
@@ -18,18 +18,9 @@ class Carts(CartBase, table=True):
     """Cart model - persists checkout state per human per popup."""
 
     __table_args__ = (
+        # Open-checkout and authenticated carts are both keyed by (human, popup),
+        # so a buyer has a single cart per popup across both flows.
         UniqueConstraint("human_id", "popup_id", name="uq_cart_human_popup"),
-        # One anonymous cart per (tenant, popup, email). Partial so it only
-        # applies to open-checkout carts (human_id IS NULL) and never collides
-        # with authenticated carts, which leave email NULL.
-        Index(
-            "uq_cart_tenant_popup_email",
-            "tenant_id",
-            "popup_id",
-            "email",
-            unique=True,
-            postgresql_where=text("human_id IS NULL"),
-        ),
     )
 
     id: uuid.UUID = Field(

--- a/backend/app/api/checkout/router.py
+++ b/backend/app/api/checkout/router.py
@@ -35,6 +35,7 @@ from app.api.checkout.schemas import (
     OpenTicketingPurchaseResponse,
     PendingReleaseOpenRequest,
 )
+from app.api.human.crud import humans_crud
 from app.api.payment.crud import payments_crud
 from app.api.payment.router import (
     _extract_meta_attribution,
@@ -268,18 +269,26 @@ async def upsert_open_cart(
     db: SessionDep,
     tenant: PublicTenant,
 ) -> OpenCartPublic:
-    """Save (create or replace) the anonymous open-checkout cart for an email.
+    """Save (create or replace) the open-checkout cart for an email.
 
-    Fully public (no JWT), keyed by (popup, email). Returns a signed
+    Fully public (no JWT). The email is resolved to a human so the cart is keyed
+    by (human, popup) — the same key as the authenticated portal cart — and a
+    buyer never ends up with two carts for the same popup. Returns a signed
     `restore_token` when the popup configures an open_checkout_signing_secret so
     the client can later rebuild the cart cross-device. Rate-limited 30/min/IP.
     """
     popup = get_open_ticketing_popup(db, slug, tenant.id)
-    cart = carts_crud.upsert_anonymous(
+    # Normalize before resolving the human: SQLModel skips the HumanBase email
+    # validator on table inserts, so find_or_create is case-sensitive and a
+    # differently-cased email would otherwise spawn a second human and cart.
+    email = cart_in.email.lower()
+    human = humans_crud.find_or_create(db, email=email, tenant_id=tenant.id)
+    cart = carts_crud.upsert_open_cart(
         db,
         tenant_id=tenant.id,
         popup_id=popup.id,
-        email=cart_in.email,
+        human_id=human.id,
+        email=email,
         items=cart_in.items,
     )
     secret = popup.open_checkout_signing_secret
@@ -316,7 +325,7 @@ async def restore_open_cart(
     if not verify_cart_restore_token(str(cid), sig, secret):
         raise HTTPException(status_code=403, detail="Invalid cart link")
 
-    cart = carts_crud.find_anonymous_by_id_popup(db, cid, popup.id)
+    cart = carts_crud.find_by_id_popup(db, cid, popup.id)
     if cart is None:
         raise HTTPException(status_code=404, detail="Cart not found")
     return _to_open_cart_public(cart, restore_token=sig)

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -2596,20 +2596,21 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
 
         return payment, preview
 
-    def _direct_buyer_email(self, session: Session, payment: Payments) -> str | None:
-        """Resolve the buyer email for a direct-sale payment via its attendee.
+    def _direct_buyer_human_id(
+        self, session: Session, payment: Payments
+    ) -> uuid.UUID | None:
+        """Resolve the buyer's human_id for a direct-sale payment via its attendee.
 
-        Direct-sale payments have no application; the buyer is the human behind
-        the (single) attendee on the payment's product snapshot. Used to clear
-        the anonymous open-checkout cart keyed by that email.
+        Used to clear the open-checkout cart, which is now keyed by (human, popup)
+        like the authenticated portal cart.
         """
         snapshot = payment.products_snapshot
         if not snapshot:
             return None
         attendee = session.get(Attendees, snapshot[0].attendee_id)
-        if attendee is None or attendee.human is None:
+        if attendee is None:
             return None
-        return attendee.human.email
+        return attendee.human_id
 
     def approve_payment(
         self,
@@ -2674,9 +2675,9 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             if payment.application_id is not None:
                 self._create_ambassador_group(session, payment)
 
-            # Clear cart after successful payment. Application flow clears by
-            # human; direct-sale (open checkout) clears the anonymous cart by the
-            # buyer email so a returning buyer never restores an already-paid cart.
+            # Clear cart after successful payment so a returning buyer never
+            # restores an already-paid cart. Both the application flow and open
+            # checkout key the cart by (human, popup), so delete by human.
             from app.api.cart.crud import carts_crud
 
             if payment.application:
@@ -2686,10 +2687,12 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
                     popup_id=payment.application.popup_id,
                 )
             elif payment.popup_id:
-                buyer_email = self._direct_buyer_email(session, payment)
-                if buyer_email:
-                    carts_crud.delete_anonymous_by_email_popup(
-                        session, buyer_email, payment.popup_id
+                buyer_human_id = self._direct_buyer_human_id(session, payment)
+                if buyer_human_id:
+                    carts_crud.delete_by_human_popup(
+                        session,
+                        human_id=buyer_human_id,
+                        popup_id=payment.popup_id,
                     )
 
             # Single atomic commit for the entire operation
@@ -3016,7 +3019,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         2. The popup has an open_checkout_signing_secret.
         3. HMAC signature is valid for the given cid and secret.
         4. The referenced cart belongs to this popup (popup_id match built into
-           carts_crud.find_anonymous_by_id_popup).
+           carts_crud.find_by_id_popup).
         5. The cart's email matches the buyer email (case-insensitive).
 
         A valid token for a different email or a different popup is always invalid.
@@ -3030,7 +3033,7 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
             return False
         from app.api.cart.crud import carts_crud as _carts_crud  # noqa: PLC0415
 
-        cart = _carts_crud.find_anonymous_by_id_popup(session, cid, popup.id)
+        cart = _carts_crud.find_by_id_popup(session, cid, popup.id)
         if cart is None:
             return False
         cart_email: str = getattr(cart, "email", None) or ""

--- a/backend/tests/api/checkout/test_open_cart.py
+++ b/backend/tests/api/checkout/test_open_cart.py
@@ -11,7 +11,9 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
+from app.api.cart.crud import carts_crud
 from app.api.cart.models import Carts
+from app.api.human.crud import humans_crud
 from app.api.popup.models import Popups
 from app.api.product.models import Products
 from app.api.shared.enums import SaleType
@@ -101,10 +103,52 @@ def test_upsert_open_cart_creates_cart_and_returns_restore_token(
     assert body["restore_token"] == build_cart_restore_token(body["id"], "s3cr3t")
 
     cart = db.exec(
-        select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_(None))
+        select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_not(None))
     ).first()
     assert cart is not None
     assert cart.email == "buyer@test.com"
+    # The cart is linked to the human resolved from the email, so it shares the
+    # (human, popup) key with the authenticated portal cart.
+    human = humans_crud.find_or_create(
+        db, email="buyer@test.com", tenant_id=tenant_a.id
+    )
+    assert cart.human_id == human.id
+
+
+def test_open_cart_converges_with_authenticated_cart(
+    client: TestClient,
+    db: Session,
+    tenant_a: Tenants,
+) -> None:
+    """Portal and open-checkout carts for the same email+popup are ONE cart.
+
+    A person who has an authenticated portal cart and then saves an
+    open-checkout cart for the same popup must not end up with two rows, so the
+    future cart-recovery email job never mails them twice.
+    """
+    popup = _make_popup(db, tenant_a, slug_prefix="converge", signing_secret="s3cr3t")
+    product = _make_product(db, popup)
+    db.commit()
+
+    # Authenticated portal cart first (keyed by human).
+    human = humans_crud.find_or_create(
+        db, email="buyer@test.com", tenant_id=tenant_a.id
+    )
+    portal_cart = carts_crud.get_or_create(
+        db, human_id=human.id, popup_id=popup.id, tenant_id=tenant_a.id
+    )
+
+    # Then the open-checkout upsert for the same email resolves to that cart.
+    response = client.put(
+        f"/api/v1/checkout/{popup.slug}/cart",
+        json={"email": "buyer@test.com", "items": _items(product, promo_code="A")},
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["id"] == str(portal_cart.id)
+
+    carts = list(db.exec(select(Carts).where(Carts.popup_id == popup.id)).all())
+    assert len(carts) == 1
 
 
 def test_upsert_open_cart_without_secret_has_null_restore_token(
@@ -152,7 +196,7 @@ def test_upsert_open_cart_is_idempotent_per_email(
 
     carts = list(
         db.exec(
-            select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_(None))
+            select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_not(None))
         ).all()
     )
     assert len(carts) == 1
@@ -188,7 +232,7 @@ def test_upsert_open_cart_email_is_case_insensitive(
 
     carts = list(
         db.exec(
-            select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_(None))
+            select(Carts).where(Carts.popup_id == popup.id, Carts.human_id.is_not(None))
         ).all()
     )
     assert len(carts) == 1


### PR DESCRIPTION
## Problem

Open-checkout carts were anonymous (`human_id NULL`, keyed by email) and lived in a separate uniqueness domain from authenticated portal carts (`uq_cart_human_popup` vs the partial `uq_cart_tenant_popup_email WHERE human_id IS NULL`). So the same person could hold **two carts for one popup** — one per flow — and a future cart-recovery email job would mail them twice.

## Change

Resolve the buyer email to a human at cart-save time and key the open-checkout cart by `(human, popup)` — the same key as the portal cart — so both flows converge on **one row**.

| File | Change |
|------|--------|
| `backend/app/api/checkout/router.py` | `upsert_open_cart`: `email.lower()` → `humans_crud.find_or_create` → `carts_crud.upsert_open_cart(human_id=…)`; restore uses `find_by_id_popup` |
| `backend/app/api/cart/crud.py` | Add `upsert_open_cart` + `find_by_id_popup`; drop the now-unused `*_anonymous` helpers |
| `backend/app/api/payment/crud.py` | Payment-approval cleanup deletes by human (`_direct_buyer_human_id`); continuity proof uses `find_by_id_popup` |
| `backend/app/api/cart/models.py` | Drop the partial index `uq_cart_tenant_popup_email` (no cart has `human_id NULL` anymore) |
| `backend/app/alembic/versions/e266b8601d0c_…py` | Migration dropping the index (schema only, no data) |
| `backend/tests/api/checkout/test_open_cart.py` | Updated assertions + new `test_open_cart_converges_with_authenticated_cart` |

Existing duplicate carts are test data and are removed manually, so there is no data backfill.

### Note

`HumanBase.normalize_email` does **not** run on `table=True` inserts (SQLModel skips pydantic validation on table models), so `find_or_create` is case-sensitive. The endpoint lowercases the email before resolving the human to avoid spawning a second human+cart. The broader human-email case duplication is pre-existing and out of scope here.

## Verification

- `pytest` open-cart + open-ticketing-payment + enforcement — 37 passed
- `scripts/lint.sh` (ruff) — pass
- `alembic heads` — single head (`e266b8601d0c`)