### PR TITLE
fix(backoffice): exclude display-only fields from application columns and truncate long labels

### DIFF
--- a/backoffice/src/components/Common/DataTable.tsx
+++ b/backoffice/src/components/Common/DataTable.tsx
@@ -402,7 +402,10 @@ export function DataTable<TData, TValue>({
                   <p>Toggle columns</p>
                 </TooltipContent>
               </Tooltip>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent
+                align="end"
+                className="max-h-[70vh] w-56 overflow-y-auto"
+              >
                 <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 {table
@@ -418,7 +421,12 @@ export function DataTable<TData, TValue>({
                       checked={col.getIsVisible()}
                       onCheckedChange={(value) => col.toggleVisibility(!!value)}
                     >
-                      {col.columnDef.meta?.label}
+                      <span
+                        className="truncate"
+                        title={col.columnDef.meta?.label}
+                      >
+                        {col.columnDef.meta?.label}
+                      </span>
                     </DropdownMenuCheckboxItem>
                   ))}
               </DropdownMenuContent>

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -104,6 +104,7 @@ interface ApplicationSchema {
       type?: string
       position?: number
       options?: string[]
+      config?: { is_checkbox?: boolean }
       [key: string]: unknown
     }
   >
@@ -128,12 +129,22 @@ function formatCustomFieldValue(value: unknown, type?: string): string {
     const sig = value as { signature?: string }
     return sig?.signature ? "Signed" : "—"
   }
+  if (type === "image_upload") return "Uploaded"
   if (type === "date" && typeof value === "string") {
     return new Date(value).toLocaleDateString()
   }
   if (Array.isArray(value)) return value.join(", ")
   if (typeof value === "object") return "—"
   return String(value)
+}
+
+// Display-only fields never collect a response, so they have no data to
+// surface as a column. rich_text collects a boolean only in checkbox mode.
+function isDisplayOnlyField(def: {
+  type?: string
+  config?: { is_checkbox?: boolean }
+}): boolean {
+  return def.type === "rich_text" && !def.config?.is_checkbox
 }
 
 // Build one toggleable, hidden-by-default column per custom form-builder
@@ -144,6 +155,7 @@ function buildCustomFieldColumns(
 ): ColumnDef<ApplicationPublic>[] {
   const customFields = formSchema?.custom_fields ?? {}
   return Object.entries(customFields)
+    .filter(([, def]) => !isDisplayOnlyField(def))
     .sort(
       ([, a], [, b]) =>
         (a.position ?? Number.MAX_SAFE_INTEGER) -
@@ -154,7 +166,11 @@ function buildCustomFieldColumns(
       return {
         id: `custom_${name}`,
         accessorFn: (row) => row.custom_fields?.[name],
-        header: label,
+        header: () => (
+          <span className="block max-w-48 truncate" title={label}>
+            {label}
+          </span>
+        ),
         meta: { label, toggleable: true, defaultHidden: true },
         enableSorting: false,
         cell: ({ row }) => (
@@ -1204,6 +1220,10 @@ function Applications() {
       // Try to match each data key to the current schema for label
       // and position; fall back to a formatted version of the key.
       const customColumns = [...seenKeys]
+        .filter((name) => {
+          const schemaDef = schemaLookup[name]
+          return !schemaDef || !isDisplayOnlyField(schemaDef)
+        })
         .map((name) => {
           const schemaDef = schemaLookup[name] as
             | { label?: string; position?: number }


### PR DESCRIPTION
## Summary

The applications table column toggle built one column per form-builder field, which caused two problems:

- **Display-only fields produced dead columns.** `rich_text` fields ("Text with link") are presentation content and never collect a response, so their columns rendered as all dashes. They are now excluded from both the dynamic columns and the CSV export, except when `config.is_checkbox` is set (checkbox mode does collect a boolean).
- **Question-style labels broke the layout.** Full-sentence labels blew up the toggle menu and table headers. Menu items and dynamic column headers now truncate to one line with the full text available on hover, and the toggle menu scrolls when a form has many fields.

Also, `image_upload` values now render as "Uploaded" instead of the raw URL, matching how signature fields render as "Signed".

## Test plan

- `pnpm --filter backoffice run lint` and `pnpm --filter backoffice run build` pass.
- Manually verified against a popup with rich_text fields and long question labels.