### PR TITLE
feat(form-builder): regenerate field key on label edit while unused

### DIFF
--- a/backend/app/api/form_field/crud.py
+++ b/backend/app/api/form_field/crud.py
@@ -67,16 +67,76 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         return session.exec(statement).first()
 
     def generate_field_name(
-        self, session: Session, label: str, popup_id: uuid.UUID
+        self,
+        session: Session,
+        label: str,
+        popup_id: uuid.UUID,
+        exclude_id: uuid.UUID | None = None,
     ) -> str:
-        """Generate a unique field name from a label."""
+        """Generate a unique field name from a label.
+
+        ``exclude_id`` skips a field's own row in the collision check so a
+        rename can't be suffixed against itself.
+        """
         base = _slugify(label)
         name = base
         counter = 1
-        while self.get_by_name(session, name, popup_id):
+        while True:
+            existing = self.get_by_name(session, name, popup_id)
+            if existing is None or existing.id == exclude_id:
+                return name
             name = f"{base}_{counter}"
             counter += 1
-        return name
+
+    def is_field_name_in_use(
+        self, session: Session, name: str, popup_id: uuid.UUID
+    ) -> bool:
+        """Return True if submitted data or config references this field name.
+
+        Checks application custom_fields (and their snapshots) plus ticketing
+        step section visibility conditions. Once any of these reference the
+        name, renaming it would orphan data, so the key must stay frozen.
+        """
+        from app.api.application.models import Applications, ApplicationSnapshots
+        from app.api.ticketing_step.crud import ticketing_steps_crud
+
+        app_stmt = (
+            select(Applications.id)
+            .where(
+                Applications.popup_id == popup_id,
+                col(Applications.custom_fields).has_key(name),
+            )
+            .limit(1)
+        )
+        if session.exec(app_stmt).first() is not None:
+            return True
+
+        snapshot_stmt = (
+            select(ApplicationSnapshots.id)
+            .join(
+                Applications,
+                col(ApplicationSnapshots.application_id) == col(Applications.id),
+            )
+            .where(
+                Applications.popup_id == popup_id,
+                col(ApplicationSnapshots.custom_fields).has_key(name),
+            )
+            .limit(1)
+        )
+        if session.exec(snapshot_stmt).first() is not None:
+            return True
+
+        steps, _ = ticketing_steps_crud.find_by_popup(session, popup_id, limit=1000)
+        for step in steps:
+            sections = (step.template_config or {}).get("sections", [])
+            for section in sections:
+                if not isinstance(section, dict):
+                    continue
+                visible_if = section.get("visible_if")
+                if isinstance(visible_if, dict) and visible_if.get("field_id") == name:
+                    return True
+
+        return False
 
     def find_by_popup(
         self,

--- a/backend/app/api/form_field/router.py
+++ b/backend/app/api/form_field/router.py
@@ -334,10 +334,23 @@ async def update_form_field(
     field = crud.form_fields_crud.get(db, field_id)
 
     if field:
-        # NOTE: field.name is a stable internal key generated once at creation.
-        # It MUST NOT change when the label is edited — existing application
-        # custom_fields reference this key and renaming it would silently break
-        # the link to all previously submitted data.
+        # NOTE: field.name regenerates on label edits only while the key is
+        # still unused (no submitted answers, no ticketing step references).
+        # After first use it is frozen forever — application custom_fields and
+        # step visibility conditions are keyed by it.
+        new_label = field_in.label
+        if (
+            "label" in field_in.model_fields_set
+            and new_label
+            and new_label != field.label
+            and crud._slugify(new_label) != field.name
+            and not crud.form_fields_crud.is_field_name_in_use(
+                db, field.name, field.popup_id
+            )
+        ):
+            field.name = crud.form_fields_crud.generate_field_name(
+                db, new_label, field.popup_id, exclude_id=field.id
+            )
         updated = crud.form_fields_crud.update(db, field, field_in)
         return _to_public(updated)
 

--- a/backend/tests/api/form_field/test_form_field_rename.py
+++ b/backend/tests/api/form_field/test_form_field_rename.py
@@ -1,0 +1,279 @@
+"""Tests for regenerating FormFields.name on label edit while the key is unused.
+
+The internal key follows the label until any application answer or ticketing
+step visibility condition references it; from then on it is frozen.
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.api.ticketing_step.models import TicketingSteps
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_field(
+    client: TestClient,
+    token: str,
+    popup_id: str,
+    label: str,
+) -> dict:
+    resp = client.post(
+        "/api/v1/form-fields",
+        headers=_admin_headers(token),
+        json={"popup_id": popup_id, "label": label, "field_type": "text"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _patch_field(
+    client: TestClient,
+    token: str,
+    field_id: str,
+    payload: dict,
+) -> dict:
+    resp = client.patch(
+        f"/api/v1/form-fields/{field_id}",
+        headers=_admin_headers(token),
+        json=payload,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _create_application_with_answer(
+    db: Session, tenant: Tenants, popup: Popups, field_name: str
+) -> Applications:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"rename-test-{uuid.uuid4().hex[:8]}@example.com",
+    )
+    db.add(human)
+    db.flush()
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        custom_fields={field_name: "some answer"},
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+# ---------------------------------------------------------------------------
+# Rename while unused
+# ---------------------------------------------------------------------------
+
+
+class TestRenameWhileUnused:
+    def test_label_edit_regenerates_name(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        data = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"New text field {suffix}",
+        )
+        assert data["name"] == f"new_text_field_{suffix}"
+
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"label": f"Dietary Restrictions {suffix}"},
+        )
+        assert updated["label"] == f"Dietary Restrictions {suffix}"
+        assert updated["name"] == f"dietary_restrictions_{suffix}"
+
+    def test_second_label_edit_follows_again(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        data = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"New text field {suffix}",
+        )
+        _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"label": f"First Rename {suffix}"},
+        )
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"label": f"Second Rename {suffix}"},
+        )
+        assert updated["name"] == f"second_rename_{suffix}"
+
+    def test_slug_collision_gets_suffixed(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"Company Name {suffix}",
+        )
+        other = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"Placeholder {suffix}",
+        )
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            other["id"],
+            {"label": f"Company Name {suffix}"},
+        )
+        assert updated["name"] == f"company_name_{suffix}_1"
+
+    def test_patch_without_label_keeps_name(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        data = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"Untouched Label {suffix}",
+        )
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"required": True},
+        )
+        assert updated["name"] == data["name"]
+        assert updated["required"] is True
+
+    def test_label_edit_with_same_slug_keeps_name(
+        self,
+        client: TestClient,
+        admin_token_tenant_a: str,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        data = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"Same Slug {suffix}",
+        )
+        # Different label text, identical slug — no pointless suffix churn.
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"label": f"Same  Slug   {suffix}!"},
+        )
+        assert updated["name"] == data["name"]
+
+
+# ---------------------------------------------------------------------------
+# Frozen after first use
+# ---------------------------------------------------------------------------
+
+
+class TestNameFrozenWhenUsed:
+    def test_application_answer_freezes_name(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_token_tenant_a: str,
+        tenant_a: Tenants,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        data = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"Answered Field {suffix}",
+        )
+        _create_application_with_answer(db, tenant_a, popup_tenant_a, data["name"])
+
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"label": f"Renamed After Answer {suffix}"},
+        )
+        assert updated["label"] == f"Renamed After Answer {suffix}"
+        assert updated["name"] == data["name"]
+
+    def test_ticketing_step_reference_freezes_name(
+        self,
+        client: TestClient,
+        db: Session,
+        admin_token_tenant_a: str,
+        tenant_a: Tenants,
+        popup_tenant_a: Popups,
+    ) -> None:
+        suffix = uuid.uuid4().hex[:6]
+        data = _create_field(
+            client,
+            admin_token_tenant_a,
+            str(popup_tenant_a.id),
+            label=f"Step Gated Field {suffix}",
+        )
+        step = TicketingSteps(
+            tenant_id=tenant_a.id,
+            popup_id=popup_tenant_a.id,
+            step_type="custom",
+            title=f"Tickets {suffix}",
+            template="ticket-select",
+            template_config={
+                "sections": [
+                    {
+                        "title": "Conditional section",
+                        "visible_if": {"field_id": data["name"], "value": True},
+                    }
+                ]
+            },
+        )
+        db.add(step)
+        db.commit()
+
+        updated = _patch_field(
+            client,
+            admin_token_tenant_a,
+            data["id"],
+            {"label": f"Renamed After Step {suffix}"},
+        )
+        assert updated["label"] == f"Renamed After Step {suffix}"
+        assert updated["name"] == data["name"]

--- a/backoffice/src/components/form-builder/FieldConfigPanel.tsx
+++ b/backoffice/src/components/form-builder/FieldConfigPanel.tsx
@@ -208,6 +208,7 @@ export function FieldConfigPanel({
             onChange={(e) => handleChange("label", e.target.value)}
             placeholder="Field label"
           />
+          <p className="text-xs text-muted-foreground">Key: {field.name}</p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Field keys (`FormFields.name`) were slugified once from the placeholder label at drag-drop creation ("New text field" → `new_text_field`) and frozen forever, so every field kept a permanently generic key in answers, exports, and visibility conditions.
- The key now regenerates from the label on edit while the field is unused, then freezes at first use exactly as before.
- A field counts as used when its key appears in `applications.custom_fields`, in `application_snapshots.custom_fields` (popup-scoped join), or in a ticketing step `template_config.sections[].visible_if.field_id`.
- The field config panel now shows the key read-only, so admins can see the column their data exports under.

## Changes

| File | Change |
|------|--------|
| `backend/app/api/form_field/crud.py` | `is_field_name_in_use()` (three-branch usage check) and `exclude_id` on `generate_field_name()` so a rename never collides with its own row |
| `backend/app/api/form_field/router.py` | `update_form_field` regenerates the name before persisting when the label changed and the key is unused; stability note updated |
| `backend/tests/api/form_field/test_form_field_rename.py` | 7 tests: rename follows label, freeze by answer, freeze by ticketing reference, collision suffix, non-label patch, same-slug no-op |
| `backoffice/src/components/form-builder/FieldConfigPanel.tsx` | Read-only `Key` line under the display label input |

## Notes

- `payments.buyer_snapshot` is intentionally excluded from the usage check: it is an immutable self-describing snapshot whose readers use fixed keys.
- `FormFieldUpdate` still does not expose `name`; the rename is always derived server-side.
- No schema shape changed, so no OpenAPI client regeneration was needed.
- Known accepted edge: a submission landing in the instant between the usage check and the rename commit keeps the old key for that single answer; validation ignores unknown keys so nothing breaks.

## Test plan

- [x] `uv run pytest tests/api/form_field/` — 31 passed (7 new)
- [x] `bash scripts/lint.sh` — ruff clean
- [x] `pnpm --filter backoffice run build` and `lint` — clean