### PR TITLE
fix(checkout): keep the Amanita phone field digits-only and length-capped

### DIFF
--- a/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.tsx
+++ b/portal/src/components/checkout-flow/skins/amanita/AmanitaBuyerStep.tsx
@@ -192,11 +192,15 @@ function AmanitaField({
             type="tel"
             inputMode="numeric"
             autoComplete="tel-national"
+            maxLength={15}
             placeholder={placeholder}
             value={national}
-            onChange={(e) =>
-              onChange(name, `+${dialFor(country)}${e.target.value}`)
-            }
+            onChange={(e) => {
+              // Keep the national part digits-only and within E.164's length —
+              // a `tel` input still accepts letters, so filter here.
+              const digits = e.target.value.replace(/\D/g, "").slice(0, 15)
+              onChange(name, `+${dialFor(country)}${digits}`)
+            }}
             aria-invalid={hasError || undefined}
             className="w-full min-w-0 rounded-xl border px-4 py-3 text-deep outline-none transition-shadow focus:ring-2 focus:ring-accent"
             style={FIELD_INPUT_STYLE(hasError)}


### PR DESCRIPTION
## Summary

The Amanita buyer step's phone field accepted letters and had no digit cap.

## Type of Change

- [x] Bug fix

## Changes Made

- The Amanita `phone` handler used a raw `tel` input (which still accepts letters) with no length limit. It now strips non-digits on change and caps the national number at 15 digits (E.164), with `maxLength` + `slice` as belt-and-suspenders.

## Testing

- [x] Portal typecheck + biome pass
- [x] AmanitaBuyerStep tests (26) pass

## Note

The generic buyer form uses `react-phone-number-input` (already restricts input); this only touches the Amanita skin's hand-rolled phone input. The two diverging phone implementations are a known consequence of Amanita forking the buyer step rather than being a pure CSS skin — logged as tech debt, not addressed here.