### PR TITLE
feat(checkout): Amanita confirm-step polish (fee, remove, quantity, badge)

### DIFF
--- a/portal/src/components/checkout-flow/CartFooter.tsx
+++ b/portal/src/components/checkout-flow/CartFooter.tsx
@@ -81,6 +81,13 @@ export default function CartFooter({
   // use it when provided to avoid letting users skip required steps.
   const positionStep = (activeSectionId ?? currentStep) as CheckoutStep
   const isConfirmStep = positionStep === "confirm" || isLastSection
+  // The service fee only shows from the confirm step on, so before it the
+  // footer reads as a products-only "Subtotal" and the fee is neither listed
+  // nor folded into the headline number.
+  const deferServiceFee = !isConfirmStep && summary.contributionSubtotal > 0
+  const footerTotal = deferServiceFee
+    ? summary.grandTotal - summary.contributionSubtotal
+    : summary.grandTotal
   const isBuyerStep = positionStep === ("buyer" as CheckoutStep)
   const currentIndex = availableSteps.indexOf(positionStep)
   // First step is whatever sits at index 0 of the configured step order
@@ -235,7 +242,7 @@ export default function CartFooter({
         )}
       >
         <div className="px-4 py-4 overflow-y-auto max-h-[calc(60vh-80px)]">
-          <CartItemList />
+          <CartItemList showServiceFee={isConfirmStep} />
         </div>
       </div>
 
@@ -272,7 +279,11 @@ export default function CartFooter({
               <div className="flex flex-col items-start min-w-0 overflow-hidden">
                 <div className="flex items-center gap-1.5">
                   <span className="text-[10px] lg:text-xs text-checkout-bottom-bar-text/60 uppercase tracking-wider font-medium">
-                    {isEditing ? t("checkout.to_pay") : t("common.total")}
+                    {isEditing
+                      ? t("checkout.to_pay")
+                      : deferServiceFee
+                        ? t("openCheckout.summary_subtotal")
+                        : t("common.total")}
                   </span>
                   {cartUiEnabled &&
                     hasItems &&
@@ -283,7 +294,7 @@ export default function CartFooter({
                     ))}
                 </div>
                 <span className="text-lg lg:text-2xl font-bold text-checkout-bottom-bar-text truncate max-w-full">
-                  {formatCurrency(summary.grandTotal)}
+                  {formatCurrency(footerTotal)}
                 </span>
                 {summary.creditApplied > 0 && (
                   <span className="text-[10px] lg:text-xs text-orange-400 font-medium">

--- a/portal/src/components/checkout-flow/CartItemList.tsx
+++ b/portal/src/components/checkout-flow/CartItemList.tsx
@@ -17,7 +17,13 @@ import { useCheckout } from "@/providers/checkoutProvider"
 import { useCityProvider } from "@/providers/cityProvider"
 import { formatCurrency } from "@/types/checkout"
 
-export default function CartItemList() {
+export default function CartItemList({
+  showServiceFee = true,
+}: {
+  /** The service fee only makes sense once the buyer reaches the confirm
+   *  step; earlier steps show products only. Defaults to shown. */
+  showServiceFee?: boolean
+} = {}) {
   const { t } = useTranslation()
   const { getCity } = useCityProvider()
   const popup = getCity()
@@ -347,8 +353,10 @@ export default function CartItemList() {
         </div>
       )}
 
-      {/* Contribution fee — mandatory when popup has it enabled; no buyer toggle */}
-      {summary.contributionSubtotal > 0 && (
+      {/* Contribution fee — mandatory when popup has it enabled; no buyer
+          toggle. Hidden until the confirm step so earlier steps show a
+          products-only cart. */}
+      {showServiceFee && summary.contributionSubtotal > 0 && (
         <div className="mb-4">
           <div className="flex items-center justify-between py-2">
             <div className="flex items-center gap-3 min-w-0">

--- a/portal/src/components/checkout-flow/SnapFooter.tsx
+++ b/portal/src/components/checkout-flow/SnapFooter.tsx
@@ -304,7 +304,7 @@ export default function SnapFooter({
         {isCartOpen && (
           <div className="bg-white shadow-2xl rounded-2xl mb-2 relative z-30 max-h-[60vh] overflow-hidden">
             <div className="px-4 py-4 overflow-y-auto max-h-[calc(60vh-80px)]">
-              <CartItemList />
+              <CartItemList showServiceFee={isOnConfirm} />
             </div>
           </div>
         )}

--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
@@ -401,6 +401,14 @@ export default function StepperCheckoutFlow({
   const current = sections[active]
   const isLast = active === last
   const nextSection = !isLast ? sections[active + 1] : undefined
+  // The service fee only shows from the confirm step on, so earlier steps read
+  // as a products-only "Subtotal" with the fee neither shown nor folded into
+  // the bar's headline number.
+  const isConfirmStep = current?.stepType === "confirm"
+  const deferServiceFee = !isConfirmStep && summary.contributionSubtotal > 0
+  const footerTotal = deferServiceFee
+    ? summary.grandTotal - summary.contributionSubtotal
+    : summary.grandTotal
   // Both of these read the cart through the provider rather than re-deriving
   // it from `cart.*`: an open checkout routes ticket picks to
   // `cart.dynamicItems`, never `cart.passes` (useTicketsStep.ts:284,336), so
@@ -728,9 +736,13 @@ export default function StepperCheckoutFlow({
                 {t("common.back")}
               </button>
               <div className="flex min-w-0 flex-col items-center">
-                <span className={TOTAL_LABEL_CLASSES[skin]}>Total</span>
+                <span className={TOTAL_LABEL_CLASSES[skin]}>
+                  {deferServiceFee
+                    ? t("openCheckout.summary_subtotal")
+                    : t("common.total")}
+                </span>
                 <span className={TOTAL_VALUE_CLASSES[skin]}>
-                  {formatCurrency(summary.grandTotal)}
+                  {formatCurrency(footerTotal)}
                 </span>
               </div>
               {isLast ? (

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.test.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.test.tsx
@@ -116,7 +116,7 @@ describe("AmanitaConfirmSection", () => {
 
   it("renders cart line items from the real cart/summary", () => {
     render(<AmanitaConfirmSection />)
-    expect(screen.getByText("General Pass")).toBeTruthy()
+    expect(screen.getByText(/General Pass/)).toBeTruthy()
     expect(screen.getAllByText(/\$100/).length).toBeGreaterThan(0)
   })
 
@@ -137,7 +137,7 @@ describe("AmanitaConfirmSection", () => {
       },
     }
     render(<AmanitaConfirmSection />)
-    expect(screen.getByText("Tote Bag")).toBeTruthy()
+    expect(screen.getByText(/Tote Bag/)).toBeTruthy()
   })
 
   it("calls applyPromoCode with the entered code", async () => {
@@ -258,10 +258,13 @@ describe("AmanitaConfirmSection", () => {
     }
     const { container } = render(<AmanitaConfirmSection />)
 
-    expect(screen.getByText("Full Pass")).toBeTruthy()
+    expect(screen.getByText(/Full Pass/)).toBeTruthy()
     expect(screen.queryByText("checkout.step_short.passes")).toBeNull()
-    // The order card carries its own title and nothing else above the lines.
-    expect(container.querySelectorAll("svg").length).toBe(0)
+    // The order card carries its own title and nothing else above the lines —
+    // the only icon on the line is its own remove control.
+    expect(
+      container.querySelectorAll('button[aria-label^="Remove"]').length,
+    ).toBe(1)
   })
 
   it("keeps the service fee out of the item list when the popup charges none", () => {

--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaConfirmSection.tsx
@@ -62,6 +62,29 @@ const ROW_BORDER = "rgba(4,34,49,0.12)"
 const MUTED = "#4a6670"
 const ERROR = "#b3271e"
 
+// Per-line remove control for the order summary, so an item can be dropped
+// from the cart here instead of scrolling back to its product card. Changing
+// quantity stays on the catalog card; here the cross clears the whole line.
+function RemoveButton({
+  name,
+  onClick,
+}: {
+  name: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Remove ${name}`}
+      className="p-1 shrink-0 transition-colors hover:opacity-70"
+      style={{ color: MUTED }}
+    >
+      <X className="h-4 w-4" />
+    </button>
+  )
+}
+
 function SectionLabel({
   icon: Icon,
   children,
@@ -121,8 +144,28 @@ export default function AmanitaConfirmSection({
     buyerValues,
     buyerGeneralError,
     removeMealPlan,
+    togglePass,
+    resetDayProduct,
+    removeDynamicItem,
+    clearHousing,
+    updateMerchQuantity,
+    clearPatron,
     housingDatesShown,
   } = useCheckout()
+
+  // Removing a pass mirrors the footer cart: day passes reset, everything else
+  // toggles its quantity to zero.
+  const handleRemovePass = (attendeeId: string, productId: string) => {
+    const pass = cart.passes.find(
+      (p) => p.attendeeId === attendeeId && p.productId === productId,
+    )
+    if (!pass) return
+    if (pass.product.duration_type === "day") {
+      resetDayProduct(attendeeId, productId)
+    } else {
+      togglePass(attendeeId, productId, 0)
+    }
+  }
   const { getCity } = useCityProvider()
   const popup = getCity()
   const { getRelevantApplication } = useApplication()
@@ -327,8 +370,7 @@ export default function AmanitaConfirmSection({
                         >
                           <div className="flex flex-col">
                             <span style={{ color: MUTED }}>
-                              {pass.quantity > 1 && <>{pass.quantity} × </>}
-                              {pass.product.name}
+                              {pass.quantity} × {pass.product.name}
                             </span>
                             {isNonDiscountable(pass.product) && (
                               <span
@@ -339,9 +381,17 @@ export default function AmanitaConfirmSection({
                               </span>
                             )}
                           </div>
-                          <span className="font-medium text-deep shrink-0">
-                            {formatCurrency(pass.originalPrice ?? pass.price)}
-                          </span>
+                          <div className="flex items-center gap-2 shrink-0">
+                            <span className="font-medium text-deep">
+                              {formatCurrency(pass.originalPrice ?? pass.price)}
+                            </span>
+                            <RemoveButton
+                              name={pass.product.name}
+                              onClick={() =>
+                                handleRemovePass(attendeeId, pass.productId)
+                              }
+                            />
+                          </div>
                         </div>
                       ))}
                     </div>
@@ -366,8 +416,7 @@ export default function AmanitaConfirmSection({
                       >
                         <div className="flex flex-col">
                           <span style={{ color: MUTED }}>
-                            {item.quantity > 1 && <>{item.quantity} × </>}
-                            {item.product.name}
+                            {item.quantity} × {item.product.name}
                           </span>
                           {isNonDiscountable(item.product) && (
                             <span
@@ -378,9 +427,17 @@ export default function AmanitaConfirmSection({
                             </span>
                           )}
                         </div>
-                        <span className="font-medium text-deep shrink-0">
-                          {formatCurrency(item.price)}
-                        </span>
+                        <div className="flex items-center gap-2 shrink-0">
+                          <span className="font-medium text-deep">
+                            {formatCurrency(item.price)}
+                          </span>
+                          <RemoveButton
+                            name={item.product.name}
+                            onClick={() =>
+                              removeDynamicItem(stepType, item.productId)
+                            }
+                          />
+                        </div>
                       </div>
                     ))}
                   </div>
@@ -400,10 +457,7 @@ export default function AmanitaConfirmSection({
                 <div className="flex items-start justify-between">
                   <div>
                     <p className="text-sm font-medium text-deep">
-                      {cart.housing.quantity > 1 && (
-                        <>{cart.housing.quantity} × </>
-                      )}
-                      {cart.housing.product.name}
+                      {cart.housing.quantity} × {cart.housing.product.name}
                     </p>
                     <p className="text-xs" style={{ color: MUTED }}>
                       {cart.housing.pricePerDay !== false
@@ -425,9 +479,15 @@ export default function AmanitaConfirmSection({
                       </p>
                     )}
                   </div>
-                  <span className="font-medium text-deep text-sm shrink-0">
-                    {formatCurrency(cart.housing.totalPrice)}
-                  </span>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="font-medium text-deep text-sm">
+                      {formatCurrency(cart.housing.totalPrice)}
+                    </span>
+                    <RemoveButton
+                      name={cart.housing.product.name}
+                      onClick={clearHousing}
+                    />
+                  </div>
                 </div>
               </div>
             </>
@@ -449,8 +509,7 @@ export default function AmanitaConfirmSection({
                     >
                       <div className="flex flex-col">
                         <span style={{ color: MUTED }}>
-                          {item.quantity > 1 && <>{item.quantity} × </>}
-                          {item.product.name}
+                          {item.quantity} × {item.product.name}
                         </span>
                         {isNonDiscountable(item.product) && (
                           <span
@@ -461,9 +520,15 @@ export default function AmanitaConfirmSection({
                           </span>
                         )}
                       </div>
-                      <span className="font-medium text-deep shrink-0">
-                        {formatCurrency(item.totalPrice)}
-                      </span>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <span className="font-medium text-deep">
+                          {formatCurrency(item.totalPrice)}
+                        </span>
+                        <RemoveButton
+                          name={item.product.name}
+                          onClick={() => updateMerchQuantity(item.productId, 0)}
+                        />
+                      </div>
                     </div>
                   ))}
                 </div>
@@ -491,9 +556,15 @@ export default function AmanitaConfirmSection({
                       {notEligibleCaption}
                     </span>
                   </div>
-                  <span className="font-medium text-deep shrink-0">
-                    {formatCurrency(cart.patron.amount)}
-                  </span>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="font-medium text-deep">
+                      {formatCurrency(cart.patron.amount)}
+                    </span>
+                    <RemoveButton
+                      name={t("checkout.amanita.confirm_patron_label")}
+                      onClick={clearPatron}
+                    />
+                  </div>
                 </div>
               </div>
             </>
@@ -536,17 +607,12 @@ export default function AmanitaConfirmSection({
                         <span className="font-medium text-deep">
                           {formatCurrency(mp.product.price)}
                         </span>
-                        <button
-                          type="button"
+                        <RemoveButton
+                          name={mp.product.name}
                           onClick={() =>
                             removeMealPlan(mp.attendeeId, mp.productId)
                           }
-                          aria-label={`Remove ${mp.product.name}`}
-                          className="p-1 transition-colors"
-                          style={{ color: MUTED }}
-                        >
-                          <X className="w-4 h-4" />
-                        </button>
+                        />
                       </div>
                     </div>
                   ))}

--- a/portal/src/hooks/checkout/useCartSummary.ts
+++ b/portal/src/hooks/checkout/useCartSummary.ts
@@ -148,13 +148,16 @@ export function useCartSummary({
     // it removed (the surplus carries over as balance).
     const creditApplied = discountedSubtotal - grandTotal
 
+    // Count total units, not distinct lines: a cart with "2 × A" and "1 × B"
+    // reads as 3 items, not 2. Patron is a single contribution and meal plans
+    // are one per attendee/week, so those stay line-counted.
     const itemCount =
-      selectedPasses.length +
-      (housing ? 1 : 0) +
-      merch.length +
+      selectedPasses.reduce((sum, p) => sum + (p.quantity ?? 1), 0) +
+      (housing ? (housing.quantity ?? 1) : 0) +
+      merch.reduce((sum, m) => sum + (m.quantity ?? 1), 0) +
       (patron ? 1 : 0) +
       mealPlans.length +
-      allDynamicItems.length
+      allDynamicItems.reduce((sum, d) => sum + (d.quantity ?? 1), 0)
 
     return {
       passesSubtotal,


### PR DESCRIPTION
## Summary

Amanita open-checkout confirm-step polish.

## Type of Change

- [x] Bug fix
- [x] New feature (non-breaking)

## Changes Made

- **Service fee only on confirm**: earlier steps show a products-only "Subtotal" in the footer; the service fee (its line + the amount folded into the total) appears only on the confirm step. Covers both shells — the scrolly `CartFooter`/`CartItemList`/`SnapFooter` and the stepper's own bottom bar.
- **Remove items from the confirm order list**: each line gets a remove (×) control, so a shopper can drop an item without going back to its product card. Quantity editing stays on the catalog card.
- **Always show the quantity prefix** ("N ×"), not only when greater than one.
- **Cart badge counts units**: `summary.itemCount` summed distinct lines, so "2 × A" + "1 × B" showed 2; it now sums quantities (→ 3).

## Testing

- [x] Portal typecheck + biome pass
- [x] Amanita confirm tests pass; StepperCheckoutFlow tests pass
- [x] Reviewed against the prod API on localhost