### PR TITLE
feat(capi): only emit Purchase event for ticket products

### DIFF
--- a/backend/app/services/meta_capi.py
+++ b/backend/app/services/meta_capi.py
@@ -10,6 +10,7 @@ from typing import Any
 import httpx
 from loguru import logger
 
+from app.api.product.schemas import CATEGORY_TICKET
 from app.utils.encryption import decrypt
 
 META_GRAPH_API_VERSION = "v21.0"
@@ -48,6 +49,14 @@ def prepare_purchase_event(
     if resolved_popup is None:
         logger.warning(
             "Skipping Meta CAPI Purchase: popup missing event_id={} payment_id={}",
+            _purchase_event_id(payment),
+            str(getattr(payment, "id", "")),
+        )
+        return None
+
+    if not _has_ticket_product(payment):
+        logger.info(
+            "Skipping Meta CAPI Purchase: no ticket products event_id={} payment_id={}",
             _purchase_event_id(payment),
             str(getattr(payment, "id", "")),
         )
@@ -364,6 +373,7 @@ def _payment_product_snapshot(item: Any) -> SimpleNamespace:
         effective_unit_price=getattr(item, "effective_unit_price", None),
         product_price=getattr(item, "product_price", Decimal("0")),
         product_name=getattr(item, "product_name", "") or "",
+        product_category=getattr(item, "product_category", "") or "",
         attendee=None,
     )
 
@@ -425,6 +435,14 @@ def _custom_data(
     if include_order_id:
         custom_data["order_id"] = str(getattr(payment, "id", ""))
     return custom_data
+
+
+def _has_ticket_product(payment: Any) -> bool:
+    for item in getattr(payment, "products_snapshot", None) or []:
+        category = (getattr(item, "product_category", "") or "").strip().lower()
+        if category == CATEGORY_TICKET:
+            return True
+    return False
 
 
 def _contents(payment: Any) -> list[dict[str, Any]]:

--- a/backend/tests/test_meta_capi.py
+++ b/backend/tests/test_meta_capi.py
@@ -47,6 +47,7 @@ def test_prepare_purchase_event_includes_popup_purchase_metadata() -> None:
         effective_unit_price=None,
         product_price=Decimal("12.50"),
         product_name="Weekend Pass",
+        product_category="ticket",
         attendee=attendee,
     )
     payment = SimpleNamespace(
@@ -118,6 +119,43 @@ def test_prepare_purchase_event_includes_popup_purchase_metadata() -> None:
     assert "Lovelace" not in serialized_payload
     assert DUMMY_ACCESS_TOKEN not in serialized_payload
     assert DUMMY_ACCESS_TOKEN not in serialized_event
+
+
+def test_prepare_purchase_event_skips_when_no_ticket_products() -> None:
+    payment = SimpleNamespace(
+        id=uuid4(),
+        amount=Decimal("40.00"),
+        amount_charged=None,
+        currency="USD",
+        products_snapshot=[
+            SimpleNamespace(
+                product_id=uuid4(),
+                quantity=1,
+                effective_unit_price=None,
+                product_price=Decimal("40.00"),
+                product_name="Travel Insurance",
+                product_category="other",
+                attendee=None,
+            )
+        ],
+        application=None,
+        buyer_email="buyer@example.com",
+        buyer_name="Ada Lovelace",
+        buyer_snapshot=None,
+    )
+    popup = SimpleNamespace(
+        id=uuid4(),
+        slug="summer-popup",
+        name="Summer Popup",
+        currency="USD",
+    )
+    tenant = SimpleNamespace(
+        meta_tracking_enabled=True,
+        meta_pixel_id="123456789",
+        meta_capi_access_token_encrypted=encrypt(DUMMY_ACCESS_TOKEN),
+    )
+
+    assert prepare_purchase_event(tenant, payment, popup) is None
 
 
 def test_prepare_initiate_checkout_event_uses_payment_currency_without_order_id() -> (


### PR DESCRIPTION
## What

Meta CAPI **Purchase** event now only fires when the order contains at least one product with `product_category == "ticket"`. Orders made up of only non-ticket products (insurance, merch, housing, etc.) no longer emit a Purchase event.

## Why

Ad attribution should count ticket conversions only, not ancillary purchases.

## How

- New `_has_ticket_product()` gate in `prepare_purchase_event` (case-insensitive on `product_category` vs `CATEGORY_TICKET`); skips with a log line when absent.
- Preserve `product_category` in `_payment_product_snapshot`. Both emit paths (`enqueue_purchase_event`, `fire_and_forget_purchase_event`) snapshot the payment before the background task runs, so the field must survive the snapshot for the gate to see it.
- Category is used only for the gate; it is not added to the Meta payload.
- `InitiateCheckout` is intentionally left unchanged (still fires for any product).

## Tests

- Added `test_prepare_purchase_event_skips_when_no_ticket_products`.
- Updated the existing Purchase fixture to carry `product_category`.
- `pytest tests/test_meta_capi.py` green; ruff check + format clean.