### PR TITLE
fix(portal/checkout): invalidate application credit on pending hold release

### DIFF
--- a/portal/src/providers/checkoutProvider.tsx
+++ b/portal/src/providers/checkoutProvider.tsx
@@ -705,11 +705,18 @@ export function CheckoutProvider({
 
       releasePromise
         .then((result) => {
-          if (result.released && slug) {
-            // Release succeeded — invalidate the checkout runtime so stock/availability
-            // reflects the freed hold on the next render cycle.
+          if (result.released) {
+            if (slug) {
+              // Release succeeded — invalidate the checkout runtime so
+              // stock/availability reflects the freed hold on the next render.
+              queryClient.invalidateQueries({
+                queryKey: queryKeys.checkout.runtime(slug),
+              })
+            }
+            // The freed hold also restores application credit; refetch the
+            // application so the visible balance matches the backend.
             queryClient.invalidateQueries({
-              queryKey: queryKeys.checkout.runtime(slug),
+              queryKey: queryKeys.applications.mine(),
             })
           }
         })


### PR DESCRIPTION
## What

When a pending payment hold is released on checkout return, invalidate `queryKeys.applications.mine()` in addition to `checkout.runtime(slug)` so the visible application credit balance refetches and matches the backend.

## Why

Releasing a hold restores the application's credit on the backend, but the frontend only invalidated the checkout runtime. The credit balance shown to the user stayed stale until the next unrelated refetch.

## Context

This is recovered work from `feat/supersede-on-checkout-return`. That branch merged via **PR #441**, but one follow-up commit made right after the merge never landed in dev — it carried this extra `applications.mine()` invalidation. This PR brings just that lost delta onto current dev (rewritten against the current file, no stale rename).

## Scope

Single file, `portal/src/providers/checkoutProvider.tsx` (+11 / -4).

## Verification

- `pnpm --filter portal run lint` — passes
- `pnpm --filter portal run build` — clean, no TS errors