### PR TITLE
fix(backend): merge divergent alembic heads from trial provisioning

### DIFF
--- a/backend/app/alembic/versions/f30eec99dce9_merge_tenant_trials_and_drop_anonymous_.py
+++ b/backend/app/alembic/versions/f30eec99dce9_merge_tenant_trials_and_drop_anonymous_.py
@@ -1,0 +1,21 @@
+"""merge tenant_trials and drop_anonymous_cart_email_index heads
+
+Revision ID: f30eec99dce9
+Revises: b3d8f1a6c4e2, e266b8601d0c
+Create Date: 2026-07-22 11:59:36.842480
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f30eec99dce9"
+down_revision = ("b3d8f1a6c4e2", "e266b8601d0c")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Problem
PR #498 merged into `dev` with backend CI red. Root cause: two alembic heads both branching from `d4f7b2a9c1e6`:
- `b3d8f1a6c4e2` (tenant_trials, added by #498)
- `e266b8601d0c` (drop_anonymous_cart_email_index, already on dev)

`alembic upgrade head` errors with "Multiple head revisions are present", which errored out all 1982 backend tests.

## Fix
Merge migration `f30eec99dce9` revising both heads (empty up/down). `alembic heads` now returns a single head.

## Verification
- `alembic heads` → single head `f30eec99dce9`
- `ruff check` + `ruff format` clean