### PR TITLE
fix(backoffice): hide product slug field in product form

### DIFF
--- a/backoffice/src/components/forms/ProductForm.tsx
+++ b/backoffice/src/components/forms/ProductForm.tsx
@@ -425,16 +425,6 @@ export function ProductForm({ defaultValues, onSuccess }: ProductFormProps) {
               </form.Field>
             </div>
 
-            {/* Product Details metadata (edit only) */}
-            {isEdit && (
-              <div className="flex gap-6 text-sm text-muted-foreground">
-                <div>
-                  <span className="text-xs uppercase tracking-wider">Slug</span>
-                  <p className="font-mono">{defaultValues.slug}</p>
-                </div>
-              </div>
-            )}
-
             <Separator />
 
             {/* Description */}


### PR DESCRIPTION
## Summary
Removes the read-only product `slug` field from the backoffice product form (edit mode). The slug is auto-generated and was surfaced purely as reference metadata, which caused confusion for users.

## Why
The product slug is not a user-facing identifier: no API route resolves products by slug, and both frontends only echo it back. Its only load-bearing role is as a join key in backend seed data. Showing it in the form added no value and misled users into thinking it was meaningful/editable.

## Scope
- UI-only change: removed the metadata block rendering the slug in `ProductForm.tsx`.
- The `slug` column, unique constraint, and seed pipeline are left untouched.

## Verification
- `pnpm --filter backoffice run build` compiles clean.
- Pre-commit hooks (biome) passed.