### PR TITLE
Release: per-step FAQs, footer notes, and CORS for the amanita skin art

### DIFF
--- a/backoffice/src/components/ticketing-step-builder/template-configs/FaqItemsEditor.test.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/FaqItemsEditor.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * FaqItemsEditor is shared by the `faqs` template's editor and the per-step
+ * "FAQs" card, so these cover the editing behaviour both inherit — in
+ * particular that typing in the title field survives, which a naive
+ * "drop the config when there are no questions" owner breaks.
+ */
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import {
+  buildFaqsValue,
+  type FaqItem,
+  FaqItemsEditor,
+  parseFaqItems,
+} from "./FaqItemsEditor"
+
+describe("parseFaqItems", () => {
+  it("returns an empty list for anything that isn't an array", () => {
+    expect(parseFaqItems(undefined)).toEqual([])
+    expect(parseFaqItems(null)).toEqual([])
+    expect(parseFaqItems("nope")).toEqual([])
+    expect(parseFaqItems({ 0: "nope" })).toEqual([])
+  })
+})
+
+describe("buildFaqsValue", () => {
+  const items: FaqItem[] = [{ id: "a", question: "Q", answer: "A" }]
+
+  it("drops the block entirely once it holds nothing", () => {
+    expect(buildFaqsValue("", [])).toBeUndefined()
+    expect(buildFaqsValue("   ", [])).toBeUndefined()
+  })
+
+  it("keeps a title typed before the first question exists", () => {
+    // Otherwise the field erases itself as the organizer types into it.
+    expect(buildFaqsValue("P", [])).toEqual({ title: "P", items: [] })
+  })
+
+  it("stores the title untrimmed so a space can be typed mid-title", () => {
+    expect(buildFaqsValue("Preguntas ", items)?.title).toBe("Preguntas ")
+  })
+
+  it("omits an empty title rather than storing a blank string", () => {
+    expect(buildFaqsValue("", items)).toEqual({ title: undefined, items })
+  })
+})
+
+describe("FaqItemsEditor", () => {
+  const items: FaqItem[] = [
+    { id: "a", question: "¿Puedo hacer fuego?", answer: "No." },
+  ]
+
+  function renderEditor(props: Partial<{ title: string; items: FaqItem[] }>) {
+    const onChangeTitle = vi.fn()
+    const onChangeItems = vi.fn()
+    render(
+      <FaqItemsEditor
+        title={props.title ?? ""}
+        items={props.items ?? []}
+        onChangeTitle={onChangeTitle}
+        onChangeItems={onChangeItems}
+      />,
+    )
+    return { onChangeTitle, onChangeItems }
+  }
+
+  it("reports the title verbatim, including a trailing space", () => {
+    // The owner trims only to decide emptiness — trimming the stored value on
+    // each keystroke would make a multi-word title untypeable.
+    const { onChangeTitle } = renderEditor({ title: "Preguntas" })
+
+    fireEvent.change(screen.getByDisplayValue("Preguntas"), {
+      target: { value: "Preguntas " },
+    })
+
+    expect(onChangeTitle).toHaveBeenCalledWith("Preguntas ")
+  })
+
+  it("shows the empty state until a question is added", () => {
+    const { onChangeItems } = renderEditor({})
+
+    expect(screen.getByText(/No questions added yet/)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Question/ }))
+
+    expect(onChangeItems.mock.calls[0][0]).toHaveLength(1)
+  })
+
+  it("edits a question and an answer in place", () => {
+    const { onChangeItems } = renderEditor({ items })
+
+    fireEvent.change(screen.getByDisplayValue("¿Puedo hacer fuego?"), {
+      target: { value: "¿Hay electricidad?" },
+    })
+    expect(onChangeItems.mock.calls[0][0]).toEqual([
+      { id: "a", question: "¿Hay electricidad?", answer: "No." },
+    ])
+
+    fireEvent.change(screen.getByDisplayValue("No."), {
+      target: { value: "No hay." },
+    })
+    expect(onChangeItems.mock.calls[1][0]).toEqual([
+      { id: "a", question: "¿Puedo hacer fuego?", answer: "No hay." },
+    ])
+  })
+
+  it("removes a question", () => {
+    const { onChangeItems } = renderEditor({
+      items: [...items, { id: "b", question: "Otra", answer: "" }],
+    })
+
+    // One trash button per row; the second row's is the last button rendered.
+    const buttons = screen.getAllByRole("button")
+    fireEvent.click(buttons[buttons.length - 1])
+
+    expect(onChangeItems.mock.calls[0][0]).toEqual(items)
+  })
+})

--- a/backoffice/src/components/ticketing-step-builder/template-configs/FaqItemsEditor.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/FaqItemsEditor.tsx
@@ -1,0 +1,250 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { GripVertical, HelpCircle, Plus, Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+
+// The title + sortable question list, shared by the `faqs` template's own
+// editor (FaqsConfig, which adds a layout picker on top) and the per-step
+// "FAQs" card on the step page, which writes to `template_config.faqs`. Both
+// author the same `{id, question, answer}[]` shape.
+
+export interface FaqItem {
+  id: string
+  question: string
+  answer: string
+}
+
+export function parseFaqItems(raw: unknown): FaqItem[] {
+  return Array.isArray(raw) ? (raw as FaqItem[]) : []
+}
+
+/**
+ * The value to store for an edited FAQ block, or `undefined` once it holds
+ * nothing — leaving `{items: []}` behind would litter the config, same reason
+ * `footer_text` saves as `value || undefined`.
+ *
+ * A title with no questions is deliberately kept: an organizer who names the
+ * section before writing their first question would otherwise watch the field
+ * erase itself keystroke by keystroke. The title is also stored untrimmed, or
+ * the space in a two-word title would vanish as it's typed; readers trim.
+ */
+export function buildFaqsValue(
+  title: string,
+  items: FaqItem[],
+): { title?: string; items: FaqItem[] } | undefined {
+  if (items.length === 0 && !title.trim()) return undefined
+  return { title: title || undefined, items }
+}
+
+function SortableFaqCard({
+  item,
+  onUpdateQuestion,
+  onUpdateAnswer,
+  onDelete,
+}: {
+  item: FaqItem
+  onUpdateQuestion: (id: string, question: string) => void
+  onUpdateAnswer: (id: string, answer: string) => void
+  onDelete: (id: string) => void
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-start gap-2 rounded-lg border bg-background p-2 shadow-sm"
+    >
+      <button
+        type="button"
+        className="cursor-grab text-muted-foreground hover:text-foreground shrink-0 mt-2"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+
+      <div className="flex flex-col gap-1.5 flex-1 min-w-0">
+        <Input
+          value={item.question}
+          onChange={(e) => onUpdateQuestion(item.id, e.target.value)}
+          placeholder="Question"
+          className="h-8 text-sm"
+        />
+        <Textarea
+          value={item.answer}
+          onChange={(e) => onUpdateAnswer(item.id, e.target.value)}
+          placeholder="Answer"
+          className="text-sm min-h-16"
+        />
+      </div>
+
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive mt-1"
+        onClick={() => onDelete(item.id)}
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  )
+}
+
+export function FaqItemsEditor({
+  title,
+  items,
+  onChangeTitle,
+  onChangeItems,
+  titlePlaceholder = "Frequently Asked Questions",
+  titleDescription,
+}: {
+  title: string
+  items: FaqItem[]
+  onChangeTitle: (title: string) => void
+  onChangeItems: (items: FaqItem[]) => void
+  titlePlaceholder?: string
+  titleDescription?: string
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  )
+
+  const handleAddItem = () => {
+    onChangeItems([
+      ...items,
+      { id: crypto.randomUUID(), question: "", answer: "" },
+    ])
+  }
+
+  const handleUpdateQuestion = (id: string, question: string) => {
+    onChangeItems(
+      items.map((item) => (item.id === id ? { ...item, question } : item)),
+    )
+  }
+
+  const handleUpdateAnswer = (id: string, answer: string) => {
+    onChangeItems(
+      items.map((item) => (item.id === id ? { ...item, answer } : item)),
+    )
+  }
+
+  const handleDeleteItem = (id: string) => {
+    onChangeItems(items.filter((item) => item.id !== id))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = items.findIndex((item) => item.id === active.id)
+    const newIndex = items.findIndex((item) => item.id === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    onChangeItems(arrayMove(items, oldIndex, newIndex))
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Section title */}
+      <div className="flex flex-col gap-2">
+        <Label className="text-sm font-medium">Section Title (optional)</Label>
+        <Input
+          value={title}
+          onChange={(e) => onChangeTitle(e.target.value)}
+          placeholder={titlePlaceholder}
+        />
+        {titleDescription && (
+          <p className="text-xs text-muted-foreground">{titleDescription}</p>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Questions list */}
+      <div>
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <Label className="text-sm font-medium">
+              Questions ({items.length})
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              Add and reorder questions visitors will see
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleAddItem}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add Question
+          </Button>
+        </div>
+
+        {items.length > 0 ? (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={items.map((item) => item.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="flex flex-col gap-2">
+                {items.map((item) => (
+                  <SortableFaqCard
+                    key={item.id}
+                    item={item}
+                    onUpdateQuestion={handleUpdateQuestion}
+                    onUpdateAnswer={handleUpdateAnswer}
+                    onDelete={handleDeleteItem}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        ) : (
+          <div className="rounded-lg border border-dashed p-6 text-center">
+            <HelpCircle className="h-8 w-8 text-muted-foreground/30 mx-auto mb-2" />
+            <p className="text-sm text-muted-foreground">
+              No questions added yet. Click "Add Question" to start.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/backoffice/src/components/ticketing-step-builder/template-configs/FaqsConfig.test.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/FaqsConfig.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Covers the config shape FaqsConfig writes, which its editor UI now shares
+ * with the per-step "FAQs" card via FaqItemsEditor. The portal reads these
+ * keys positionally out of untyped JSON, so a silent rename here would break
+ * the checkout with nothing to catch it.
+ */
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { FaqsConfig } from "./FaqsConfig"
+import { TEMPLATE_CONFIG_REGISTRY } from "./index"
+
+describe("FaqsConfig", () => {
+  function renderConfig(config: Record<string, unknown> | null = null) {
+    const onChange = vi.fn()
+    render(
+      <FaqsConfig
+        config={config}
+        onChange={onChange}
+        popupId="popup-1"
+        productCategory={null}
+      />,
+    )
+    return onChange
+  }
+
+  const items = [{ id: "a", question: "¿Puedo hacer fuego?", answer: "No." }]
+
+  it("is wired into the config registry", () => {
+    expect(TEMPLATE_CONFIG_REGISTRY.faqs).toBe(FaqsConfig)
+  })
+
+  it("renders authored questions and the section title", () => {
+    renderConfig({ title: "Preguntas sobre el acampe", items })
+
+    expect(screen.getByDisplayValue("Preguntas sobre el acampe")).toBeTruthy()
+    expect(screen.getByDisplayValue("¿Puedo hacer fuego?")).toBeTruthy()
+    expect(screen.getByText("Questions (1)")).toBeTruthy()
+  })
+
+  it("appends a question with a stable id, preserving the rest of the config", () => {
+    const onChange = renderConfig({ variant: "cards", items })
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Question/ }))
+
+    const next = onChange.mock.calls[0][0]
+    expect(next.variant).toBe("cards")
+    expect(next.items).toHaveLength(2)
+    expect(next.items[0]).toEqual(items[0])
+    expect(next.items[1]).toMatchObject({ question: "", answer: "" })
+    expect(next.items[1].id).toBeTruthy()
+  })
+
+  it("saves a blank title as undefined rather than an empty string", () => {
+    const onChange = renderConfig({ title: "Algo", items })
+
+    fireEvent.change(screen.getByDisplayValue("Algo"), {
+      target: { value: "" },
+    })
+
+    expect(onChange.mock.calls[0][0].title).toBeUndefined()
+  })
+
+  it("keeps the accordion layout implicit and names the others", () => {
+    const onChange = renderConfig({ items })
+
+    fireEvent.click(screen.getByRole("button", { name: /Two Column/ }))
+    expect(onChange.mock.calls[0][0].variant).toBe("two-column")
+
+    fireEvent.click(screen.getByRole("button", { name: /Accordion/ }))
+    expect(onChange.mock.calls[1][0].variant).toBeUndefined()
+  })
+
+  it("survives a config whose items are missing or malformed", () => {
+    expect(() => renderConfig(null)).not.toThrow()
+    expect(screen.getByText("Questions (0)")).toBeTruthy()
+  })
+})

--- a/backoffice/src/components/ticketing-step-builder/template-configs/FaqsConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/FaqsConfig.tsx
@@ -1,36 +1,9 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core"
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
-import { Check, GripVertical, HelpCircle, Plus, Trash2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
+import { Check } from "lucide-react"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
-import { Textarea } from "@/components/ui/textarea"
 import { cn } from "@/lib/utils"
+import { type FaqItem, FaqItemsEditor, parseFaqItems } from "./FaqItemsEditor"
 import type { TemplateConfigProps } from "./types"
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface FaqItem {
-  id: string
-  question: string
-  answer: string
-}
 
 // ---------------------------------------------------------------------------
 // Variants
@@ -126,138 +99,13 @@ const VARIANT_PREVIEW_MAP: Record<string, React.FC> = {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function parseItems(config: Record<string, unknown> | null): FaqItem[] {
-  if (!config || !Array.isArray(config.items)) return []
-  return config.items as FaqItem[]
-}
-
-// ---------------------------------------------------------------------------
-// Sortable FAQ card
-// ---------------------------------------------------------------------------
-
-function SortableFaqCard({
-  item,
-  onUpdateQuestion,
-  onUpdateAnswer,
-  onDelete,
-}: {
-  item: FaqItem
-  onUpdateQuestion: (id: string, question: string) => void
-  onUpdateAnswer: (id: string, answer: string) => void
-  onDelete: (id: string) => void
-}) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: item.id })
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  }
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className="flex items-start gap-2 rounded-lg border bg-background p-2 shadow-sm"
-    >
-      <button
-        type="button"
-        className="cursor-grab text-muted-foreground hover:text-foreground shrink-0 mt-2"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="h-4 w-4" />
-      </button>
-
-      <div className="flex flex-col gap-1.5 flex-1 min-w-0">
-        <Input
-          value={item.question}
-          onChange={(e) => onUpdateQuestion(item.id, e.target.value)}
-          placeholder="Question"
-          className="h-8 text-sm"
-        />
-        <Textarea
-          value={item.answer}
-          onChange={(e) => onUpdateAnswer(item.id, e.target.value)}
-          placeholder="Answer"
-          className="text-sm min-h-16"
-        />
-      </div>
-
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive mt-1"
-        onClick={() => onDelete(item.id)}
-      >
-        <Trash2 className="h-3.5 w-3.5" />
-      </Button>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
 export function FaqsConfig({ config, onChange }: TemplateConfigProps) {
   const variant = (config?.variant as string) || "accordion"
   const title = (config?.title as string) || ""
-  const items = parseItems(config)
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-  )
-
-  const updateItems = (updated: FaqItem[]) => {
-    onChange({ ...config, items: updated })
-  }
-
-  const handleAddItem = () => {
-    const newItem: FaqItem = {
-      id: crypto.randomUUID(),
-      question: "",
-      answer: "",
-    }
-    updateItems([...items, newItem])
-  }
-
-  const handleUpdateQuestion = (id: string, question: string) => {
-    updateItems(
-      items.map((item) => (item.id === id ? { ...item, question } : item)),
-    )
-  }
-
-  const handleUpdateAnswer = (id: string, answer: string) => {
-    updateItems(
-      items.map((item) => (item.id === id ? { ...item, answer } : item)),
-    )
-  }
-
-  const handleDeleteItem = (id: string) => {
-    updateItems(items.filter((item) => item.id !== id))
-  }
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-
-    const oldIndex = items.findIndex((item) => item.id === active.id)
-    const newIndex = items.findIndex((item) => item.id === over.id)
-    if (oldIndex === -1 || newIndex === -1) return
-
-    updateItems(arrayMove(items, oldIndex, newIndex))
-  }
+  const items = parseFaqItems(config?.items)
 
   return (
     <div className="flex flex-col gap-5">
@@ -317,77 +165,16 @@ export function FaqsConfig({ config, onChange }: TemplateConfigProps) {
 
       <Separator />
 
-      {/* Section title */}
-      <div className="flex flex-col gap-2">
-        <Label className="text-sm font-medium">Section Title (optional)</Label>
-        <Input
-          value={title}
-          onChange={(e) =>
-            onChange({
-              ...config,
-              title: e.target.value || undefined,
-            })
-          }
-          placeholder="Frequently Asked Questions"
-        />
-      </div>
-
-      <Separator />
-
-      {/* Questions list */}
-      <div>
-        <div className="flex items-center justify-between mb-3">
-          <div>
-            <Label className="text-sm font-medium">
-              Questions ({items.length})
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              Add and reorder questions visitors will see
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleAddItem}
-          >
-            <Plus className="h-3.5 w-3.5 mr-1" />
-            Add Question
-          </Button>
-        </div>
-
-        {items.length > 0 ? (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={items.map((item) => item.id)}
-              strategy={verticalListSortingStrategy}
-            >
-              <div className="flex flex-col gap-2">
-                {items.map((item) => (
-                  <SortableFaqCard
-                    key={item.id}
-                    item={item}
-                    onUpdateQuestion={handleUpdateQuestion}
-                    onUpdateAnswer={handleUpdateAnswer}
-                    onDelete={handleDeleteItem}
-                  />
-                ))}
-              </div>
-            </SortableContext>
-          </DndContext>
-        ) : (
-          <div className="rounded-lg border border-dashed p-6 text-center">
-            <HelpCircle className="h-8 w-8 text-muted-foreground/30 mx-auto mb-2" />
-            <p className="text-sm text-muted-foreground">
-              No questions added yet. Click "Add Question" to start.
-            </p>
-          </div>
-        )}
-      </div>
+      <FaqItemsEditor
+        title={title}
+        items={items}
+        onChangeTitle={(next) =>
+          onChange({ ...config, title: next || undefined })
+        }
+        onChangeItems={(next: FaqItem[]) =>
+          onChange({ ...config, items: next })
+        }
+      />
     </div>
   )
 }

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -22,6 +22,12 @@ import {
   TEMPLATE_DEFINITIONS,
 } from "@/components/ticketing-step-builder/constants"
 import { TEMPLATE_CONFIG_REGISTRY } from "@/components/ticketing-step-builder/template-configs"
+import {
+  buildFaqsValue,
+  type FaqItem,
+  FaqItemsEditor,
+  parseFaqItems,
+} from "@/components/ticketing-step-builder/template-configs/FaqItemsEditor"
 import { TranslationManager } from "@/components/translations/TranslationManager"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -239,6 +245,23 @@ function StepConfigContent({ stepId }: { stepId: string }) {
     ? TEMPLATE_CONFIG_REGISTRY[template]
     : undefined
 
+  // This step's own FAQs, stored under `template_config.faqs` — nested rather
+  // than at the top level so they can't collide with the `faqs` template's own
+  // `items`, which feed the global drawer.
+  const stepFaqs = (templateConfig?.faqs ?? null) as Record<
+    string,
+    unknown
+  > | null
+  const stepFaqsTitle = (stepFaqs?.title as string) ?? ""
+  const stepFaqItems = parseFaqItems(stepFaqs?.items)
+
+  const setStepFaqs = (title: string, items: FaqItem[]) => {
+    setTemplateConfig({
+      ...templateConfig,
+      faqs: buildFaqsValue(title, items),
+    })
+  }
+
   const hasTranslations = (popup?.supported_languages?.length ?? 0) > 1
 
   return (
@@ -427,6 +450,30 @@ function StepConfigContent({ stepId }: { stepId: string }) {
               </div>
             </CardContent>
           </Card>
+
+          {/* This step's own FAQs, shown below its content. Hidden on the
+              `faqs` template, whose whole purpose is already a question list —
+              a step there would carry two. */}
+          {template !== "faqs" && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">FAQs</CardTitle>
+                <CardDescription>
+                  Questions shown below this step's content. Rendered only on
+                  the Amanita checkout skin.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <FaqItemsEditor
+                  title={stepFaqsTitle}
+                  items={stepFaqItems}
+                  titleDescription="Heading shown above the questions. Leave empty for none."
+                  onChangeTitle={(next) => setStepFaqs(next, stepFaqItems)}
+                  onChangeItems={(next) => setStepFaqs(stepFaqsTitle, next)}
+                />
+              </CardContent>
+            </Card>
+          )}
 
           {/* Pay button label (only for confirm step) */}
           {step.step_type === "confirm" && (

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -19,6 +19,16 @@ const nextConfig: NextConfig = {
         source: "/_next/static/:path*",
         headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
       },
+      // Skin art reached from a stylesheet resolves against the CDN, not the
+      // tenant domain, so it is cross-origin for the same reason fonts are.
+      // Chrome fetches `mask-image` in CORS mode (`background-image` it does
+      // not), so without this the masked pieces — the hero bullet star, the
+      // `.ck-gem-*` separators — silently paint nothing while the plain
+      // backgrounds beside them load fine.
+      {
+        source: "/checkout-skins/:path*",
+        headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+      },
     ]
   },
   transpilePackages: ["@edgeos/shared-form-ui", "@edgeos/shared-events"],

--- a/portal/src/components/checkout-flow/StepFootnotes.test.tsx
+++ b/portal/src/components/checkout-flow/StepFootnotes.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Tests for StepFootnotes — the stepper's renderer for a step's "Footer Note".
+ * The stepper never drew it before, so an authored note was invisible.
+ *
+ * No jest-dom in this project — assertions use `getByText`/`toBeTruthy()`.
+ */
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import StepFootnotes, { parseFootnotes } from "./StepFootnotes"
+
+const NOTE = {
+  footer_text:
+    "No hay reembolsos, sin excepción.\nEntradas transferibles hasta el 30 de octubre de 2026.",
+}
+
+describe("parseFootnotes", () => {
+  it("returns nothing when there is no note", () => {
+    expect(parseFootnotes(null)).toEqual([])
+    expect(parseFootnotes(undefined)).toEqual([])
+    expect(parseFootnotes({})).toEqual([])
+    expect(parseFootnotes({ footer_text: "" })).toEqual([])
+    expect(parseFootnotes({ footer_text: "   \n  " })).toEqual([])
+  })
+
+  it("ignores a footer_text that isn't a string", () => {
+    expect(parseFootnotes({ footer_text: 42 })).toEqual([])
+  })
+
+  it("splits on newlines, dropping blank lines", () => {
+    expect(parseFootnotes({ footer_text: "uno\n\n dos \n" })).toEqual([
+      "uno",
+      "dos",
+    ])
+  })
+
+  it("strips a leading bullet the organizer typed themselves", () => {
+    // Amanita prints its own "*"; without this the line reads "* * No hay...".
+    expect(
+      parseFootnotes({ footer_text: "* No hay reembolsos\n• Otra\n- Tercera" }),
+    ).toEqual(["No hay reembolsos", "Otra", "Tercera"])
+  })
+
+  it("keeps an asterisk that isn't the line's bullet", () => {
+    expect(parseFootnotes({ footer_text: "Ver 2*3 detalles" })).toEqual([
+      "Ver 2*3 detalles",
+    ])
+  })
+})
+
+describe("StepFootnotes", () => {
+  it("renders nothing when the step has no note", () => {
+    const { container } = render(
+      <StepFootnotes skin="amanita" templateConfig={null} />,
+    )
+    expect(container.innerHTML).toBe("")
+  })
+
+  it("renders one asterisked line per note on amanita", () => {
+    render(<StepFootnotes skin="amanita" templateConfig={NOTE} />)
+
+    expect(screen.getByText("* No hay reembolsos, sin excepción.")).toBeTruthy()
+    expect(
+      screen.getByText(
+        "* Entradas transferibles hasta el 30 de octubre de 2026.",
+      ),
+    ).toBeTruthy()
+  })
+
+  it("renders the note without asterisks on the default skin", () => {
+    render(<StepFootnotes skin="default" templateConfig={NOTE} />)
+
+    expect(screen.getByText("No hay reembolsos, sin excepción.")).toBeTruthy()
+    expect(screen.queryByText(/^\* /)).toBeNull()
+  })
+})

--- a/portal/src/components/checkout-flow/StepFootnotes.tsx
+++ b/portal/src/components/checkout-flow/StepFootnotes.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+/**
+ * A step's "Footer Note" (`template_config.footer_text`), rendered below its
+ * content — and below its FAQs, when it has them.
+ *
+ * ScrollyCheckoutFlow has drawn this since it was added, but the stepper never
+ * did, so a note authored for a stepper checkout simply never appeared. This
+ * is the stepper's renderer for it.
+ *
+ * The Amanita branch is ported from the mockup's `footnotes` block
+ * (checkout-amanita/codigo/checkout/sections.tsx, the centred asterisked
+ * clarifications under the Extras cards). The mockup models them as a
+ * `string[]`, one <p> each; the backoffice authors a single multi-line
+ * Textarea, so a line here is a footnote there — the same "one per line"
+ * convention the confirm step's insurance `benefits` field already uses.
+ */
+import type { CheckoutSkin } from "@/lib/checkout-skin"
+
+/**
+ * Split a Footer Note into the mockup's per-line footnotes.
+ *
+ * Leading bullets are stripped because Amanita prints its own "*" — an
+ * organizer who types the asterisk they can see in the design would otherwise
+ * get "* * No hay reembolsos".
+ */
+export function parseFootnotes(
+  templateConfig: Record<string, unknown> | null | undefined,
+): string[] {
+  const raw = templateConfig?.footer_text
+  if (typeof raw !== "string") return []
+  return raw
+    .split("\n")
+    .map((line) => line.replace(/^\s*[*•-]\s*/, "").trim())
+    .filter(Boolean)
+}
+
+export default function StepFootnotes({
+  skin,
+  templateConfig,
+}: {
+  skin: CheckoutSkin
+  templateConfig: Record<string, unknown> | null | undefined
+}) {
+  const footnotes = parseFootnotes(templateConfig)
+  if (footnotes.length === 0) return null
+
+  if (skin === "amanita") {
+    return (
+      <div className="mt-6 flex flex-col gap-1.5 text-center">
+        {footnotes.map((note) => (
+          <p
+            key={note}
+            className="text-xs leading-relaxed"
+            style={{ color: "rgba(241,235,227,0.66)" }}
+          >
+            * {note}
+          </p>
+        ))}
+      </div>
+    )
+  }
+
+  /* The unskinned note, kept identical to the one ScrollyCheckoutFlow already
+     draws so the two funnels don't disagree about what a Footer Note looks
+     like. */
+  return (
+    <div className="mx-auto w-full max-w-2xl">
+      {footnotes.map((note) => (
+        <p
+          key={note}
+          className="text-xs text-gray-400 leading-relaxed px-1 pt-4 text-center"
+        >
+          {note}
+        </p>
+      ))}
+    </div>
+  )
+}

--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
@@ -18,6 +18,7 @@ import { shouldUseDynamicStep } from "./registries/stepRegistry"
 import { CONTENT_ONLY_TEMPLATES } from "./registries/variantRegistry"
 import type { ScrollyCheckoutFlowProps } from "./ScrollyCheckoutFlow"
 import SectionHeader from "./SectionHeader"
+import StepFootnotes from "./StepFootnotes"
 import { AmanitaBackground } from "./skins/amanita/AmanitaBackground"
 import AmanitaBuyerStep from "./skins/amanita/AmanitaBuyerStep"
 import AmanitaCatalogSection from "./skins/amanita/AmanitaCatalogSection"
@@ -452,6 +453,11 @@ export default function StepperCheckoutFlow({
     cta_label?: string
     cta_hint?: string
   }
+  // The active step's raw config, for the trailing FAQs/footnotes blocks.
+  const currentTemplateConfig = current?.config?.template_config as
+    | Record<string, unknown>
+    | null
+    | undefined
 
   const renderStepContent = (section: (typeof sections)[number]) => {
     const { stepType, config } = section
@@ -666,15 +672,11 @@ export default function StepperCheckoutFlow({
                 offers the field on every step — buyer and confirm included —
                 and the catalog only covers the product ones. */}
             {isAmanita && (
-              <AmanitaStepFaqs
-                templateConfig={
-                  current.config?.template_config as
-                    | Record<string, unknown>
-                    | null
-                    | undefined
-                }
-              />
+              <AmanitaStepFaqs templateConfig={currentTemplateConfig} />
             )}
+            {/* Last on the step, under the FAQs — the mockup's centred
+                clarifications below the Extras cards. */}
+            <StepFootnotes skin={skin} templateConfig={currentTemplateConfig} />
           </>
         )}
       </main>

--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
@@ -23,6 +23,7 @@ import AmanitaBuyerStep from "./skins/amanita/AmanitaBuyerStep"
 import AmanitaCatalogSection from "./skins/amanita/AmanitaCatalogSection"
 import AmanitaConfirmSection from "./skins/amanita/AmanitaConfirmSection"
 import "./skins/amanita/amanita-skin.css"
+import AmanitaStepFaqs from "./skins/amanita/AmanitaStepFaqs"
 import FaqsDrawer, { type FaqDrawerItem } from "./skins/amanita/FaqsDrawer"
 import { amanitaFontVars } from "./skins/amanita/fonts"
 import ConfirmStep from "./steps/ConfirmStep"
@@ -659,6 +660,21 @@ export default function StepperCheckoutFlow({
               </div>
             )}
             {renderStepContent(current)}
+            {/* A step's own FAQs, below its content (the mockup's "Preguntas
+                sobre el acampe" under the Alojamiento cards). Rendered here
+                rather than inside AmanitaCatalogSection because the backoffice
+                offers the field on every step — buyer and confirm included —
+                and the catalog only covers the product ones. */}
+            {isAmanita && (
+              <AmanitaStepFaqs
+                templateConfig={
+                  current.config?.template_config as
+                    | Record<string, unknown>
+                    | null
+                    | undefined
+                }
+              />
+            )}
           </>
         )}
       </main>

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaStepFaqs.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaStepFaqs.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for AmanitaStepFaqs — a step's own FAQs, rendered below its content on
+ * the Amanita skin. `template_config` is unvalidated JSON from the backend, so
+ * most of these cover the parser refusing to render junk.
+ *
+ * No jest-dom in this project — assertions use `getByRole`/`getByText`/
+ * `fireEvent`/`toBeTruthy()`, same as FaqsDrawer.test.tsx.
+ */
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import AmanitaStepFaqs, { parseStepFaqs } from "./AmanitaStepFaqs"
+
+const FAQS = {
+  title: "Preguntas sobre el acampe",
+  items: [
+    {
+      id: "a",
+      question: "¿Puedo hacer fuego?",
+      answer: "No, está prohibido en todo el predio.",
+    },
+    {
+      id: "b",
+      question: "¿Hay electricidad?",
+      answer: "No hay electricidad en la zona de acampe.",
+    },
+  ],
+}
+
+describe("parseStepFaqs", () => {
+  it("returns null when there is no config at all", () => {
+    expect(parseStepFaqs(null)).toBeNull()
+    expect(parseStepFaqs(undefined)).toBeNull()
+    expect(parseStepFaqs({})).toBeNull()
+  })
+
+  it("returns null when faqs is not an object or items is not an array", () => {
+    expect(parseStepFaqs({ faqs: "nope" })).toBeNull()
+    expect(parseStepFaqs({ faqs: { items: "nope" } })).toBeNull()
+    expect(parseStepFaqs({ faqs: { items: [] } })).toBeNull()
+  })
+
+  it("drops items with no question, and returns null if none survive", () => {
+    expect(
+      parseStepFaqs({ faqs: { items: [{ answer: "huérfana" }, {}] } }),
+    ).toBeNull()
+
+    const parsed = parseStepFaqs({
+      faqs: {
+        items: [{ question: "  " }, { question: "Real?", answer: "Sí" }],
+      },
+    })
+    expect(parsed?.items).toEqual([{ question: "Real?", answer: "Sí" }])
+  })
+
+  it("coalesces a missing answer rather than rendering undefined", () => {
+    const parsed = parseStepFaqs({ faqs: { items: [{ question: "Q" }] } })
+    expect(parsed?.items).toEqual([{ question: "Q", answer: "" }])
+  })
+
+  it("treats a blank title as no title", () => {
+    const parsed = parseStepFaqs({
+      faqs: { title: "   ", items: [{ question: "Q", answer: "A" }] },
+    })
+    expect(parsed?.title).toBeUndefined()
+  })
+})
+
+describe("AmanitaStepFaqs", () => {
+  it("renders nothing when the step has no FAQs", () => {
+    const { container } = render(<AmanitaStepFaqs templateConfig={null} />)
+    expect(container.innerHTML).toBe("")
+  })
+
+  it("renders the title and one row per question", () => {
+    render(<AmanitaStepFaqs templateConfig={{ faqs: FAQS }} />)
+
+    expect(screen.getByText("Preguntas sobre el acampe")).toBeTruthy()
+    // The mockup's accordion opens the first question by default.
+    expect(
+      screen
+        .getByRole("button", { name: /Puedo hacer fuego/ })
+        .getAttribute("aria-expanded"),
+    ).toBe("true")
+    expect(
+      screen
+        .getByRole("button", { name: /Hay electricidad/ })
+        .getAttribute("aria-expanded"),
+    ).toBe("false")
+    expect(
+      screen.queryByText("No hay electricidad en la zona de acampe."),
+    ).toBeNull()
+  })
+
+  it("expands a question on click", () => {
+    render(<AmanitaStepFaqs templateConfig={{ faqs: FAQS }} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Hay electricidad/ }))
+
+    expect(
+      screen.getByText("No hay electricidad en la zona de acampe."),
+    ).toBeTruthy()
+  })
+
+  it("renders the questions with no heading when no title is authored", () => {
+    render(<AmanitaStepFaqs templateConfig={{ faqs: { items: FAQS.items } }} />)
+
+    expect(screen.queryByText("Preguntas sobre el acampe")).toBeNull()
+    expect(
+      screen.getByRole("button", { name: /Puedo hacer fuego/ }),
+    ).toBeTruthy()
+  })
+})

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaStepFaqs.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaStepFaqs.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+/**
+ * Amanita skin — a step's own FAQs, rendered below its content.
+ *
+ * Ported from the mockup's per-section questions block
+ * (checkout-amanita/codigo/checkout/sections.tsx: the `section.faqs` branch of
+ * `CatalogSectionView`, which puts "Preguntas sobre el acampe" under the
+ * Alojamiento cards). The mockup hardcoded those questions per section; here
+ * any step can carry its own, authored in the backoffice's "FAQs" card and
+ * stored under `template_config.faqs`.
+ *
+ * Nested under `faqs` rather than the top-level `items` the `faqs` *template*
+ * uses for the global drawer, so a step can't collide with itself.
+ */
+import FaqList, { type FaqItem } from "./FaqList"
+import { GoldStar } from "./GoldStar"
+
+interface StepFaqs {
+  title?: string
+  items: FaqItem[]
+}
+
+/**
+ * `template_config` is unvalidated JSON (the backend stores it as free JSONB),
+ * so this parses defensively — same posture as VariantFaqs' `parseFaqs` and
+ * StepperCheckoutFlow's `parseFaqDrawerItems`. Items with no question are
+ * dropped: an authored-but-empty row is a half-finished edit, not content, and
+ * rendering it would put a bare chevron on the page.
+ */
+export function parseStepFaqs(
+  templateConfig: Record<string, unknown> | null | undefined,
+): StepFaqs | null {
+  const raw = templateConfig?.faqs
+  if (!raw || typeof raw !== "object") return null
+
+  const record = raw as Record<string, unknown>
+  if (!Array.isArray(record.items)) return null
+
+  const items = (record.items as Array<Record<string, unknown>>)
+    .map((item) => ({
+      question: typeof item?.question === "string" ? item.question.trim() : "",
+      answer: typeof item?.answer === "string" ? item.answer : "",
+    }))
+    .filter((item) => item.question)
+  if (items.length === 0) return null
+
+  const title = typeof record.title === "string" ? record.title.trim() : ""
+  return { title: title || undefined, items }
+}
+
+export default function AmanitaStepFaqs({
+  templateConfig,
+}: {
+  templateConfig: Record<string, unknown> | null | undefined
+}) {
+  const faqs = parseStepFaqs(templateConfig)
+  if (!faqs) return null
+
+  return (
+    /* `mt-8` stands in for the `gap-6` this block would inherit as SectionShell's
+       last child in the mockup — it renders after the shell here so that every
+       step type gets it, not just the catalog ones. */
+    <div className="mt-8">
+      {faqs.title && (
+        <div className="flex items-center justify-center gap-2.5">
+          <GoldStar className="h-3 w-3" />
+          <h3 className="font-display text-lg uppercase tracking-wide text-cream md:text-xl">
+            {faqs.title}
+          </h3>
+          <GoldStar className="h-3 w-3" />
+        </div>
+      )}
+      <div className={faqs.title ? "mt-4" : ""}>
+        <FaqList items={faqs.items} />
+      </div>
+    </div>
+  )
+}

--- a/portal/src/components/checkout-flow/skins/amanita/FaqList.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/FaqList.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+/**
+ * Amanita skin — the FAQ accordion, a 1:1 port of the mockup's `FaqList`
+ * (checkout-amanita/codigo/checkout/sections.tsx). The mockup shares one
+ * accordion between its global FAQs drawer and the per-section questions
+ * ("Preguntas sobre el acampe" under the Alojamiento cards), so this lives on
+ * its own rather than inside either consumer: `FaqsDrawer` and
+ * `AmanitaStepFaqs` are the same list in two places.
+ *
+ * `q`/`a` are renamed `question`/`answer` to match this repo's
+ * `template_config` shape.
+ */
+import { useState } from "react"
+import { GoldStar } from "./GoldStar"
+
+export interface FaqItem {
+  question: string
+  answer: string
+}
+
+export default function FaqList({ items }: { items: FaqItem[] }) {
+  const [open, setOpen] = useState<number | null>(0)
+  return (
+    <div className="flex flex-col gap-3">
+      {items.map((faq, i) => {
+        const isOpen = open === i
+        return (
+          <div
+            key={`${faq.question}-${i}`}
+            className="rounded-2xl border border-white/10"
+            style={{ backgroundColor: "rgba(255,255,255,0.04)" }}
+          >
+            <button
+              type="button"
+              onClick={() => setOpen(isOpen ? null : i)}
+              aria-expanded={isOpen}
+              className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+            >
+              <span className="flex items-center gap-3">
+                <GoldStar className="h-3 w-3" />
+                <span className="text-sm font-semibold text-cream md:text-base">
+                  {faq.question}
+                </span>
+              </span>
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                className={`h-4 w-4 shrink-0 text-sand transition-transform ${isOpen ? "rotate-180" : ""}`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="m6 9 6 6 6-6" />
+              </svg>
+            </button>
+            {isOpen && (
+              <p
+                className="px-5 pb-5 pl-[3.15rem] text-left text-sm leading-relaxed"
+                style={{ color: "rgba(241,235,227,0.75)" }}
+              >
+                {faq.answer}
+              </p>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/portal/src/components/checkout-flow/skins/amanita/FaqsDrawer.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/FaqsDrawer.tsx
@@ -3,81 +3,26 @@
 /**
  * Amanita skin — global FAQs drawer (Task 10).
  *
- * Ported from checkout-amanita/codigo/checkout/sections.tsx (`FaqsDrawer` +
- * `FaqList`). In the mockup the drawer read a hardcoded `FAQS` constant; here
- * it's driven by the checkout's own `faqs`-template step data — the caller
+ * Ported from checkout-amanita/codigo/checkout/sections.tsx (`FaqsDrawer`). In
+ * the mockup the drawer read a hardcoded `FAQS` constant; here it's driven by
+ * the checkout's own `faqs`-template step data — the caller
  * (StepperCheckoutFlow) passes `items` sourced from that step's
  * `template_config.items`, `{question, answer}[]` (the same shape
  * VariantFaqs.tsx already parses for the default skin's inline rendering).
+ *
+ * The accordion itself lives in ./FaqList — the mockup shares it with the
+ * per-step questions rendered under a step's products (AmanitaStepFaqs).
  *
  * A11y ported VERBATIM from the mockup: `role="dialog"` + `aria-modal`, a
  * focus trap that cycles Tab/Shift+Tab within the panel, Escape closes,
  * body-scroll lock while open, a 44×44 (h-11/w-11) close button, and focus
  * returns to whatever had focus before opening (the "FAQs" pill) on close.
  */
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
-import { GoldStar } from "./GoldStar"
+import FaqList, { type FaqItem } from "./FaqList"
 
-export interface FaqDrawerItem {
-  question: string
-  answer: string
-}
-
-/** Accordion shared by the drawer's FAQ list — 1:1 port of the mockup's
- *  `FaqList` (renamed `q`/`a` -> `question`/`answer` to match this repo's
- *  `template_config.items` shape). */
-function FaqList({ items }: { items: FaqDrawerItem[] }) {
-  const [open, setOpen] = useState<number | null>(0)
-  return (
-    <div className="flex flex-col gap-3">
-      {items.map((faq, i) => {
-        const isOpen = open === i
-        return (
-          <div
-            key={`${faq.question}-${i}`}
-            className="rounded-2xl border border-white/10"
-            style={{ backgroundColor: "rgba(255,255,255,0.04)" }}
-          >
-            <button
-              type="button"
-              onClick={() => setOpen(isOpen ? null : i)}
-              aria-expanded={isOpen}
-              className="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
-            >
-              <span className="flex items-center gap-3">
-                <GoldStar className="h-3 w-3" />
-                <span className="text-sm font-semibold text-cream md:text-base">
-                  {faq.question}
-                </span>
-              </span>
-              <svg
-                aria-hidden="true"
-                viewBox="0 0 24 24"
-                className={`h-4 w-4 shrink-0 text-sand transition-transform ${isOpen ? "rotate-180" : ""}`}
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="m6 9 6 6 6-6" />
-              </svg>
-            </button>
-            {isOpen && (
-              <p
-                className="px-5 pb-5 pl-[3.15rem] text-left text-sm leading-relaxed"
-                style={{ color: "rgba(241,235,227,0.75)" }}
-              >
-                {faq.answer}
-              </p>
-            )}
-          </div>
-        )
-      })}
-    </div>
-  )
-}
+export type FaqDrawerItem = FaqItem
 
 export default function FaqsDrawer({
   open,


### PR DESCRIPTION
Ships everything on `dev` since the last release — the three changes merged via #479, all scoped to the Amanita checkout.

## Per-step FAQs, authored in the backoffice

Any step can now carry its own questions, shown below its content on the Amanita skin. The organizer authors them in a new "FAQs" card on the step config, stored under `template_config.faqs` — nested rather than top-level so a step whose template already *is* `faqs` (the global drawer) cannot collide with itself. The accordion is the one already ported for the drawer, lifted into `FaqList` so both share it. No backend change: `template_config` is free JSONB and the translation extractors match by key name recursively.

## The step's Footer Note, drawn in the stepper

The field has been authorable all along and `ScrollyCheckoutFlow` renders it, but the stepper never did — an organizer wrote a Footer Note on a stepper checkout and nothing appeared, with no hint as to why. Amanita styles it as the mockup's centred asterisked clarifications, one line per footnote.

## Skin art served with CORS

The hero bullet stars and the `.ck-gem-*` separators were invisible **in production only** while the backgrounds beside them loaded fine. They are the only skin pieces painted with `mask-image` from the stylesheet, and Chrome fetches `mask-image` in CORS mode — `background-image` it does not. With `ASSET_PREFIX` set, the stylesheet is served from the CDN, so `url(/checkout-skins/...)` resolves against that host rather than the tenant domain: cross-origin, no CORS header, mask discarded. Only `/_next/static` had the header baked into the origin response; `/checkout-skins/*` was left to a CloudFront policy that adds it per-request, and the edge caches a variant without it. Fixed the same way the fonts already were — baked in at the origin.

## Deploy notes

- **Needs a CloudFront invalidation on `/checkout-skins/*`.** Those objects are already cached without the CORS header and carry `Cache-Control: public, max-age=0`, so the edge revalidates and may keep the old headers on a 304. Without this, the ornaments stay invisible even after the deploy.
- No migrations, no backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
