### PR TITLE
feat(checkout): an organizer-named pay button, and amanita bar fixes

### DIFF
--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -428,6 +428,40 @@ function StepConfigContent({ stepId }: { stepId: string }) {
             </CardContent>
           </Card>
 
+          {/* Pay button label (only for confirm step) */}
+          {step.step_type === "confirm" && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Pay Button</CardTitle>
+                <CardDescription>
+                  The button that completes the purchase
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="flex flex-col gap-1.5">
+                  <Label htmlFor="confirm-cta-label">Button Label</Label>
+                  <Input
+                    id="confirm-cta-label"
+                    value={(templateConfig?.cta_label as string) ?? ""}
+                    onChange={(e) =>
+                      setTemplateConfig({
+                        ...templateConfig,
+                        cta_label: e.target.value || undefined,
+                      })
+                    }
+                    placeholder="Pagar"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Shown on both the bottom bar's button and the one inside the
+                    confirm card — they always read the same. Leave empty to use
+                    the checkout's own wording, translated per shopper. Once
+                    set, translate it in this step's Translations tab.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
           {/* Insurance Card Content (only for confirm step) */}
           {step.step_type === "confirm" &&
             (popup?.insurance_enabled ? (

--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.test.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.test.tsx
@@ -29,6 +29,8 @@ vi.mock("next/font/google", () => ({
   Quicksand: () => ({ variable: "--font-amanita-sans" }),
 }))
 
+let amanitaConfirmProps: Record<string, unknown> | null = null
+
 vi.mock("@/providers/checkoutProvider", () => ({
   useCheckout: () => ({
     availableSteps: availableStepsOverride ?? ["passes", "confirm"],
@@ -85,6 +87,15 @@ vi.mock("./skins/amanita/AmanitaBuyerStep", () => ({
 vi.mock("./skins/amanita/AmanitaCatalogSection", () => ({
   default: () => <div>amanita-catalog</div>,
 }))
+// Captured rather than rendered for real: what matters at this seam is which
+// props the bar hands down, and the real section needs a provider surface this
+// suite deliberately doesn't mock.
+vi.mock("./skins/amanita/AmanitaConfirmSection", () => ({
+  default: (props: Record<string, unknown>) => {
+    amanitaConfirmProps = props
+    return <div>amanita-confirm</div>
+  },
+}))
 vi.mock("./steps/ConfirmStep", () => ({
   default: () => <div>confirm-step</div>,
 }))
@@ -102,6 +113,7 @@ describe("StepperCheckoutFlow", () => {
     stepConfigsOverride = null
     hasAnyCartItemsOverride = null
     buyerCompleteOverride = null
+    amanitaConfirmProps = null
     markBuyerFieldsTouched.mockClear()
     triggerCheckoutToast.mockClear()
     dismissCheckoutToast.mockClear()
@@ -198,6 +210,32 @@ describe("StepperCheckoutFlow", () => {
     await waitFor(() => expect(submitPayment).toHaveBeenCalledTimes(1))
   })
 
+  // Direction arrows on the bar's two buttons. They're decoration, so they are
+  // asserted on the DOM rather than through the accessible name — which they
+  // must leave alone, since the rest of this suite finds these buttons by it.
+  describe("bottom-bar arrows", () => {
+    it("points Back left and the forward CTA right", () => {
+      const { container } = render(<StepperCheckoutFlow />)
+      fireEvent.click(screen.getByTestId("stepper-next")) // → confirm (last)
+
+      const back = screen.getByRole("button", { name: "common.back" })
+      expect(back.querySelector(".lucide-arrow-left")).toBeTruthy()
+      expect(
+        screen.getByTestId("stepper-next").querySelector(".lucide-arrow-right"),
+      ).toBeTruthy()
+      expect(container.querySelector(".lucide-arrow-left")).toBeTruthy()
+    })
+
+    it("keeps the arrows out of the buttons' accessible names", () => {
+      render(<StepperCheckoutFlow />)
+      // An <svg> contributes no text, so the label is all that's left — this
+      // is what keeps `getByRole({ name })` working across the suite.
+      expect(screen.getByTestId("stepper-next").textContent?.trim()).toBe(
+        "Review & Confirm",
+      )
+    })
+  })
+
   describe("skin", () => {
     const AMANITA_CITY = {
       terms_and_conditions_url: null,
@@ -256,6 +294,30 @@ describe("StepperCheckoutFlow", () => {
       expect(bar.style.background).toContain("linear-gradient")
     })
 
+    /* The amanita chrome is `fixed`, and a fixed element scroll-chains to the
+       viewport rather than to the page's `overflow-y-auto` scroller — so any
+       hit-testable full-bleed layer swallows the wheel across the strip it
+       covers. The gradient bar has to stay transparent to the pointer, with
+       `-auto` restored on the pills. Same contract as the bottom bar's. */
+    it("lets the wheel through the amanita nav gradient while its controls stay clickable", () => {
+      cityOverride = AMANITA_CITY
+      stepConfigsOverride = [PASSES_STEP_CONFIG]
+      const { container } = render(
+        <StepperCheckoutFlow
+          navExtraContent={<button type="button">language</button>}
+        />,
+      )
+
+      const nav = container.querySelector('nav[aria-label="Checkout sections"]')
+      const bar = nav?.parentElement as HTMLElement
+      expect(bar.classList.contains("pointer-events-none")).toBe(true)
+      expect(nav?.classList.contains("pointer-events-auto")).toBe(true)
+      // The language switcher lives in the bar but outside the <nav>, so it
+      // needs its own opt-in — it was briefly unclickable without one.
+      const extra = screen.getByText("language").parentElement as HTMLElement
+      expect(extra.classList.contains("pointer-events-auto")).toBe(true)
+    })
+
     it("keeps the default skin's nav bar full-width with its own background", () => {
       stepConfigsOverride = [PASSES_STEP_CONFIG]
       const { container } = render(<StepperCheckoutFlow />)
@@ -279,6 +341,19 @@ describe("StepperCheckoutFlow", () => {
       // The gem-frame primary must be gone — classList matches whole tokens,
       // so this does not trip on the `btn-ornate-2` above.
       expect(cta.classList.contains("btn-ornate")).toBe(false)
+    })
+
+    /* The card's CTA pays for the same order as the bar's, so the two must
+       read the same. They drifted once already — "Confirmar compra" in the
+       card against "Pagar" in the bar — because the card derived its own. */
+    it("hands the confirm card the bar's own pay label", () => {
+      cityOverride = AMANITA_CITY
+      render(<StepperCheckoutFlow />)
+      fireEvent.click(screen.getByTestId("stepper-next")) // → confirm (last)
+
+      const bar = screen.getByTestId("stepper-next")
+      expect(amanitaConfirmProps?.payLabel).toBe("checkout.actions.pay")
+      expect(bar.textContent).toContain(amanitaConfirmProps?.payLabel)
     })
 
     it("omits the generic header for amanita steps that render their own", () => {
@@ -590,6 +665,66 @@ describe("StepperCheckoutFlow", () => {
 
       expect(screen.getByText("dynamic-step")).toBeTruthy()
       expect(screen.queryByText("amanita-catalog")).toBeNull()
+    })
+  })
+
+  // The organizer names this button on the confirm step. The string arrives
+  // already translated — the backend overlays the shopper's language onto
+  // `template_config` before it reaches the client — so there is nothing to
+  // translate here; an authored label simply wins over the built-in wording.
+  describe("organizer-authored pay label", () => {
+    const AMANITA_CITY = {
+      terms_and_conditions_url: null,
+      theme_config: { checkout_skin: "amanita" },
+    }
+    const confirmStep = (templateConfig: unknown) => ({
+      id: "confirm-config-1",
+      step_type: "confirm",
+      title: "Review & Confirm",
+      template: null,
+      template_config: templateConfig,
+    })
+
+    it("puts the confirm step's cta_label on both pay buttons", () => {
+      cityOverride = AMANITA_CITY
+      stepConfigsOverride = [confirmStep({ cta_label: "Comprar ya" })]
+      render(<StepperCheckoutFlow />)
+      fireEvent.click(screen.getByTestId("stepper-next")) // → confirm (last)
+
+      expect(screen.getByTestId("stepper-next").textContent).toBe("Comprar ya")
+      expect(amanitaConfirmProps?.payLabel).toBe("Comprar ya")
+    })
+
+    it("falls back to the built-in wording when the organizer wrote none", () => {
+      stepConfigsOverride = [confirmStep({ cta_label: "   " })]
+      render(<StepperCheckoutFlow />)
+      fireEvent.click(screen.getByTestId("stepper-next")) // → confirm (last)
+
+      expect(screen.getByTestId("stepper-next").textContent).toBe(
+        "checkout.actions.pay",
+      )
+    })
+
+    /* Read from the confirm step, not whichever is active — otherwise the
+       label would change as the shopper moves through the funnel. The hero
+       already puts its own `cta_label` on the bar for its own step. */
+    it("ignores another step's cta_label", () => {
+      stepConfigsOverride = [
+        {
+          id: "passes-config-2",
+          step_type: "passes",
+          title: "Select Your Passes",
+          template: "catalog",
+          template_config: { cta_label: "Ver Entradas" },
+        },
+        confirmStep(null),
+      ]
+      render(<StepperCheckoutFlow />)
+      fireEvent.click(screen.getByTestId("stepper-next")) // → confirm (last)
+
+      expect(screen.getByTestId("stepper-next").textContent).toBe(
+        "checkout.actions.pay",
+      )
     })
   })
 })

--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { ArrowLeft, ArrowRight } from "lucide-react"
 import Image from "next/image"
 import type { CSSProperties } from "react"
 import { useCallback, useMemo, useState } from "react"
@@ -53,7 +54,7 @@ const NAV_OUTER: Record<
     className: "sticky top-0 z-40 bg-background/90 backdrop-blur",
   },
   amanita: {
-    className: "fixed inset-x-0 top-0 z-40",
+    className: "pointer-events-none fixed inset-x-0 top-0 z-40",
     style: {
       background:
         "linear-gradient(180deg, rgba(1,15,22,0.92) 0%, rgba(1,15,22,0.72) 72%, rgba(1,15,22,0) 100%)",
@@ -61,11 +62,18 @@ const NAV_OUTER: Record<
   },
 }
 
+/* amanita's `pointer-events-none`/`-auto` pair mirrors BOTTOM_OUTER/INNER's,
+ * and for the same reason as AmanitaBackground's: this bar is `fixed`, so it
+ * scroll-chains to the (unscrollable) viewport rather than to the page's
+ * `overflow-y-auto` scroller, and its full-bleed gradient would otherwise eat
+ * the wheel across the whole top strip. `-auto` is put back on the inner
+ * element so the pills stay clickable. The default skin's nav is `sticky` — it
+ * scrolls with its container, so it never had the problem. */
 const NAV_INNER: Record<CheckoutSkin, { className: string }> = {
   default: { className: "flex gap-2 overflow-x-auto px-4 py-3" },
   amanita: {
     className:
-      "no-scrollbar mx-auto flex max-w-[980px] items-center gap-1.5 overflow-x-auto px-3 py-3 md:justify-center",
+      "no-scrollbar pointer-events-auto mx-auto flex max-w-[980px] items-center gap-1.5 overflow-x-auto px-3 py-3 md:justify-center",
   },
 }
 
@@ -143,11 +151,11 @@ const BACK_BUTTON: Record<
 > = {
   default: {
     className:
-      "shrink-0 text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-40",
+      "inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground disabled:opacity-40",
   },
   amanita: {
     className:
-      "shrink-0 font-condensed text-xs font-medium uppercase tracking-[0.12em] transition-colors hover:text-cream disabled:opacity-40",
+      "inline-flex shrink-0 items-center gap-1.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] transition-colors hover:text-cream disabled:opacity-40",
     style: { color: "rgba(241,235,227,0.7)" },
   },
 }
@@ -189,10 +197,16 @@ const HINT_CLASSES: Record<
  * needs it. */
 const CTA_BUTTON_CLASSES: Record<CheckoutSkin, string> = {
   default:
-    "shrink-0 rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
+    "inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50",
   amanita:
-    "btn-ornate-2 btn-gold-fill ck-gold flex shrink-0 items-center justify-center whitespace-nowrap !px-4 py-2.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] transition-all duration-200 hover:-translate-y-0.5 md:!px-6 md:text-sm disabled:cursor-not-allowed disabled:opacity-50",
+    "btn-ornate-2 btn-gold-fill ck-gold flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap !px-4 py-2.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] transition-all duration-200 hover:-translate-y-0.5 md:!px-6 md:text-sm disabled:cursor-not-allowed disabled:opacity-50",
 }
+
+/* Bottom-bar direction arrows. `aria-hidden` because the button's own label
+ * already names the destination — the arrow is orientation, not information,
+ * and announcing it would only add noise to the accessible name the tests and
+ * screen readers read. */
+const ARROW_CLASSES = "h-3.5 w-3.5 shrink-0"
 
 /** `faqs`-template step's `template_config.items` — same `{question,
  * answer}[]` shape VariantFaqs.tsx parses for the default skin's inline
@@ -394,6 +408,29 @@ export default function StepperCheckoutFlow({
   const itemCount = summary.itemCount
   const requiresTerms = !!popup?.terms_and_conditions_url && !termsAccepted
   const canPay = hasAnyCartItems && !requiresTerms && !isSubmitting
+  // Derived once and handed to Amanita's in-card CTA below, for the same
+  // reason `handlePayment`/`canPay` are: the two buttons pay for the same
+  // order, so they must say the same thing. Re-deriving this next to the card
+  // is what let it read "Confirmar compra" while the bar read "Pagar".
+  //
+  // The organizer can name this button on the confirm step, and what they wrote
+  // wins — including on a free order, since `cta_label` is authored for this
+  // button specifically and second-guessing it would just make the field lie.
+  // It's read from the *confirm* step's config rather than `current`'s: the bar
+  // renders the pay CTA on the last step, which is where this label belongs,
+  // and the in-card CTA needs the same string regardless of which step is
+  // active. Reuses the hero's `cta_label` key, which the translation overlay
+  // already treats as copy (backend service.py `_TEXT_LEAF_KEYS`), so the
+  // string arrives here already in the shopper's language.
+  const confirmTemplateConfig = (sections.find(
+    (section) => section.stepType === "confirm",
+  )?.config?.template_config ?? {}) as { cta_label?: string }
+  const authoredPayLabel = confirmTemplateConfig.cta_label?.trim()
+  const payLabel =
+    authoredPayLabel ||
+    (summary.grandTotal === 0
+      ? t("checkout.actions.claim_pass")
+      : t("checkout.actions.pay"))
 
   // The first section is an "intro" when it's a content-only template (a hero
   // or similar): nothing has been priced yet, so the bar drops Back and Total
@@ -430,8 +467,8 @@ export default function StepperCheckoutFlow({
     if (stepType === "confirm")
       return isAmanita ? (
         /* The card's CTA is a second trigger for the same payment as the
-           bottom bar's, so it is handed the bar's own handler and gate
-           rather than re-deriving them: `canPay` already folds in
+           bottom bar's, so it is handed the bar's own handler, gate and
+           label rather than re-deriving them: `canPay` already folds in
            `!isSubmitting`, which is what stops a double charge once one of
            the two has been pressed. Two buttons, one source of truth. */
         <AmanitaConfirmSection
@@ -439,6 +476,7 @@ export default function StepperCheckoutFlow({
           onGoToTickets={goToFirstProductSection}
           onPay={handlePayment}
           payDisabled={!canPay}
+          payLabel={payLabel}
         />
       ) : (
         <ConfirmStep />
@@ -574,8 +612,12 @@ export default function StepperCheckoutFlow({
             that shouldn't read as one more step. The bar is already
             fixed/sticky, so it is the containing block — adding `relative`
             here would re-declare `position` and drop the bar out of flow. */}
+        {/* `pointer-events-auto` for the same reason the <nav> above has it:
+            amanita's bar is `pointer-events-none` so the wheel reaches the
+            page scroller through it, and this control sits outside the <nav>,
+            so it has to opt back in on its own or it can't be clicked. */}
         {navExtraContent && (
-          <div className="absolute inset-y-0 right-2 flex items-center">
+          <div className="pointer-events-auto absolute inset-y-0 right-2 flex items-center">
             {navExtraContent}
           </div>
         )}
@@ -652,6 +694,7 @@ export default function StepperCheckoutFlow({
                 className={CTA_BUTTON_CLASSES[skin]}
               >
                 {introConfig.cta_label || nextSection?.label}
+                <ArrowRight aria-hidden className={ARROW_CLASSES} />
               </button>
             </>
           ) : (
@@ -663,6 +706,7 @@ export default function StepperCheckoutFlow({
                 className={`${BACK_BUTTON[skin].className} justify-self-start`}
                 style={BACK_BUTTON[skin].style}
               >
+                <ArrowLeft aria-hidden className={ARROW_CLASSES} />
                 {t("common.back")}
               </button>
               <div className="flex min-w-0 flex-col items-center">
@@ -679,9 +723,8 @@ export default function StepperCheckoutFlow({
                   disabled={!canPay}
                   className={`${CTA_BUTTON_CLASSES[skin]} justify-self-end`}
                 >
-                  {summary.grandTotal === 0
-                    ? t("checkout.actions.claim_pass")
-                    : t("checkout.actions.pay")}
+                  {payLabel}
+                  <ArrowRight aria-hidden className={ARROW_CLASSES} />
                 </button>
               ) : (
                 <button
@@ -691,6 +734,7 @@ export default function StepperCheckoutFlow({
                   className={`${CTA_BUTTON_CLASSES[skin]} justify-self-end`}
                 >
                   {nextSection?.label}
+                  <ArrowRight aria-hidden className={ARROW_CLASSES} />
                 </button>
               )}
             </>

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBackground.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBackground.tsx
@@ -14,10 +14,18 @@ import { Stars } from "./Stars"
  * only ever fetches the one matching source, so this is both simpler and
  * avoids the double download — a legitimate use of raw `<img>` for a
  * decorative, full-bleed, art-directed background image.
+ *
+ * `pointer-events-none` is load-bearing, not tidying: the checkout scrolls in
+ * `CheckoutPageClient`'s `main.h-svh.overflow-y-auto`, but a fixed element's
+ * scroll chain starts at the viewport, not at the overflow ancestor it happens
+ * to sit in — and the document itself doesn't scroll. Hit-testable, this layer
+ * swallows the wheel everywhere it isn't covered by the content column, so the
+ * page only scrolls with the cursor over the cards. The sibling non-amanita
+ * backgrounds dodge this by painting at `-z-10`, behind the scroller's own box.
  */
 export function AmanitaBackground() {
   return (
-    <div aria-hidden className="fixed inset-0 z-0">
+    <div aria-hidden className="pointer-events-none fixed inset-0 z-0">
       <picture>
         <source
           media="(max-width: 767px)"

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.test.tsx
@@ -7,8 +7,9 @@
  * - Applying a coupon calls the real `applyPromoCode` mutation.
  * - The empty-cart state shows when the cart has no items, with a
  *   "Ver tickets" CTA that calls the `onGoToTickets` callback.
- * - There is NO second pay/confirm button in this section — payment is only
- *   triggered by the stepper's fixed bottom-bar CTA.
+ * - The in-card pay CTA appears only when the stepper hands this section a
+ *   payment handler, and then takes its label and disabled state from the
+ *   bottom bar rather than re-deriving either.
  *
  * No jest-dom in this project — assertions use
  * `getByText`/`getByRole`/`toBeTruthy()`.
@@ -216,6 +217,29 @@ describe("AmanitaConfirmSection", () => {
     expect(order).toEqual(sorted)
   })
 
+  /* `useCartSummary` folds the service fee into `summary.subtotal`, so the
+     realistic shape of a $100 order with a $10 fee is subtotal 110 / total
+     110. Printed raw, the fee showed up twice and Subtotal read the same as
+     Total — the column never added up. */
+  it("shows Subtotal without the service fee the Total adds back", () => {
+    popup = { ...popup, contribution_label: "Service fee" }
+    summary = {
+      ...summary,
+      subtotal: 110,
+      contributionSubtotal: 10,
+      grandTotal: 110,
+    }
+
+    render(<AmanitaConfirmSection />)
+
+    // Subtotal 100 + fee 10 = total 110, which is what the ladder claims.
+    const row = (label: string) =>
+      screen.getByText(label).parentElement?.textContent ?? ""
+    expect(row("checkout.amanita.confirm_subtotal_label")).toContain("$100")
+    expect(row("checkout.amanita.confirm_subtotal_label")).not.toContain("$110")
+    expect(row("checkout.amanita.confirm_total_label")).toContain("$110")
+  })
+
   it("runs the order lines flat — no group heading over the tickets", () => {
     cart = {
       ...cart,
@@ -286,5 +310,51 @@ describe("AmanitaConfirmSection", () => {
         /pay|confirmar compra|checkout\.actions\.pay/,
       )
     }
+  })
+
+  describe("in-card pay CTA", () => {
+    it("prints the label the bar passes down rather than one of its own", () => {
+      render(
+        <AmanitaConfirmSection
+          onPay={vi.fn()}
+          payLabel="checkout.actions.pay"
+        />,
+      )
+      expect(
+        screen.getByRole("button", { name: "checkout.actions.pay" }),
+      ).toBeTruthy()
+    })
+
+    /* The bug this guards: the card used to re-derive its label from
+       `summary.grandTotal`, printing "Confirmar compra" beside a bar that said
+       "Pagar". The label is the bar's to decide, so a free order's CTA has to
+       follow `payLabel` and nothing else. */
+    it("follows payLabel on a free order instead of re-deriving from the total", () => {
+      summary = { ...summary, grandTotal: 0 }
+      render(
+        <AmanitaConfirmSection
+          onPay={vi.fn()}
+          payLabel="checkout.actions.claim_pass"
+        />,
+      )
+      expect(
+        screen.getByRole("button", { name: "checkout.actions.claim_pass" }),
+      ).toBeTruthy()
+      expect(screen.queryByText("checkout.amanita.confirm_cta")).toBeNull()
+    })
+
+    it("disables the card CTA from the bar's gate", () => {
+      render(
+        <AmanitaConfirmSection
+          onPay={vi.fn()}
+          payLabel="checkout.actions.pay"
+          payDisabled
+        />,
+      )
+      const button = screen.getByRole("button", {
+        name: "checkout.actions.pay",
+      }) as HTMLButtonElement
+      expect(button.disabled).toBe(true)
+    })
   })
 })

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
@@ -232,9 +232,9 @@ export default function AmanitaConfirmSection({
             src="/checkout-skins/amanita/logo-hongo.webp"
             alt=""
             aria-hidden
-            width={647}
-            height={360}
-            className="h-12 w-auto opacity-60"
+            width={115}
+            height={30}
+            className="opacity-60"
           />
           <p className="font-display text-xl uppercase tracking-wide text-cream">
             {t("checkout.amanita.confirm_empty_title")}

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
@@ -23,11 +23,13 @@
  * Payment triggers: the mockup's in-card "Confirmar compra" button was
  * originally omitted here, leaving the stepper's fixed bottom bar as the sole
  * trigger. It is now rendered alongside the bar's, matching the mockup, so the
- * same payment has two buttons. They are deliberately NOT independent: `onPay`
- * and `payDisabled` are the bar's own handler and gate, passed down. Deriving
- * a second `canPay` here from `useCheckout()` would let the two disagree — the
- * card could still look armed while the bar is mid-submit, which is exactly
- * how a double charge gets in.
+ * same payment has two buttons. They are deliberately NOT independent: `onPay`,
+ * `payDisabled` and `payLabel` are the bar's own handler, gate and label,
+ * passed down. Deriving a second `canPay` here from `useCheckout()` would let
+ * the two disagree — the card could still look armed while the bar is
+ * mid-submit, which is exactly how a double charge gets in. The label is
+ * threaded for the milder version of the same failure: this card used to print
+ * its own "Confirmar compra" next to a bar that said "Pagar".
  */
 import type { LucideIcon } from "lucide-react"
 import {
@@ -83,6 +85,7 @@ export default function AmanitaConfirmSection({
   onGoToTickets,
   onPay,
   payDisabled,
+  payLabel,
   stepConfig,
 }: {
   onGoToTickets?: () => void
@@ -90,6 +93,11 @@ export default function AmanitaConfirmSection({
    *  passed in rather than pulled from `useCheckout()` here. */
   onPay?: () => void
   payDisabled?: boolean
+  /** The bottom bar's own CTA label, so both triggers for this payment read
+   *  the same. Passed in for the same reason `onPay` is — there is
+   *  deliberately no local fallback, since re-deriving it here is exactly how
+   *  the two came to disagree. */
+  payLabel?: string
   /** The organizer's confirm step, when one is configured — it names this
    *  section. Optional: the funnel shows a confirm step whether or not a row
    *  exists for it, and then the skin's own copy stands in. */
@@ -191,6 +199,15 @@ export default function AmanitaConfirmSection({
     summary.contributionSubtotal
   const showEligibleQualifier = summary.discount > 0 && nonDiscountableTotal > 0
   const notEligibleCaption = t("checkout.discount.not_eligible_caption")
+
+  // `summary.subtotal` already contains the service fee (useCartSummary.ts:
+  // `originalSubtotal`), but the ladder below prints that fee as its own line
+  // on the way to the Total — so showing it raw counted the fee twice on
+  // screen and, with nothing discounted, made Subtotal and Total identical.
+  // Taking it out is what makes the column add up: subtotal − adjustments +
+  // fee = total. Insurance stays in, deliberately: it has no line of its own
+  // down here, so pulling it out would leave the arithmetic short instead.
+  const subtotalBeforeFee = summary.subtotal - summary.contributionSubtotal
 
   const copy = shellCopy(stepConfig, {
     kicker: t("checkout.amanita.confirm_kicker"),
@@ -625,11 +642,12 @@ export default function AmanitaConfirmSection({
           )}
 
           {/* Terms and conditions */}
-          {/* Totals — the mockup's reading order: Subtotal, then every
-              adjustment, then the service fee the total already includes, then
-              the Total itself. Subtotal always shows: it is the top of that
-              ladder, and hiding it whenever nothing was discounted left the
-              fee looking like it was subtracted from thin air. */}
+          {/* Totals — the mockup's reading order: Subtotal (of the items, fee
+              excluded), then every adjustment, then the service fee that gets
+              added on, then the Total itself. Read top to bottom the column
+              now arrives at the Total. Subtotal always shows: it is the top of
+              that ladder, and hiding it whenever nothing was discounted left
+              the fee looking like it was added to thin air. */}
           <div
             className="border-t px-5 py-4 md:px-8"
             style={{ borderColor: ROW_BORDER }}
@@ -640,7 +658,7 @@ export default function AmanitaConfirmSection({
             >
               <p>{t("checkout.amanita.confirm_subtotal_label")}</p>
               <p className="font-condensed text-base">
-                {formatCurrency(summary.subtotal)}
+                {formatCurrency(subtotalBeforeFee)}
               </p>
             </div>
             {summary.discount > 0 && (
@@ -755,9 +773,7 @@ export default function AmanitaConfirmSection({
                 disabled={payDisabled}
                 className="btn-ornate-2 btn-gold-fill ck-gold flex w-full items-center justify-center whitespace-nowrap py-3 font-condensed text-sm font-medium uppercase tracking-[0.12em] transition-all duration-200 hover:-translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {summary.grandTotal === 0
-                  ? t("checkout.actions.claim_pass")
-                  : t("checkout.amanita.confirm_cta")}
+                {payLabel}
               </button>
             </div>
           )}

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
@@ -42,6 +42,7 @@ import {
   Utensils,
   X,
 } from "lucide-react"
+import Image from "next/image"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TicketingStepPublic } from "@/client"
@@ -222,7 +223,19 @@ export default function AmanitaConfirmSection({
          in its own words. */
       <SectionShell gem="bold" kicker={copy.kicker} title={copy.title}>
         <div className="flex flex-col items-center gap-4 py-10 text-center">
-          <ShoppingBag className="w-12 h-12 text-cream/60" aria-hidden="true" />
+          {/* The brand mark, not a shopping bag: this is the one spot on the
+              skin where a generic e-commerce glyph stood in for it. Same asset
+              and intrinsic size as the nav's "home" pill. `opacity-60` keeps
+              the muting the icon it replaces had, so the title stays the loud
+              thing here. */}
+          <Image
+            src="/checkout-skins/amanita/logo-hongo.webp"
+            alt=""
+            aria-hidden
+            width={647}
+            height={360}
+            className="h-12 w-auto opacity-60"
+          />
           <p className="font-display text-xl uppercase tracking-wide text-cream">
             {t("checkout.amanita.confirm_empty_title")}
           </p>

--- a/portal/src/components/checkout-flow/skins/amanita/SectionShell.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/SectionShell.tsx
@@ -32,9 +32,15 @@ export interface ShellCopy {
  * `template_config.kicker`, else the watermark — never the title, which the
  * shell already prints right below it.
  *
- * Note these are authored strings, so they are NOT translated: an organizer
- * writing "Tus Datos" gets exactly that in every locale. Only the fallback,
- * which the caller passes already translated, follows the shopper's language.
+ * These authored strings ARE translated, just not by i18next: the backend
+ * overlays the `translations` row for the shopper's `Accept-Language` (which
+ * portal/src/lib/api-client.ts attaches to every request) before this ever sees
+ * them, so an organizer who wrote "Tus Datos" and translated it in the
+ * backoffice gets "Your Details" here. `title`/`description` are registered in
+ * the overlay's `TRANSLATABLE_FIELDS`; `template_config` copy is deep-merged
+ * leaf by leaf. The exception is `kicker` — it is not in the overlay's
+ * `_TEXT_LEAF_KEYS`, so it stays in the source language. The fallback, which
+ * the caller passes already translated, follows the shopper's language too.
  */
 export function shellCopy(
   stepConfig: TicketingStepPublic | null | undefined,

--- a/portal/src/i18n/locales/en.json
+++ b/portal/src/i18n/locales/en.json
@@ -339,8 +339,7 @@
       "catalog_show_less": "Show less",
       "catalog_add_aria": "Add {{product}}",
       "catalog_add_one_aria": "Add one more {{product}}",
-      "catalog_remove_one_aria": "Remove one {{product}}",
-      "confirm_cta": "Confirm purchase"
+      "catalog_remove_one_aria": "Remove one {{product}}"
     }
   },
   "openCheckout": {

--- a/portal/src/i18n/locales/es.json
+++ b/portal/src/i18n/locales/es.json
@@ -339,8 +339,7 @@
       "catalog_show_less": "Ver menos",
       "catalog_add_aria": "Agregar {{product}}",
       "catalog_add_one_aria": "Agregar uno más de {{product}}",
-      "catalog_remove_one_aria": "Quitar uno de {{product}}",
-      "confirm_cta": "Confirmar compra"
+      "catalog_remove_one_aria": "Quitar uno de {{product}}"
     }
   },
   "openCheckout": {


### PR DESCRIPTION
Four details on the Amanita checkout, found while looking at the skin's shell.

## Scrolling only worked over the ticket cards

`AmanitaBackground` is a `fixed` full-viewport layer. A fixed element scroll-chains to the **viewport**, not to the `overflow-y-auto` ancestor it happens to sit in — and the document itself doesn't scroll, since the scroller is `CheckoutPageClient`'s inner `<main>`. So the background ate the wheel everywhere outside the 760px column, and the page only moved with the cursor over the cards.

It's decorative and `aria-hidden`, so `pointer-events-none` is the fix. The tell that this is amanita-only: the sibling backgrounds (`CheckoutBackgroundImage`/`Video`) paint at `-z-10`, behind the scroller's own box, so they never win a hit-test.

The nav's full-bleed gradient is `fixed` for the same reason and gets the same treatment — with `pointer-events-auto` restored on the pills **and** on the language switcher, which is pinned to the bar *outside* the `<nav>` and would otherwise stop taking clicks.

## Direction arrows on the bottom bar

Back gets `←`, the forward CTA `→` (all three branches: intro, next step, pay). They're `aria-hidden` — the label already names the destination, and the accessible name is what the suite finds these buttons by.

## One pay label, and the organizer owns it

The confirm card's CTA and the bottom bar's pay for the same order, and already shared a handler and gate deliberately — but not the label, so the card read **"Confirmar compra"** beside a bar reading **"Pagar"**. The label is now derived once and passed down like the rest; the dead `checkout.amanita.confirm_cta` key is gone.

That label is also editable from the confirm step in the backoffice. It reuses the hero's `template_config.cta_label`, which the translation overlay **already** treats as copy — so **no backend change**, and it arrives in the shopper's language: write "Pagar" on the step, "Pay" in its Translations tab.

Two judgement calls worth flagging for review:
- Read from the **confirm** step, not the active one — otherwise the label would change as the shopper moves through the funnel.
- An authored label **wins even on a free order** (over "Reclamar pase"). Second-guessing it would make the field lie.

## Subtotal equalled Total on the confirm card

`useCartSummary` folds the service fee into `summary.subtotal`, but the card prints that fee as its own line on the way to the Total — so it counted twice on screen, and with nothing discounted Subtotal and Total read identical. Subtotal now excludes it, and the column adds up: `subtotal − adjustments + fee = total`.

Insurance deliberately stays in: it has no line of its own down there, so pulling it out would leave the column short instead of balanced. Scoped to the Amanita card rather than `useCartSummary`, whose `subtotal` is also read by `ConfirmStep`, `CartFooter`, `CartItemList` and `SnapFooter` — this is a presentation bug, not a math one.

## Also

Corrects `SectionShell`'s note claiming authored strings are never translated. The backend overlays the shopper's `Accept-Language` onto `title`, `description` and `template_config` copy before the portal ever sees them. `kicker` is the one genuine exception — it isn't in the overlay's leaf keys (and isn't editable from the backoffice either).

## Testing

`portal`: 42 stepper + 18 confirm-section tests green, covering the pointer-events contract, the arrows staying out of accessible names, the two CTAs agreeing, the authored label winning/falling back/ignoring other steps, and the subtotal arithmetic. Biome clean; backoffice typecheck clean on the touched file.

Pre-existing on `dev`, not touched here: 17 failures across 5 unrelated portal test files, and a `noUselessFragments` lint in `AmanitaConfirmSection.tsx` — both verified against HEAD before this branch's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)