### PR TITLE
fix(backoffice): sidebar label contrast + admin terminology

### DIFF
--- a/backoffice/src/components/Common/Appearance.tsx
+++ b/backoffice/src/components/Common/Appearance.tsx
@@ -32,7 +32,7 @@ export const SidebarAppearance = () => {
       <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <SidebarMenuButton tooltip="Appearance" data-testid="theme-button">
-            <Icon className="size-4 text-muted-foreground" />
+            <Icon className="size-4 text-sidebar-foreground/70" />
             <span>Appearance</span>
             <span className="sr-only">Toggle theme</span>
           </SidebarMenuButton>

--- a/backoffice/src/components/Sidebar/PopupSelector.tsx
+++ b/backoffice/src/components/Sidebar/PopupSelector.tsx
@@ -104,7 +104,7 @@ export function PopupSelector() {
 
   if (needsTenantSelection) {
     return (
-      <div className="py-2 text-sm text-muted-foreground">
+      <div className="py-2 text-sm text-sidebar-foreground/70">
         Select an organization first
       </div>
     )
@@ -113,7 +113,7 @@ export function PopupSelector() {
   if (isLoading) {
     return (
       <div className="space-y-2">
-        <Label className="text-xs text-muted-foreground">Gathering</Label>
+        <Label className="text-xs text-sidebar-foreground/70">Gathering</Label>
         <Skeleton className="h-9 w-full" />
       </div>
     )
@@ -121,7 +121,7 @@ export function PopupSelector() {
 
   if (!popups?.results?.length) {
     return (
-      <div className="py-2 text-sm text-muted-foreground">
+      <div className="py-2 text-sm text-sidebar-foreground/70">
         {isError ? "Failed to load gatherings" : "No gatherings available"}
       </div>
     )
@@ -129,7 +129,7 @@ export function PopupSelector() {
 
   return (
     <div className="space-y-2">
-      <Label className="text-xs text-muted-foreground flex items-center gap-1">
+      <Label className="text-xs text-sidebar-foreground/70 flex items-center gap-1">
         <Calendar className="h-3 w-3" />
         Gathering
       </Label>

--- a/backoffice/src/components/Sidebar/TenantSelector.tsx
+++ b/backoffice/src/components/Sidebar/TenantSelector.tsx
@@ -77,7 +77,9 @@ export function TenantSelector() {
   if (isLoading) {
     return (
       <div className="space-y-2">
-        <Label className="text-xs text-muted-foreground">Organization</Label>
+        <Label className="text-xs text-sidebar-foreground/70">
+          Organization
+        </Label>
         <Skeleton className="h-9 w-full" />
       </div>
     )
@@ -85,7 +87,7 @@ export function TenantSelector() {
 
   if (!tenants?.results?.length) {
     return (
-      <div className="py-2 text-sm text-muted-foreground">
+      <div className="py-2 text-sm text-sidebar-foreground/70">
         {isError
           ? "Failed to load organizations"
           : "No organizations available"}
@@ -95,7 +97,7 @@ export function TenantSelector() {
 
   return (
     <div className="space-y-2">
-      <Label className="text-xs text-muted-foreground flex items-center gap-1">
+      <Label className="text-xs text-sidebar-foreground/70 flex items-center gap-1">
         <Building2 className="h-3 w-3" />
         Organization
       </Label>

--- a/backoffice/src/components/Sidebar/User.tsx
+++ b/backoffice/src/components/Sidebar/User.tsx
@@ -25,15 +25,20 @@ import useAuth from "@/hooks/useAuth"
 interface UserInfoProps {
   fullName?: string
   email?: string
+  emailClassName?: string
 }
 
-function UserInfo({ fullName, email }: UserInfoProps) {
+function UserInfo({
+  fullName,
+  email,
+  emailClassName = "text-muted-foreground",
+}: UserInfoProps) {
   return (
     <div className="flex items-center gap-2.5 w-full min-w-0 group-data-[collapsible=icon]:justify-center">
       <UserIcon className="size-4 shrink-0" />
       <div className="flex flex-col items-start min-w-0 group-data-[collapsible=icon]:hidden">
         <p className="text-sm font-medium truncate w-full">{fullName}</p>
-        <p className="text-xs text-muted-foreground truncate w-full">{email}</p>
+        <p className={`text-xs ${emailClassName} truncate w-full`}>{email}</p>
       </div>
     </div>
   )
@@ -64,8 +69,12 @@ export function User({ user }: { user: any }) {
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
               data-testid="user-menu"
             >
-              <UserInfo fullName={user?.full_name} email={user?.email} />
-              <ChevronsUpDown className="ml-auto size-4 text-muted-foreground group-data-[collapsible=icon]:hidden" />
+              <UserInfo
+                fullName={user?.full_name}
+                email={user?.email}
+                emailClassName="text-sidebar-foreground/70"
+              />
+              <ChevronsUpDown className="ml-auto size-4 text-sidebar-foreground/70 group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/backoffice/src/components/Tasks/TaskDialog.tsx
+++ b/backoffice/src/components/Tasks/TaskDialog.tsx
@@ -206,7 +206,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
       return
     }
     if (form.visibility === "tenant" && !form.target_tenant_id) {
-      showErrorToast("Pick a tenant for tenant-scoped visibility")
+      showErrorToast("Pick an organization for organization-scoped visibility")
       return
     }
     if (isEdit) updateMutation.mutate()
@@ -438,7 +438,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
 
             {isSuperadmin && form.visibility === "tenant" && (
               <div className="space-y-2">
-                <Label>Tenant</Label>
+                <Label>Organization</Label>
                 <Select
                   value={form.target_tenant_id || NONE}
                   onValueChange={(v) =>
@@ -447,7 +447,7 @@ export function TaskDialog({ open, onOpenChange, taskId }: TaskDialogProps) {
                   disabled={readOnly}
                 >
                   <SelectTrigger>
-                    <SelectValue placeholder="Select a tenant" />
+                    <SelectValue placeholder="Select an organization" />
                   </SelectTrigger>
                   <SelectContent>
                     {tenants.map((t) => (

--- a/backoffice/src/components/Tasks/taskMeta.ts
+++ b/backoffice/src/components/Tasks/taskMeta.ts
@@ -78,6 +78,6 @@ export const TASK_VISIBILITIES: TaskVisibility[] = [
 
 export const VISIBILITY_LABELS: Record<TaskVisibility, string> = {
   internal: "Internal (superadmins)",
-  universal: "Universal (all tenants)",
-  tenant: "Tenant",
+  universal: "Universal (all organizations)",
+  tenant: "Organization",
 }

--- a/backoffice/src/components/forms/TenantCredentialsSection.tsx
+++ b/backoffice/src/components/forms/TenantCredentialsSection.tsx
@@ -28,12 +28,14 @@ const CREDENTIAL_META: Record<
 > = {
   crud: {
     label: "CRUD (read/write)",
-    description: "Used by admin sessions. Row-level scoped to this tenant.",
+    description:
+      "Used by admin sessions. Row-level scoped to this organization.",
     Icon: KeyRound,
   },
   readonly: {
     label: "Read-only",
-    description: "Used by viewer sessions. SELECT-only, scoped to this tenant.",
+    description:
+      "Used by viewer sessions. SELECT-only, scoped to this organization.",
     Icon: ShieldCheck,
   },
 }
@@ -145,8 +147,8 @@ export function TenantCredentialsSection({
       <div className="py-3">
         <Alert>
           <AlertDescription>
-            Direct database credentials for this tenant. Use only for support,
-            migrations, or audits.
+            Direct database credentials for this organization. Use only for
+            support, migrations, or audits.
           </AlertDescription>
         </Alert>
       </div>
@@ -174,8 +176,8 @@ export function TenantCredentialsSection({
         <div className="py-3">
           <Alert variant="destructive">
             <AlertDescription>
-              No credentials configured for this tenant yet. Credentials are
-              generated on first tenant connection.
+              No credentials configured for this organization yet. Credentials
+              are generated on first connection.
             </AlertDescription>
           </Alert>
         </div>
@@ -234,9 +236,9 @@ export function TenantCredentialsSection({
                       )}
                     />
                     <p className="text-xs text-muted-foreground">
-                      Read-only PostgreSQL URL scoped to this tenant. Scope is
-                      enforced by the database, so the holder of this URL cannot
-                      read other tenants' data. Append{" "}
+                      Read-only PostgreSQL URL scoped to this organization.
+                      Scope is enforced by the database, so the holder of this
+                      URL cannot read other organizations' data. Append{" "}
                       <code className="rounded bg-muted px-1 py-0.5 text-[10px] font-mono">
                         ?sslmode=require
                       </code>{" "}

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -363,7 +363,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
               <InlineRow
                 icon={<Megaphone className="h-4 w-4 text-muted-foreground" />}
                 label="Meta Pixel"
-                description="Load the tenant's Meta Pixel on the portal and checkout."
+                description="Load the organization's Meta Pixel on the portal and checkout."
               >
                 <Switch
                   id="meta_tracking_enabled"
@@ -450,7 +450,7 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
               <InlineRow
                 icon={<Megaphone className="h-4 w-4 text-muted-foreground" />}
                 label="Google Analytics"
-                description="Load the tenant's Google Analytics on the portal and checkout."
+                description="Load the organization's Google Analytics on the portal and checkout."
               >
                 <Switch
                   id="ga_tracking_enabled"

--- a/backoffice/src/components/forms/UserForm.tsx
+++ b/backoffice/src/components/forms/UserForm.tsx
@@ -60,7 +60,7 @@ const ROLE_OPTIONS: {
   {
     value: "admin",
     label: "Admin",
-    description: "Full tenant access",
+    description: "Full organization access",
   },
   {
     value: "operator",

--- a/backoffice/src/routes/_layout/admin/index.tsx
+++ b/backoffice/src/routes/_layout/admin/index.tsx
@@ -170,7 +170,7 @@ function TenantUsersTableContent({ tenantId }: { tenantId: string | null }) {
           <EmptyState
             icon={Users}
             title="No users yet"
-            description="Add users to manage access for this tenant."
+            description="Add users to manage access for this organization."
             action={
               <Button asChild>
                 <Link to="/admin/new">
@@ -257,9 +257,9 @@ function TenantUsersTable({ tenantId }: { tenantId: string | null }) {
     return (
       <Alert>
         <AlertCircle className="h-4 w-4" />
-        <AlertTitle>Select a tenant</AlertTitle>
+        <AlertTitle>Select an organization</AlertTitle>
         <AlertDescription>
-          Please select a tenant from the sidebar to view users.
+          Please select an organization from the sidebar to view users.
         </AlertDescription>
       </Alert>
     )

--- a/backoffice/src/routes/_layout/events/$eventId.tsx
+++ b/backoffice/src/routes/_layout/events/$eventId.tsx
@@ -173,7 +173,9 @@ function EventViewContent() {
 
   const handleShare = async () => {
     if (!portalUrl) {
-      showErrorToast("Set a portal domain for this tenant to share events")
+      showErrorToast(
+        "Set a portal domain for this organization to share events",
+      )
       return
     }
     try {

--- a/backoffice/src/routes/_layout/humans/index.tsx
+++ b/backoffice/src/routes/_layout/humans/index.tsx
@@ -444,9 +444,9 @@ function Humans() {
       {needsTenantSelection && (
         <Alert>
           <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Select a tenant</AlertTitle>
+          <AlertTitle>Select an organization</AlertTitle>
           <AlertDescription>
-            Please select a tenant from the sidebar to view humans.
+            Please select an organization from the sidebar to view humans.
           </AlertDescription>
         </Alert>
       )}

--- a/backoffice/src/routes/_layout/popups/index.tsx
+++ b/backoffice/src/routes/_layout/popups/index.tsx
@@ -264,9 +264,10 @@ function Popups() {
       {needsTenantSelection && (
         <Alert>
           <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Select a tenant</AlertTitle>
+          <AlertTitle>Select an organization</AlertTitle>
           <AlertDescription>
-            Please select a tenant from the sidebar to view and manage pop-ups.
+            Please select an organization from the sidebar to view and manage
+            gatherings.
           </AlertDescription>
         </Alert>
       )}
@@ -274,7 +275,7 @@ function Popups() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Gatherings</h1>
           <p className="text-muted-foreground">
-            Manage your pop-ups and their configurations
+            Manage your gatherings and their configurations
           </p>
         </div>
         {canManagePopups && <AddPopupButton />}


### PR DESCRIPTION
## What

Two backoffice-only, user-facing polish changes.

### 1. Sidebar label contrast in light theme (fix)
The sidebar keeps a fixed dark navy background in **both** themes, but several labels used page-level muted tokens (`text-muted-foreground`), which resolve to dark gray in light theme and become nearly invisible on the navy. Switched them to `sidebar-foreground` tokens:
- Workspace switcher labels ("Organization" / "Gathering") and their empty/error states
- User email + chevron, and the appearance icon

The shared `UserInfo` renders both on the sidebar surface **and** inside a portal dropdown, so its email token is now parametrized: sidebar usage gets the sidebar token, the dropdown keeps the page-level token (which is correct against the popover background).

### 2. Terminology alignment (copy)
Finished the user-facing rename in admin surfaces:
- Leftover **"pop-up" → "gathering"** on the gatherings list page
- **"tenant" → "organization"** across alerts, empty states, task visibility labels, role descriptions, tracking toggles and database credential notes — matching the sidebar's "Organization" label

Code identifiers, route paths, API fields and the generated client are untouched.

## Out of scope
- Portal terminology (attendee-facing; deliberately kept for a separate product decision)
- `src/client/schemas.gen.ts` field descriptions still say "tenant" — those are generated from the backend OpenAPI and must be changed backend-side, not here

## Testing
- `pnpm --filter backoffice build` green
- `pnpm --filter backoffice lint` clean
- Verify visually: sidebar labels readable in light theme; no "tenant"/"pop-up" copy left in admin screens