### PR TITLE
feat(checkout): hero edition line as free translatable text

### DIFF
--- a/backend/app/api/translation/service.py
+++ b/backend/app/api/translation/service.py
@@ -127,6 +127,7 @@ _TEXT_LEAF_KEYS = frozenset(
         # `headline` is the largest text on the page, so leaving them out made
         # a "translated" checkout still open in the source language.
         "headline",
+        "edition",
         "date_badge",
         "cta_label",
         "cta_hint",

--- a/backend/tests/api/translation/test_translation_service.py
+++ b/backend/tests/api/translation/test_translation_service.py
@@ -107,6 +107,7 @@ class TestExtractTranslatableLeaves:
         # an otherwise translated checkout with no field to fix it in.
         config = {
             "headline": "4 días de música, arte, yoga y talleres",
+            "edition": "Tercera edición: El Portal",
             "subtitle": "Una celebración de amor, apertura y conexión",
             "date_badge": "Experiencia Extendida — 17, 18 y 19 de noviembre",
             "cta_label": "Ver Entradas →",
@@ -117,6 +118,7 @@ class TestExtractTranslatableLeaves:
         }
         assert extract_translatable_leaves(config) == {
             "headline": "4 días de música, arte, yoga y talleres",
+            "edition": "Tercera edición: El Portal",
             "subtitle": "Una celebración de amor, apertura y conexión",
             "date_badge": "Experiencia Extendida — 17, 18 y 19 de noviembre",
             "cta_label": "Ver Entradas →",

--- a/backoffice/src/components/ticketing-step-builder/template-configs/HeroConfig.tsx
+++ b/backoffice/src/components/ticketing-step-builder/template-configs/HeroConfig.tsx
@@ -46,11 +46,6 @@ const IMAGE_FIELDS = [
     description: "The large artwork at the top of the hero.",
   },
   {
-    key: "edition_url",
-    label: "Edition banner",
-    description: "Secondary banner under the wordmark.",
-  },
-  {
     key: "divider_url",
     label: "Divider ornament",
     description: "Sits above the subtitle.",
@@ -58,6 +53,11 @@ const IMAGE_FIELDS = [
 ] as const
 
 const TEXT_FIELDS = [
+  {
+    key: "edition",
+    label: "Edition",
+    placeholder: "Tercera edición: El Portal",
+  },
   {
     key: "headline",
     label: "Headline",

--- a/backoffice/src/components/translations/templateConfigLeaves.ts
+++ b/backoffice/src/components/translations/templateConfigLeaves.ts
@@ -25,6 +25,7 @@ const TEXT_LEAF_KEYS = new Set([
   // `headline` is the largest text on the page, so leaving them out made a
   // "translated" checkout still open in the source language.
   "headline",
+  "edition",
   "date_badge",
   "cta_label",
   "cta_hint",

--- a/portal/src/components/checkout-flow/variants/VariantHero.tsx
+++ b/portal/src/components/checkout-flow/variants/VariantHero.tsx
@@ -19,7 +19,9 @@ import type { VariantProps } from "../registries/variantRegistry"
 // present, never throw on an empty/undefined config:
 //   {
 //     "date_logo_url": "https://…",   // wordmark + date banner image
-//     "edition_url": "https://…",     // edition banner image (e.g. "3rd ed.")
+//     "edition": "string",            // edition line (e.g. "Third edition")
+//     "edition_url": "https://…",     // legacy edition banner image — used only
+//                                     //   when `edition` text is absent
 //     "headline": "string",           // main H1
 //     "subtitle": "string",           // italic tagline under the headline
 //     "date_badge": "string",         // pill text (e.g. extended dates)
@@ -40,6 +42,7 @@ import type { VariantProps } from "../registries/variantRegistry"
 
 interface HeroConfig {
   date_logo_url?: string
+  edition?: string
   edition_url?: string
   headline?: string
   subtitle?: string
@@ -116,6 +119,7 @@ export default function VariantHero({
 
   const hasAnyContent =
     config.date_logo_url ||
+    config.edition ||
     config.edition_url ||
     config.headline ||
     config.subtitle ||
@@ -136,14 +140,18 @@ export default function VariantHero({
           eager={isFirstSection}
         />
       )}
-      {config.edition_url && (
+      {config.edition ? (
+        <p className="font-condensed text-sm font-semibold uppercase tracking-[0.24em] text-sand md:text-base">
+          {config.edition}
+        </p>
+      ) : config.edition_url ? (
         <HeroImage
           src={config.edition_url}
           alt=""
           className="w-[min(240px,60%)]"
           eager={isFirstSection}
         />
-      )}
+      ) : null}
 
       {config.headline && (
         <h1


### PR DESCRIPTION
## Summary

Turn the checkout hero's "edition banner" from a baked image into free, translatable text.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- **Portal** `VariantHero`: new `edition` text field, rendered gold / uppercase / letter-spaced. Falls back to the legacy `edition_url` image when no text is set, so existing popups are unaffected.
- **Backend** `translation/service.py`: `edition` added to the translatable template_config leaves (+ test).
- **Backoffice**: `HeroConfig` editor swaps the "Edition banner" image field for an "Edition" text field; `templateConfigLeaves` exposes it in the Translations tab.
- No migration or OpenAPI client regen — `template_config` is a free dict and the leaf whitelist is a runtime set.

## Testing

- [x] Backend ruff + translation tests (24) pass
- [x] Portal + backoffice biome + tsc pass
- [x] VariantHero (12) and HeroConfig (8) tests pass

## Notes for reviewer

- The renderer prefers `edition` text over the legacy `edition_url` image; a popup only shows the new text once an organizer sets it on the hero step.