### PR TITLE
fix(backend): enforce form validation on application updates and close base-field bypasses

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 from sqlalchemy import desc, exists, or_
@@ -478,12 +478,14 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         # the form never asked for.
         is_express_checkout = bool(getattr(app_data, "group_id", None))
 
-        # Validate custom_fields against form field definitions
-        if validate_custom_fields and app_data.custom_fields:
+        # Validate custom_fields against form field definitions. Non-draft
+        # submissions must run even with empty/absent custom_fields so
+        # missing required fields are reported.
+        if validate_custom_fields and (app_data.custom_fields or not is_draft):
             is_valid, errors = form_fields_crud.validate_custom_fields(
                 session,
                 app_data.popup_id,
-                app_data.custom_fields,
+                app_data.custom_fields or {},
                 skip_required=is_draft,
                 is_express_checkout=is_express_checkout,
             )
@@ -716,12 +718,14 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         # portal; mirror that scope here when the admin creates one too.
         is_express_checkout = bool(getattr(app_data, "group_id", None))
 
-        # Validate custom_fields against form field definitions
-        if validate_custom_fields and app_data.custom_fields:
+        # Validate custom_fields against form field definitions. Non-draft
+        # submissions must run even with empty/absent custom_fields so
+        # missing required fields are reported.
+        if validate_custom_fields and (app_data.custom_fields or not is_draft):
             is_valid, errors = form_fields_crud.validate_custom_fields(
                 session,
                 app_data.popup_id,
-                app_data.custom_fields,
+                app_data.custom_fields or {},
                 skip_required=is_draft,
                 is_express_checkout=is_express_checkout,
             )
@@ -924,6 +928,108 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             _maybe_grant_fee_credit(session, application)
         else:
             self.create_snapshot(session, application, "submitted")
+
+    def validate_portal_update(
+        self,
+        session: Session,
+        application: Applications,
+        update_data: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Validate a portal application update against the popup's form.
+
+        The portal sends the full form state on every save and omits
+        cleared/empty answers, so an incoming ``custom_fields`` dict replaces
+        the stored answers for every field the current form renders: a
+        schema-known key absent from the payload means "cleared". Stored keys
+        the form does not render (deleted, renamed, or hidden fields, or
+        fields outside the Express Checkout mini-form) are preserved so old
+        answers stay interpretable.
+
+        When the update results in a non-draft status (submitting, or editing
+        an already-submitted application), that resolved state must satisfy
+        the same required and type checks the create path enforces. Draft
+        saves skip required checks but still type-check the resolved values.
+
+        ``update_data`` must contain only the keys the caller explicitly sent
+        (``model_dump(exclude_unset=True)``).
+
+        Returns the resolved ``custom_fields`` the caller must store, or
+        ``None`` when the payload does not update them.
+        """
+        from app.api.form_field.crud import form_fields_crud
+
+        incoming_status = update_data.get("status")
+        if incoming_status is not None:
+            incoming_status = getattr(incoming_status, "value", incoming_status)
+        resulting_status = incoming_status or application.status
+        is_draft = _is_draft_status(resulting_status)
+
+        # Group applications use the Express Checkout reduced form on the
+        # portal; keep the relaxed required subset for their updates too.
+        is_express_checkout = bool(update_data.get("group_id") or application.group_id)
+
+        stored_custom: dict[str, Any] = application.custom_fields or {}
+        incoming_custom = update_data.get("custom_fields")
+        resolved_custom: dict[str, Any] | None = None
+        if incoming_custom is not None:
+            rendered = form_fields_crud.get_portal_rendered_field_names(
+                session,
+                application.popup_id,
+                is_express_checkout=is_express_checkout,
+            )
+            resolved_custom = {
+                k: v for k, v in stored_custom.items() if k not in rendered
+            } | incoming_custom
+
+        # Validate exactly the state that will be stored. When custom_fields
+        # isn't in the payload the stored answers stay untouched, but a
+        # non-draft result must still satisfy required checks against them.
+        if resolved_custom is not None:
+            custom_fields = resolved_custom
+        else:
+            custom_fields = {} if is_draft else stored_custom
+
+        is_valid, errors = form_fields_crud.validate_custom_fields(
+            session,
+            application.popup_id,
+            custom_fields,
+            skip_required=is_draft,
+            is_express_checkout=is_express_checkout,
+        )
+        if not is_valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"message": "Invalid custom fields", "errors": errors},
+            )
+
+        if is_draft:
+            return resolved_custom
+
+        # Base fields: stored application values overlaid with the incoming
+        # payload; target=human fields fall back to the Human record inside
+        # validate_base_fields.
+        base_data: dict[str, Any] = {
+            "referral": application.referral,
+            "info_not_shared": application.info_not_shared,
+            "scholarship_request": application.scholarship_request,
+            "scholarship_details": application.scholarship_details,
+            "scholarship_video_url": application.scholarship_video_url,
+        }
+        base_data.update({k: v for k, v in update_data.items() if v is not None})
+        is_valid, errors = form_fields_crud.validate_base_fields(
+            session,
+            application.popup_id,
+            base_data,
+            application.human,
+            is_express_checkout=is_express_checkout,
+        )
+        if not is_valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"message": "Invalid base fields", "errors": errors},
+            )
+
+        return resolved_custom
 
     def update_with_profile(
         self,

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -1066,6 +1066,23 @@ async def update_my_application(
     profile_update = {k: v for k, v in update_data.items() if k in profile_fields}
     app_update = {k: v for k, v in update_data.items() if k not in profile_fields}
 
+    # Enforce form validation before any state is applied: submits (and edits
+    # of already-submitted applications) validate the merged state with full
+    # required checks; draft saves only type-check provided values.
+    resolved_custom_fields = crud.applications_crud.validate_portal_update(
+        db, application, update_data
+    )
+
+    # Store exactly what was validated: incoming custom_fields replace the
+    # stored answers for every field the current form renders (the portal
+    # sends the full form state, so an absent key means "cleared"), while
+    # answers the form no longer renders are preserved.
+    if "custom_fields" in app_update:
+        if app_update["custom_fields"] is None:
+            del app_update["custom_fields"]
+        elif resolved_custom_fields is not None:
+            app_update["custom_fields"] = resolved_custom_fields
+
     # Update human profile if needed
     if profile_update:
         humans_crud.update(db, application.human, HumanUpdate(**profile_update))

--- a/backend/app/api/base_field_config/crud.py
+++ b/backend/app/api/base_field_config/crud.py
@@ -1,6 +1,7 @@
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from fastapi import HTTPException, status
 from pydantic import BaseModel
 from sqlmodel import Session, select
 
@@ -23,6 +24,47 @@ def field_applies_to_popup(field_name: str, popup: "Popups") -> bool:
     if field_name in SCHOLARSHIP_FIELDS and not popup.allows_scholarship:
         return False
     return True
+
+
+def ensure_base_field_update_allowed(
+    config: BaseFieldConfigs, update_fields: dict[str, Any]
+) -> None:
+    """Enforce catalog invariants on a base field config update.
+
+    ``update_fields`` must contain only the keys the caller explicitly sent
+    (``model_dump(exclude_unset=True)``). Shared by the /form-fields and
+    /base-field-configs update routes so both enforce the same rules.
+    """
+    definition = BASE_FIELD_DEFINITIONS.get(config.field_name, {})
+
+    # Non-removable elementals (first_name, last_name) cannot be made optional.
+    if (
+        not definition.get("removable", True)
+        and "required" in update_fields
+        and update_fields["required"] is False
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Field '{config.field_name}' is required and cannot be made optional",
+        )
+
+    # `field_type` is only writeable on base configs whose catalog entry
+    # whitelists alternatives — and only to a value inside that whitelist.
+    if "field_type" in update_fields:
+        allowed_field_types = definition.get("allowed_field_types")
+        if not allowed_field_types:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Field '{config.field_name}' does not allow type overrides",
+            )
+        new_type = update_fields["field_type"]
+        if new_type is not None and new_type not in allowed_field_types:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Field type '{new_type}' is not allowed for '{config.field_name}'"
+                ),
+            )
 
 
 class BaseFieldConfigsCRUD(

--- a/backend/app/api/base_field_config/router.py
+++ b/backend/app/api/base_field_config/router.py
@@ -2,7 +2,10 @@ import uuid
 
 from fastapi import APIRouter, HTTPException, Query, status
 
-from app.api.base_field_config.crud import base_field_configs_crud
+from app.api.base_field_config.crud import (
+    base_field_configs_crud,
+    ensure_base_field_update_allowed,
+)
 from app.api.base_field_config.schemas import (
     BaseFieldConfigPublic,
     BaseFieldConfigUpdate,
@@ -35,6 +38,8 @@ async def update_base_field_config(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Base field config not found",
         )
+
+    ensure_base_field_update_allowed(config, config_in.model_dump(exclude_unset=True))
 
     updated = base_field_configs_crud.update(db, config, config_in)
     return BaseFieldConfigPublic.model_validate(updated)

--- a/backend/app/api/checkout/crud.py
+++ b/backend/app/api/checkout/crud.py
@@ -185,7 +185,10 @@ def runtime_for_slug(
                     key=lambda f: f.position,
                 ),
             )
+            # Hidden sections (and their fields) are never surfaced to the
+            # anonymous checkout, mirroring build_schema_for_popup.
             for sec in sections
+            if not sec.hidden
         ],
         ticketing_steps=[_step(step) for step in ticketing_steps],
         attendee_categories=[

--- a/backend/app/api/form_field/crud.py
+++ b/backend/app/api/form_field/crud.py
@@ -271,16 +271,9 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
         # were rendered — restrict required validation to that subset.
         express_section_keys: set[str] = set()
         if is_express_checkout:
-            from app.api.base_field_config.constants import BASE_FIELD_DEFINITIONS
-            from app.api.base_field_config.crud import base_field_configs_crud
-
-            base_configs = base_field_configs_crud.find_by_popup(session, popup_id)
-            for config in base_configs:
-                definition = BASE_FIELD_DEFINITIONS.get(config.field_name)
-                if not definition:
-                    continue
-                if _is_express_checkout_base_field(config.field_name, definition):
-                    express_section_keys.add(_section_key(config.section_id))
+            express_section_keys = self.get_express_checkout_section_keys(
+                session, popup_id
+            )
 
         errors: list[str] = []
 
@@ -399,6 +392,66 @@ class FormFieldsCRUD(BaseCRUD[FormFields, FormFieldCreate, FormFieldUpdate]):
                         )
 
         return len(errors) == 0, errors
+
+    def get_express_checkout_section_keys(
+        self, session: Session, popup_id: uuid.UUID
+    ) -> set[str]:
+        """Section keys the portal /groups Express Checkout mini-form renders.
+
+        A section is rendered when it contains at least one Express Checkout
+        base field (mirrors ``getCheckoutMiniFormSchema`` in the portal).
+        """
+        from app.api.base_field_config.constants import BASE_FIELD_DEFINITIONS
+        from app.api.base_field_config.crud import base_field_configs_crud
+
+        section_keys: set[str] = set()
+        base_configs = base_field_configs_crud.find_by_popup(session, popup_id)
+        for config in base_configs:
+            definition = BASE_FIELD_DEFINITIONS.get(config.field_name)
+            if not definition:
+                continue
+            if _is_express_checkout_base_field(config.field_name, definition):
+                section_keys.add(_section_key(config.section_id))
+        return section_keys
+
+    def get_portal_rendered_field_names(
+        self,
+        session: Session,
+        popup_id: uuid.UUID,
+        is_express_checkout: bool = False,
+    ) -> set[str]:
+        """Names of custom fields the portal form currently renders.
+
+        Mirrors ``build_schema_for_popup`` visibility: fields in hidden
+        sections are excluded. When ``is_express_checkout`` is True, the set
+        is further restricted to the sections the Express Checkout mini-form
+        renders. Stored answers outside this set (deleted, renamed, or hidden
+        fields) are never part of a portal payload, so update paths must
+        preserve them instead of treating their absence as a cleared value.
+        """
+        from app.api.form_section.crud import form_sections_crud
+
+        fields, _ = self.find_by_popup(session, popup_id, skip=0, limit=1000)
+        sections, _ = form_sections_crud.find_by_popup(session, popup_id, limit=None)
+        hidden_section_ids = {s.id for s in sections if s.hidden}
+
+        express_section_keys: set[str] | None = None
+        if is_express_checkout:
+            express_section_keys = self.get_express_checkout_section_keys(
+                session, popup_id
+            )
+
+        names: set[str] = set()
+        for field in fields:
+            if field.section_id and field.section_id in hidden_section_ids:
+                continue
+            if (
+                express_section_keys is not None
+                and _section_key(field.section_id) not in express_section_keys
+            ):
+                continue
+            names.add(field.name)
+        return names
 
     def build_schema_for_popup(
         self, session: Session, popup_id: uuid.UUID

--- a/backend/app/api/form_field/router.py
+++ b/backend/app/api/form_field/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Header, HTTPException, status
 from app.api.base_field_config.constants import BASE_FIELD_DEFINITIONS
 from app.api.base_field_config.crud import (
     base_field_configs_crud,
+    ensure_base_field_update_allowed,
     field_applies_to_popup,
 )
 from app.api.base_field_config.models import BaseFieldConfigs
@@ -371,37 +372,10 @@ async def update_form_field(
             k: getattr(field_in, k) for k in field_in.model_fields_set & configurable
         }
 
-        # Non-removable elementals (first_name, last_name) cannot be made optional.
-        definition = BASE_FIELD_DEFINITIONS.get(base_config.field_name, {})
-        if (
-            not definition.get("removable", True)
-            and "required" in update_data
-            and update_data["required"] is False
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Field '{base_config.field_name}' is required and cannot be made optional",
-            )
-
-        # `field_type` is only writeable on base configs whose catalog entry
-        # whitelists alternatives — and only to a value inside that whitelist.
-        allowed_field_types = definition.get("allowed_field_types")
         if "field_type" in field_in.model_fields_set:
-            if not allowed_field_types:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Field '{base_config.field_name}' does not allow type overrides",
-                )
-            new_type = field_in.field_type
-            if new_type is not None and new_type not in allowed_field_types:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        f"Field type '{new_type}' is not allowed for "
-                        f"'{base_config.field_name}'"
-                    ),
-                )
-            update_data["field_type"] = new_type
+            update_data["field_type"] = field_in.field_type
+
+        ensure_base_field_update_allowed(base_config, update_data)
 
         config_update = BaseFieldConfigUpdate(**update_data)
         updated_config = base_field_configs_crud.update(db, base_config, config_update)

--- a/backend/app/api/payment/crud.py
+++ b/backend/app/api/payment/crud.py
@@ -596,11 +596,13 @@ class PaymentsCRUD(BaseCRUD[Payments, PaymentCreate, PaymentUpdate]):
         form_data: dict[str, Any],
     ) -> None:
         """Validate required custom buyer fields. form_data is keyed by raw field name; base fields (email/first_name/last_name) live top-level on BuyerInfo and are validated by Pydantic."""
+        # Hidden sections are never rendered in the checkout, so their fields
+        # can't be required here.
         required_field_names = {
             field.name
             for section in popup.form_sections
             for field in section.form_fields
-            if section.kind == "standard" and field.required
+            if section.kind == "standard" and not section.hidden and field.required
         }
 
         missing = [

--- a/backend/tests/api/application/test_portal_update_validation.py
+++ b/backend/tests/api/application/test_portal_update_validation.py
@@ -1,0 +1,514 @@
+"""Server-side validation on the portal application PATCH path.
+
+The portal's real submit flow is create-draft then PATCH with
+status="in review", so the PATCH route must enforce the same required,
+type, and option checks as the create path. Draft saves only type-check
+the values provided.
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.form_field.models import FormFields
+from app.api.form_section.models import FormSections
+from app.api.group.models import Groups
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from app.core.security import create_access_token
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    slug = f"upd-val-{uuid.uuid4().hex[:8]}"
+    popup = Popups(name=f"Update Validation {slug}", slug=slug, tenant_id=tenant.id)
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_field(
+    db: Session,
+    popup: Popups,
+    *,
+    name: str,
+    label: str,
+    field_type: str = "text",
+    required: bool = True,
+    options: list[str] | None = None,
+    position: int = 0,
+) -> FormFields:
+    field = FormFields(
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        name=name,
+        label=label,
+        field_type=field_type,
+        required=required,
+        options=options,
+        position=position,
+    )
+    db.add(field)
+    db.commit()
+    db.refresh(field)
+    return field
+
+
+def _make_human_token(db: Session, tenant: Tenants) -> tuple[Humans, str]:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"upd-val-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Pat",
+        last_name="Doe",
+    )
+    db.add(human)
+    db.commit()
+    db.refresh(human)
+    return human, create_access_token(subject=human.id, token_type="human")
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_draft(
+    client: TestClient,
+    token: str,
+    popup: Popups,
+    custom_fields: dict | None = None,
+) -> dict:
+    payload: dict = {
+        "popup_id": str(popup.id),
+        "first_name": "Pat",
+        "last_name": "Doe",
+        "status": "draft",
+    }
+    if custom_fields is not None:
+        payload["custom_fields"] = custom_fields
+    resp = client.post("/api/v1/applications/my", headers=_headers(token), json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _patch(client: TestClient, token: str, popup: Popups, payload: dict):
+    return client.patch(
+        f"/api/v1/applications/my/{popup.id}",
+        headers=_headers(token),
+        json=payload,
+    )
+
+
+def _errors(resp) -> list[str]:
+    return resp.json()["detail"]["errors"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH submit validation (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+class TestPatchSubmitValidation:
+    def test_submit_missing_required_custom_field_returns_400(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup)
+
+        resp = _patch(client, token, popup, {"status": "in review"})
+
+        assert resp.status_code == 400, resp.text
+        assert any("Motivation" in e for e in _errors(resp))
+
+    def test_submit_with_invalid_select_option_returns_400(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(
+            db,
+            popup,
+            name="shirt_size",
+            label="Shirt size",
+            field_type="select",
+            options=["S", "M", "L"],
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup)
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"status": "in review", "custom_fields": {"shirt_size": "XXL"}},
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert any("must be one of" in e for e in _errors(resp))
+
+    def test_unknown_custom_fields_do_not_bypass_required_checks(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup)
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"status": "in review", "custom_fields": {"mystery_key": "x"}},
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert any("Motivation" in e for e in _errors(resp))
+
+    def test_unknown_custom_fields_are_stored_alongside_valid_ones(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        """Unknown keys are skipped in validation (create-path semantics) and
+        stored with the rest of the payload."""
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup)
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {
+                "status": "in review",
+                "custom_fields": {"motivation": "I want in", "mystery_key": "x"},
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        stored = resp.json()["custom_fields"]
+        assert stored["motivation"] == "I want in"
+        assert stored["mystery_key"] == "x"
+
+    def test_draft_partial_update_skips_required_checks(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _make_field(
+            db,
+            popup,
+            name="shirt_size",
+            label="Shirt size",
+            field_type="select",
+            options=["S", "M", "L"],
+            position=1,
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup)
+
+        resp = _patch(client, token, popup, {"custom_fields": {"shirt_size": "M"}})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == ApplicationStatus.DRAFT.value
+
+    def test_draft_update_still_type_checks_provided_values(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(
+            db,
+            popup,
+            name="shirt_size",
+            label="Shirt size",
+            field_type="select",
+            options=["S", "M", "L"],
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup)
+
+        resp = _patch(client, token, popup, {"custom_fields": {"shirt_size": "XXL"}})
+
+        assert resp.status_code == 400, resp.text
+        assert any("must be one of" in e for e in _errors(resp))
+
+    def test_edit_after_submit_with_full_state_passes(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        """Editing a submitted application with the full form state (what the
+        portal always sends) passes and stores exactly that state."""
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _make_field(
+            db,
+            popup,
+            name="shirt_size",
+            label="Shirt size",
+            field_type="select",
+            options=["S", "M", "L"],
+            position=1,
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(
+            client, token, popup, {"motivation": "I want in", "shirt_size": "S"}
+        )
+        submit = _patch(client, token, popup, {"status": "in review"})
+        assert submit.status_code == 200, submit.text
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"custom_fields": {"motivation": "I want in", "shirt_size": "M"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        stored = resp.json()["custom_fields"]
+        assert stored["shirt_size"] == "M"
+        assert stored["motivation"] == "I want in"
+
+    def test_edit_after_submit_rejects_invalid_option(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(
+            db,
+            popup,
+            name="shirt_size",
+            label="Shirt size",
+            field_type="select",
+            options=["S", "M", "L"],
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup, {"shirt_size": "S"})
+        submit = _patch(client, token, popup, {"status": "in review"})
+        assert submit.status_code == 200, submit.text
+
+        resp = _patch(client, token, popup, {"custom_fields": {"shirt_size": "XXL"}})
+
+        assert resp.status_code == 400, resp.text
+        assert any("must be one of" in e for e in _errors(resp))
+
+
+# ---------------------------------------------------------------------------
+# Non-draft create with empty/absent custom_fields (Fix 2)
+# ---------------------------------------------------------------------------
+
+
+class TestNonDraftCreateRequiresCustomFields:
+    def test_create_in_review_without_custom_fields_returns_400(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+
+        resp = client.post(
+            "/api/v1/applications/my",
+            headers=_headers(token),
+            json={
+                "popup_id": str(popup.id),
+                "first_name": "Pat",
+                "last_name": "Doe",
+                "status": "in review",
+            },
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert any("Motivation" in e for e in _errors(resp))
+
+    def test_create_in_review_with_empty_custom_fields_returns_400(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+
+        resp = client.post(
+            "/api/v1/applications/my",
+            headers=_headers(token),
+            json={
+                "popup_id": str(popup.id),
+                "first_name": "Pat",
+                "last_name": "Doe",
+                "status": "in review",
+                "custom_fields": {},
+            },
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert any("Motivation" in e for e in _errors(resp))
+
+    def test_create_draft_without_custom_fields_succeeds(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+
+        data = _create_draft(client, token, popup)
+        assert data["status"] == ApplicationStatus.DRAFT.value
+
+
+# ---------------------------------------------------------------------------
+# Replace semantics for custom_fields (Fix 3)
+#
+# The portal sends the full form state on every save and omits cleared/empty
+# answers, so a schema-known key absent from the payload means "cleared".
+# Keys the current form doesn't render (deleted/renamed/hidden fields, or
+# fields outside the Express Checkout mini-form) are preserved.
+# ---------------------------------------------------------------------------
+
+
+class TestPatchReplaceSemantics:
+    def test_omitting_optional_field_clears_it(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _make_field(
+            db, popup, name="nickname", label="Nickname", required=False, position=1
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(
+            client, token, popup, {"motivation": "I want in", "nickname": "Paddy"}
+        )
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"status": "in review", "custom_fields": {"motivation": "I want in"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        stored = resp.json()["custom_fields"]
+        assert "nickname" not in stored
+        assert stored["motivation"] == "I want in"
+
+    def test_orphan_keys_survive_updates_that_omit_them(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        """A stored key with no matching form field (deleted/renamed field)
+        is preserved even though the payload doesn't mention it."""
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(
+            client, token, popup, {"motivation": "I want in", "legacy_key": "keep me"}
+        )
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"status": "in review", "custom_fields": {"motivation": "still in"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        stored = resp.json()["custom_fields"]
+        assert stored["legacy_key"] == "keep me"
+        assert stored["motivation"] == "still in"
+
+    def test_required_field_absent_from_incoming_returns_400(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        """A stored answer must not satisfy a required check when the payload
+        omits the field — the portal sends the full state, so absence means
+        the user cleared it."""
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _make_field(
+            db, popup, name="nickname", label="Nickname", required=False, position=1
+        )
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(client, token, popup, {"motivation": "I want in"})
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"status": "in review", "custom_fields": {"nickname": "Paddy"}},
+        )
+
+        assert resp.status_code == 400, resp.text
+        assert any("Motivation" in e for e in _errors(resp))
+
+    def test_hidden_section_answers_survive_updates(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        """Fields in hidden sections aren't rendered by the portal, so their
+        stored answers are preserved instead of treated as cleared."""
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        section = FormSections(
+            tenant_id=popup.tenant_id,
+            popup_id=popup.id,
+            label="Hidden extras",
+            hidden=True,
+        )
+        db.add(section)
+        db.commit()
+        db.refresh(section)
+        hidden_field = _make_field(
+            db, popup, name="extra_info", label="Extra info", required=False, position=1
+        )
+        hidden_field.section_id = section.id
+        db.add(hidden_field)
+        db.commit()
+        _, token = _make_human_token(db, tenant_a)
+        _create_draft(
+            client, token, popup, {"motivation": "I want in", "extra_info": "kept"}
+        )
+
+        resp = _patch(
+            client,
+            token,
+            popup,
+            {"status": "in review", "custom_fields": {"motivation": "still in"}},
+        )
+
+        assert resp.status_code == 200, resp.text
+        stored = resp.json()["custom_fields"]
+        assert stored["extra_info"] == "kept"
+
+    def test_express_checkout_update_preserves_unrendered_answers(
+        self, client: TestClient, db: Session, tenant_a: Tenants
+    ) -> None:
+        """Group applications use the Express Checkout mini-form, which only
+        renders a subset of the schema. Fields it doesn't render must survive
+        the update and stay exempt from required checks."""
+        popup = _make_popup(db, tenant_a)
+        _make_field(db, popup, name="motivation", label="Motivation")
+        _, token = _make_human_token(db, tenant_a)
+        data = _create_draft(client, token, popup, {"motivation": "I want in"})
+
+        group = Groups(
+            tenant_id=popup.tenant_id,
+            popup_id=popup.id,
+            name="Test Group",
+            slug=f"grp-{uuid.uuid4().hex[:8]}",
+        )
+        db.add(group)
+        db.commit()
+        db.refresh(group)
+        app_row = db.get(Applications, uuid.UUID(data["id"]))
+        assert app_row is not None
+        app_row.group_id = group.id
+        db.add(app_row)
+        db.commit()
+
+        resp = _patch(
+            client, token, popup, {"status": "in review", "custom_fields": {}}
+        )
+
+        assert resp.status_code == 200, resp.text
+        stored = resp.json()["custom_fields"]
+        assert stored["motivation"] == "I want in"

--- a/backend/tests/api/checkout/test_bootstrap.py
+++ b/backend/tests/api/checkout/test_bootstrap.py
@@ -81,7 +81,12 @@ def _make_product(
 
 
 def _make_form_section(
-    db: Session, popup: Popups, *, order: int = 0, label: str = "Buyer Info"
+    db: Session,
+    popup: Popups,
+    *,
+    order: int = 0,
+    label: str = "Buyer Info",
+    hidden: bool = False,
 ) -> FormSections:
     section = FormSections(
         id=uuid.uuid4(),
@@ -89,6 +94,7 @@ def _make_form_section(
         popup_id=popup.id,
         label=label,
         order=order,
+        hidden=hidden,
     )
     db.add(section)
     db.flush()
@@ -266,6 +272,66 @@ def test_runtime_only_enabled_ticketing_steps(
     assert response.status_code == 200, response.text
     body = response.json()
     assert [step["title"] for step in body["ticketing_steps"]] == ["Visible Step"]
+
+
+def test_runtime_excludes_hidden_sections_and_their_fields(
+    client: TestClient, db: Session, tenant_a: Tenants
+) -> None:
+    """Hidden sections and their fields never reach the anonymous checkout,
+    in buyer_form or in form_schema."""
+    popup = _make_direct_popup(db, tenant_a)
+    visible = _make_form_section(db, popup, label="Visible Info")
+    _make_form_field(db, popup, visible, name="visible_field", label="Visible")
+    hidden = _make_form_section(db, popup, label="Secret Info", order=1, hidden=True)
+    hidden_field = _make_form_field(
+        db, popup, hidden, name="secret_field", label="Secret"
+    )
+    db.commit()
+
+    response = client.get(
+        f"/api/v1/checkout/{popup.slug}/runtime",
+        headers={"X-Tenant-Id": str(tenant_a.id)},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    section_labels = [sec["label"] for sec in body["buyer_form"]]
+    assert section_labels == ["Visible Info"]
+    field_names = [f["name"] for sec in body["buyer_form"] for f in sec["form_fields"]]
+    assert hidden_field.name not in field_names
+
+    schema = body["form_schema"]
+    assert hidden_field.name not in schema["custom_fields"]
+    assert str(hidden.id) not in [sec["id"] for sec in schema["sections"]]
+
+
+def test_purchase_validation_ignores_required_fields_in_hidden_sections(
+    db: Session, tenant_a: Tenants
+) -> None:
+    """The purchase-side required check mirrors the bootstrap: fields in
+    hidden sections are never asked, so they can't block a buyer."""
+    from fastapi import HTTPException
+
+    from app.api.payment.crud import payments_crud
+
+    popup = _make_direct_popup(db, tenant_a)
+    hidden = _make_form_section(db, popup, label="Hidden", hidden=True)
+    _make_form_field(db, popup, hidden, name="hidden_req", label="Hidden Req")
+    visible = _make_form_section(db, popup, label="Visible", order=1)
+    visible_field = _make_form_field(
+        db, popup, visible, name="visible_req", label="Visible Req"
+    )
+    db.commit()
+    db.refresh(popup)
+
+    # Hidden required field missing → accepted.
+    payments_crud._validate_open_ticketing_form_data(popup, {visible_field.name: "ok"})
+
+    # Visible required field missing → still rejected.
+    with pytest.raises(HTTPException) as exc_info:
+        payments_crud._validate_open_ticketing_form_data(popup, {})
+    assert exc_info.value.status_code == 422
 
 
 def test_runtime_unknown_slug_returns_404(

--- a/backend/tests/api/form_field/test_base_field_config_guards.py
+++ b/backend/tests/api/form_field/test_base_field_config_guards.py
@@ -1,0 +1,194 @@
+"""Guards shared by /base-field-configs and /form-fields base-config updates.
+
+Both PATCH routes must enforce the catalog invariants identically:
+- non-removable elementals cannot be made optional
+- field_type only changes within the catalog's allowed_field_types whitelist
+"""
+
+import uuid
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.base_field_config.models import BaseFieldConfigs
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_popup(db: Session, tenant: Tenants) -> Popups:
+    slug = f"bfc-guard-{uuid.uuid4().hex[:8]}"
+    popup = Popups(name=f"BFC Guard {slug}", slug=slug, tenant_id=tenant.id)
+    db.add(popup)
+    db.commit()
+    db.refresh(popup)
+    return popup
+
+
+def _make_config(
+    db: Session,
+    popup: Popups,
+    field_name: str,
+    *,
+    required: bool = True,
+) -> BaseFieldConfigs:
+    config = BaseFieldConfigs(
+        tenant_id=popup.tenant_id,
+        popup_id=popup.id,
+        field_name=field_name,
+        required=required,
+        label=field_name.replace("_", " ").title(),
+    )
+    db.add(config)
+    db.commit()
+    db.refresh(config)
+    return config
+
+
+# ---------------------------------------------------------------------------
+# /base-field-configs PATCH
+# ---------------------------------------------------------------------------
+
+
+class TestBaseFieldConfigPatchGuards:
+    def test_non_removable_field_cannot_be_made_optional(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "first_name")
+
+        resp = client.patch(
+            f"/api/v1/base-field-configs/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"required": False},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "cannot be made optional" in resp.json()["detail"]
+
+    def test_field_type_override_rejected_without_whitelist(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "telegram")
+
+        resp = client.patch(
+            f"/api/v1/base-field-configs/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"field_type": "select"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "does not allow type overrides" in resp.json()["detail"]
+
+    def test_field_type_outside_whitelist_rejected(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "residence")
+
+        resp = client.patch(
+            f"/api/v1/base-field-configs/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"field_type": "textarea"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "is not allowed" in resp.json()["detail"]
+
+    def test_field_type_inside_whitelist_accepted(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "residence")
+
+        resp = client.patch(
+            f"/api/v1/base-field-configs/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"field_type": "country_select"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["field_type"] == "country_select"
+
+    def test_legal_update_still_works(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "first_name")
+
+        resp = client.patch(
+            f"/api/v1/base-field-configs/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"label": "Given name", "position": 3},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["label"] == "Given name"
+        assert body["position"] == 3
+
+
+# ---------------------------------------------------------------------------
+# /form-fields PATCH keeps enforcing the same guards
+# ---------------------------------------------------------------------------
+
+
+class TestFormFieldsRouteMirrorsGuards:
+    def test_non_removable_field_cannot_be_made_optional_via_form_fields(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "last_name")
+
+        resp = client.patch(
+            f"/api/v1/form-fields/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"required": False},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "cannot be made optional" in resp.json()["detail"]
+
+    def test_field_type_outside_whitelist_rejected_via_form_fields(
+        self,
+        client: TestClient,
+        db: Session,
+        tenant_a: Tenants,
+        admin_token_tenant_a: str,
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        config = _make_config(db, popup, "residence")
+
+        resp = client.patch(
+            f"/api/v1/form-fields/{config.id}",
+            headers=_admin_headers(admin_token_tenant_a),
+            json={"field_type": "textarea"},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "is not allowed" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

A security review of the form builder found that the portal's real submit path (create draft, then PATCH `/applications/my/{popup_id}` with `status=in_review`) applied all fields via bare `setattr` with no server-side validation: required, type, and option checks only ran on the create path, so they were effectively client-side only. This PR closes that hole plus three related bypasses:

- **Portal PATCH now validates.** New `applications_crud.validate_portal_update` runs before any state is applied: draft saves type-check the provided values, non-draft results (submit and edit-after-submit) run full required checks. The router stores exactly the state that was validated.
- **Clear/preserve semantics.** The portal always sends the full form state and omits empty values, so incoming values replace the answers for fields the portal currently renders (absent key means cleared), while answers the form no longer renders are preserved: fields removed from the schema, fields in hidden sections, and fields outside the express-checkout mini-form. This keeps old answers interpretable and keeps the express-checkout flow from wiping non-rendered answers.
- **Non-draft creates always validate.** Previously an empty or absent `custom_fields` dict skipped required validation entirely.
- **Hidden sections no longer leak.** The anonymous checkout bootstrap serialized every section including hidden ones; they are now filtered like the schema endpoint does. Open ticketing validation also stops requiring fields from hidden sections, which would have blocked every buyer once a hidden section contained a required field.
- **Base-field guards enforced on both routes.** The `/base-field-configs` PATCH bypassed the invariants the form-fields route enforces (non-removable fields cannot be made optional, `field_type` limited to the catalog whitelist). The guard now lives in a shared helper used by both.

## Test plan

- 23 new tests: `test_portal_update_validation.py` (16, covering submit validation, replace/preserve semantics, orphan and express-checkout preservation), `test_base_field_config_guards.py` (7, both PATCH routes), plus hidden-section coverage in `test_bootstrap.py`.
- Full `tests/api/application` regression suite green (76 passed), plus form_field and checkout suites.
- `ruff check` and `ruff format --check` clean. No migrations.