### PR TITLE
fix(checkout): persist open-checkout cart and buyer form across a reload

### DIFF
--- a/portal/src/hooks/checkout/useOpenCartPersistence.ts
+++ b/portal/src/hooks/checkout/useOpenCartPersistence.ts
@@ -542,8 +542,10 @@ export function useOpenCartPersistence({
         ? (state as CartSelectionState & { buyerEmail?: string }).buyerEmail
         : buyerEmail
 
-    // Require a valid email AND at least one product in cart
-    if (!email || !email.includes("@")) return
+    // Need at least one product to save. The email is only required for the
+    // backend upsert (cross-device recovery) — the localStorage copy below is
+    // written regardless, so a same-browser reload keeps the cart even before
+    // the buyer reaches the "your information" step and enters an email.
     if (!hasCartItems(state)) return
 
     if (debounceRef.current) {
@@ -559,6 +561,10 @@ export function useOpenCartPersistence({
         cartId: cartMetaRef.current.cartId,
         restoreToken: cartMetaRef.current.restoreToken,
       })
+
+      // The backend upsert (cross-device recovery) needs an email; until the
+      // buyer provides one the localStorage copy above is enough.
+      if (!email || !email.includes("@")) return
 
       // Serialize through inFlightUpsertRef so this call cannot race the
       // mount restore-refresh upsert and clobber cartMetaRef (P4 fix).

--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -583,6 +583,38 @@ export function CheckoutProvider({
     sig: openCartSig,
   })
 
+  // Persist the buyer's "your information" fields for a same-browser reload,
+  // mirroring the open cart. Backend recovery stays cart-only; this is just a
+  // local convenience so a refresh doesn't wipe a half-filled form. Only for
+  // open checkout — authenticated flows carry buyer data on the account.
+  const buyerStorageKey = openCartPopupSlug
+    ? `open-checkout-buyer:${openCartPopupSlug}`
+    : null
+  const buyerRestoredRef = useRef(false)
+  useEffect(() => {
+    if (!buyerStorageKey || buyerRestoredRef.current) return
+    buyerRestoredRef.current = true
+    // A signed-link / external prefill wins — never clobber it.
+    if (Object.keys(initialBuyerValues).length > 0) return
+    try {
+      const raw = localStorage.getItem(buyerStorageKey)
+      if (!raw) return
+      const parsed = JSON.parse(raw) as Record<string, unknown>
+      if (parsed && typeof parsed === "object") setBuyerValues(parsed)
+    } catch {
+      // corrupt or unavailable storage — start fresh
+    }
+  }, [buyerStorageKey, initialBuyerValues])
+  useEffect(() => {
+    if (!buyerStorageKey) return
+    if (Object.keys(buyerValues).length === 0) return
+    try {
+      localStorage.setItem(buyerStorageKey, JSON.stringify(buyerValues))
+    } catch {
+      // quota exceeded / private mode — non-fatal
+    }
+  }, [buyerStorageKey, buyerValues])
+
   const queryClient = useQueryClient()
   const router = useRouter()
 


### PR DESCRIPTION
## Summary

Make the open-checkout survive a page reload.

## Type of Change

- [x] Bug fix

## Changes Made

- **Cart**: `useOpenCartPersistence` gated the whole save (localStorage + backend upsert) on a valid email, entered only on the buyer step — so products added on the first step were lost on reload. localStorage now saves whenever the cart has items; the backend upsert (cross-device recovery) stays email-keyed and unchanged.
- **Buyer form**: `buyerValues` ("your information") had zero persistence. It's now saved to `localStorage["open-checkout-buyer:<slug>"]` on change and restored on mount (open checkout only), without clobbering a signed-link prefill.

## Testing

- [x] Portal typecheck + biome pass
- [x] useOpenCartPersistence (45) and checkoutProvider (6) tests pass
- [x] Reviewed against the prod API on localhost

## Notes for reviewer

- Buyer name/email now sit in localStorage (own browser); not cleared on payment success (leaves a next-visit prefill) — flagged as a possible follow-up.