### PR TITLE
feat(checkout): the step config owns the buyer step, and the Amanita headings read it

### DIFF
--- a/backoffice/src/components/ticketing-step-builder/AddStepDialog.tsx
+++ b/backoffice/src/components/ticketing-step-builder/AddStepDialog.tsx
@@ -62,6 +62,14 @@ export function AddStepDialog({
     enabled: !!popupId && open,
   })
 
+  // A template may pin the step_type (see TemplateDefinition.stepType). The
+  // title-derived type still tracks the input underneath, so clearing the
+  // template hands the step back to the normal naming rule.
+  const pinnedStepType = TEMPLATE_DEFINITIONS.find(
+    (def) => def.key === template,
+  )?.stepType
+  const effectiveStepType = pinnedStepType ?? stepType
+
   const handleTitleChange = (value: string) => {
     setTitle(value)
     setStepType(
@@ -83,11 +91,16 @@ export function AddStepDialog({
       await TicketingStepsService.createTicketingStep({
         requestBody: {
           popup_id: popupId,
-          step_type: stepType,
+          step_type: effectiveStepType,
           title,
           order: insertOrder,
           is_enabled: true,
-          product_category: productCategory || null,
+          // Send a category only when the picker is on screen: a template
+          // that shows no products hides it, and a category chosen before
+          // that template was picked would otherwise ride along invisibly.
+          product_category: CONTENT_ONLY_TEMPLATES.has(template)
+            ? null
+            : productCategory || null,
           template: template || null,
         },
       })
@@ -108,7 +121,8 @@ export function AddStepDialog({
     onError: createErrorHandler(showErrorToast),
   })
 
-  const canSubmit = title.trim().length > 0 && stepType.trim().length > 0
+  const canSubmit =
+    title.trim().length > 0 && effectiveStepType.trim().length > 0
 
   return (
     <Dialog

--- a/backoffice/src/components/ticketing-step-builder/constants.ts
+++ b/backoffice/src/components/ticketing-step-builder/constants.ts
@@ -13,6 +13,7 @@ import {
   ShoppingBag,
   Sparkles,
   Ticket,
+  User,
   Utensils,
   Video,
 } from "lucide-react"
@@ -28,6 +29,12 @@ export interface TemplateDefinition {
   label: string
   description: string
   icon: LucideIcon
+  /** Pins the step's `step_type` instead of deriving it from the title.
+   *  For templates the checkout routes by step_type rather than by template
+   *  (the buyer form is rendered by `step_type === "buyer"`, not by its
+   *  template), a title-derived type like "your-information" would leave the
+   *  step configured and invisible. */
+  stepType?: string
 }
 
 export const TEMPLATE_DEFINITIONS: TemplateDefinition[] = [
@@ -97,6 +104,14 @@ export const TEMPLATE_DEFINITIONS: TemplateDefinition[] = [
     description: "Weekly meal plans with per-day dish picker",
     icon: Utensils,
   },
+  {
+    key: "buyer-form",
+    label: "Buyer Form",
+    description:
+      "Collects the buyer's details before payment. The fields come from the form builder — only the heading is configured here",
+    icon: User,
+    stepType: "buyer",
+  },
 ]
 
 /** Templates that don't display products and therefore don't need a product category. */
@@ -106,6 +121,7 @@ export const CONTENT_ONLY_TEMPLATES = new Set([
   "image-gallery",
   "faqs",
   "rich-text",
+  "buyer-form",
 ])
 
 export const STEP_TYPE_DEFINITIONS: StepTypeDefinition[] = [
@@ -114,6 +130,7 @@ export const STEP_TYPE_DEFINITIONS: StepTypeDefinition[] = [
   { step_type: "merch", defaultTitle: "Merchandise", icon: ShoppingBag },
   { step_type: "patron", defaultTitle: "Patron", icon: Heart },
   { step_type: "meal_plan", defaultTitle: "Meal Plan", icon: Utensils },
+  { step_type: "buyer", defaultTitle: "Your information", icon: User },
   { step_type: "insurance_checkout", defaultTitle: "Insurance", icon: Shield },
   { step_type: "confirm", defaultTitle: "Review & Confirm", icon: CheckCircle },
 ]

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -370,7 +370,8 @@ function StepConfigContent({ stepId }: { stepId: string }) {
               </div>
 
               {!CONTENT_ONLY_TEMPLATES.has(template) &&
-                step.step_type !== "confirm" && (
+                step.step_type !== "confirm" &&
+                step.step_type !== "buyer" && (
                   <div className="flex flex-col gap-1.5">
                     <Label htmlFor="step-product-category">
                       Product Category
@@ -578,8 +579,11 @@ function StepConfigContent({ stepId }: { stepId: string }) {
               </Alert>
             ))}
 
-          {/* Template Selection & Configuration (hidden for confirm step) */}
-          {step.step_type !== "confirm" && (
+          {/* Template Selection & Configuration (hidden for the steps whose
+              template is not a choice: confirm, and buyer — the checkout
+              renders both by step_type, so swapping their template would only
+              produce a step that no longer draws itself.) */}
+          {step.step_type !== "confirm" && step.step_type !== "buyer" && (
             <>
               <Card>
                 <CardHeader>

--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
@@ -419,7 +419,14 @@ export default function StepperCheckoutFlow({
     const { stepType, config } = section
     const isFirstSection = active === 0
     if (stepType === "buyer")
-      return isAmanita ? <AmanitaBuyerStep /> : <OpenCheckoutBuyerStep />
+      return isAmanita ? (
+        /* `contentOwnsHeader` suppresses the generic SectionHeader on this
+           skin, so the step's configured title/description/watermark only
+           reach the screen if its own shell is given the config. */
+        <AmanitaBuyerStep stepConfig={config} />
+      ) : (
+        <OpenCheckoutBuyerStep />
+      )
     if (stepType === "confirm")
       return isAmanita ? (
         /* The card's CTA is a second trigger for the same payment as the
@@ -428,6 +435,7 @@ export default function StepperCheckoutFlow({
            `!isSubmitting`, which is what stops a double charge once one of
            the two has been pressed. Two buttons, one source of truth. */
         <AmanitaConfirmSection
+          stepConfig={config}
           onGoToTickets={goToFirstProductSection}
           onPay={handlePayment}
           payDisabled={!canPay}

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.test.tsx
@@ -12,6 +12,7 @@
  */
 import { fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { TicketingStepPublic } from "@/client"
 import type { ApplicationFormSchema } from "@/types/form-schema"
 import AmanitaBuyerStep from "./AmanitaBuyerStep"
 
@@ -380,6 +381,62 @@ describe("AmanitaBuyerStep — schema-driven rendering", () => {
       invalidFields = ["email"]
       render(<AmanitaBuyerStep />)
       expect(screen.queryByText("checkout.field_required")).toBeNull()
+    })
+  })
+
+  // The stepper hides its generic SectionHeader on this skin, so the step
+  // config's copy reaches the shopper through this section's shell or not at
+  // all. It used to hardcode the skin's strings: an organizer renamed the step
+  // in the backoffice and nothing on screen moved.
+  describe("step heading", () => {
+    const CONFIG = {
+      id: "s1",
+      step_type: "buyer",
+      title: "Tus Datos",
+      description: "Necesitamos saber a quién le emitimos las entradas.",
+      watermark: "Paso 2",
+      template_config: null,
+    } as unknown as TicketingStepPublic
+
+    it("takes title, description and watermark from the step config", () => {
+      render(<AmanitaBuyerStep stepConfig={CONFIG} />)
+      expect(screen.getByText("Tus Datos")).toBeTruthy()
+      expect(
+        screen.getByText(
+          "Necesitamos saber a quién le emitimos las entradas.",
+        ),
+      ).toBeTruthy()
+      expect(screen.getByText("Paso 2")).toBeTruthy()
+    })
+
+    it("prefers a template_config kicker over the watermark", () => {
+      render(
+        <AmanitaBuyerStep
+          stepConfig={
+            { ...CONFIG, template_config: { kicker: "Casi listo" } } as never
+          }
+        />,
+      )
+      expect(screen.getByText("Casi listo")).toBeTruthy()
+      expect(screen.queryByText("Paso 2")).toBeNull()
+    })
+
+    // An organizer who cleared the description wants no intro — not the
+    // skin's opinion of one.
+    it("shows no intro when the configured step has no description", () => {
+      render(
+        <AmanitaBuyerStep
+          stepConfig={{ ...CONFIG, description: null } as never}
+        />,
+      )
+      expect(screen.queryByText("checkout.amanita.buyer_intro")).toBeNull()
+    })
+
+    it("falls back to the skin's copy when no step is configured", () => {
+      render(<AmanitaBuyerStep />)
+      expect(screen.getByText("checkout.amanita.buyer_title")).toBeTruthy()
+      expect(screen.getByText("checkout.amanita.buyer_kicker")).toBeTruthy()
+      expect(screen.getByText("checkout.amanita.buyer_intro")).toBeTruthy()
     })
   })
 

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.test.tsx
@@ -402,9 +402,7 @@ describe("AmanitaBuyerStep — schema-driven rendering", () => {
       render(<AmanitaBuyerStep stepConfig={CONFIG} />)
       expect(screen.getByText("Tus Datos")).toBeTruthy()
       expect(
-        screen.getByText(
-          "Necesitamos saber a quién le emitimos las entradas.",
-        ),
+        screen.getByText("Necesitamos saber a quién le emitimos las entradas."),
       ).toBeTruthy()
       expect(screen.getByText("Paso 2")).toBeTruthy()
     })

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.tsx
@@ -19,9 +19,10 @@
 import { type CSSProperties, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { getCheckoutSchemaSections } from "@/app/checkout/types"
+import type { TicketingStepPublic } from "@/client"
 import { useCheckout } from "@/providers/checkoutProvider"
 import type { FormFieldSchema } from "@/types/form-schema"
-import { SectionShell } from "./SectionShell"
+import { SectionShell, shellCopy } from "./SectionShell"
 
 /** Curated WhatsApp country list. Rendered as TEXT ("AR +54") — no flag
  *  emojis (they don't render on Chrome/Windows, a known repo gotcha). */
@@ -303,7 +304,14 @@ function AmanitaField({
   )
 }
 
-export default function AmanitaBuyerStep() {
+export default function AmanitaBuyerStep({
+  stepConfig,
+}: {
+  /** The organizer's buyer step, when one is configured — it names this
+   *  section. Optional: a popup with no buyer step row still collects the
+   *  schema's fields, so the skin's own copy stands in. */
+  stepConfig?: TicketingStepPublic | null
+}) {
   const { t } = useTranslation()
   const {
     buyerValues,
@@ -341,12 +349,18 @@ export default function AmanitaBuyerStep() {
   const hoistedTitle =
     realSections.length === 1 ? realSections[0].title : undefined
 
+  const copy = shellCopy(stepConfig, {
+    kicker: t("checkout.amanita.buyer_kicker"),
+    title: t("checkout.amanita.buyer_title"),
+    intro: t("checkout.amanita.buyer_intro"),
+  })
+
   return (
     <SectionShell
       gem="flourish"
-      kicker={t("checkout.amanita.buyer_kicker")}
-      title={t("checkout.amanita.buyer_title")}
-      intro={t("checkout.amanita.buyer_intro")}
+      kicker={copy.kicker}
+      title={copy.title}
+      intro={copy.intro}
     >
       <div
         className="rounded-2xl bg-cream p-6 text-left md:p-8"

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.test.tsx
@@ -15,6 +15,7 @@
  */
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { TicketingStepPublic } from "@/client"
 import { createInitialCartState } from "@/types/checkout"
 import AmanitaConfirmSection from "./AmanitaConfirmSection"
 
@@ -242,6 +243,39 @@ describe("AmanitaConfirmSection", () => {
   it("keeps the service fee out of the item list when the popup charges none", () => {
     render(<AmanitaConfirmSection />)
     expect(screen.queryByText("checkout.contribution.fallbackLabel")).toBeNull()
+  })
+
+  // Same contract as the buyer step: with the stepper's generic
+  // SectionHeader suppressed on this skin, ignoring the config is what makes
+  // an organizer's rename invisible.
+  describe("step heading", () => {
+    const CONFIG = {
+      id: "s2",
+      step_type: "confirm",
+      title: "Revisá tu compra",
+      description: "Un último vistazo antes de pagar.",
+      watermark: "Paso 3",
+      template_config: null,
+    } as unknown as TicketingStepPublic
+
+    it("takes title, description and watermark from the step config", () => {
+      render(<AmanitaConfirmSection stepConfig={CONFIG} />)
+      expect(screen.getByText("Revisá tu compra")).toBeTruthy()
+      expect(screen.getByText("Un último vistazo antes de pagar.")).toBeTruthy()
+      expect(screen.getByText("Paso 3")).toBeTruthy()
+    })
+
+    it("keeps the configured title on the empty-cart state", () => {
+      cart = createInitialCartState()
+      render(<AmanitaConfirmSection stepConfig={CONFIG} />)
+      expect(screen.getByText("Revisá tu compra")).toBeTruthy()
+    })
+
+    it("falls back to the skin's copy when no step is configured", () => {
+      render(<AmanitaConfirmSection />)
+      expect(screen.getByText("checkout.amanita.confirm_title")).toBeTruthy()
+      expect(screen.getByText("checkout.amanita.confirm_kicker")).toBeTruthy()
+    })
   })
 
   it("does NOT render a second pay/confirm button — the bottom bar owns payment", () => {

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
@@ -42,12 +42,13 @@ import {
 } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
+import type { TicketingStepPublic } from "@/client"
 import { useApplication } from "@/providers/applicationProvider"
 import { useCheckout } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 import { formatCheckoutDate, formatCurrency } from "@/types/checkout"
 import { CornerFrame } from "./Ornaments"
-import { SectionShell } from "./SectionShell"
+import { SectionShell, shellCopy } from "./SectionShell"
 
 const CREAM_CARD_STYLE = {
   border: "1px solid rgba(193,170,136,0.4)",
@@ -82,12 +83,17 @@ export default function AmanitaConfirmSection({
   onGoToTickets,
   onPay,
   payDisabled,
+  stepConfig,
 }: {
   onGoToTickets?: () => void
   /** The stepper's own payment handler — see the header note on why this is
    *  passed in rather than pulled from `useCheckout()` here. */
   onPay?: () => void
   payDisabled?: boolean
+  /** The organizer's confirm step, when one is configured — it names this
+   *  section. Optional: the funnel shows a confirm step whether or not a row
+   *  exists for it, and then the skin's own copy stands in. */
+  stepConfig?: TicketingStepPublic | null
 }) {
   const { t } = useTranslation()
   const {
@@ -186,13 +192,18 @@ export default function AmanitaConfirmSection({
   const showEligibleQualifier = summary.discount > 0 && nonDiscountableTotal > 0
   const notEligibleCaption = t("checkout.discount.not_eligible_caption")
 
+  const copy = shellCopy(stepConfig, {
+    kicker: t("checkout.amanita.confirm_kicker"),
+    title: t("checkout.amanita.confirm_title"),
+    intro: t("checkout.amanita.confirm_intro"),
+  })
+
   if (!hasCartItems) {
     return (
-      <SectionShell
-        gem="bold"
-        kicker={t("checkout.amanita.confirm_kicker")}
-        title={t("checkout.amanita.confirm_title")}
-      >
+      /* No intro here even when one is configured: it describes reviewing an
+         order, and there is nothing to review yet — the empty state says so
+         in its own words. */
+      <SectionShell gem="bold" kicker={copy.kicker} title={copy.title}>
         <div className="flex flex-col items-center gap-4 py-10 text-center">
           <ShoppingBag className="w-12 h-12 text-cream/60" aria-hidden="true" />
           <p className="font-display text-xl uppercase tracking-wide text-cream">
@@ -219,9 +230,9 @@ export default function AmanitaConfirmSection({
   return (
     <SectionShell
       gem="bold"
-      kicker={t("checkout.amanita.confirm_kicker")}
-      title={t("checkout.amanita.confirm_title")}
-      intro={t("checkout.amanita.confirm_intro")}
+      kicker={copy.kicker}
+      title={copy.title}
+      intro={copy.intro}
     >
       {buyerGeneralError ? (
         <div

--- a/portal/src/components/checkout-flow/skins/amanita/SectionShell.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/SectionShell.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import type { TicketingStepPublic } from "@/client"
 import { Gem, type GemVariant } from "./Gem"
 
 /**
@@ -9,6 +10,52 @@ import { Gem, type GemVariant } from "./Gem"
  * Relies on the `.ck-section`, `.ck-gem*`, `.font-display`, `.font-condensed`,
  * `.text-sand`/`.text-cream` scoped utilities from amanita-skin.css (Task 3).
  */
+export interface ShellCopy {
+  kicker?: string
+  title: string
+  intro?: string
+}
+
+/**
+ * The heading a step shows, read from what the organizer authored in the
+ * backoffice rather than from the skin.
+ *
+ * On Amanita the stepper suppresses its generic `SectionHeader`
+ * (`contentOwnsHeader`) because every section draws its own — so a section
+ * that ignores `stepConfig` is the only place the step's configured title,
+ * description and watermark can go missing, and the organizer edits the step
+ * with nothing on screen changing.
+ *
+ * A configured step owns all three: an empty description means the organizer
+ * wants no intro, not that the skin should supply one. `fallback` covers the
+ * step that has no config row at all. `kicker` prefers a distinct
+ * `template_config.kicker`, else the watermark — never the title, which the
+ * shell already prints right below it.
+ *
+ * Note these are authored strings, so they are NOT translated: an organizer
+ * writing "Tus Datos" gets exactly that in every locale. Only the fallback,
+ * which the caller passes already translated, follows the shopper's language.
+ */
+export function shellCopy(
+  stepConfig: TicketingStepPublic | null | undefined,
+  fallback: ShellCopy,
+): ShellCopy {
+  if (!stepConfig) return fallback
+
+  const templateConfig = (stepConfig.template_config ?? null) as Record<
+    string,
+    unknown
+  > | null
+  const templateKicker =
+    typeof templateConfig?.kicker === "string" ? templateConfig.kicker : null
+
+  return {
+    kicker: templateKicker ?? stepConfig.watermark ?? undefined,
+    title: stepConfig.title || fallback.title,
+    intro: stepConfig.description ?? undefined,
+  }
+}
+
 export function SectionShell({
   gem,
   kicker,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -184,8 +184,6 @@
     "sold_out": "Sold out",
     "sale_upcoming": "Upcoming",
     "sale_ended": "Ended",
-    "buyer_step_title": "Your information",
-    "buyer_step_description": "Complete your information before payment.",
     "buyer_hero_title": "You're one step away!",
     "buyer_hero_subtitle": "We need a couple of details to reserve your spot.",
     "buyer_hero_trust": "Your privacy matters. We don't share your data with third parties.",

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -184,8 +184,6 @@
     "sold_out": "Agotado",
     "sale_upcoming": "Próximamente",
     "sale_ended": "Finalizado",
-    "buyer_step_title": "Tu información",
-    "buyer_step_description": "Completá tus datos antes del pago.",
     "buyer_hero_title": "¡Estás a un paso!",
     "buyer_hero_subtitle": "Necesitamos un par de datos para reservar tu lugar.",
     "buyer_hero_trust": "Tu privacidad nos es importante. No compartimos tus datos con terceros.",

--- a/portal/src/i18n/locales/is.json
+++ b/portal/src/i18n/locales/is.json
@@ -169,8 +169,6 @@
     "sold_out": "Uppselt",
     "sale_upcoming": "Væntanlegt",
     "sale_ended": "Lokið",
-    "buyer_step_title": "Upplýsingar þínar",
-    "buyer_step_description": "Fylltu út upplýsingar þínar áður en þú greiðir.",
     "loading_info": "Hleður upplýsingum þínum",
     "processing": "Vinn úr skráningu þinni",
     "processing_subtitle": "Þetta gæti tekið nokkur augnablik",

--- a/portal/src/i18n/locales/zh.json
+++ b/portal/src/i18n/locales/zh.json
@@ -169,8 +169,6 @@
     "sold_out": "已售罄",
     "sale_upcoming": "即将开售",
     "sale_ended": "已结束",
-    "buyer_step_title": "您的信息",
-    "buyer_step_description": "请在付款前填写您的信息。",
     "buyer_hero_title": "就差一步！",
     "buyer_hero_subtitle": "我们需要几条信息来保留您的位置。",
     "buyer_hero_trust": "您的隐私很重要。我们不会与第三方共享您的数据。",

--- a/portal/src/providers/checkoutProvider.test.tsx
+++ b/portal/src/providers/checkoutProvider.test.tsx
@@ -4,9 +4,10 @@
  * allActiveProducts to cart selection hooks.
  */
 import { renderHook } from "@testing-library/react"
-import type { ReactNode } from "react"
+import type { ComponentProps, ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 import type { TicketingStepPublic } from "@/client"
+import type { ApplicationFormSchema } from "@/types/form-schema"
 import type { ProductsPass } from "@/types/Products"
 import { CheckoutProvider, useCheckout } from "./checkoutProvider"
 
@@ -55,8 +56,10 @@ vi.mock("@tanstack/react-query", () => ({
     isPending: false,
   }),
 }))
+// `i18n` and not just `t`: usePaymentSubmit reads i18n.language, so a mock
+// without it throws before any assertion runs.
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (k: string) => k }),
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: "en" } }),
 }))
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
@@ -113,6 +116,7 @@ function makeProduct(
 function makeWrapper(
   steps: TicketingStepPublic[],
   products: ProductsPass[],
+  extraProps: Partial<ComponentProps<typeof CheckoutProvider>> = {},
 ): ({ children }: { children: ReactNode }) => ReactNode {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
@@ -120,12 +124,84 @@ function makeWrapper(
         configuredStepsOverride={steps}
         productsOverride={products}
         cartPersistenceEnabled={false}
+        {...extraProps}
       >
         {children}
       </CheckoutProvider>
     ) as ReactNode
   }
 }
+
+// The provider used to synthesize a buyer step whenever an open-ticketing
+// popup carried no `buyer` row, which meant the step could not be left out:
+// it showed up in checkout no matter what the step config said. It's an
+// ordinary configured step now — these pin that the config is the only source.
+describe("checkoutProvider — the buyer step comes from the step config", () => {
+  const BUYER_SCHEMA = {
+    base_fields: {
+      email: { type: "email", label: "Email", required: true, position: 0 },
+    },
+    custom_fields: {},
+    sections: [],
+  } as unknown as ApplicationFormSchema
+
+  // Exactly the conditions that used to trigger the synthesis.
+  const OPEN_TICKETING = {
+    buyerFormSchema: BUYER_SCHEMA,
+    submitMode: "open-ticketing" as const,
+  }
+
+  it("adds no buyer step when the config has none", () => {
+    const steps = [
+      makeStep({ id: "s1", step_type: "tickets" }),
+      makeStep({ id: "s2", step_type: "confirm" }),
+    ]
+
+    const { result } = renderHook(() => useCheckout(), {
+      wrapper: makeWrapper(steps, [], OPEN_TICKETING),
+    })
+
+    expect(result.current.stepConfigs.map((s) => s.step_type)).toEqual([
+      "tickets",
+      "confirm",
+    ])
+    expect(result.current.availableSteps).not.toContain("buyer")
+  })
+
+  // Without a step to send them to, nothing may claim the shopper left
+  // something unfilled — that bounce had nowhere to land.
+  it("reports no incomplete step when no buyer step is configured", () => {
+    const steps = [makeStep({ id: "s1", step_type: "tickets" })]
+
+    const { result } = renderHook(() => useCheckout(), {
+      wrapper: makeWrapper(steps, [], OPEN_TICKETING),
+    })
+
+    expect(result.current.findFirstIncompleteStep()).toBeNull()
+  })
+
+  // The funnel walks the configs in the order the API sends them, so the
+  // position the organizer chose is the position the shopper walks.
+  it("keeps a configured buyer step, in the organizer's order", () => {
+    const steps = [
+      makeStep({ id: "s1", step_type: "tickets" }),
+      makeStep({ id: "s2", step_type: "buyer" }),
+      makeStep({ id: "s3", step_type: "confirm" }),
+    ]
+
+    const { result } = renderHook(() => useCheckout(), {
+      wrapper: makeWrapper(steps, [], OPEN_TICKETING),
+    })
+
+    expect(result.current.availableSteps).toEqual([
+      "passes",
+      "buyer",
+      "confirm",
+    ])
+    // Its empty form is still what gates payment.
+    expect(result.current.findFirstIncompleteStep()).toBe("buyer")
+  })
+})
 
 describe("checkoutProvider — step-aware product wiring", () => {
   it("exposes productsByStepId from useStepProductResolver on context", () => {

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -283,56 +283,12 @@ export function CheckoutProvider({
       }),
     enabled: !configuredStepsOverride && !!cityId && isAuthenticated,
   })
+  // The funnel is exactly what the organizer configured. The buyer step used
+  // to be synthesized here when a popup carried no `buyer` row, which made it
+  // impossible to leave out: it reappeared in checkout no matter what the step
+  // config said. It is a real step now, added from the backoffice like any
+  // other — a popup without one collects no buyer info.
   const configuredSteps = configuredStepsOverride ?? stepsData?.results ?? []
-  const effectiveConfiguredSteps = useMemo(() => {
-    if (!buyerFormSchema || submitMode !== "open-ticketing") {
-      return configuredSteps
-    }
-
-    // Post-migration, every direct-sale popup carries a real `buyer` row whose
-    // position the admin controls from the backoffice — use it as-is.
-    if (configuredSteps.some((step) => step.step_type === "buyer")) {
-      return configuredSteps
-    }
-
-    // Legacy fallback: popup hasn't been migrated yet. Synthesize a buyer
-    // step and slot it just before confirm so checkout still works.
-    const confirmStep = configuredSteps.find(
-      (step) => step.step_type === "confirm",
-    )
-
-    const buyerStep: TicketingStepPublic = {
-      id: "buyer-step",
-      tenant_id: cityId ?? "",
-      popup_id: cityId ?? "",
-      step_type: "buyer",
-      title: t("checkout.buyer_step_title"),
-      description: t("checkout.buyer_step_description"),
-      order: 9998,
-      is_enabled: true,
-      protected: true,
-      product_category: null,
-      template: null,
-      template_config: null,
-      watermark: null,
-      show_title: confirmStep?.show_title ?? true,
-      show_watermark: confirmStep?.show_watermark ?? true,
-    }
-
-    const confirmIndex = configuredSteps.findIndex(
-      (step) => step.step_type === "confirm",
-    )
-
-    if (confirmIndex === -1) {
-      return [...configuredSteps, buyerStep]
-    }
-
-    return [
-      ...configuredSteps.slice(0, confirmIndex),
-      buyerStep,
-      ...configuredSteps.slice(confirmIndex),
-    ]
-  }, [buyerFormSchema, cityId, configuredSteps, submitMode, t])
 
   const isBuyerInfoComplete =
     !buyerFormSchema ||
@@ -368,7 +324,7 @@ export function CheckoutProvider({
   // Each step's product list is derived from step.product_category at runtime,
   // not from a hardcoded "merch"/"housing"/"patreon" filter on the full list.
   const { productsByStepId, getProductsForStep } = useStepProductResolver(
-    effectiveConfiguredSteps,
+    configuredSteps,
     products,
   )
 
@@ -778,7 +734,7 @@ export function CheckoutProvider({
     isStepComplete: isStepCompleteFn,
   } = useCheckoutSteps({
     initialStep,
-    configuredSteps: effectiveConfiguredSteps,
+    configuredSteps: configuredSteps,
     productsByStepId,
     selectedPassesCount: selectedPasses.length,
     dynamicItemsCount: Object.values(dynamicItems).flat().length,
@@ -1113,7 +1069,7 @@ export function CheckoutProvider({
         ) {
           return false
         }
-        const config = effectiveConfiguredSteps.find(
+        const config = configuredSteps.find(
           (c) =>
             c.step_type === stepName ||
             (c.step_type === "tickets" && stepName === "passes"),
@@ -1131,7 +1087,7 @@ export function CheckoutProvider({
       }
       return productSteps[0]
     },
-    [availableSteps, effectiveConfiguredSteps],
+    [availableSteps, configuredSteps],
   )
 
   // hasAnyCartItems: mirrors CartFooter's old `canContinue` cart check,
@@ -1368,7 +1324,7 @@ export function CheckoutProvider({
   const value: CheckoutContextValue = {
     currentStep,
     availableSteps,
-    stepConfigs: effectiveConfiguredSteps,
+    stepConfigs: configuredSteps,
     cart,
     summary,
     allProducts: products,


### PR DESCRIPTION
Follow-up to #474 (already merged), on the same branch.

## What changed

**1. The Amanita buyer and confirm sections now read their heading from the step config.**

Amanita suppresses the stepper's generic `SectionHeader` because each of its sections draws its own. The catalog section already read `stepConfig`; buyer and confirm were never handed one and printed hardcoded i18n strings — so an organizer could rename the step in the backoffice and nothing on screen moved. A new `shellCopy()` beside `SectionShell` gives all three one rule:

- **title** ← `stepConfig.title`
- **intro/subtitle** ← `stepConfig.description`
- **kicker** ← `template_config.kicker`, else `stepConfig.watermark` (never the title, which the shell already prints below it)

A configured step owns all three: an empty description means no intro, not the skin's opinion of one. The i18n strings remain as the fallback for a popup with no config row.

Note these are organizer-authored strings, so they are **not** translated — same as the catalog section and the generic header.

**2. The buyer step is now a real step the config owns.**

`checkoutProvider` synthesized a `buyer` row whenever an open-ticketing popup had none, which made the step impossible to leave out — it appeared regardless of the step config, and no backoffice edit could reach it. That's gone: the funnel walks exactly what's configured.

For that to be a real choice the step has to be addable, so the backoffice offers a **Buyer Form** template. It pins `step_type: "buyer"` through a new `TemplateDefinition.stepType` — the dialog otherwise derives the type from the title, and a step created as `your-information` would be configured and invisible, since the checkout routes this step by `step_type`, not by template.

The template carries no config of its own: the heading fields belong to the shared step form and the fields themselves still come from the form builder. So there's no `TEMPLATE_CONFIG_REGISTRY` entry and no config card. Its template picker is hidden on the detail page, as confirm's already is — swapping it could only produce a step that stops drawing itself.

## Consequences worth flagging

- **A direct-sale popup with no buyer step now collects no buyer info**, and payment 422s on the backend's required `email`/`first_name`/`last_name` until an admin adds the step. Deliberate, but it removes a safety net.
- **Popups created via the API have never had a buyer step**: `popup/router.py:230` calls `seed_ticketing_steps_for_popup` without `sale_type`, so the `_direct_sale_only` buyer row is skipped. Not touched here — worth a separate fix.
- **Nothing prevents two buyer steps** the way `patron-preset`'s singleton guard does (`ticketing_step/router.py:165`).
- Popups whose buyer row was seeded/backfilled have `protected=True`, so the backend blocks deleting or disabling it.

## Verification

- 322 checkout tests pass. Six new: 3 pin that no buyer step is synthesized / that a configured one keeps its place and still gates payment; 3 pin the heading contract on the buyer step, plus 3 on confirm.
- **Fixed 3 red tests inherited from dev** in `checkoutProvider.test.tsx` — its `react-i18next` mock exposed only `t` while `usePaymentSubmit` reads `i18n.language`.
- 4 failures remain, all inherited from dev and unrelated (3 in `useTicketsStep` `setRowQuantity` routing, 1 in `VariantPatronPreset`); confirmed via stash that they predate this branch. Note CI's frontend job is biome + tsc only, so it does not run vitest — green CI is not evidence about those.
- `tsc` clean on every file touched. The backoffice carries 14 pre-existing errors in `ProductForm` tests, also inherited.
- **Biome was never run locally** — its native binary fails to load on this machine — so formatting rests on CI.
- **The backoffice has no unit-test runner for `src/`** (`test:e2e` only includes `e2e/**`), so the `step_type` pinning is verified by types and reading, not by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)