### PR TITLE
feat(portal/checkout): auto-scroll active pill into view in stepper navbar

### DIFF
--- a/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
+++ b/portal/src/components/checkout-flow/StepperCheckoutFlow.tsx
@@ -290,11 +290,32 @@ export default function StepperCheckoutFlow({
   // overflow container (not the window), so on a step change we reset that
   // scroller rather than leaving the previous step's Y position.
   const rootRef = useRef<HTMLDivElement>(null)
+  // The pill row overflows horizontally when there are many steps. Keep a
+  // handle on the track and each pill so a step change can bring the active
+  // pill into view (keyed by `section.id` because the navbar maps over
+  // `navSections` while `active` indexes into `sections`).
+  const navRef = useRef<HTMLElement>(null)
+  const pillRefs = useRef<Map<string, HTMLButtonElement>>(new Map())
   // biome-ignore lint/correctness/useExhaustiveDependencies: `active` is the trigger; the body only reads a ref
   useEffect(() => {
     const scroller = rootRef.current?.closest(".overflow-y-auto")
     if (scroller) scroller.scrollTop = 0
     else window.scrollTo(0, 0)
+  }, [active])
+
+  // Centre the active pill in its horizontal track on step change (click or
+  // Back/Next). Mirrors ScrollySectionNav's compact-mode safety net so both
+  // shells behave the same. Separate from the vertical reset above: distinct
+  // concerns, distinct effects.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `active` is the trigger; the body only reads refs
+  useEffect(() => {
+    const activeId = sections[active]?.id
+    const btn = activeId ? pillRefs.current.get(activeId) : undefined
+    const nav = navRef.current
+    if (btn && nav) {
+      const target = btn.offsetLeft + btn.offsetWidth / 2 - nav.clientWidth / 2
+      nav.scrollTo({ left: Math.max(0, target), behavior: "smooth" })
+    }
   }, [active])
 
   const goTo = useCallback(
@@ -564,6 +585,7 @@ export default function StepperCheckoutFlow({
         style={NAV_OUTER[skin].style}
       >
         <nav
+          ref={navRef}
           aria-label="Checkout sections"
           className={NAV_INNER[skin].className}
         >
@@ -580,6 +602,10 @@ export default function StepperCheckoutFlow({
             return (
               <button
                 key={section.id}
+                ref={(el) => {
+                  if (el) pillRefs.current.set(section.id, el)
+                  else pillRefs.current.delete(section.id)
+                }}
                 type="button"
                 onClick={() => goTo(idx)}
                 aria-current={isActive ? "step" : undefined}


### PR DESCRIPTION
## Problema

En el checkout con shell `stepper` (skins **amanita** y `default`), el navbar muestra una fila de "pills", una por paso. Cuando hay muchos pasos la fila hace overflow horizontal (`overflow-x-auto`), pero al avanzar de paso la pill activa se re-estiliza sin que el `<nav>` scrollee para traerla a la vista. Con muchas pills, la pill activa queda fuera del área visible y el usuario pierde la referencia de en qué paso está.

## Solución

Replica el patrón que ya existe y funciona en el otro shell (`ScrollySectionNav.tsx`): al cambiar de paso, se centra suavemente la pill activa dentro de su track horizontal.

Cambios en un único archivo — `portal/src/components/checkout-flow/StepperCheckoutFlow.tsx`:

- **`navRef`** conectado al `<nav>` compartido (handle del track).
- **`pillRefs`** — `Map<string, HTMLButtonElement>` keyed por `section.id` (no por índice: el navbar mapea `navSections` mientras `active` indexa `sections`), con callback ref que registra/limpia cada pill.
- **`useEffect([active])`** separado del reset vertical existente: resuelve el id activo, busca el botón y hace `nav.scrollTo({ left: Math.max(0, target), behavior: "smooth" })` con `target = btn.offsetLeft + btn.offsetWidth/2 - nav.clientWidth/2`.

Aplica a **ambos skins** vía el `<nav>` compartido, sin ramas por skin. No se toca `amanita-skin.css`; el fix es puramente de comportamiento JS.

## Notas
- La pill de "FAQs" de amanita queda fuera del `navSections.map`, no es un paso lineal y no necesita ref.
- El clamp `Math.max(0, …)` cubre el primer paso (sin scroll negativo); el último paso scrollea al final.

## Verificación
- `biome lint` sobre el archivo tocado: limpio.
- Verificación end-to-end en el portal (skin amanita con pasos suficientes para overflow) pendiente de correr en un entorno con el popup configurado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)