### PR TITLE
fix(backoffice): review queue pending total and stale page on gathering switch

### DIFF
--- a/backoffice/src/components/Sidebar/PopupSelector.tsx
+++ b/backoffice/src/components/Sidebar/PopupSelector.tsx
@@ -52,6 +52,17 @@ export function PopupSelector() {
     setSelectedPopupId(value)
     if (isOnEditPage) {
       navigate({ to: getWorkspaceFallbackPath(location.pathname) })
+    } else {
+      // A page number from the previous popup would leave the new list on an
+      // empty page, so drop it while keeping the rest of the filters.
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          page: undefined,
+        }),
+        replace: true,
+      })
     }
   }
 

--- a/backoffice/src/routes/_layout/applications/review-queue.tsx
+++ b/backoffice/src/routes/_layout/applications/review-queue.tsx
@@ -30,14 +30,15 @@ function ReviewQueuePage() {
       ApplicationReviewsService.listPendingReviews({
         popupId: selectedPopupId || undefined,
         skip: 0,
-        limit: 100,
+        limit: 1000,
       }),
     enabled: isContextReady && isOperatorOrAbove,
   })
 
   const applications = (pendingData?.results ??
     []) as unknown as ApplicationPublic[]
-  const total = applications.length
+  const loaded = applications.length
+  const total = pendingData?.paging?.total ?? loaded
   const current = applications[currentIndex]
 
   if (!isContextReady || !isOperatorOrAbove) {
@@ -102,7 +103,7 @@ function ReviewQueuePage() {
   const handleReviewed = () => {
     queryClient.invalidateQueries({ queryKey: ["pending-reviews"] })
     queryClient.invalidateQueries({ queryKey: ["applications"] })
-    setCurrentIndex((i) => Math.min(i, total - 2 < 0 ? 0 : total - 2))
+    setCurrentIndex((i) => Math.min(i, loaded - 2 < 0 ? 0 : loaded - 2))
   }
 
   return (
@@ -145,8 +146,8 @@ function ReviewQueuePage() {
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => setCurrentIndex((i) => Math.min(total - 1, i + 1))}
-          disabled={currentIndex >= total - 1}
+          onClick={() => setCurrentIndex((i) => Math.min(loaded - 1, i + 1))}
+          disabled={currentIndex >= loaded - 1}
         >
           Next
           <ArrowRight className="ml-1 h-4 w-4" />


### PR DESCRIPTION
## Summary

Two small list-behavior fixes:

### Review queue capped at 100
The queue fetched at most 100 pending applications and used the page length as the total, so anything beyond 100 was invisible and the "Application X of Y" counter was wrong. It now loads up to the backend maximum (1000) and reads the exact total from `paging.total`. Queues larger than the window drain naturally: each review/skip removes the application server-side and refetches.

### Stale page when switching gathering
Table page numbers live in the URL search params and survived gathering switches, leaving every list (applications, payments, attendees, etc.) on a page that is often empty for the new gathering. The popup selector now strips `page` centrally on switch while keeping search, sort and other filters.

## Test plan
- Biome and `tsc` build pass locally. No backend changes, no client regeneration needed.
- Manual: queue counter matches the applications list pending count; switching gathering from page >1 of any list lands on page 1 with filters intact.