### PR TITLE
fix(portal): allow editing applications while in review

### DIFF
--- a/portal/src/app/portal/[popupSlug]/application/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/page.tsx
@@ -96,8 +96,7 @@ export default function FormPage() {
   useEffect(() => {
     if (
       application &&
-      (application.status === "accepted" ||
-        application.status === "rejected")
+      (application.status === "accepted" || application.status === "rejected")
     ) {
       router.replace(`/portal/${city?.slug}`)
     }

--- a/portal/src/app/portal/[popupSlug]/application/page.tsx
+++ b/portal/src/app/portal/[popupSlug]/application/page.tsx
@@ -90,14 +90,13 @@ export default function FormPage() {
     }
   }, [importSource, existingApp])
 
-  // Once submitted, the application is no longer accessible from the form —
-  // same behavior as a fee-less submit. draft/pending_fee stay editable so the
-  // applicant can still finish or retry the fee payment.
+  // Resolved applications are no longer accessible from the form.
+  // draft/pending_fee/in review stay editable so the applicant can still finish,
+  // retry the fee payment, or update details while the application is under review.
   useEffect(() => {
     if (
       application &&
-      (application.status === "in review" ||
-        application.status === "accepted" ||
+      (application.status === "accepted" ||
         application.status === "rejected")
     ) {
       router.replace(`/portal/${city?.slug}`)
@@ -142,10 +141,9 @@ export default function FormPage() {
     return <Loader />
   }
 
-  // Submitted or resolved applications never render the form. The effect above
-  // redirects to the portal home; show a loader meanwhile to avoid flashing it.
+  // Resolved applications never render the form. The effect above redirects to
+  // the portal home; show a loader meanwhile to avoid flashing it.
   if (
-    application?.status === "in review" ||
     application?.status === "accepted" ||
     application?.status === "rejected"
   ) {


### PR DESCRIPTION
## Problema

En el portal, cuando una aplicación está **in review**, el botón "Editar aplicación" (`Edit Application`) navegaba a la página del formulario, pero esa página bloqueaba el render y redirigía al usuario de vuelta a la home. Resultado: el botón prometía editar pero era imposible hacerlo.

## Causa raíz

En `portal/src/app/portal/[popupSlug]/application/page.tsx`, dos guards agrupaban `in review` junto con `accepted` y `rejected`:

- Un `useEffect` que hacía `router.replace()` a la home del portal.
- Un guard de render que devolvía `<Loader />` en vez del formulario.

## Fix

Se remueve `"in review"` de ambos guards, dejando bloqueadas solo las aplicaciones **resueltas** (`accepted` / `rejected`).

| Status | Antes | Ahora |
|--------|-------|-------|
| `draft` / `pending_fee` | editable | editable |
| `in review` | 🔒 bloqueada | ✅ editable |
| `accepted` / `rejected` | 🔒 bloqueada | 🔒 bloqueada |

## Por qué el flujo completo funciona sin más cambios

- El prefill (`getRelevantApplication()`) ya seleccionaba la app in-review y precarga el formulario.
- El submit usa `updateMyApplication` (PATCH) cuando existe `application.id`, así que editar hace un update, no una nueva aplicación. El backend ya permite updates en estado `in review`.

## Test plan

- [ ] Con una aplicación en estado `in review`, hacer click en "Editar aplicación" → debe abrir el formulario precargado (antes redirigía a la home).
- [ ] Modificar campos y reenviar → la aplicación se actualiza y permanece en `in review`.
- [ ] Verificar que aplicaciones `accepted` / `rejected` siguen sin poder abrir el formulario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)