### PR TITLE
fix(payments): gate sweeper installment approval on paid cuota, drop email

### DIFF
--- a/backend/app/services/pending_payment_sweeper.py
+++ b/backend/app/services/pending_payment_sweeper.py
@@ -3,10 +3,19 @@
 Finds PENDING SimpleFi payments older than the configured staleness threshold
 and reconciles them with the current SimpleFi status:
 
-  - approved / active / completed  → approve path (``_reconcile_approved``)
-  - terminal (cancelled/expired/refunded) → ``update_status(EXPIRED)``
-  - still pending on SimpleFi      → skip (retried next run)
-  - status fetch fails             → skip + log (retried next run)
+  - one-shot request approved              → approve path (``_reconcile_approved``)
+  - installment plan with a charged cuota  → approve path (``_reconcile_approved``)
+  - terminal (cancelled/expired/refunded)  → ``update_status(EXPIRED)``
+  - still pending on SimpleFi               → skip (retried next run)
+  - status fetch fails                      → skip + log (retried next run)
+
+For installment plans the approve gate is ``paid_installments_count >= 1`` (or a
+``completed`` plan), NOT the ``active`` status: an activated plan can still have
+zero installments charged.  Our Payment row represents only the first cuota, so
+approving on ``active`` alone would assign products before any money cleared.
+
+The sweeper never sends a confirmation email; it only reconciles state.  Email
+delivery stays owned by the webhook path.
 
 Popup with no ``simplefi_api_key`` → expire locally (``expired_orphaned``
 action); same policy as ``supersede_pending_payments`` in ADR-2.  These are
@@ -27,9 +36,6 @@ from sqlmodel import Session
 from app.api.payment.crud import payments_crud
 from app.api.payment.models import Payments
 from app.api.payment.schemas import PaymentStatus
-from app.services.payment_notifications import (
-    _send_payment_confirmed_email,
-)
 from app.services.simplefi import get_simplefi_client
 
 # Session-level advisory lock key — must be distinct from every other job's
@@ -39,7 +45,10 @@ SWEEP_ADVISORY_LOCK_KEY = 7384925163
 
 # SimpleFi statuses that indicate the provider already cancelled the payment.
 _TERMINAL_STATUSES = frozenset({"canceled", "cancelled", "expired", "refunded"})
-# SimpleFi statuses that mean the buyer actually paid.
+# SimpleFi statuses that mean a one-shot payment request was actually paid.
+# Installment plans do NOT use this set — they gate on paid_installments_count
+# (see _reconcile_candidate), because "active" means "plan activated", not
+# "first cuota charged".
 _APPROVED_STATUSES = frozenset({"approved", "active", "completed"})
 
 
@@ -49,8 +58,7 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
     Returns a string action token for summary counters:
     - ``"expired"``              — SimpleFi-confirmed terminal, holds released
     - ``"expired_orphaned"``     — no API key to check; expired locally
-    - ``"approved_reconciled"``  — payment approved, confirmation email sent
-    - ``"approved_email_failed"``— payment approved, but email dispatch failed
+    - ``"approved_reconciled"``  — payment approved (no email sent by the sweeper)
     - ``"skipped_still_pending"``— SimpleFi still shows pending, try next run
     - ``"skipped_error"``        — SimpleFi call failed, try next run
 
@@ -107,26 +115,22 @@ async def _reconcile_candidate(session: Session, payment: Payments) -> str:
 
     normalized = status_resp.status.lower().strip()
 
-    if normalized in _APPROVED_STATUSES:
+    if payment.is_installment_plan:
+        # For a plan our Payment row represents only the first cuota. "active"
+        # means the plan was activated, not that a cuota cleared, so gate on
+        # paid_installments_count instead: >= 1 means the buyer paid at least
+        # the first installment. A "completed" plan is paid by definition.
+        paid_count = status_resp.paid_installments_count or 0
+        buyer_paid = normalized == "completed" or paid_count >= 1
+    else:
+        buyer_paid = normalized in _APPROVED_STATUSES
+
+    if buyer_paid:
         # SimpleFi shows the buyer paid.  Idempotently approve and issue
-        # tickets; send confirmation email best-effort (the webhook may have
-        # been lost, leaving the buyer without email or products).
-        approved_payment = payments_crud._reconcile_approved(session, payment)
-        # Use _send_payment_confirmed_email directly (not the _best_effort
-        # wrapper) so we can detect and count email failures in the summary
-        # without hiding them from ops.  A failed email does NOT affect
-        # the payment's approved status.
-        try:
-            await _send_payment_confirmed_email(approved_payment, db_session=session)
-        except Exception:
-            logger.warning(
-                "sweeper: email dispatch failed payment={} tenant={} popup={}; "
-                "payment is approved",
-                payment.id,
-                payment.tenant_id,
-                payment.popup_id,
-            )
-            return "approved_email_failed"
+        # tickets (the webhook may have been lost, leaving the buyer without
+        # products).  The sweeper does NOT send a confirmation email — that
+        # stays owned by the webhook path.
+        payments_crud._reconcile_approved(session, payment)
         logger.info(
             "sweeper: payment={} tenant={} action=approved_reconciled simplefi_status={}",
             payment.id,
@@ -180,7 +184,6 @@ async def _run_sweep(
         "expired": 0,
         "expired_orphaned": 0,
         "approved_reconciled": 0,
-        "email_failures": 0,
         "skipped": 0,
         "failures": 0,
     }
@@ -194,12 +197,6 @@ async def _run_sweep(
                 summary["expired_orphaned"] = int(summary["expired_orphaned"]) + 1
             elif action == "approved_reconciled":
                 summary["approved_reconciled"] = int(summary["approved_reconciled"]) + 1
-            elif action == "approved_email_failed":
-                # Payment WAS approved — count as reconciled AND track email failure.
-                # Do NOT count in "failures" (that counter is for unexpected errors
-                # that prevented the reconciliation from completing).
-                summary["approved_reconciled"] = int(summary["approved_reconciled"]) + 1
-                summary["email_failures"] = int(summary["email_failures"]) + 1
             else:
                 # "skipped_still_pending", "skipped_error"
                 summary["skipped"] = int(summary["skipped"]) + 1
@@ -223,12 +220,11 @@ async def _run_sweep(
 
     logger.info(
         "sweeper: run complete candidates={} expired={} expired_orphaned={} "
-        "approved_reconciled={} email_failures={} skipped={} failures={}",
+        "approved_reconciled={} skipped={} failures={}",
         summary["candidates"],
         summary["expired"],
         summary["expired_orphaned"],
         summary["approved_reconciled"],
-        summary["email_failures"],
         summary["skipped"],
         summary["failures"],
     )
@@ -252,8 +248,7 @@ async def sweep_pending_payments(
     during the run.
 
     Returns a summary dict with keys: ``status``, ``candidates``, ``expired``,
-    ``expired_orphaned``, ``approved_reconciled``, ``email_failures``,
-    ``skipped``, ``failures``.
+    ``expired_orphaned``, ``approved_reconciled``, ``skipped``, ``failures``.
     """
     lock_conn = session.get_bind().connect()
     try:

--- a/backend/app/services/simplefi/client.py
+++ b/backend/app/services/simplefi/client.py
@@ -64,10 +64,18 @@ class SimpleFIPaymentResponse(BaseModel):
 
 
 class SimpleFIPaymentRequestStatus(BaseModel):
-    """Minimal payment request status payload."""
+    """Minimal payment request status payload.
+
+    ``paid_installments_count`` is only populated for installment plans. For
+    one-shot payment requests it stays ``None``. It carries how many
+    installments SimpleFi has actually charged, which is the real "buyer paid"
+    signal for a plan — the ``active`` status alone only means the plan was
+    activated, not that the first installment cleared.
+    """
 
     id: str
     status: str
+    paid_installments_count: int | None = None
 
 
 class SimpleFIClient:
@@ -508,6 +516,7 @@ class SimpleFIClient:
         return SimpleFIPaymentRequestStatus(
             id=payload["id"],
             status=payload["status"],
+            paid_installments_count=payload.get("paid_installments_count"),
         )
 
 

--- a/backend/tests/api/payment/test_pending_hold_pr3_sweeper.py
+++ b/backend/tests/api/payment/test_pending_hold_pr3_sweeper.py
@@ -13,7 +13,7 @@ import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from sqlalchemy import text
 from sqlmodel import Session
@@ -164,10 +164,17 @@ def _fresh_coupon_uses(db: Session, coupon_id: uuid.UUID) -> int:
     return c.current_uses
 
 
-def _simplefi_status_mock(status_str: str) -> MagicMock:
-    """Build a SimpleFIPaymentRequestStatus-like mock returning the given status."""
+def _simplefi_status_mock(
+    status_str: str, paid_installments_count: int | None = None
+) -> MagicMock:
+    """Build a SimpleFIPaymentRequestStatus-like mock returning the given status.
+
+    ``paid_installments_count`` is only meaningful for installment plans; it
+    defaults to ``None`` to mirror a one-shot payment request.
+    """
     mock = MagicMock()
     mock.status = status_str
+    mock.paid_installments_count = paid_installments_count
     return mock
 
 
@@ -254,11 +261,6 @@ PATCH_STATUS = "app.services.simplefi.client.SimpleFIClient.get_payment_request_
 PATCH_PLAN_STATUS = (
     "app.services.simplefi.client.SimpleFIClient.get_installment_plan_status"
 )
-# The sweeper imports _send_payment_confirmed_email at module level from
-# app.services.payment_notifications, binding it in its own namespace.
-# To intercept the call, patch the name in the SWEEPER module, not the
-# source module (standard from-import patch location rule).
-PATCH_EMAIL = "app.services.pending_payment_sweeper._send_payment_confirmed_email"
 
 
 class TestSweeperMatrix:
@@ -326,11 +328,7 @@ class TestSweeperMatrix:
         coupon = _make_coupon(db, popup, current_uses=2)
         payment = _make_stale_pending_payment(db, tenant_a, popup, coupon=coupon)
 
-        with (
-            patch(PATCH_STATUS, return_value=_simplefi_status_mock("approved")),
-            patch(PATCH_EMAIL) as mock_email,
-        ):
-            mock_email.return_value = None
+        with patch(PATCH_STATUS, return_value=_simplefi_status_mock("approved")):
             result = asyncio.run(
                 sweep_pending_payments(
                     db, threshold_minutes=STALE_MINUTES, batch_size=100
@@ -739,36 +737,38 @@ class TestSweeperSessionRollbackOnFailure:
 
 
 # ---------------------------------------------------------------------------
-# B2: Approved-path email failure is counted in email_failures, not failures
+# B2: Installment plan approval gates on paid_installments_count, not "active"
 # ---------------------------------------------------------------------------
 
 
-class TestSweeperApprovedEmailFailure:
-    """B2: when the email dispatch fails for an approved payment, the payment
-    IS approved in the DB, the summary shows approved_reconciled=1 and
-    email_failures=1, and failures stays 0.
+class TestSweeperInstallmentPlanApprovalGate:
+    """B2: for installment plans the sweeper approves on a charged cuota, not
+    on the ``active`` plan status.
 
-    The payment being approved must NOT be undone just because email failed.
-    Email failure is an ops signal (alert/retry), not a payment failure.
+    Our Payment row represents only the first cuota. A plan can be ``active``
+    (activated) with ``paid_installments_count == 0`` — no money cleared yet.
+    Approving on ``active`` alone would assign products before the buyer paid.
+    The real signal is ``paid_installments_count >= 1`` (or a completed plan).
     """
 
-    def test_email_failure_counted_separately_payment_approved(
+    def test_active_plan_with_zero_cuotas_is_skipped_not_approved(
         self,
         db: Session,
         tenant_a: Tenants,
     ) -> None:
-        """Approved payment with email failure: approved_reconciled=1,
-        email_failures=1, failures=0, payment status APPROVED in DB."""
-        popup = _make_popup_with_key(db, tenant_a, slug_prefix="b2-ef")
-        payment = _make_stale_pending_payment(db, tenant_a, popup)
+        """Installment plan 'active' with paid_installments_count=0 → skip.
 
-        with (
-            patch(PATCH_STATUS, return_value=_simplefi_status_mock("approved")),
-            patch(
-                PATCH_EMAIL,
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("smtp down"),
-            ) as _mock_email,
+        The plan is activated but no cuota cleared; the sweeper must not
+        approve or assign products.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="b2-act0")
+        payment = _make_stale_pending_payment(
+            db, tenant_a, popup, is_installment_plan=True
+        )
+
+        with patch(
+            PATCH_PLAN_STATUS,
+            return_value=_simplefi_status_mock("active", paid_installments_count=0),
         ):
             result = asyncio.run(
                 sweep_pending_payments(
@@ -776,14 +776,61 @@ class TestSweeperApprovedEmailFailure:
                 )
             )
 
-        # Payment MUST be APPROVED — email failure must not revert approval.
-        assert _fresh_status(db, payment.id) == PaymentStatus.APPROVED.value
+        assert _fresh_status(db, payment.id) == PaymentStatus.PENDING.value
+        assert result["skipped"] >= 1
+        assert result["approved_reconciled"] == 0
 
-        # Summary: approved counted, email failure tracked separately,
-        # general failures counter untouched.
+    def test_active_plan_with_first_cuota_paid_is_approved(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Installment plan 'active' with paid_installments_count=1 → approve.
+
+        First cuota cleared, so the Payment (which represents that cuota) is
+        approved and products are assigned.
+        """
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="b2-act1")
+        payment = _make_stale_pending_payment(
+            db, tenant_a, popup, is_installment_plan=True
+        )
+
+        with patch(
+            PATCH_PLAN_STATUS,
+            return_value=_simplefi_status_mock("active", paid_installments_count=1),
+        ):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment.id) == PaymentStatus.APPROVED.value
         assert result["approved_reconciled"] >= 1
-        assert result["email_failures"] >= 1
-        assert result["failures"] == 0
+
+    def test_completed_plan_is_approved(
+        self,
+        db: Session,
+        tenant_a: Tenants,
+    ) -> None:
+        """Installment plan 'completed' → approve (paid by definition)."""
+        popup = _make_popup_with_key(db, tenant_a, slug_prefix="b2-comp")
+        payment = _make_stale_pending_payment(
+            db, tenant_a, popup, is_installment_plan=True
+        )
+
+        with patch(
+            PATCH_PLAN_STATUS,
+            return_value=_simplefi_status_mock("completed", paid_installments_count=3),
+        ):
+            result = asyncio.run(
+                sweep_pending_payments(
+                    db, threshold_minutes=STALE_MINUTES, batch_size=100
+                )
+            )
+
+        assert _fresh_status(db, payment.id) == PaymentStatus.APPROVED.value
+        assert result["approved_reconciled"] >= 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_simplefi_cancel_methods.py
+++ b/backend/tests/test_simplefi_cancel_methods.py
@@ -492,6 +492,27 @@ def test_get_installment_plan_status_handles_flat_payload(monkeypatch) -> None:
     result = client.get_installment_plan_status("plan-2")
     assert result.id == "plan-2"
     assert result.status == "active"
+    # Absent in the payload → None (the sweeper treats that as zero cuotas).
+    assert result.paid_installments_count is None
+
+
+def test_get_installment_plan_status_parses_paid_installments_count(
+    monkeypatch,
+) -> None:
+    """paid_installments_count is the sweeper's approve signal, so it must be parsed."""
+    _stub_make_request(
+        monkeypatch,
+        {
+            "installment_plan": {
+                "id": "plan-3",
+                "status": "active",
+                "paid_installments_count": 1,
+            }
+        },
+    )
+    client = SimpleFIClient("fake-key")
+    result = client.get_installment_plan_status("plan-3")
+    assert result.paid_installments_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Hardens the pending-payment sweeper. Two changes, sweeper only — the webhook path is untouched.

### 1. Installment approval gates on a charged cuota, not the `active` status

The sweeper approved installment plans whenever SimpleFi reported the plan as `active`. But `active` only means the plan was **activated**, not that the first installment cleared — an activated plan can carry `paid_installments_count == 0`. Our `Payment` row represents only the first cuota, so a lost `new_payment` webhook let the sweeper approve and assign products **before any money cleared**.

Now, for installment plans, the sweeper approves only when `paid_installments_count >= 1` (or the plan is `completed`). Otherwise it leaves the payment pending and retries next run. One-shot payment requests keep their existing approved-status logic.

To support this, `paid_installments_count` is exposed on `SimpleFIPaymentRequestStatus` and populated in `get_installment_plan_status` (it was fetched by SimpleFi but discarded).

### 2. Sweeper no longer sends confirmation emails

Email delivery stays owned by the webhook path. Dropped the `approved_email_failed` action and the `email_failures` summary counter.

## Not in scope

- The webhook (`_handle_installment_payment`) is unchanged — it still approves on the first cuota.
- Cuotas 2..N have no associated `Payment` in EdgeOS (pending debt / deuda pendiente). That is known and to be designed separately.

## Tests

- Added coverage for the cuota gate: `active` + 0 cuotas → skipped; `active` + 1 → approved; `completed` → approved.
- Added parsing coverage for `paid_installments_count`.
- Removed the obsolete email-failure test class.
- `77 passed`, ruff clean.