### PR TITLE
feat(checkout): Amanita card polish, buyer heading, translatable watermark

### DIFF
--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -11,7 +11,7 @@ TRANSLATABLE_FIELDS: dict[str, list[str]] = {
     "group": ["name", "description", "welcome_message"],
     "form_field": ["label", "placeholder", "help_text", "options"],
     "form_section": ["label", "description"],
-    "ticketing_step": ["title", "description"],
+    "ticketing_step": ["title", "description", "watermark"],
 }
 
 

--- a/backend/tests/api/translation/test_translation_service.py
+++ b/backend/tests/api/translation/test_translation_service.py
@@ -174,6 +174,13 @@ class TestApplyTicketingStepOverlay:
         }
         assert result["template_config"]["footer_text"] == "Pie"
 
+    def test_watermark_is_overlaid(self):
+        data = {"title": "Titulo", "watermark": "Elegi tus entradas"}
+        translation = {"title": "Title", "watermark": "Pick your tickets"}
+        result = apply_ticketing_step_overlay(data, translation)
+        assert result["title"] == "Title"
+        assert result["watermark"] == "Pick your tickets"
+
 
 class TestFieldHint:
     def test_flat_key(self):

--- a/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
+++ b/backoffice/src/routes/_layout/ticketing-steps/$stepId.tsx
@@ -778,8 +778,12 @@ function StepConfigContent({ stepId }: { stepId: string }) {
             <TranslationManager
               entityType="ticketing_step"
               entityId={step.id}
-              translatableFields={["title", "description"]}
-              sourceData={{ title: step.title, description: step.description }}
+              translatableFields={["title", "description", "watermark"]}
+              sourceData={{
+                title: step.title,
+                description: step.description,
+                watermark: step.watermark ?? "",
+              }}
               nestedField="template_config"
               nestedSource={step.template_config}
               supportedLanguages={popup!.supported_languages!}

--- a/portal/src/app/checkout/[popupSlug]/components/OpenTicketingBuyerForm.tsx
+++ b/portal/src/app/checkout/[popupSlug]/components/OpenTicketingBuyerForm.tsx
@@ -235,17 +235,10 @@ export function OpenTicketingBuyerForm({
       <section className="space-y-6 px-6 py-6">
         {sections.map((section) => (
           <section key={section.id} className="space-y-4">
-            {sections.length > 1 ? (
-              <div>
-                <h3 className="text-base font-semibold">{section.title}</h3>
-                {section.subtitle ? (
-                  <p className="text-sm text-muted-foreground">
-                    {section.subtitle}
-                  </p>
-                ) : null}
-              </div>
-            ) : null}
-
+            {/* The whole buyer step already announces itself with its own
+                step title, so the personal-info sections stay unlabelled —
+                the synthetic base group and any single configured section
+                both read as one block instead of a redundant heading. */}
             <div className="grid gap-4 md:grid-cols-2">
               {section.fields.map(({ name, field }) => {
                 if (name === "email") {

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.test.tsx
@@ -140,8 +140,9 @@ describe("AmanitaBuyerStep — schema-driven rendering", () => {
   describe("section heading", () => {
     // The structural email/first_name/last_name carry no section_id, so
     // getCheckoutSchemaSections parks them in a synthetic "_unsectioned_base"
-    // group titled with a hardcoded "Personal information". Rendering that
-    // alongside the organizer's own section printed the heading twice.
+    // group titled with a hardcoded "Personal information". The buyer step
+    // suppresses every section heading, so neither that artifact nor the
+    // organizer's own section label ever reaches the card.
     function twoSectionSchema() {
       return {
         base_fields: {
@@ -174,10 +175,13 @@ describe("AmanitaBuyerStep — schema-driven rendering", () => {
       } as unknown as ApplicationFormSchema
     }
 
-    it("prints the organizer's heading exactly once", () => {
+    // The step already leads with its own title, so the buyer form prints
+    // no section heading at all — neither the organizer's own section label
+    // nor the synthetic "Personal information" portal artifact.
+    it("never prints the organizer's section heading", () => {
       buyerFormSchema = twoSectionSchema()
       render(<AmanitaBuyerStep />)
-      expect(screen.getAllByText("Personal Information")).toHaveLength(1)
+      expect(screen.queryByText("Personal Information")).toBeNull()
     })
 
     it("never prints the synthetic 'Personal information' group title", () => {
@@ -186,17 +190,10 @@ describe("AmanitaBuyerStep — schema-driven rendering", () => {
       expect(screen.queryByText("Personal information")).toBeNull()
     })
 
-    // "arriba de todo los campos" — the heading leads, every field follows it.
-    it("puts the heading above every field", () => {
+    it("renders no section heading element", () => {
       buyerFormSchema = twoSectionSchema()
       const { container } = render(<AmanitaBuyerStep />)
-      const heading = screen.getByText("Personal Information")
-      const email = screen.getByLabelText("Email")
-      expect(
-        heading.compareDocumentPosition(email) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
-      ).toBeTruthy()
-      expect(container.querySelectorAll("h3")).toHaveLength(1)
+      expect(container.querySelectorAll("h3")).toHaveLength(0)
     })
   })
 

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.tsx
@@ -96,13 +96,6 @@ function dialFor(code: string): string {
   return WA_COUNTRIES.find((c) => c.code === code)?.dial ?? "54"
 }
 
-/** getCheckoutSchemaSections parks fields that carry no section_id — the
- *  structural email/first_name/last_name — in this synthetic group and titles
- *  it with a hardcoded "Personal information". That title is a portal
- *  artifact, not the organizer's, and printing it next to their own section
- *  showed the heading twice. Only real sections get to name themselves. */
-const SYNTHETIC_SECTION_ID = "_unsectioned_base"
-
 type FieldEntry = { name: string; field: FormFieldSchema }
 
 /** Group a section's fields into rows. first_name + last_name share one, the
@@ -340,15 +333,6 @@ export default function AmanitaBuyerStep({
   // what blocks Pay can never disagree.
   const invalidFields = new Set(getBuyerInvalidFields())
 
-  // With a single organizer section — the normal open-ticketing shape — its
-  // heading leads the whole card, so the structural fields sitting in the
-  // synthetic group read as part of it instead of as an untitled orphan
-  // block. Several sections keep their headings in place, where they still
-  // tell the shopper what changed.
-  const realSections = sections.filter((s) => s.id !== SYNTHETIC_SECTION_ID)
-  const hoistedTitle =
-    realSections.length === 1 ? realSections[0].title : undefined
-
   const copy = shellCopy(stepConfig, {
     kicker: t("checkout.amanita.buyer_kicker"),
     title: t("checkout.amanita.buyer_title"),
@@ -385,21 +369,12 @@ export default function AmanitaBuyerStep({
           </p>
         </div>
 
-        {hoistedTitle ? (
-          <h3 className="mt-6 font-condensed text-sm font-medium uppercase tracking-[0.14em] text-primary">
-            {hoistedTitle}
-          </h3>
-        ) : null}
-
+        {/* The step already leads with its own title, so the buyer sections
+            stay unlabelled — the synthetic base group and any single
+            configured section both read as one block instead of printing a
+            redundant "Personal information" heading. */}
         {sections.map((section) => (
           <div key={section.id} className="mt-6 flex flex-col gap-5">
-            {!hoistedTitle &&
-            section.id !== SYNTHETIC_SECTION_ID &&
-            section.title ? (
-              <h3 className="font-condensed text-sm font-medium uppercase tracking-[0.14em] text-primary">
-                {section.title}
-              </h3>
-            ) : null}
             {toRows(section.fields).map((row) => {
               const renderField = ({ name, field }: FieldEntry) => {
                 const error =

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaCatalogSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaCatalogSection.tsx
@@ -251,7 +251,7 @@ function ProductCard({
 
   return (
     <article
-      className="overflow-hidden rounded-2xl bg-cream text-left md:flex"
+      className="overflow-hidden rounded-2xl bg-cream text-left md:flex md:min-h-[19rem]"
       style={CREAM_CARD_STYLE}
     >
       {image && (
@@ -262,8 +262,9 @@ function ProductCard({
           <Image
             src={image}
             alt={section.label}
-            width={640}
-            height={360}
+            width={1600}
+            height={1200}
+            sizes="(min-width: 768px) 40vw, 100vw"
             loading="lazy"
             className="h-full w-full object-cover"
             {...imageOptimization(image)}

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
@@ -578,80 +578,76 @@ export default function AmanitaConfirmSection({
           {/* Coupon — no rule above it: it reads as part of the order, and the
               only divider before the totals is the one the ladder sits on. */}
           {popup?.allows_coupons && hasDiscountableItems && (
-            <>
-              <div className="px-5 py-4 md:px-8">
-                <label
-                  htmlFor="ck-cupon"
-                  className="font-condensed text-xs font-medium uppercase tracking-[0.16em] text-primary"
-                >
-                  {t("checkout.amanita.confirm_coupon_label")}
-                </label>
-                <div className="mt-1.5 flex gap-2">
-                  <input
-                    id="ck-cupon"
-                    type="text"
-                    value={promoInput}
-                    onChange={(e) => {
-                      setPromoInput(e.target.value.toUpperCase())
-                      setPromoError("")
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault()
-                        handleApplyPromo()
-                      }
-                    }}
-                    placeholder={t(
-                      "checkout.amanita.confirm_coupon_placeholder",
-                    )}
-                    disabled={cart.promoCodeValid}
-                    className="w-full min-w-0 rounded-xl border px-4 py-2.5 text-sm uppercase text-deep outline-none transition-shadow focus:ring-2 focus:ring-accent disabled:opacity-60"
-                    style={{
-                      backgroundColor: "#faf6ef",
-                      borderColor: promoError ? ERROR : "rgba(4,34,49,0.18)",
-                    }}
-                  />
-                  {cart.promoCodeValid ? (
-                    <button
-                      type="button"
-                      onClick={handleClearPromo}
-                      aria-label={t("checkout.amanita.confirm_coupon_remove")}
-                      className="shrink-0 rounded-full border px-4 py-2.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] text-deep transition-colors"
-                      style={{ borderColor: "rgba(4,34,49,0.18)" }}
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={handleApplyPromo}
-                      disabled={promoLoading || isLoading || !promoInput.trim()}
-                      className="shrink-0 rounded-full bg-primary px-5 py-2.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] text-cream transition-colors hover:bg-deep disabled:opacity-60"
-                    >
-                      {promoLoading || isLoading ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        t("checkout.amanita.confirm_coupon_apply")
-                      )}
-                    </button>
-                  )}
-                </div>
-                {promoError && (
-                  <div
-                    className="flex items-center gap-1.5 text-xs mt-2"
-                    style={{ color: ERROR }}
+            <div className="px-5 py-4 md:px-8">
+              <label
+                htmlFor="ck-cupon"
+                className="font-condensed text-xs font-medium uppercase tracking-[0.16em] text-primary"
+              >
+                {t("checkout.amanita.confirm_coupon_label")}
+              </label>
+              <div className="mt-1.5 flex gap-2">
+                <input
+                  id="ck-cupon"
+                  type="text"
+                  value={promoInput}
+                  onChange={(e) => {
+                    setPromoInput(e.target.value.toUpperCase())
+                    setPromoError("")
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      handleApplyPromo()
+                    }
+                  }}
+                  placeholder={t("checkout.amanita.confirm_coupon_placeholder")}
+                  disabled={cart.promoCodeValid}
+                  className="w-full min-w-0 rounded-xl border px-4 py-2.5 text-sm uppercase text-deep outline-none transition-shadow focus:ring-2 focus:ring-accent disabled:opacity-60"
+                  style={{
+                    backgroundColor: "#faf6ef",
+                    borderColor: promoError ? ERROR : "rgba(4,34,49,0.18)",
+                  }}
+                />
+                {cart.promoCodeValid ? (
+                  <button
+                    type="button"
+                    onClick={handleClearPromo}
+                    aria-label={t("checkout.amanita.confirm_coupon_remove")}
+                    className="shrink-0 rounded-full border px-4 py-2.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] text-deep transition-colors"
+                    style={{ borderColor: "rgba(4,34,49,0.18)" }}
                   >
-                    <AlertCircle className="w-3 h-3" />
-                    <span>{promoError}</span>
-                  </div>
-                )}
-                {cart.promoCodeValid && (
-                  <p className="text-xs font-semibold mt-2 text-primary">
-                    {t("checkout.amanita.confirm_coupon_applied")}
-                  </p>
+                    <X className="w-4 h-4" />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleApplyPromo}
+                    disabled={promoLoading || isLoading || !promoInput.trim()}
+                    className="shrink-0 rounded-full bg-primary px-5 py-2.5 font-condensed text-xs font-medium uppercase tracking-[0.12em] text-cream transition-colors hover:bg-deep disabled:opacity-60"
+                  >
+                    {promoLoading || isLoading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      t("checkout.amanita.confirm_coupon_apply")
+                    )}
+                  </button>
                 )}
               </div>
-            </>
+              {promoError && (
+                <div
+                  className="flex items-center gap-1.5 text-xs mt-2"
+                  style={{ color: ERROR }}
+                >
+                  <AlertCircle className="w-3 h-3" />
+                  <span>{promoError}</span>
+                </div>
+              )}
+              {cart.promoCodeValid && (
+                <p className="text-xs font-semibold mt-2 text-primary">
+                  {t("checkout.amanita.confirm_coupon_applied")}
+                </p>
+              )}
+            </div>
           )}
 
           {/* Terms and conditions */}

--- a/portal/src/components/checkout-flow/skins/amanita/amanita-skin.css
+++ b/portal/src/components/checkout-flow/skins/amanita/amanita-skin.css
@@ -122,17 +122,17 @@
    Assets rewritten to /checkout-skins/amanita/... */
 .checkout-amanita .btn-ornate,
 .checkout-amanita .btn-ornate-2 {
-  background-color: rgba(7, 19, 34, 0.92) !important;
-  background-size: 100% 100% !important;
-  background-repeat: no-repeat !important;
-  border-radius: 12px !important;
-  color: #f1ebe3 !important;
+  background-color: rgba(7, 19, 34, 0.92);
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+  border-radius: 12px;
+  color: #f1ebe3;
 }
 .checkout-amanita .btn-ornate {
-  background-image: url("/checkout-skins/amanita/btn-primary.webp") !important;
+  background-image: url("/checkout-skins/amanita/btn-primary.webp");
 }
 .checkout-amanita .btn-ornate-2 {
-  background-image: url("/checkout-skins/amanita/btn-secondary-1.webp") !important;
+  background-image: url("/checkout-skins/amanita/btn-secondary-1.webp");
 }
 
 /* `.btn-gold-fill` turns an ornate button into a flat gold plate (the frame
@@ -145,13 +145,13 @@
    The `!important`s match the rules they override above. */
 .checkout-amanita .btn-ornate.btn-gold-fill,
 .checkout-amanita .btn-ornate-2.btn-gold-fill {
-  background-color: #bfa67f !important;
-  color: #0a1a24 !important;
-  text-shadow: none !important;
+  background-color: #bfa67f;
+  color: #0a1a24;
+  text-shadow: none;
 }
 .checkout-amanita .btn-ornate.btn-gold-fill:hover,
 .checkout-amanita .btn-ornate-2.btn-gold-fill:hover {
-  background-color: #cdb48c !important;
+  background-color: #cdb48c;
 }
 
 /* Also the focus ring: the reference does this with `focus-visible:ring-*`
@@ -159,14 +159,14 @@
    expressed here instead. */
 .checkout-amanita .ck-gold,
 .checkout-amanita .ck-gold:hover {
-  box-shadow: 0 0 0 1px rgba(84, 62, 26, 0.22) !important;
+  box-shadow: 0 0 0 1px rgba(84, 62, 26, 0.22);
 }
 .checkout-amanita .ck-gold:focus-visible {
   outline: none;
   box-shadow:
     0 0 0 1px rgba(84, 62, 26, 0.22),
     0 0 0 2px var(--color-deep),
-    0 0 0 4px var(--color-accent) !important;
+    0 0 0 4px var(--color-accent);
 }
 
 /* ── 6 · Twinkling stars animation ──────────────────────────────── */
@@ -194,10 +194,10 @@
   .checkout-amanita *,
   .checkout-amanita *::before,
   .checkout-amanita *::after {
-    animation-duration: 0.001ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.001ms !important;
-    scroll-behavior: auto !important;
+    animation-duration: 0.001ms;
+    animation-iteration-count: 1;
+    transition-duration: 0.001ms;
+    scroll-behavior: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Open-checkout polish for the Amanita skin plus a small backoffice/i18n addition, bundled from local review against the prod API.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **Buyer step heading**: the buyer step already leads with its own title, so both the generic and Amanita buyer forms no longer print a section heading. This also stops the synthetic `_unsectioned_base` group from leaking its hardcoded "Personal information" title next to a real configured section.
- **Translatable watermark**: `watermark` is now a translatable field on `ticketing_step`, so the decorative watermark text can be authored per language in the step's Translations tab.
- **Amanita catalog cards**: card art fills its column edge to edge and a `min-height` keeps cards a consistent size regardless of how many product rows they hold; a larger `next/image` variant is requested so higher-resolution artwork stays sharp when a card grows.
- **Biome autofixes** (`style`): a useless fragment and now-flagged `!important` declarations removed by the pre-commit hook (not feature work).

## Changes Table

| File | Change |
|------|--------|
| `portal/.../OpenTicketingBuyerForm.tsx` | Remove generic buyer section heading |
| `portal/.../amanita/AmanitaBuyerStep.tsx` (+test) | Remove Amanita buyer section heading |
| `backend/app/api/translation/service.py` (+test) | Add `watermark` to `ticketing_step` translatable fields |
| `backoffice/.../ticketing-steps/$stepId.tsx` | Expose `watermark` in the step Translations tab |
| `portal/.../amanita/AmanitaCatalogSection.tsx` | Fill card art, standardize card height, larger image variant |
| `portal/.../amanita/AmanitaConfirmSection.tsx`, `amanita-skin.css` | Biome unsafe autofixes |

## Testing

- [x] Backend linting passes (`ruff check`)
- [x] Backend translation tests pass (`pytest tests/api/translation`)
- [x] Backoffice + portal build and typecheck pass (`tsc`)
- [x] Biome passes on both apps (`biome ci .`)
- [x] Manually reviewed against the prod API on localhost

## Notes for reviewer

- The `!important` removals in `amanita-skin.css` come from a biome unsafe fix; worth an eyeball on the ornate buttons.
- Some Amanita card images on the CDN are low resolution (e.g. 640x427); the sharper image variant only helps where the source is large enough. Fully crisp art needs higher-resolution uploads.