### PR TITLE
fix(portal): drop hardcoded help email, hide button without tenant sender_email

### DIFF
--- a/portal/src/components/HelpButton.tsx
+++ b/portal/src/components/HelpButton.tsx
@@ -13,25 +13,23 @@ import { useCityProvider } from "@/providers/cityProvider"
 import { useTenant } from "@/providers/tenantProvider"
 
 /**
- * Fallback support address used when the tenant has no configured
- * `sender_email`. Per-popup email is not exposed on `PopupPublic`, so the
- * tenant address is the most specific override available to the portal.
- */
-const FALLBACK_EMAIL = "info@edgecity.live"
-
-/**
  * Floating help button shown on every portal page. Opens a small popover that
  * lets the visitor email support. The destination is the tenant's configured
- * `sender_email`, falling back to {@link FALLBACK_EMAIL}. Must be mounted inside
- * both `CityProvider` and `TenantProvider` (see `Providers.tsx`).
+ * `sender_email`; when the tenant has no address the button is not rendered.
+ * Must be mounted inside both `CityProvider` and `TenantProvider` (see
+ * `Providers.tsx`).
  */
 const HelpButton = () => {
   const { t } = useTranslation()
   const { tenant } = useTenant()
   const { getCity } = useCityProvider()
 
+  const email = tenant?.sender_email?.trim()
+  if (!email) {
+    return null
+  }
+
   const popup = getCity()
-  const email = tenant?.sender_email?.trim() || FALLBACK_EMAIL
   const subject = popup?.name
     ? t("help.email_subject", { popup: popup.name })
     : t("help.email_subject_generic")


### PR DESCRIPTION
## What

The floating help button hardcoded a real tenant support address as a fallback for when the tenant had no `sender_email`. That violates the no-hardcoded-tenant-data rule.

## Change

- Removed the `FALLBACK_EMAIL` constant entirely.
- When `tenant.sender_email` is missing/empty, `HelpButton` returns `null` — no generic mailto, no fallback. The button only renders when the tenant provides its own address.

The email lives at the tenant level (popups don't have a custom support email), so `tenant.sender_email` is the single source of truth.