### PR TITLE
feat(applications): complex filters for the applications list

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
-from sqlalchemy import desc, exists, or_
+from sqlalchemy import and_, desc, exists, or_
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, col, func, select
@@ -19,6 +19,8 @@ from app.api.application.schemas import (
     ApplicationCommentCreate,
     ApplicationCommentUpdate,
     ApplicationCreate,
+    ApplicationFilterCondition,
+    ApplicationFilters,
     ApplicationStatus,
     ApplicationUpdate,
     PopupAccessResponse,
@@ -69,6 +71,76 @@ def _is_draft_status(status_value: object) -> bool:
     if status_value is None:
         return True
     return getattr(status_value, "value", status_value) == ApplicationStatus.DRAFT.value
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE wildcards so user input matches literally."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _text_condition_expression(column, op: str, value):
+    """Boolean expression for a nullable text column.
+
+    eq is exact; contains is case-insensitive; negative ops (neq,
+    not_contains) also match NULL/missing values; is_empty means NULL or "".
+    """
+    if op == "eq":
+        return column == value
+    if op == "neq":
+        return or_(column.is_(None), column != value)
+    if op == "contains":
+        return column.ilike(f"%{_escape_like(str(value))}%", escape="\\")
+    if op == "not_contains":
+        return or_(
+            column.is_(None),
+            ~column.ilike(f"%{_escape_like(str(value))}%", escape="\\"),
+        )
+    if op == "is_empty":
+        return or_(column.is_(None), column == "")
+    return and_(column.is_not(None), column != "")
+
+
+def _filter_condition_expression(condition: ApplicationFilterCondition):
+    """Map one validated filter condition to a SQLAlchemy boolean expression."""
+    custom_name = condition.custom_field_name
+    if custom_name is not None:
+        # JSONB accessor keeps the field name a bound parameter, never raw SQL.
+        column = col(Applications.custom_fields)[custom_name].astext
+        return _text_condition_expression(column, condition.op, condition.value)
+
+    if condition.field == "status":
+        if condition.op == "eq":
+            return Applications.status == condition.value
+        return Applications.status != condition.value
+
+    if condition.field == "scholarship_request":
+        return col(Applications.scholarship_request) == condition.value
+
+    if condition.field in ("submitted_at", "accepted_at"):
+        column = col(getattr(Applications, condition.field))
+        if condition.op == "before":
+            return func.date(column) < condition.date_value
+        if condition.op == "after":
+            return func.date(column) > condition.date_value
+        if condition.op == "is_empty":
+            return column.is_(None)
+        return column.is_not(None)
+
+    if condition.field in ("gender", "age"):
+        column = col(getattr(Humans, condition.field))
+    else:
+        column = col(getattr(Applications, condition.field))
+    return _text_condition_expression(column, condition.op, condition.value)
+
+
+def build_application_filter_expression(filters: ApplicationFilters):
+    """Combine the filter group into one boolean expression (None when empty)."""
+    expressions = [_filter_condition_expression(c) for c in filters.conditions]
+    if not expressions:
+        return None
+    if filters.match == "any":
+        return or_(*expressions)
+    return and_(*expressions)
 
 
 class RedFlaggedHumanError(Exception):
@@ -134,6 +206,7 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         status_filter: ApplicationStatus | None = None,
         search: str | None = None,
         reviewed_by: uuid.UUID | None = None,
+        filters: ApplicationFilters | None = None,
     ) -> tuple[list[Applications], int]:
         """Find applications by popup_id with optional status filter and eager loading."""
         base_statement = select(Applications).where(Applications.popup_id == popup_id)
@@ -143,19 +216,32 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 Applications.status == status_filter.value
             )
 
-        # Apply text search if provided - search in human fields
-        if search:
-            search_term = f"%{search}%"
+        # Join Humans once, whether needed by text search, a human-field
+        # filter condition, or both.
+        needs_human_join = bool(search) or bool(
+            filters and filters.references_human_fields()
+        )
+        if needs_human_join:
             base_statement = base_statement.join(
                 Humans,
                 Applications.human_id == Humans.id,  # type: ignore[arg-type]
-            ).where(
+            )
+
+        # Apply text search if provided - search in human fields
+        if search:
+            search_term = f"%{search}%"
+            base_statement = base_statement.where(
                 or_(
                     col(Humans.first_name).ilike(search_term),
                     col(Humans.last_name).ilike(search_term),
                     col(Humans.email).ilike(search_term),
                 )
             )
+
+        if filters is not None:
+            filter_expression = build_application_filter_expression(filters)
+            if filter_expression is not None:
+                base_statement = base_statement.where(filter_expression)
 
         if reviewed_by:
             has_review = (

--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -15,6 +15,7 @@ from app.api.application.models import (
     ApplicationSnapshots,
 )
 from app.api.application.schemas import (
+    VIRTUAL_REVIEWER_FIELDS,
     ApplicationAdminCreate,
     ApplicationCommentCreate,
     ApplicationCommentUpdate,
@@ -100,8 +101,25 @@ def _text_condition_expression(column, op: str, value):
     return and_(column.is_not(None), column != "")
 
 
-def _filter_condition_expression(condition: ApplicationFilterCondition):
+def _filter_condition_expression(
+    condition: ApplicationFilterCondition,
+    reviewer_id: uuid.UUID | None = None,
+):
     """Map one validated filter condition to a SQLAlchemy boolean expression."""
+    if condition.field in VIRTUAL_REVIEWER_FIELDS:
+        # Same EXISTS shape as find_pending_review, scoped to the current user.
+        model = (
+            ApplicationReviewSkips
+            if condition.field == "skipped_by_me"
+            else ApplicationReviews
+        )
+        has_row = (
+            exists()
+            .where(model.application_id == Applications.id)
+            .where(model.reviewer_id == reviewer_id)
+        )
+        return has_row if condition.value else ~has_row
+
     custom_name = condition.custom_field_name
     if custom_name is not None:
         # JSONB accessor keeps the field name a bound parameter, never raw SQL.
@@ -133,9 +151,27 @@ def _filter_condition_expression(condition: ApplicationFilterCondition):
     return _text_condition_expression(column, condition.op, condition.value)
 
 
-def build_application_filter_expression(filters: ApplicationFilters):
-    """Combine the filter group into one boolean expression (None when empty)."""
-    expressions = [_filter_condition_expression(c) for c in filters.conditions]
+def build_application_filter_expression(
+    filters: ApplicationFilters,
+    reviewer_id: uuid.UUID | None = None,
+):
+    """Combine the filter group into one boolean expression (None when empty).
+
+    ``reviewer_id`` resolves the per-current-user virtual fields
+    (skipped_by_me, reviewed_by_me); using them without it is a 422.
+    """
+    if reviewer_id is None:
+        for condition in filters.conditions:
+            if condition.field in VIRTUAL_REVIEWER_FIELDS:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"Filtering by '{condition.field}' requires a signed-in user."
+                    ),
+                )
+    expressions = [
+        _filter_condition_expression(c, reviewer_id) for c in filters.conditions
+    ]
     if not expressions:
         return None
     if filters.match == "any":
@@ -207,8 +243,13 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         search: str | None = None,
         reviewed_by: uuid.UUID | None = None,
         filters: ApplicationFilters | None = None,
+        reviewer_id: uuid.UUID | None = None,
     ) -> tuple[list[Applications], int]:
-        """Find applications by popup_id with optional status filter and eager loading."""
+        """Find applications by popup_id with optional status filter and eager loading.
+
+        ``reviewer_id`` is the calling user's id, used only by the virtual
+        per-user filter fields (skipped_by_me, reviewed_by_me).
+        """
         base_statement = select(Applications).where(Applications.popup_id == popup_id)
 
         if status_filter:
@@ -239,7 +280,9 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             )
 
         if filters is not None:
-            filter_expression = build_application_filter_expression(filters)
+            filter_expression = build_application_filter_expression(
+                filters, reviewer_id
+            )
             if filter_expression is not None:
                 base_statement = base_statement.where(filter_expression)
 

--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -120,6 +120,15 @@ def _filter_condition_expression(
         )
         return has_row if condition.value else ~has_row
 
+    if condition.field == "reviewed_by":
+        # Any-reviewer variant: independent of the calling user's reviewer_id.
+        has_row = (
+            exists()
+            .where(ApplicationReviews.application_id == Applications.id)
+            .where(ApplicationReviews.reviewer_id == condition.uuid_value)
+        )
+        return has_row if condition.op == "eq" else ~has_row
+
     custom_name = condition.custom_field_name
     if custom_name is not None:
         # JSONB accessor keeps the field name a bound parameter, never raw SQL.

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -209,7 +209,9 @@ async def list_applications(
     It only applies to the popup_id listing and is combined (AND) with the
     legacy status_filter/search/reviewed_by params. The virtual fields
     ``skipped_by_me`` and ``reviewed_by_me`` (op ``eq``, boolean value)
-    resolve against the calling user's own skips and reviews.
+    resolve against the calling user's own skips and reviews. The
+    ``reviewed_by`` field (ops ``eq``/``neq``, reviewer user id as UUID
+    string) matches applications reviewed (or not) by that reviewer.
     """
     parsed_filters = parse_application_filters(filters)
     if popup_id:

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -36,6 +36,7 @@ from app.api.application.schemas import (
     ParticipationResponse,
     PopupAccessResponse,
     ScholarshipDecisionRequest,
+    parse_application_filters,
 )
 from app.api.application_review.crud import (
     application_review_skips_crud,
@@ -197,10 +198,18 @@ async def list_applications(
     reviewed_by: uuid.UUID | None = None,
     status_filter: ApplicationStatus | None = None,
     search: str | None = None,
+    filters: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[ApplicationPublic]:
-    """List applications with optional filters (BO only)."""
+    """List applications with optional filters (BO only).
+
+    ``filters`` is a JSON filter group:
+    ``{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}``.
+    It only applies to the popup_id listing and is combined (AND) with the
+    legacy status_filter/search/reviewed_by params.
+    """
+    parsed_filters = parse_application_filters(filters)
     if popup_id:
         applications, total = crud.applications_crud.find_by_popup(
             db,
@@ -210,6 +219,7 @@ async def list_applications(
             status_filter=status_filter,
             search=search,
             reviewed_by=reviewed_by,
+            filters=parsed_filters,
         )
     elif human_id:
         applications, total = crud.applications_crud.find_by_human(

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -207,7 +207,9 @@ async def list_applications(
     ``filters`` is a JSON filter group:
     ``{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}``.
     It only applies to the popup_id listing and is combined (AND) with the
-    legacy status_filter/search/reviewed_by params.
+    legacy status_filter/search/reviewed_by params. The virtual fields
+    ``skipped_by_me`` and ``reviewed_by_me`` (op ``eq``, boolean value)
+    resolve against the calling user's own skips and reviews.
     """
     parsed_filters = parse_application_filters(filters)
     if popup_id:
@@ -220,6 +222,7 @@ async def list_applications(
             search=search,
             reviewed_by=reviewed_by,
             filters=parsed_filters,
+            reviewer_id=getattr(current_user, "id", None),
         )
     elif human_id:
         applications, total = crud.applications_crud.find_by_human(

--- a/backend/app/api/application/schemas.py
+++ b/backend/app/api/application/schemas.py
@@ -1,10 +1,18 @@
+import json
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum, StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from fastapi import HTTPException
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from pydantic import Field as PydanticField
 from sqlalchemy import Boolean, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
@@ -387,6 +395,122 @@ class ApplicationFilter(BaseModel):
     status: ApplicationStatus | None = None
     email: str | None = None
     scholarship_status: str | None = None
+
+
+# Complex list filters (BO applications table).
+# Allowed operators per field. `custom.<name>` targets custom_fields[<name>].
+# Text eq/neq are exact (case-sensitive); contains/not_contains are
+# case-insensitive. is_empty matches NULL or empty string.
+_TEXT_OPS = {"eq", "neq", "contains", "not_contains", "is_empty", "not_empty"}
+_ENUMISH_OPS = {"eq", "neq", "is_empty", "not_empty"}
+_DATE_OPS = {"before", "after", "is_empty", "not_empty"}
+
+APPLICATION_FILTER_FIELD_OPS: dict[str, set[str]] = {
+    "status": {"eq", "neq"},
+    "scholarship_request": {"eq"},
+    "scholarship_status": _ENUMISH_OPS,
+    "submitted_at": _DATE_OPS,
+    "accepted_at": _DATE_OPS,
+    "referral": _TEXT_OPS,
+    "gender": _ENUMISH_OPS,
+    "age": _ENUMISH_OPS,
+}
+CUSTOM_FIELD_PREFIX = "custom."
+_VALUELESS_OPS = {"is_empty", "not_empty"}
+
+
+class ApplicationFilterCondition(BaseModel):
+    """One condition of the applications list filter group."""
+
+    field: str
+    op: str
+    value: str | bool | None = None
+
+    @model_validator(mode="after")
+    def validate_field_op(self) -> "ApplicationFilterCondition":
+        if self.field.startswith(CUSTOM_FIELD_PREFIX):
+            if not self.field[len(CUSTOM_FIELD_PREFIX) :]:
+                raise ValueError("Custom field name is missing.")
+            allowed = _TEXT_OPS
+        else:
+            allowed = APPLICATION_FILTER_FIELD_OPS.get(self.field)
+            if allowed is None:
+                raise ValueError(f"Filtering by '{self.field}' is not supported.")
+        if self.op not in allowed:
+            raise ValueError(
+                f"Operator '{self.op}' is not supported for '{self.field}'."
+            )
+
+        if self.op in _VALUELESS_OPS:
+            return self
+
+        if self.field == "status":
+            valid_statuses = {s.value for s in ApplicationStatus}
+            if self.value not in valid_statuses:
+                raise ValueError("Invalid status value.")
+        elif self.field == "scholarship_request":
+            if not isinstance(self.value, bool):
+                raise ValueError("Scholarship request filter needs true or false.")
+        elif self.op in {"before", "after"}:
+            if not isinstance(self.value, str):
+                raise ValueError(f"Invalid date for '{self.field}'.")
+            try:
+                date.fromisoformat(self.value)
+            except ValueError:
+                raise ValueError(f"Invalid date for '{self.field}'.") from None
+        elif not isinstance(self.value, str):
+            raise ValueError(f"Invalid value for '{self.field}'.")
+        return self
+
+    @property
+    def custom_field_name(self) -> str | None:
+        """Custom field key when this condition targets custom_fields."""
+        if self.field.startswith(CUSTOM_FIELD_PREFIX):
+            return self.field[len(CUSTOM_FIELD_PREFIX) :]
+        return None
+
+    @property
+    def date_value(self) -> date:
+        """Parsed ISO date value for before/after conditions."""
+        return date.fromisoformat(str(self.value))
+
+
+class ApplicationFilters(BaseModel):
+    """Filter group for the BO applications list.
+
+    ``match`` combines conditions with AND ("all") or OR ("any").
+    """
+
+    match: Literal["all", "any"] = "all"
+    conditions: list[ApplicationFilterCondition] = PydanticField(default_factory=list)
+
+    def references_human_fields(self) -> bool:
+        """True when any condition targets a Humans column (needs join)."""
+        return any(c.field in ("gender", "age") for c in self.conditions)
+
+
+def parse_application_filters(raw: str | None) -> ApplicationFilters | None:
+    """Parse the ``filters`` query param JSON into ApplicationFilters.
+
+    Raises HTTPException 422 with a user-oriented message when the JSON is
+    malformed or a condition uses an unsupported field, operator, or value.
+    """
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(
+            status_code=422, detail="Filters are not valid. Please check them."
+        ) from None
+    try:
+        return ApplicationFilters.model_validate(payload)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        message = str(first.get("msg", "")).removeprefix("Value error, ").strip()
+        if not message or first.get("type") != "value_error":
+            message = "Filters are not valid. Please check them."
+        raise HTTPException(status_code=422, detail=message) from None
 
 
 class ScholarshipDecisionRequest(BaseModel):

--- a/backend/app/api/application/schemas.py
+++ b/backend/app/api/application/schemas.py
@@ -414,7 +414,11 @@ APPLICATION_FILTER_FIELD_OPS: dict[str, set[str]] = {
     "referral": _TEXT_OPS,
     "gender": _ENUMISH_OPS,
     "age": _ENUMISH_OPS,
+    "skipped_by_me": {"eq"},
+    "reviewed_by_me": {"eq"},
 }
+# Virtual fields resolved against the calling user's own review/skip rows.
+VIRTUAL_REVIEWER_FIELDS = frozenset({"skipped_by_me", "reviewed_by_me"})
 CUSTOM_FIELD_PREFIX = "custom."
 _VALUELESS_OPS = {"is_empty", "not_empty"}
 
@@ -451,6 +455,9 @@ class ApplicationFilterCondition(BaseModel):
         elif self.field == "scholarship_request":
             if not isinstance(self.value, bool):
                 raise ValueError("Scholarship request filter needs true or false.")
+        elif self.field in VIRTUAL_REVIEWER_FIELDS:
+            if not isinstance(self.value, bool):
+                raise ValueError(f"Filter '{self.field}' needs true or false.")
         elif self.op in {"before", "after"}:
             if not isinstance(self.value, str):
                 raise ValueError(f"Invalid date for '{self.field}'.")

--- a/backend/app/api/application/schemas.py
+++ b/backend/app/api/application/schemas.py
@@ -416,6 +416,7 @@ APPLICATION_FILTER_FIELD_OPS: dict[str, set[str]] = {
     "age": _ENUMISH_OPS,
     "skipped_by_me": {"eq"},
     "reviewed_by_me": {"eq"},
+    "reviewed_by": {"eq", "neq"},
 }
 # Virtual fields resolved against the calling user's own review/skip rows.
 VIRTUAL_REVIEWER_FIELDS = frozenset({"skipped_by_me", "reviewed_by_me"})
@@ -458,6 +459,15 @@ class ApplicationFilterCondition(BaseModel):
         elif self.field in VIRTUAL_REVIEWER_FIELDS:
             if not isinstance(self.value, bool):
                 raise ValueError(f"Filter '{self.field}' needs true or false.")
+        elif self.field == "reviewed_by":
+            if not isinstance(self.value, str):
+                raise ValueError("Filter 'reviewed_by' needs a valid reviewer.")
+            try:
+                uuid.UUID(self.value)
+            except ValueError:
+                raise ValueError(
+                    "Filter 'reviewed_by' needs a valid reviewer."
+                ) from None
         elif self.op in {"before", "after"}:
             if not isinstance(self.value, str):
                 raise ValueError(f"Invalid date for '{self.field}'.")
@@ -480,6 +490,11 @@ class ApplicationFilterCondition(BaseModel):
     def date_value(self) -> date:
         """Parsed ISO date value for before/after conditions."""
         return date.fromisoformat(str(self.value))
+
+    @property
+    def uuid_value(self) -> uuid.UUID:
+        """Parsed UUID value for reviewer id conditions."""
+        return uuid.UUID(str(self.value))
 
 
 class ApplicationFilters(BaseModel):

--- a/backend/tests/api/application/test_list_filters.py
+++ b/backend/tests/api/application/test_list_filters.py
@@ -401,6 +401,92 @@ class TestApplicationListFilters:
         )
         assert _ids(response) == {str(pending.id)}
 
+    def test_reviewed_by_eq_and_neq(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        reviewer_a = _make_admin(db, tenant_a)
+        reviewer_b = _make_admin(db, tenant_a)
+        reviewed_by_a = _make_application(db, tenant_a, popup)
+        reviewed_by_b = _make_application(db, tenant_a, popup)
+        unreviewed = _make_application(db, tenant_a, popup)
+        _make_review(db, tenant_a, reviewed_by_a, reviewer_a)
+        _make_review(db, tenant_a, reviewed_by_b, reviewer_b)
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            _one("reviewed_by", "eq", str(reviewer_a.id)),
+        )
+        assert _ids(response) == {str(reviewed_by_a.id)}
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            _one("reviewed_by", "neq", str(reviewer_a.id)),
+        )
+        assert _ids(response) == {str(reviewed_by_b.id), str(unreviewed.id)}
+
+    def test_reviewed_by_combined_with_status(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        reviewer = _make_admin(db, tenant_a)
+        match = _make_application(
+            db, tenant_a, popup, status=ApplicationStatus.ACCEPTED.value
+        )
+        in_review = _make_application(db, tenant_a, popup)
+        _make_review(db, tenant_a, match, reviewer)
+        _make_review(db, tenant_a, in_review, reviewer)
+        _make_application(db, tenant_a, popup, status=ApplicationStatus.ACCEPTED.value)
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            {
+                "match": "all",
+                "conditions": [
+                    {"field": "status", "op": "eq", "value": "accepted"},
+                    {"field": "reviewed_by", "op": "eq", "value": str(reviewer.id)},
+                ],
+            },
+        )
+        assert _ids(response) == {str(match.id)}
+
+    def test_reviewed_by_invalid_uuid_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("reviewed_by", "eq", "not-a-uuid")
+        )
+        assert response.status_code == 422, response.text
+
+    def test_reviewed_by_disallowed_op_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            _one("reviewed_by", "contains", str(uuid.uuid4())),
+        )
+        assert response.status_code == 422, response.text
+
     def test_virtual_field_non_boolean_value_returns_422(
         self, db: Session, tenant_a: Tenants, client: TestClient
     ) -> None:

--- a/backend/tests/api/application/test_list_filters.py
+++ b/backend/tests/api/application/test_list_filters.py
@@ -18,13 +18,16 @@ from sqlmodel import Session
 
 from app.api.application.models import Applications
 from app.api.application.schemas import ApplicationStatus
+from app.api.application_review.models import ApplicationReviewSkips
 from app.api.human.models import Humans
 from app.api.popup.models import Popups
 from app.api.tenant.models import Tenants
+from app.api.user.models import Users
 from tests.api.application_review.test_pending_reviews import (
     _auth,
     _make_admin,
     _make_popup,
+    _make_review,
 )
 
 # ---------------------------------------------------------------------------
@@ -66,6 +69,22 @@ def _make_application(
     db.commit()
     db.refresh(application)
     return application
+
+
+def _make_skip(
+    db: Session,
+    tenant: Tenants,
+    application: Applications,
+    reviewer: Users,
+) -> None:
+    db.add(
+        ApplicationReviewSkips(
+            application_id=application.id,
+            reviewer_id=reviewer.id,
+            tenant_id=tenant.id,
+        )
+    )
+    db.commit()
 
 
 def _list(
@@ -304,3 +323,96 @@ class TestApplicationListFilters:
             client, admin, tenant_a, popup, {"match": "all", "conditions": []}
         )
         assert _ids(response) == {str(first.id), str(second.id)}
+
+    def test_skipped_by_me_is_per_reviewer(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        reviewer_a = _make_admin(db, tenant_a)
+        reviewer_b = _make_admin(db, tenant_a)
+        skipped = _make_application(db, tenant_a, popup)
+        other = _make_application(db, tenant_a, popup)
+        _make_skip(db, tenant_a, skipped, reviewer_a)
+
+        response = _list(
+            client, reviewer_a, tenant_a, popup, _one("skipped_by_me", "eq", True)
+        )
+        assert _ids(response) == {str(skipped.id)}
+
+        # The skip belongs to reviewer A only; B sees no skipped apps.
+        response = _list(
+            client, reviewer_b, tenant_a, popup, _one("skipped_by_me", "eq", True)
+        )
+        assert _ids(response) == set()
+
+        response = _list(
+            client, reviewer_a, tenant_a, popup, _one("skipped_by_me", "eq", False)
+        )
+        assert _ids(response) == {str(other.id)}
+
+    def test_reviewed_by_me_is_per_reviewer(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        reviewer_a = _make_admin(db, tenant_a)
+        reviewer_b = _make_admin(db, tenant_a)
+        reviewed = _make_application(db, tenant_a, popup)
+        other = _make_application(db, tenant_a, popup)
+        _make_review(db, tenant_a, reviewed, reviewer_a)
+
+        response = _list(
+            client, reviewer_a, tenant_a, popup, _one("reviewed_by_me", "eq", True)
+        )
+        assert _ids(response) == {str(reviewed.id)}
+
+        response = _list(
+            client, reviewer_b, tenant_a, popup, _one("reviewed_by_me", "eq", True)
+        )
+        assert _ids(response) == set()
+
+        response = _list(
+            client, reviewer_a, tenant_a, popup, _one("reviewed_by_me", "eq", False)
+        )
+        assert _ids(response) == {str(other.id)}
+
+    def test_my_pending_work_combined_filter(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        # "My pending work": in review AND not yet reviewed by me.
+        popup = _make_popup(db, tenant_a)
+        reviewer = _make_admin(db, tenant_a)
+        pending = _make_application(db, tenant_a, popup)
+        reviewed = _make_application(db, tenant_a, popup)
+        _make_review(db, tenant_a, reviewed, reviewer)
+        _make_application(db, tenant_a, popup, status=ApplicationStatus.ACCEPTED.value)
+
+        response = _list(
+            client,
+            reviewer,
+            tenant_a,
+            popup,
+            {
+                "match": "all",
+                "conditions": [
+                    {"field": "status", "op": "eq", "value": "in review"},
+                    {"field": "reviewed_by_me", "op": "eq", "value": False},
+                ],
+            },
+        )
+        assert _ids(response) == {str(pending.id)}
+
+    def test_virtual_field_non_boolean_value_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("skipped_by_me", "eq", "yes")
+        )
+        assert response.status_code == 422, response.text
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("reviewed_by_me", "contains", True)
+        )
+        assert response.status_code == 422, response.text

--- a/backend/tests/api/application/test_list_filters.py
+++ b/backend/tests/api/application/test_list_filters.py
@@ -1,0 +1,306 @@
+"""Complex ``filters`` query param on GET /applications (BO list).
+
+The param carries a JSON filter group ({match, conditions[]}) that is
+compiled to one SQL boolean expression and ANDed with the legacy params.
+Invalid JSON, unknown fields, or disallowed operators return 422.
+
+Each test creates a fresh popup and filters by popup_id so it is isolated
+from the session-scoped shared fixtures (db / tenant_a have no per-test
+rollback).
+"""
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.application.models import Applications
+from app.api.application.schemas import ApplicationStatus
+from app.api.human.models import Humans
+from app.api.popup.models import Popups
+from app.api.tenant.models import Tenants
+from tests.api.application_review.test_pending_reviews import (
+    _auth,
+    _make_admin,
+    _make_popup,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_application(
+    db: Session,
+    tenant: Tenants,
+    popup: Popups,
+    *,
+    status: str = ApplicationStatus.IN_REVIEW.value,
+    custom_fields: dict | None = None,
+    referral: str | None = None,
+    submitted_at: datetime | None = None,
+    gender: str | None = None,
+) -> Applications:
+    human = Humans(
+        tenant_id=tenant.id,
+        email=f"filters-applicant-{uuid.uuid4().hex[:8]}@test.com",
+        first_name="Filters",
+        last_name="Applicant",
+        gender=gender,
+    )
+    db.add(human)
+    db.flush()
+
+    application = Applications(
+        tenant_id=tenant.id,
+        popup_id=popup.id,
+        human_id=human.id,
+        status=status,
+        custom_fields=custom_fields or {},
+        referral=referral,
+        submitted_at=submitted_at,
+    )
+    db.add(application)
+    db.commit()
+    db.refresh(application)
+    return application
+
+
+def _list(
+    client: TestClient,
+    admin,
+    tenant: Tenants,
+    popup: Popups,
+    filters: dict | str | None = None,
+    **extra_params,
+):
+    params: dict = {"popup_id": str(popup.id), **extra_params}
+    if filters is not None:
+        params["filters"] = filters if isinstance(filters, str) else json.dumps(filters)
+    return client.get(
+        "/api/v1/applications", params=params, headers=_auth(admin, tenant)
+    )
+
+
+def _ids(response) -> set[str]:
+    assert response.status_code == 200, response.text
+    return {row["id"] for row in response.json()["results"]}
+
+
+def _one(field: str, op: str, value=None) -> dict:
+    return {
+        "match": "all",
+        "conditions": [{"field": field, "op": op, "value": value}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplicationListFilters:
+    def test_status_eq(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        accepted = _make_application(
+            db, tenant_a, popup, status=ApplicationStatus.ACCEPTED.value
+        )
+        _make_application(db, tenant_a, popup)
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("status", "eq", "accepted")
+        )
+        assert _ids(response) == {str(accepted.id)}
+
+    def test_custom_field_eq_and_contains(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        engineer = _make_application(
+            db, tenant_a, popup, custom_fields={"role": "Engineer"}
+        )
+        designer = _make_application(
+            db, tenant_a, popup, custom_fields={"role": "Product Designer"}
+        )
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("custom.role", "eq", "Engineer")
+        )
+        assert _ids(response) == {str(engineer.id)}
+
+        # contains is case-insensitive
+        response = _list(
+            client, admin, tenant_a, popup, _one("custom.role", "contains", "design")
+        )
+        assert _ids(response) == {str(designer.id)}
+
+    def test_match_all_vs_any(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        both = _make_application(
+            db,
+            tenant_a,
+            popup,
+            status=ApplicationStatus.ACCEPTED.value,
+            custom_fields={"role": "Engineer"},
+        )
+        only_status = _make_application(
+            db, tenant_a, popup, status=ApplicationStatus.ACCEPTED.value
+        )
+        only_role = _make_application(
+            db, tenant_a, popup, custom_fields={"role": "Engineer"}
+        )
+        _make_application(db, tenant_a, popup)
+
+        conditions = [
+            {"field": "status", "op": "eq", "value": "accepted"},
+            {"field": "custom.role", "op": "eq", "value": "Engineer"},
+        ]
+
+        response = _list(
+            client, admin, tenant_a, popup, {"match": "all", "conditions": conditions}
+        )
+        assert _ids(response) == {str(both.id)}
+
+        response = _list(
+            client, admin, tenant_a, popup, {"match": "any", "conditions": conditions}
+        )
+        assert _ids(response) == {str(both.id), str(only_status.id), str(only_role.id)}
+
+    def test_custom_field_is_empty(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        missing = _make_application(db, tenant_a, popup, custom_fields={})
+        blank = _make_application(db, tenant_a, popup, custom_fields={"role": ""})
+        filled = _make_application(
+            db, tenant_a, popup, custom_fields={"role": "Engineer"}
+        )
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("custom.role", "is_empty")
+        )
+        assert _ids(response) == {str(missing.id), str(blank.id)}
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("custom.role", "not_empty")
+        )
+        assert _ids(response) == {str(filled.id)}
+
+    def test_submitted_at_before_and_after(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        early = _make_application(
+            db, tenant_a, popup, submitted_at=datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+        )
+        late = _make_application(
+            db, tenant_a, popup, submitted_at=datetime(2026, 3, 20, 12, 0, tzinfo=UTC)
+        )
+        _make_application(db, tenant_a, popup, submitted_at=None)
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("submitted_at", "before", "2026-03-10")
+        )
+        assert _ids(response) == {str(early.id)}
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("submitted_at", "after", "2026-03-10")
+        )
+        assert _ids(response) == {str(late.id)}
+
+    def test_malformed_filters_json_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(client, admin, tenant_a, popup, "{not json")
+        assert response.status_code == 422, response.text
+
+    def test_unknown_field_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(client, admin, tenant_a, popup, _one("credit", "eq", "100"))
+        assert response.status_code == 422, response.text
+
+    def test_disallowed_op_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("status", "contains", "acc")
+        )
+        assert response.status_code == 422, response.text
+
+    def test_legacy_params_combine_with_filters(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        match = _make_application(
+            db,
+            tenant_a,
+            popup,
+            status=ApplicationStatus.ACCEPTED.value,
+            referral="alice",
+        )
+        _make_application(db, tenant_a, popup, status=ApplicationStatus.ACCEPTED.value)
+        _make_application(db, tenant_a, popup, referral="alice")
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            _one("referral", "eq", "alice"),
+            status_filter=ApplicationStatus.ACCEPTED.value,
+        )
+        assert _ids(response) == {str(match.id)}
+
+    def test_human_field_filter_combined_with_search(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        # gender lives on Humans; combined with search this must join once.
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        match = _make_application(db, tenant_a, popup, gender="female")
+        _make_application(db, tenant_a, popup, gender="male")
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            _one("gender", "eq", "female"),
+            search="Filters",
+        )
+        assert _ids(response) == {str(match.id)}
+
+    def test_empty_conditions_is_noop(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        first = _make_application(db, tenant_a, popup)
+        second = _make_application(db, tenant_a, popup)
+
+        response = _list(
+            client, admin, tenant_a, popup, {"match": "all", "conditions": []}
+        )
+        assert _ids(response) == {str(first.id), str(second.id)}

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -388,7 +388,9 @@ export class ApplicationsService {
      * It only applies to the popup_id listing and is combined (AND) with the
      * legacy status_filter/search/reviewed_by params. The virtual fields
      * ``skipped_by_me`` and ``reviewed_by_me`` (op ``eq``, boolean value)
-     * resolve against the calling user's own skips and reviews.
+     * resolve against the calling user's own skips and reviews. The
+     * ``reviewed_by`` field (ops ``eq``/``neq``, reviewer user id as UUID
+     * string) matches applications reviewed (or not) by that reviewer.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -382,12 +382,18 @@ export class ApplicationsService {
     /**
      * List Applications
      * List applications with optional filters (BO only).
+     *
+     * ``filters`` is a JSON filter group:
+     * ``{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}``.
+     * It only applies to the popup_id listing and is combined (AND) with the
+     * legacy status_filter/search/reviewed_by params.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId
      * @param data.reviewedBy
      * @param data.statusFilter
      * @param data.search
+     * @param data.filters
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -407,6 +413,7 @@ export class ApplicationsService {
                 reviewed_by: data.reviewedBy,
                 status_filter: data.statusFilter,
                 search: data.search,
+                filters: data.filters,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -386,7 +386,9 @@ export class ApplicationsService {
      * ``filters`` is a JSON filter group:
      * ``{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}``.
      * It only applies to the popup_id listing and is combined (AND) with the
-     * legacy status_filter/search/reviewed_by params.
+     * legacy status_filter/search/reviewed_by params. The virtual fields
+     * ``skipped_by_me`` and ``reviewed_by_me`` (op ``eq``, boolean value)
+     * resolve against the calling user's own skips and reviews.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -4518,6 +4518,7 @@ export type ApplicationReviewsUnskipApplicationData = {
 export type ApplicationReviewsUnskipApplicationResponse = (void);
 
 export type ApplicationsListApplicationsData = {
+    filters?: (string | null);
     humanId?: (string | null);
     /**
      * Maximum number of items to return

--- a/backoffice/src/components/Applications/ApplicationFilterBuilder.tsx
+++ b/backoffice/src/components/Applications/ApplicationFilterBuilder.tsx
@@ -1,0 +1,452 @@
+import { Funnel, Plus, Trash2 } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+export type FilterMatch = "all" | "any"
+
+export interface FilterCondition {
+  field: string
+  op: string
+  value: string | boolean | null
+}
+
+/** Custom form-builder field exposed as a filterable attribute. */
+export interface CustomFilterField {
+  name: string
+  label: string
+  options?: string[]
+  isSelect: boolean
+}
+
+const NO_VALUE_OPS = new Set(["is_empty", "not_empty"])
+
+const OP_LABELS: Record<string, string> = {
+  eq: "is",
+  neq: "is not",
+  contains: "contains",
+  not_contains: "doesn't contain",
+  is_empty: "is empty",
+  not_empty: "is not empty",
+  before: "before",
+  after: "after",
+}
+
+type FieldKind = "select" | "boolean" | "date" | "text"
+
+interface FilterFieldDef {
+  key: string
+  label: string
+  kind: FieldKind
+  ops: string[]
+  options?: { value: string; label: string }[]
+}
+
+const EMPTYABLE_TEXT_OPS = ["eq", "neq", "is_empty", "not_empty"]
+const FULL_TEXT_OPS = [
+  "eq",
+  "neq",
+  "contains",
+  "not_contains",
+  "is_empty",
+  "not_empty",
+]
+const DATE_OPS = ["before", "after", "is_empty", "not_empty"]
+
+const SCHOLARSHIP_STATUS_OPTIONS = [
+  { value: "pending", label: "Pending" },
+  { value: "approved", label: "Approved" },
+  { value: "rejected", label: "Rejected" },
+]
+
+function buildFieldDefs(
+  statusOptions: { value: string; label: string }[],
+  customFields: CustomFilterField[],
+): FilterFieldDef[] {
+  const fixed: FilterFieldDef[] = [
+    {
+      key: "status",
+      label: "Status",
+      kind: "select",
+      ops: ["eq", "neq"],
+      options: statusOptions,
+    },
+    {
+      key: "scholarship_request",
+      label: "Scholarship requested",
+      kind: "boolean",
+      ops: ["eq"],
+    },
+    {
+      key: "scholarship_status",
+      label: "Scholarship status",
+      kind: "select",
+      ops: EMPTYABLE_TEXT_OPS,
+      options: SCHOLARSHIP_STATUS_OPTIONS,
+    },
+    { key: "submitted_at", label: "Submitted", kind: "date", ops: DATE_OPS },
+    { key: "accepted_at", label: "Accepted", kind: "date", ops: DATE_OPS },
+    { key: "referral", label: "Referral", kind: "text", ops: FULL_TEXT_OPS },
+    { key: "gender", label: "Gender", kind: "text", ops: EMPTYABLE_TEXT_OPS },
+    { key: "age", label: "Age", kind: "text", ops: EMPTYABLE_TEXT_OPS },
+  ]
+  const custom: FilterFieldDef[] = customFields.map((field) => ({
+    key: `custom.${field.name}`,
+    label: field.label,
+    kind: field.isSelect ? "select" : "text",
+    ops: FULL_TEXT_OPS,
+    options: field.isSelect
+      ? (field.options ?? []).map((opt) => ({ value: opt, label: opt }))
+      : undefined,
+  }))
+  return [...fixed, ...custom]
+}
+
+function defaultValueFor(
+  def: FilterFieldDef,
+  op: string,
+): FilterCondition["value"] {
+  if (NO_VALUE_OPS.has(op)) return null
+  if (def.kind === "boolean") return true
+  if (def.kind === "select") return def.options?.[0]?.value ?? ""
+  return ""
+}
+
+export function isCompleteCondition(condition: FilterCondition): boolean {
+  if (NO_VALUE_OPS.has(condition.op)) return true
+  return condition.value !== null && condition.value !== ""
+}
+
+/** Keeps only well-shaped conditions coming from the URL. */
+export function sanitizeFilterConditions(raw: unknown): FilterCondition[] {
+  if (!Array.isArray(raw)) return []
+  const conditions: FilterCondition[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue
+    const { field, op, value } = item as Record<string, unknown>
+    if (typeof field !== "string" || !field) continue
+    if (typeof op !== "string" || !(op in OP_LABELS)) continue
+    conditions.push({
+      field,
+      op,
+      value:
+        typeof value === "string" || typeof value === "boolean" ? value : null,
+    })
+  }
+  return conditions
+}
+
+function DebouncedTextInput({
+  value,
+  onCommit,
+  type = "text",
+}: {
+  value: string
+  onCommit: (value: string) => void
+  type?: string
+}) {
+  const [local, setLocal] = useState(value)
+  const committed = useRef(value)
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => {
+    if (value !== committed.current) {
+      committed.current = value
+      setLocal(value)
+    }
+  }, [value])
+
+  useEffect(() => () => clearTimeout(timer.current), [])
+
+  return (
+    <Input
+      type={type}
+      className="h-8 flex-1"
+      placeholder="Value"
+      value={local}
+      onChange={(e) => {
+        const next = e.target.value
+        setLocal(next)
+        clearTimeout(timer.current)
+        timer.current = setTimeout(() => {
+          committed.current = next
+          onCommit(next)
+        }, 300)
+      }}
+    />
+  )
+}
+
+function ConditionValueInput({
+  def,
+  condition,
+  onValueChange,
+}: {
+  def: FilterFieldDef
+  condition: FilterCondition
+  onValueChange: (value: FilterCondition["value"]) => void
+}) {
+  if (NO_VALUE_OPS.has(condition.op)) return null
+
+  if (def.kind === "boolean") {
+    return (
+      <Select
+        value={condition.value === false ? "false" : "true"}
+        onValueChange={(v) => onValueChange(v === "true")}
+      >
+        <SelectTrigger className="h-8 flex-1">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="true">Yes</SelectItem>
+          <SelectItem value="false">No</SelectItem>
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  if (def.kind === "select") {
+    const current = typeof condition.value === "string" ? condition.value : ""
+    return (
+      <Select
+        value={current || undefined}
+        onValueChange={(v) => onValueChange(v)}
+      >
+        <SelectTrigger className="h-8 flex-1">
+          <SelectValue placeholder="Value" />
+        </SelectTrigger>
+        <SelectContent>
+          {(def.options ?? []).map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  const current = typeof condition.value === "string" ? condition.value : ""
+  if (def.kind === "date") {
+    return (
+      <Input
+        type="date"
+        className="h-8 flex-1"
+        value={current}
+        onChange={(e) => onValueChange(e.target.value)}
+      />
+    )
+  }
+
+  return <DebouncedTextInput value={current} onCommit={onValueChange} />
+}
+
+export function ApplicationFilterBuilder({
+  statusOptions,
+  customFields,
+  match,
+  conditions,
+  onChange,
+}: {
+  statusOptions: { value: string; label: string }[]
+  customFields: CustomFilterField[]
+  match: FilterMatch
+  conditions: FilterCondition[]
+  onChange: (match: FilterMatch, conditions: FilterCondition[]) => void
+}) {
+  const fieldDefs = buildFieldDefs(statusOptions, customFields)
+  const fixedDefs = fieldDefs.filter((def) => !def.key.startsWith("custom."))
+  const customDefs = fieldDefs.filter((def) => def.key.startsWith("custom."))
+  const activeCount = conditions.filter(isCompleteCondition).length
+
+  const findDef = (key: string) => fieldDefs.find((def) => def.key === key)
+
+  const addCondition = () => {
+    const statusDef = fieldDefs[0]
+    onChange(match, [
+      ...conditions,
+      {
+        field: statusDef.key,
+        op: statusDef.ops[0],
+        value: defaultValueFor(statusDef, statusDef.ops[0]),
+      },
+    ])
+  }
+
+  const updateCondition = (index: number, next: FilterCondition) => {
+    onChange(
+      match,
+      conditions.map((cond, i) => (i === index ? next : cond)),
+    )
+  }
+
+  const removeCondition = (index: number) => {
+    onChange(
+      match,
+      conditions.filter((_, i) => i !== index),
+    )
+  }
+
+  const changeField = (index: number, key: string) => {
+    const def = findDef(key)
+    if (!def) return
+    updateCondition(index, {
+      field: key,
+      op: def.ops[0],
+      value: defaultValueFor(def, def.ops[0]),
+    })
+  }
+
+  const changeOp = (index: number, op: string) => {
+    const condition = conditions[index]
+    const def = findDef(condition.field)
+    if (!def) return
+    const needsReset = NO_VALUE_OPS.has(op) !== NO_VALUE_OPS.has(condition.op)
+    updateCondition(index, {
+      ...condition,
+      op,
+      value: needsReset ? defaultValueFor(def, op) : condition.value,
+    })
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="h-9">
+          <Funnel className="mr-2 h-4 w-4" />
+          Filter
+          {activeCount > 0 && (
+            <span className="ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/10 px-1.5 text-xs font-medium text-primary tabular-nums">
+              {activeCount}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[560px] p-3">
+        {conditions.length === 0 ? (
+          <div className="flex flex-col items-start gap-2">
+            <p className="text-sm text-muted-foreground">
+              No filters applied. Add a filter to narrow down applications.
+            </p>
+            <Button variant="outline" size="sm" onClick={addCondition}>
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              Add filter
+            </Button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span>Match</span>
+              <Select
+                value={match}
+                onValueChange={(v) => onChange(v as FilterMatch, conditions)}
+              >
+                <SelectTrigger className="h-7 w-[70px] text-foreground">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">all</SelectItem>
+                  <SelectItem value="any">any</SelectItem>
+                </SelectContent>
+              </Select>
+              <span>of the following filters</span>
+            </div>
+            {conditions.map((condition, index) => {
+              const def = findDef(condition.field)
+              return (
+                <div
+                  key={`${index}-${condition.field}-${condition.op}`}
+                  className="flex items-center gap-2"
+                >
+                  <Select
+                    value={condition.field}
+                    onValueChange={(key) => changeField(index, key)}
+                  >
+                    <SelectTrigger className="h-8 w-[170px] shrink-0">
+                      <SelectValue placeholder="Field" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {fixedDefs.map((fieldDef) => (
+                          <SelectItem key={fieldDef.key} value={fieldDef.key}>
+                            {fieldDef.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                      {customDefs.length > 0 && (
+                        <SelectGroup>
+                          <SelectLabel>Form fields</SelectLabel>
+                          {customDefs.map((fieldDef) => (
+                            <SelectItem key={fieldDef.key} value={fieldDef.key}>
+                              {fieldDef.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    value={condition.op}
+                    onValueChange={(op) => changeOp(index, op)}
+                  >
+                    <SelectTrigger className="h-8 w-[140px] shrink-0">
+                      <SelectValue placeholder="Operator" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(def?.ops ?? []).map((op) => (
+                        <SelectItem key={op} value={op}>
+                          {OP_LABELS[op]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {def ? (
+                    <ConditionValueInput
+                      def={def}
+                      condition={condition}
+                      onValueChange={(value) =>
+                        updateCondition(index, { ...condition, value })
+                      }
+                    />
+                  ) : (
+                    <div className="flex-1" />
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 shrink-0 text-muted-foreground"
+                    aria-label="Remove filter"
+                    onClick={() => removeCondition(index)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              )
+            })}
+            <div>
+              <Button variant="ghost" size="sm" onClick={addCondition}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                Add filter
+              </Button>
+            </div>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/backoffice/src/components/Applications/ApplicationFilterBuilder.tsx
+++ b/backoffice/src/components/Applications/ApplicationFilterBuilder.tsx
@@ -99,6 +99,18 @@ function buildFieldDefs(
       ops: EMPTYABLE_TEXT_OPS,
       options: SCHOLARSHIP_STATUS_OPTIONS,
     },
+    {
+      key: "skipped_by_me",
+      label: "Skipped by me",
+      kind: "boolean",
+      ops: ["eq"],
+    },
+    {
+      key: "reviewed_by_me",
+      label: "Reviewed by me",
+      kind: "boolean",
+      ops: ["eq"],
+    },
     { key: "submitted_at", label: "Submitted", kind: "date", ops: DATE_OPS },
     { key: "accepted_at", label: "Accepted", kind: "date", ops: DATE_OPS },
     { key: "referral", label: "Referral", kind: "text", ops: FULL_TEXT_OPS },

--- a/backoffice/src/components/Applications/ApplicationFilterBuilder.tsx
+++ b/backoffice/src/components/Applications/ApplicationFilterBuilder.tsx
@@ -77,6 +77,7 @@ const SCHOLARSHIP_STATUS_OPTIONS = [
 function buildFieldDefs(
   statusOptions: { value: string; label: string }[],
   customFields: CustomFilterField[],
+  reviewerOptions: { value: string; label: string }[] = [],
 ): FilterFieldDef[] {
   const fixed: FilterFieldDef[] = [
     {
@@ -111,6 +112,17 @@ function buildFieldDefs(
       kind: "boolean",
       ops: ["eq"],
     },
+    ...(reviewerOptions.length
+      ? [
+          {
+            key: "reviewed_by",
+            label: "Reviewed by",
+            kind: "select",
+            ops: ["eq", "neq"],
+            options: reviewerOptions,
+          } satisfies FilterFieldDef,
+        ]
+      : []),
     { key: "submitted_at", label: "Submitted", kind: "date", ops: DATE_OPS },
     { key: "accepted_at", label: "Accepted", kind: "date", ops: DATE_OPS },
     { key: "referral", label: "Referral", kind: "text", ops: FULL_TEXT_OPS },
@@ -271,17 +283,19 @@ function ConditionValueInput({
 export function ApplicationFilterBuilder({
   statusOptions,
   customFields,
+  reviewerOptions,
   match,
   conditions,
   onChange,
 }: {
   statusOptions: { value: string; label: string }[]
   customFields: CustomFilterField[]
+  reviewerOptions?: { value: string; label: string }[]
   match: FilterMatch
   conditions: FilterCondition[]
   onChange: (match: FilterMatch, conditions: FilterCondition[]) => void
 }) {
-  const fieldDefs = buildFieldDefs(statusOptions, customFields)
+  const fieldDefs = buildFieldDefs(statusOptions, customFields, reviewerOptions)
   const fixedDefs = fieldDefs.filter((def) => !def.key.startsWith("custom."))
   const customDefs = fieldDefs.filter((def) => def.key.startsWith("custom."))
   const activeCount = conditions.filter(isCompleteCondition).length

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -451,6 +451,31 @@ export const Route = createFileRoute("/_layout/applications/")({
   }),
 })
 
+// Single source for the filter-related search params, shared by the table
+// and the CSV export so both always query the same subset.
+function useApplicationsFilterParams() {
+  const searchParams = Route.useSearch()
+  const filterMatch = searchParams.match ?? "all"
+  const filterConditions = useMemo(
+    () => searchParams.filters ?? [],
+    [searchParams.filters],
+  )
+  // Rows with a missing value stay in the UI but never reach the request.
+  const filtersJson = useMemo(() => {
+    const complete = filterConditions.filter(isCompleteCondition)
+    return complete.length
+      ? JSON.stringify({ match: filterMatch, conditions: complete })
+      : undefined
+  }, [filterConditions, filterMatch])
+  return {
+    search: searchParams.search ?? "",
+    reviewerId: searchParams.reviewerId,
+    filterMatch,
+    filterConditions,
+    filtersJson,
+  }
+}
+
 function SubmitReviewDialog({
   application,
   decision,
@@ -949,20 +974,8 @@ function ApplicationsTableContent({
     searchParams,
     "/applications",
   )
-  const reviewerId = searchParams.reviewerId
-  const filterMatch = searchParams.match ?? "all"
-  const filterConditions = useMemo(
-    () => searchParams.filters ?? [],
-    [searchParams.filters],
-  )
-
-  // Rows with a missing value stay in the UI but never reach the request.
-  const filtersJson = useMemo(() => {
-    const complete = filterConditions.filter(isCompleteCondition)
-    return complete.length
-      ? JSON.stringify({ match: filterMatch, conditions: complete })
-      : undefined
-  }, [filterConditions, filterMatch])
+  const { reviewerId, filterMatch, filterConditions, filtersJson } =
+    useApplicationsFilterParams()
 
   // The quick status select is a shortcut over the filter conditions: it maps
   // to a single "status is X" condition and shows Custom for anything richer.
@@ -1308,6 +1321,7 @@ function AddApplicationButton() {
 function Applications() {
   const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
+  const { search, reviewerId, filtersJson } = useApplicationsFilterParams()
   const [isExporting, setIsExporting] = useState(false)
   const [view, setView] = useState<ApplicationsView>(readStoredApplicationsView)
 
@@ -1337,6 +1351,9 @@ function Applications() {
     [formSchema],
   )
 
+  // Export what the table shows: the same search, reviewer and filter
+  // conditions drive the fetch, just without pagination.
+  const isExportFiltered = Boolean(search || reviewerId || filtersJson)
   const handleExport = async () => {
     if (!selectedPopupId) return
     setIsExporting(true)
@@ -1346,6 +1363,9 @@ function Applications() {
           skip,
           limit,
           popupId: selectedPopupId,
+          search: search || undefined,
+          reviewedBy: reviewerId || undefined,
+          filters: filtersJson,
         }),
       )
 
@@ -1403,7 +1423,7 @@ function Applications() {
         .map(({ key, label }) => ({ key, label }))
 
       exportToCsv(
-        "applications",
+        isExportFiltered ? "applications-filtered" : "applications",
         results as unknown as Record<string, unknown>[],
         [...baseColumns, ...customColumns],
       )
@@ -1448,9 +1468,18 @@ function Applications() {
               variant="outline"
               onClick={handleExport}
               disabled={isExporting}
+              title={
+                isExportFiltered
+                  ? "Exports the applications matching the current filters"
+                  : "Exports all applications for this gathering"
+              }
             >
               <Download className="mr-2 h-4 w-4" />
-              {isExporting ? "Exporting..." : "Export CSV"}
+              {isExporting
+                ? "Exporting..."
+                : isExportFiltered
+                  ? "Export filtered CSV"
+                  : "Export CSV"}
             </Button>
           )}
           {isSuperadmin && isContextReady && <AddApplicationButton />}

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -33,7 +33,6 @@ import {
   DashboardService,
   FormFieldsService,
   type HumanRating,
-  type PopupReviewerPublic,
   PopupReviewersService,
   PopupsService,
   type ReviewDecision,
@@ -354,66 +353,6 @@ function StatusDropdownFilter({
             </span>
           </SelectItem>
         )}
-      </SelectContent>
-    </Select>
-  )
-}
-
-function ReviewerDropdownFilter({
-  reviewers,
-  selected,
-  onSelect,
-  disabled = false,
-}: {
-  reviewers: PopupReviewerPublic[]
-  selected: string | undefined
-  onSelect: (value: string | undefined) => void
-  disabled?: boolean
-}) {
-  // Reviewer combinations built in the filter builder (or reviewers no longer
-  // in this popup) render as a read-only "Custom" entry.
-  const isCustom =
-    selected === "custom" ||
-    (!!selected && !reviewers.some((reviewer) => reviewer.user_id === selected))
-  const selectedReviewer =
-    selected && !isCustom
-      ? reviewers.find((reviewer) => reviewer.user_id === selected)
-      : undefined
-
-  const currentLabel = disabled
-    ? "No reviewers"
-    : isCustom
-      ? "Custom"
-      : (selectedReviewer?.user_full_name ??
-        selectedReviewer?.user_email ??
-        "All reviewers")
-
-  return (
-    <Select
-      value={isCustom ? "custom" : (selected ?? "all")}
-      onValueChange={(value) => onSelect(value === "all" ? undefined : value)}
-      disabled={disabled}
-    >
-      <SelectTrigger className="h-9 w-[220px]">
-        <SelectValue>{currentLabel}</SelectValue>
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="all">All reviewers</SelectItem>
-        {isCustom && (
-          <SelectItem value="custom" disabled>
-            <span className="flex w-full items-center justify-between gap-4">
-              <span>Custom</span>
-              <span className="text-muted-foreground">via filters</span>
-            </span>
-          </SelectItem>
-        )}
-        {reviewers.map((reviewer) => (
-          <SelectItem key={reviewer.id} value={reviewer.user_id}>
-            {reviewer.user_full_name ??
-              reviewer.user_email ??
-              "Unknown reviewer"}
-          </SelectItem>
-        ))}
       </SelectContent>
     </Select>
   )
@@ -1055,11 +994,6 @@ function ApplicationsTableContent({
     [upsertQuickFilter],
   )
 
-  const setReviewerFilter = useCallback(
-    (value: string | undefined) => upsertQuickFilter("reviewed_by", value),
-    [upsertQuickFilter],
-  )
-
   const { data: applications } = useQuery({
     ...getApplicationsQueryOptions(
       selectedPopupId,
@@ -1250,14 +1184,6 @@ function ApplicationsTableContent({
             selected={statusFilter}
             onSelect={setStatusFilter}
           />
-          {selectedPopupId ? (
-            <ReviewerDropdownFilter
-              reviewers={reviewers}
-              selected={reviewerFilter}
-              onSelect={setReviewerFilter}
-              disabled={reviewers.length === 0}
-            />
-          ) : null}
           <ApplicationFilterBuilder
             statusOptions={FILTER_STATUS_OPTIONS}
             customFields={customFilterFields}

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -240,7 +240,6 @@ function getApplicationsQueryOptions(
   page: number,
   pageSize: number,
   search?: string,
-  reviewedBy?: string,
   filters?: string,
 ) {
   return {
@@ -249,15 +248,10 @@ function getApplicationsQueryOptions(
         skip: page * pageSize,
         limit: pageSize,
         popupId: popupId || undefined,
-        reviewedBy: reviewedBy || undefined,
         search: search || undefined,
         filters: filters || undefined,
       }),
-    queryKey: [
-      "applications",
-      popupId,
-      { page, pageSize, search, reviewedBy, filters },
-    ],
+    queryKey: ["applications", popupId, { page, pageSize, search, filters }],
   }
 }
 
@@ -376,19 +370,27 @@ function ReviewerDropdownFilter({
   onSelect: (value: string | undefined) => void
   disabled?: boolean
 }) {
-  const selectedReviewer = selected
-    ? reviewers.find((reviewer) => reviewer.user_id === selected)
-    : undefined
+  // Reviewer combinations built in the filter builder (or reviewers no longer
+  // in this popup) render as a read-only "Custom" entry.
+  const isCustom =
+    selected === "custom" ||
+    (!!selected && !reviewers.some((reviewer) => reviewer.user_id === selected))
+  const selectedReviewer =
+    selected && !isCustom
+      ? reviewers.find((reviewer) => reviewer.user_id === selected)
+      : undefined
 
   const currentLabel = disabled
     ? "No reviewers"
-    : (selectedReviewer?.user_full_name ??
-      selectedReviewer?.user_email ??
-      "All reviewers")
+    : isCustom
+      ? "Custom"
+      : (selectedReviewer?.user_full_name ??
+        selectedReviewer?.user_email ??
+        "All reviewers")
 
   return (
     <Select
-      value={selected ?? "all"}
+      value={isCustom ? "custom" : (selected ?? "all")}
       onValueChange={(value) => onSelect(value === "all" ? undefined : value)}
       disabled={disabled}
     >
@@ -397,6 +399,14 @@ function ReviewerDropdownFilter({
       </SelectTrigger>
       <SelectContent>
         <SelectItem value="all">All reviewers</SelectItem>
+        {isCustom && (
+          <SelectItem value="custom" disabled>
+            <span className="flex w-full items-center justify-between gap-4">
+              <span>Custom</span>
+              <span className="text-muted-foreground">via filters</span>
+            </span>
+          </SelectItem>
+        )}
         {reviewers.map((reviewer) => (
           <SelectItem key={reviewer.id} value={reviewer.user_id}>
             {reviewer.user_full_name ??
@@ -418,7 +428,6 @@ const VALID_STATUSES: Set<string> = new Set([
 ])
 
 type ApplicationsSearchParams = TableSearchParams & {
-  reviewerId?: string
   match?: FilterMatch
   filters?: FilterCondition[]
 }
@@ -427,7 +436,7 @@ export const Route = createFileRoute("/_layout/applications/")({
   component: Applications,
   validateSearch: (raw: Record<string, unknown>): ApplicationsSearchParams => {
     const filters = sanitizeFilterConditions(raw.filters)
-    // Legacy ?status= links fold into the filter conditions.
+    // Legacy ?status= and ?reviewerId= links fold into the filter conditions.
     if (
       typeof raw.status === "string" &&
       VALID_STATUSES.has(raw.status) &&
@@ -435,11 +444,15 @@ export const Route = createFileRoute("/_layout/applications/")({
     ) {
       filters.push({ field: "status", op: "eq", value: raw.status })
     }
+    if (
+      typeof raw.reviewerId === "string" &&
+      raw.reviewerId &&
+      !filters.some((condition) => condition.field === "reviewed_by")
+    ) {
+      filters.push({ field: "reviewed_by", op: "eq", value: raw.reviewerId })
+    }
     return {
       ...validateTableSearch(raw),
-      ...(typeof raw.reviewerId === "string" && raw.reviewerId
-        ? { reviewerId: raw.reviewerId }
-        : {}),
       ...(raw.match === "any" && filters.length
         ? { match: "any" as const }
         : {}),
@@ -469,7 +482,6 @@ function useApplicationsFilterParams() {
   }, [filterConditions, filterMatch])
   return {
     search: searchParams.search ?? "",
-    reviewerId: searchParams.reviewerId,
     filterMatch,
     filterConditions,
     filtersJson,
@@ -974,41 +986,34 @@ function ApplicationsTableContent({
     searchParams,
     "/applications",
   )
-  const { reviewerId, filterMatch, filterConditions, filtersJson } =
+  const { filterMatch, filterConditions, filtersJson } =
     useApplicationsFilterParams()
 
-  // The quick status select is a shortcut over the filter conditions: it maps
-  // to a single "status is X" condition and shows Custom for anything richer.
-  const statusFilter: ApplicationStatus | "custom" | undefined = useMemo(() => {
-    const statusConditions = filterConditions.filter(
-      (condition) => condition.field === "status",
-    )
-    if (statusConditions.length === 0) return undefined
-    const [only] = statusConditions
-    if (
-      statusConditions.length === 1 &&
-      only.op === "eq" &&
-      (filterMatch === "all" || filterConditions.length === 1)
-    ) {
-      return only.value as ApplicationStatus
-    }
-    return "custom"
-  }, [filterConditions, filterMatch])
-
-  const setReviewerFilter = useCallback(
-    (value: string | undefined) => {
-      navigate({
-        to: "/applications",
-        search: (prev: Record<string, unknown>) => ({
-          ...prev,
-          reviewerId: value,
-          page: 0,
-        }),
-        replace: true,
-      })
+  // The quick selects are shortcuts over the filter conditions: each maps to
+  // a single "field is X" condition and shows Custom for anything richer.
+  const deriveQuickFilter = useCallback(
+    (field: string): string | undefined => {
+      const matching = filterConditions.filter(
+        (condition) => condition.field === field,
+      )
+      if (matching.length === 0) return undefined
+      const [only] = matching
+      if (
+        matching.length === 1 &&
+        only.op === "eq" &&
+        (filterMatch === "all" || filterConditions.length === 1)
+      ) {
+        return typeof only.value === "string" ? only.value : "custom"
+      }
+      return "custom"
     },
-    [navigate],
+    [filterConditions, filterMatch],
   )
+  const statusFilter = deriveQuickFilter("status") as
+    | ApplicationStatus
+    | "custom"
+    | undefined
+  const reviewerFilter = deriveQuickFilter("reviewed_by")
 
   const setFilters = useCallback(
     (match: FilterMatch, conditions: FilterCondition[]) => {
@@ -1016,9 +1021,10 @@ function ApplicationsTableContent({
         to: "/applications",
         search: (prev: Record<string, unknown>) => ({
           ...prev,
-          // Scrub the legacy param so validateSearch cannot fold it back into
-          // a resurrected condition after the user edits the filters.
+          // Scrub the legacy params so validateSearch cannot fold them back
+          // into resurrected conditions after the user edits the filters.
           status: undefined,
+          reviewerId: undefined,
           match:
             match === "any" && conditions.length ? ("any" as const) : undefined,
           filters: conditions.length ? conditions : undefined,
@@ -1030,17 +1036,28 @@ function ApplicationsTableContent({
     [navigate],
   )
 
-  const setStatusFilter = useCallback(
-    (value: ApplicationStatus | undefined) => {
+  const upsertQuickFilter = useCallback(
+    (field: string, value: string | undefined) => {
       const rest = filterConditions.filter(
-        (condition) => condition.field !== "status",
+        (condition) => condition.field !== field,
       )
       setFilters(
         filterMatch,
-        value ? [...rest, { field: "status", op: "eq", value }] : rest,
+        value ? [...rest, { field, op: "eq", value }] : rest,
       )
     },
     [filterConditions, filterMatch, setFilters],
+  )
+
+  const setStatusFilter = useCallback(
+    (value: ApplicationStatus | undefined) =>
+      upsertQuickFilter("status", value),
+    [upsertQuickFilter],
+  )
+
+  const setReviewerFilter = useCallback(
+    (value: string | undefined) => upsertQuickFilter("reviewed_by", value),
+    [upsertQuickFilter],
   )
 
   const { data: applications } = useQuery({
@@ -1049,7 +1066,6 @@ function ApplicationsTableContent({
       pagination.pageIndex,
       pagination.pageSize,
       search,
-      reviewerId,
       filtersJson,
     ),
     placeholderData: keepPreviousData,
@@ -1104,24 +1120,27 @@ function ApplicationsTableContent({
 
   const reviewers = popupReviewers?.results ?? []
 
+  // Drop reviewer conditions that reference reviewers outside the current
+  // popup (e.g. after switching gatherings).
   useEffect(() => {
-    if (!reviewerId) return
-    if (!selectedPopupId) {
-      setReviewerFilter(undefined)
-      return
-    }
-    if (
-      popupReviewers &&
-      !reviewers.some((reviewer) => reviewer.user_id === reviewerId)
-    ) {
-      setReviewerFilter(undefined)
+    if (!popupReviewers) return
+    const isInvalid = (condition: FilterCondition) =>
+      condition.field === "reviewed_by" &&
+      (!selectedPopupId ||
+        !reviewers.some((reviewer) => reviewer.user_id === condition.value))
+    if (filterConditions.some(isInvalid)) {
+      setFilters(
+        filterMatch,
+        filterConditions.filter((condition) => !isInvalid(condition)),
+      )
     }
   }, [
     popupReviewers,
-    reviewerId,
     reviewers,
     selectedPopupId,
-    setReviewerFilter,
+    filterConditions,
+    filterMatch,
+    setFilters,
   ])
 
   const bulkReviewMutation = useMutation({
@@ -1193,7 +1212,11 @@ function ApplicationsTableContent({
   })
 
   const isWeightedVoting = approvalStrategy?.strategy_type === "weighted"
-  const columns = getColumns(isWeightedVoting, !!reviewerId, customColumns)
+  const columns = getColumns(
+    isWeightedVoting,
+    !!reviewerFilter && reviewerFilter !== "custom",
+    customColumns,
+  )
   const canBulkReview = isOperatorOrAbove && !isWeightedVoting
 
   if (!applications) return <Skeleton className="h-64 w-full" />
@@ -1230,7 +1253,7 @@ function ApplicationsTableContent({
           {selectedPopupId ? (
             <ReviewerDropdownFilter
               reviewers={reviewers}
-              selected={reviewerId}
+              selected={reviewerFilter}
               onSelect={setReviewerFilter}
               disabled={reviewers.length === 0}
             />
@@ -1238,6 +1261,13 @@ function ApplicationsTableContent({
           <ApplicationFilterBuilder
             statusOptions={FILTER_STATUS_OPTIONS}
             customFields={customFilterFields}
+            reviewerOptions={reviewers.map((reviewer) => ({
+              value: reviewer.user_id,
+              label:
+                reviewer.user_full_name ??
+                reviewer.user_email ??
+                reviewer.user_id,
+            }))}
             match={filterMatch}
             conditions={filterConditions}
             onChange={setFilters}
@@ -1321,7 +1351,7 @@ function AddApplicationButton() {
 function Applications() {
   const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
-  const { search, reviewerId, filtersJson } = useApplicationsFilterParams()
+  const { search, filtersJson } = useApplicationsFilterParams()
   const [isExporting, setIsExporting] = useState(false)
   const [view, setView] = useState<ApplicationsView>(readStoredApplicationsView)
 
@@ -1353,7 +1383,7 @@ function Applications() {
 
   // Export what the table shows: the same search, reviewer and filter
   // conditions drive the fetch, just without pagination.
-  const isExportFiltered = Boolean(search || reviewerId || filtersJson)
+  const isExportFiltered = Boolean(search || filtersJson)
   const handleExport = async () => {
     if (!selectedPopupId) return
     setIsExporting(true)
@@ -1364,7 +1394,6 @@ function Applications() {
           limit,
           popupId: selectedPopupId,
           search: search || undefined,
-          reviewedBy: reviewerId || undefined,
           filters: filtersJson,
         }),
       )

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -240,7 +240,6 @@ function getApplicationsQueryOptions(
   page: number,
   pageSize: number,
   search?: string,
-  statusFilter?: ApplicationStatus,
   reviewedBy?: string,
   filters?: string,
 ) {
@@ -252,13 +251,12 @@ function getApplicationsQueryOptions(
         popupId: popupId || undefined,
         reviewedBy: reviewedBy || undefined,
         search: search || undefined,
-        statusFilter: statusFilter || undefined,
         filters: filters || undefined,
       }),
     queryKey: [
       "applications",
       popupId,
-      { page, pageSize, search, statusFilter, reviewedBy, filters },
+      { page, pageSize, search, reviewedBy, filters },
     ],
   }
 }
@@ -293,7 +291,7 @@ function StatusDropdownFilter({
 }: {
   popupId: string | null
   requiresApplicationFee?: boolean
-  selected: ApplicationStatus | undefined
+  selected: ApplicationStatus | "custom" | undefined
   onSelect: (value: ApplicationStatus | undefined) => void
 }) {
   const { counts, total } = useStatusCounts(popupId)
@@ -301,9 +299,15 @@ function StatusDropdownFilter({
     requiresApplicationFee === false
       ? APPLICATION_STATUS_OPTIONS.filter((opt) => opt.value !== "pending_fee")
       : APPLICATION_STATUS_OPTIONS
-  const selectedOption = selected
-    ? statusOptions.find((option) => option.value === selected)
-    : undefined
+  // Status combinations built in the filter builder (or statuses outside the
+  // quick options) render as a read-only "Custom" entry.
+  const isCustom =
+    selected === "custom" ||
+    (!!selected && !statusOptions.some((option) => option.value === selected))
+  const selectedOption =
+    selected && !isCustom
+      ? statusOptions.find((option) => option.value === selected)
+      : undefined
 
   const options = [
     { value: "all" as const, label: "All", count: total },
@@ -314,21 +318,24 @@ function StatusDropdownFilter({
     })),
   ]
 
-  const currentLabel = selectedOption?.label ?? "All"
-  const currentCount = selectedOption
-    ? (counts[selectedOption.value] ?? 0)
-    : total
+  const currentLabel = isCustom ? "Custom" : (selectedOption?.label ?? "All")
+  const currentCount = isCustom
+    ? null
+    : selectedOption
+      ? (counts[selectedOption.value] ?? 0)
+      : total
 
   return (
     <Select
-      value={selectedOption?.value ?? "all"}
+      value={isCustom ? "custom" : (selectedOption?.value ?? "all")}
       onValueChange={(v) =>
         onSelect(v === "all" ? undefined : (v as ApplicationStatus))
       }
     >
       <SelectTrigger className="h-9 w-[180px]">
         <SelectValue>
-          {currentLabel} ({currentCount})
+          {currentLabel}
+          {currentCount !== null ? ` (${currentCount})` : ""}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
@@ -345,6 +352,14 @@ function StatusDropdownFilter({
             </span>
           </SelectItem>
         ))}
+        {isCustom && (
+          <SelectItem value="custom" disabled>
+            <span className="flex w-full items-center justify-between gap-4">
+              <span>Custom</span>
+              <span className="text-muted-foreground">via filters</span>
+            </span>
+          </SelectItem>
+        )}
       </SelectContent>
     </Select>
   )
@@ -404,7 +419,6 @@ const VALID_STATUSES: Set<string> = new Set([
 
 type ApplicationsSearchParams = TableSearchParams & {
   reviewerId?: string
-  status?: ApplicationStatus
   match?: FilterMatch
   filters?: FilterCondition[]
 }
@@ -413,11 +427,16 @@ export const Route = createFileRoute("/_layout/applications/")({
   component: Applications,
   validateSearch: (raw: Record<string, unknown>): ApplicationsSearchParams => {
     const filters = sanitizeFilterConditions(raw.filters)
+    // Legacy ?status= links fold into the filter conditions.
+    if (
+      typeof raw.status === "string" &&
+      VALID_STATUSES.has(raw.status) &&
+      !filters.some((condition) => condition.field === "status")
+    ) {
+      filters.push({ field: "status", op: "eq", value: raw.status })
+    }
     return {
       ...validateTableSearch(raw),
-      ...(typeof raw.status === "string" && VALID_STATUSES.has(raw.status)
-        ? { status: raw.status as ApplicationStatus }
-        : {}),
       ...(typeof raw.reviewerId === "string" && raw.reviewerId
         ? { reviewerId: raw.reviewerId }
         : {}),
@@ -930,7 +949,6 @@ function ApplicationsTableContent({
     searchParams,
     "/applications",
   )
-  const statusFilter = searchParams.status
   const reviewerId = searchParams.reviewerId
   const filterMatch = searchParams.match ?? "all"
   const filterConditions = useMemo(
@@ -946,20 +964,23 @@ function ApplicationsTableContent({
       : undefined
   }, [filterConditions, filterMatch])
 
-  const setStatusFilter = useCallback(
-    (value: ApplicationStatus | undefined) => {
-      navigate({
-        to: "/applications",
-        search: (prev: Record<string, unknown>) => ({
-          ...prev,
-          status: value,
-          page: 0,
-        }),
-        replace: true,
-      })
-    },
-    [navigate],
-  )
+  // The quick status select is a shortcut over the filter conditions: it maps
+  // to a single "status is X" condition and shows Custom for anything richer.
+  const statusFilter: ApplicationStatus | "custom" | undefined = useMemo(() => {
+    const statusConditions = filterConditions.filter(
+      (condition) => condition.field === "status",
+    )
+    if (statusConditions.length === 0) return undefined
+    const [only] = statusConditions
+    if (
+      statusConditions.length === 1 &&
+      only.op === "eq" &&
+      (filterMatch === "all" || filterConditions.length === 1)
+    ) {
+      return only.value as ApplicationStatus
+    }
+    return "custom"
+  }, [filterConditions, filterMatch])
 
   const setReviewerFilter = useCallback(
     (value: string | undefined) => {
@@ -993,13 +1014,25 @@ function ApplicationsTableContent({
     [navigate],
   )
 
+  const setStatusFilter = useCallback(
+    (value: ApplicationStatus | undefined) => {
+      const rest = filterConditions.filter(
+        (condition) => condition.field !== "status",
+      )
+      setFilters(
+        filterMatch,
+        value ? [...rest, { field: "status", op: "eq", value }] : rest,
+      )
+    },
+    [filterConditions, filterMatch, setFilters],
+  )
+
   const { data: applications } = useQuery({
     ...getApplicationsQueryOptions(
       selectedPopupId,
       pagination.pageIndex,
       pagination.pageSize,
       search,
-      statusFilter,
       reviewerId,
       filtersJson,
     ),
@@ -1030,13 +1063,28 @@ function ApplicationsTableContent({
   })
 
   useEffect(() => {
-    if (
-      popup?.requires_application_fee === false &&
-      statusFilter === "pending_fee"
-    ) {
-      setStatusFilter(undefined)
+    if (popup?.requires_application_fee !== false) return
+    const hasPendingFee = filterConditions.some(
+      (condition) =>
+        condition.field === "status" && condition.value === "pending_fee",
+    )
+    if (hasPendingFee) {
+      setFilters(
+        filterMatch,
+        filterConditions.filter(
+          (condition) =>
+            !(
+              condition.field === "status" && condition.value === "pending_fee"
+            ),
+        ),
+      )
     }
-  }, [popup?.requires_application_fee, setStatusFilter, statusFilter])
+  }, [
+    popup?.requires_application_fee,
+    filterConditions,
+    filterMatch,
+    setFilters,
+  ])
 
   const reviewers = popupReviewers?.results ?? []
 

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -1003,6 +1003,9 @@ function ApplicationsTableContent({
         to: "/applications",
         search: (prev: Record<string, unknown>) => ({
           ...prev,
+          // Scrub the legacy param so validateSearch cannot fold it back into
+          // a resurrected condition after the user edits the filters.
+          status: undefined,
           match:
             match === "any" && conditions.length ? ("any" as const) : undefined,
           filters: conditions.length ? conditions : undefined,

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -1278,6 +1278,7 @@ function Applications() {
   const { isOperatorOrAbove, isSuperadmin } = useAuth()
   const { isContextReady, selectedPopupId } = useWorkspace()
   const { search, filtersJson } = useApplicationsFilterParams()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
   const [isExporting, setIsExporting] = useState(false)
   const [view, setView] = useState<ApplicationsView>(readStoredApplicationsView)
 
@@ -1323,6 +1324,15 @@ function Applications() {
           filters: filtersJson,
         }),
       )
+
+      if (results.length === 0) {
+        showErrorToast(
+          isExportFiltered
+            ? "No applications match the current filters"
+            : "There are no applications to export",
+        )
+        return
+      }
 
       const baseColumns = [
         { key: "human.email", label: "Email" },
@@ -1381,6 +1391,9 @@ function Applications() {
         isExportFiltered ? "applications-filtered" : "applications",
         results as unknown as Record<string, unknown>[],
         [...baseColumns, ...customColumns],
+      )
+      showSuccessToast(
+        `Exported ${results.length} application${results.length === 1 ? "" : "s"}`,
       )
     } finally {
       setIsExporting(false)

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -206,11 +206,6 @@ const APPLICATION_STATUS_OPTIONS: {
   { value: "rejected", label: "Rejected" },
 ]
 
-const FILTER_STATUS_OPTIONS = [
-  ...APPLICATION_STATUS_OPTIONS,
-  { value: "withdrawn", label: "Withdrawn" },
-]
-
 // Custom form fields become filterable attributes; select-like fields keep
 // their options so the value input can offer them.
 function buildCustomFilterFields(
@@ -1185,7 +1180,13 @@ function ApplicationsTableContent({
             onSelect={setStatusFilter}
           />
           <ApplicationFilterBuilder
-            statusOptions={FILTER_STATUS_OPTIONS}
+            statusOptions={
+              popup?.requires_application_fee === false
+                ? APPLICATION_STATUS_OPTIONS.filter(
+                    (opt) => opt.value !== "pending_fee",
+                  )
+                : APPLICATION_STATUS_OPTIONS
+            }
             customFields={customFilterFields}
             reviewerOptions={reviewers.map((reviewer) => ({
               value: reviewer.user_id,

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -39,6 +39,14 @@ import {
   type ReviewDecision,
 } from "@/client"
 import {
+  ApplicationFilterBuilder,
+  type CustomFilterField,
+  type FilterCondition,
+  type FilterMatch,
+  isCompleteCondition,
+  sanitizeFilterConditions,
+} from "@/components/Applications/ApplicationFilterBuilder"
+import {
   type ApplicationsView,
   ApplicationsViewSwitcher,
 } from "@/components/applications/ApplicationsViewSwitcher"
@@ -199,6 +207,34 @@ const APPLICATION_STATUS_OPTIONS: {
   { value: "rejected", label: "Rejected" },
 ]
 
+const FILTER_STATUS_OPTIONS = [
+  ...APPLICATION_STATUS_OPTIONS,
+  { value: "withdrawn", label: "Withdrawn" },
+]
+
+// Custom form fields become filterable attributes; select-like fields keep
+// their options so the value input can offer them.
+function buildCustomFilterFields(
+  formSchema?: ApplicationSchema,
+): CustomFilterField[] {
+  const customFields = formSchema?.custom_fields ?? {}
+  return Object.entries(customFields)
+    .filter(([, def]) => !isDisplayOnlyField(def))
+    .sort(
+      ([, a], [, b]) =>
+        (a.position ?? Number.MAX_SAFE_INTEGER) -
+        (b.position ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map(([name, def]) => ({
+      name,
+      label: def.short_label || def.label || name,
+      options: def.options,
+      isSelect:
+        (def.type === "select" || def.type === "multiselect") &&
+        (def.options?.length ?? 0) > 0,
+    }))
+}
+
 function getApplicationsQueryOptions(
   popupId: string | null,
   page: number,
@@ -206,6 +242,7 @@ function getApplicationsQueryOptions(
   search?: string,
   statusFilter?: ApplicationStatus,
   reviewedBy?: string,
+  filters?: string,
 ) {
   return {
     queryFn: () =>
@@ -216,11 +253,12 @@ function getApplicationsQueryOptions(
         reviewedBy: reviewedBy || undefined,
         search: search || undefined,
         statusFilter: statusFilter || undefined,
+        filters: filters || undefined,
       }),
     queryKey: [
       "applications",
       popupId,
-      { page, pageSize, search, statusFilter, reviewedBy },
+      { page, pageSize, search, statusFilter, reviewedBy, filters },
     ],
   }
 }
@@ -367,19 +405,28 @@ const VALID_STATUSES: Set<string> = new Set([
 type ApplicationsSearchParams = TableSearchParams & {
   reviewerId?: string
   status?: ApplicationStatus
+  match?: FilterMatch
+  filters?: FilterCondition[]
 }
 
 export const Route = createFileRoute("/_layout/applications/")({
   component: Applications,
-  validateSearch: (raw: Record<string, unknown>): ApplicationsSearchParams => ({
-    ...validateTableSearch(raw),
-    ...(typeof raw.status === "string" && VALID_STATUSES.has(raw.status)
-      ? { status: raw.status as ApplicationStatus }
-      : {}),
-    ...(typeof raw.reviewerId === "string" && raw.reviewerId
-      ? { reviewerId: raw.reviewerId }
-      : {}),
-  }),
+  validateSearch: (raw: Record<string, unknown>): ApplicationsSearchParams => {
+    const filters = sanitizeFilterConditions(raw.filters)
+    return {
+      ...validateTableSearch(raw),
+      ...(typeof raw.status === "string" && VALID_STATUSES.has(raw.status)
+        ? { status: raw.status as ApplicationStatus }
+        : {}),
+      ...(typeof raw.reviewerId === "string" && raw.reviewerId
+        ? { reviewerId: raw.reviewerId }
+        : {}),
+      ...(raw.match === "any" && filters.length
+        ? { match: "any" as const }
+        : {}),
+      ...(filters.length ? { filters } : {}),
+    }
+  },
   head: () => ({
     meta: [{ title: "Applications - EdgeOS" }],
   }),
@@ -868,8 +915,10 @@ const getColumns = (
 
 function ApplicationsTableContent({
   customColumns,
+  customFilterFields,
 }: {
   customColumns: ColumnDef<ApplicationPublic>[]
+  customFilterFields: CustomFilterField[]
 }) {
   const { selectedPopupId } = useWorkspace()
   const { isOperatorOrAbove } = useAuth()
@@ -883,6 +932,19 @@ function ApplicationsTableContent({
   )
   const statusFilter = searchParams.status
   const reviewerId = searchParams.reviewerId
+  const filterMatch = searchParams.match ?? "all"
+  const filterConditions = useMemo(
+    () => searchParams.filters ?? [],
+    [searchParams.filters],
+  )
+
+  // Rows with a missing value stay in the UI but never reach the request.
+  const filtersJson = useMemo(() => {
+    const complete = filterConditions.filter(isCompleteCondition)
+    return complete.length
+      ? JSON.stringify({ match: filterMatch, conditions: complete })
+      : undefined
+  }, [filterConditions, filterMatch])
 
   const setStatusFilter = useCallback(
     (value: ApplicationStatus | undefined) => {
@@ -914,6 +976,23 @@ function ApplicationsTableContent({
     [navigate],
   )
 
+  const setFilters = useCallback(
+    (match: FilterMatch, conditions: FilterCondition[]) => {
+      navigate({
+        to: "/applications",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          match:
+            match === "any" && conditions.length ? ("any" as const) : undefined,
+          filters: conditions.length ? conditions : undefined,
+          page: 0,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
   const { data: applications } = useQuery({
     ...getApplicationsQueryOptions(
       selectedPopupId,
@@ -922,6 +1001,7 @@ function ApplicationsTableContent({
       search,
       statusFilter,
       reviewerId,
+      filtersJson,
     ),
     placeholderData: keepPreviousData,
   })
@@ -1091,6 +1171,13 @@ function ApplicationsTableContent({
               disabled={reviewers.length === 0}
             />
           ) : null}
+          <ApplicationFilterBuilder
+            statusOptions={FILTER_STATUS_OPTIONS}
+            customFields={customFilterFields}
+            match={filterMatch}
+            conditions={filterConditions}
+            onChange={setFilters}
+          />
         </div>
       }
       serverPagination={{
@@ -1191,6 +1278,11 @@ function Applications() {
 
   const customColumns = useMemo(
     () => buildCustomFieldColumns(formSchema),
+    [formSchema],
+  )
+
+  const customFilterFields = useMemo(
+    () => buildCustomFilterFields(formSchema),
     [formSchema],
   )
 
@@ -1318,7 +1410,10 @@ function Applications() {
       ) : (
         <QueryErrorBoundary>
           <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-            <ApplicationsTableContent customColumns={customColumns} />
+            <ApplicationsTableContent
+              customColumns={customColumns}
+              customFilterFields={customFilterFields}
+            />
           </Suspense>
         </QueryErrorBoundary>
       )}

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -388,7 +388,9 @@ export class ApplicationsService {
      * It only applies to the popup_id listing and is combined (AND) with the
      * legacy status_filter/search/reviewed_by params. The virtual fields
      * ``skipped_by_me`` and ``reviewed_by_me`` (op ``eq``, boolean value)
-     * resolve against the calling user's own skips and reviews.
+     * resolve against the calling user's own skips and reviews. The
+     * ``reviewed_by`` field (ops ``eq``/``neq``, reviewer user id as UUID
+     * string) matches applications reviewed (or not) by that reviewer.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -382,12 +382,18 @@ export class ApplicationsService {
     /**
      * List Applications
      * List applications with optional filters (BO only).
+     *
+     * ``filters`` is a JSON filter group:
+     * ``{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}``.
+     * It only applies to the popup_id listing and is combined (AND) with the
+     * legacy status_filter/search/reviewed_by params.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId
      * @param data.reviewedBy
      * @param data.statusFilter
      * @param data.search
+     * @param data.filters
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -407,6 +413,7 @@ export class ApplicationsService {
                 reviewed_by: data.reviewedBy,
                 status_filter: data.statusFilter,
                 search: data.search,
+                filters: data.filters,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -386,7 +386,9 @@ export class ApplicationsService {
      * ``filters`` is a JSON filter group:
      * ``{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}``.
      * It only applies to the popup_id listing and is combined (AND) with the
-     * legacy status_filter/search/reviewed_by params.
+     * legacy status_filter/search/reviewed_by params. The virtual fields
+     * ``skipped_by_me`` and ``reviewed_by_me`` (op ``eq``, boolean value)
+     * resolve against the calling user's own skips and reviews.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -4518,6 +4518,7 @@ export type ApplicationReviewsUnskipApplicationData = {
 export type ApplicationReviewsUnskipApplicationResponse = (void);
 
 export type ApplicationsListApplicationsData = {
+    filters?: (string | null);
     humanId?: (string | null);
     /**
      * Maximum number of items to return


### PR DESCRIPTION
## Summary

NocoDB-style complex filtering for the backoffice applications list.

### Backend
- New optional `filters` JSON query param on the BO list endpoint: `{"match": "all"|"any", "conditions": [{"field", "op", "value"}]}`, combined with AND against the legacy `status_filter`/`search`/`reviewed_by` params (which keep working for API consumers).
- Filterable fields: status, scholarship request/status, submitted/accepted dates, referral, gender and age (Humans join, deduplicated with the search join), and any custom form field via JSONB.
- Per-user virtual fields `skipped_by_me` and `reviewed_by_me` (boolean, resolved from the auth token as EXISTS subqueries), enabling views like "in review and not reviewed by me". Identity-less callers get a 422.
- `reviewed_by` field for any reviewer (value = reviewer user id, `eq`/`neq`), so "not reviewed by X" and reviewer combinations work. The legacy `reviewed_by` query param stays untouched for API consumers.
- Per-field operator whitelist (is, is not, contains, doesn't contain, is empty, is not empty, before, after) validated to user-oriented 422s. `contains` is case-insensitive with escaped wildcards; negative ops match missing values.

### Backoffice
- Filter builder popover in the toolbar: condition rows with typed field/operator/value inputs (selects with options for status and select-type custom fields, Yes/No for booleans, date pickers, debounced text), match all/any toggle, active-filter count badge, add/remove rows.
- State lives in the URL search params, so filtered views are shareable links. Filter changes reset to page 1. Incomplete rows stay in the UI without hitting the API.
- The status quick select (with per-status counts) merged into the same state: it is a shortcut that upserts a single "status is X" condition, and richer combinations render as a read-only "Custom" entry. The reviewer dropdown was removed entirely; reviewer filtering lives only in the builder ("Reviewed by" field with the popup reviewers as options). Legacy `?status=` and `?reviewerId=` links fold into the filters param and get scrubbed on the first filter edit (functional search updaters receive the raw location search, so the legacy keys must be removed explicitly or they resurrect conditions). Reviewer conditions referencing reviewers outside the current popup are dropped automatically on gathering switch.
- CSV export now respects the active search, reviewer and filter conditions (previously it always exported the whole popup). The button reads "Export filtered CSV" and the file is named `applications-filtered` when a filter is on.

## Test plan
- Backend: new `tests/api/application/test_list_filters.py` (11 tests: ops, match all/any, empty checks, dates, 422 validation, legacy param combination) plus 26 passing regression tests; `scripts/lint.sh` clean.
- Backoffice: Biome + `tsc` build + 111 vitest tests pass; portal build passes (client regen only).
- Manual: quick select and builder stay coherent both ways; deleting conditions leaves a clean URL. No DB migration.

## Out of scope
- Group-by with counts (NocoDB's grouping) is a separate feature.
