### PR TITLE
fix(portal): preserve popup URL through login

### DIFF
--- a/portal/src/components/Authentication.test.tsx
+++ b/portal/src/components/Authentication.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockReplace = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}))
+
+let authState: { user: { id: string } | null; isUserLoading: boolean }
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => authState,
+}))
+
+vi.mock("@/components/ui/Loader", () => ({
+  Loader: () => <div data-testid="loader" />,
+}))
+
+import Authentication from "./Authentication"
+
+describe("Authentication", () => {
+  beforeEach(() => {
+    mockReplace.mockClear()
+    window.history.replaceState({}, "", "/")
+  })
+
+  it("preserves the requested popup URL when sending a visitor to login", async () => {
+    authState = { user: null, isUserLoading: false }
+    window.history.replaceState(
+      {},
+      "",
+      "/portal/tech-summit-2025?tab=events#schedule",
+    )
+
+    render(
+      <Authentication>
+        <div>Portal content</div>
+      </Authentication>,
+    )
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        "/auth?redirect=%2Fportal%2Ftech-summit-2025%3Ftab%3Devents%23schedule",
+      )
+    })
+    expect(screen.getByTestId("loader")).toBeTruthy()
+    expect(screen.queryByText("Portal content")).toBeNull()
+  })
+
+  it("renders the requested page for an authenticated visitor", () => {
+    authState = { user: { id: "human-1" }, isUserLoading: false }
+
+    render(
+      <Authentication>
+        <div>Portal content</div>
+      </Authentication>,
+    )
+
+    expect(screen.getByText("Portal content")).toBeTruthy()
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+})

--- a/portal/src/components/Authentication.tsx
+++ b/portal/src/components/Authentication.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import { type ReactNode, useEffect } from "react"
 import { Loader } from "@/components/ui/Loader"
 import useAuth from "@/hooks/useAuth"
+import { getAuthRedirectPath } from "@/lib/safe-return-to"
 
 const Authentication = ({ children }: { children: ReactNode }) => {
   const { user, isUserLoading } = useAuth()
@@ -11,7 +12,8 @@ const Authentication = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     if (!isUserLoading && !user) {
-      router.replace("/auth")
+      const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
+      router.replace(getAuthRedirectPath(returnTo))
     }
   }, [user, isUserLoading, router])
 

--- a/portal/src/lib/safe-return-to.test.ts
+++ b/portal/src/lib/safe-return-to.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { getAuthRedirectPath, getSafeReturnTo } from "./safe-return-to"
+
+describe("getSafeReturnTo", () => {
+  it("keeps internal paths, query strings, and hashes", () => {
+    expect(getSafeReturnTo("/portal/tech-summit-2025?tab=events#details")).toBe(
+      "/portal/tech-summit-2025?tab=events#details",
+    )
+  })
+
+  it("rejects external and protocol-relative URLs", () => {
+    expect(getSafeReturnTo("https://example.com/portal/event")).toBeNull()
+    expect(getSafeReturnTo("//example.com/portal/event")).toBeNull()
+  })
+})
+
+describe("getAuthRedirectPath", () => {
+  it("preserves a popup deep link for post-login navigation", () => {
+    expect(getAuthRedirectPath("/portal/tech-summit-2025")).toBe(
+      "/auth?redirect=%2Fportal%2Ftech-summit-2025",
+    )
+  })
+
+  it("falls back to auth for unsafe return paths", () => {
+    expect(getAuthRedirectPath("https://example.com")).toBe("/auth")
+  })
+
+  it("does not redirect the auth page back to itself", () => {
+    expect(getAuthRedirectPath("/auth?redirect=%2Fportal")).toBe("/auth")
+  })
+})

--- a/portal/src/lib/safe-return-to.ts
+++ b/portal/src/lib/safe-return-to.ts
@@ -9,3 +9,22 @@ export function getSafeReturnTo(value: string | null | undefined) {
     return null
   }
 }
+
+/** Build an auth URL that returns to the requested internal page after login. */
+export function getAuthRedirectPath(returnTo: string | null | undefined) {
+  const safeReturnTo = getSafeReturnTo(returnTo)
+
+  // Never point the auth page back at itself. Besides being unnecessary, this
+  // can create a redirect loop when a login request itself returns 401.
+  if (
+    !safeReturnTo ||
+    safeReturnTo === "/auth" ||
+    safeReturnTo.startsWith("/auth?") ||
+    safeReturnTo.startsWith("/auth#") ||
+    safeReturnTo.startsWith("/auth/")
+  ) {
+    return "/auth"
+  }
+
+  return `/auth?redirect=${encodeURIComponent(safeReturnTo)}`
+}

--- a/portal/src/providers/queryProvider.tsx
+++ b/portal/src/providers/queryProvider.tsx
@@ -8,17 +8,22 @@ import {
 } from "@tanstack/react-query"
 import { type ReactNode, useState } from "react"
 import { ApiError } from "@/client"
+import { getAuthRedirectPath } from "@/lib/safe-return-to"
 
 function handleApiError(error: Error) {
   if (error instanceof ApiError && error.status === 401) {
     if (typeof window !== "undefined") {
       localStorage.removeItem("token")
+      const { pathname, search, hash } = window.location
       const isPublicRoute =
-        window.location.pathname.startsWith("/checkout") ||
-        window.location.pathname.startsWith("/groups/") ||
-        window.location.pathname.includes("/invite/")
-      if (!isPublicRoute) {
-        window.location.href = "/auth"
+        pathname.startsWith("/checkout") ||
+        pathname.startsWith("/groups/") ||
+        pathname.includes("/invite/")
+      const isAuthRoute = pathname === "/auth" || pathname.startsWith("/auth/")
+      if (!isPublicRoute && !isAuthRoute) {
+        window.location.replace(
+          getAuthRedirectPath(`${pathname}${search}${hash}`),
+        )
       }
     }
   }


### PR DESCRIPTION
## Summary

Preserve the requested portal popup URL through passwordless authentication instead of falling back to the first available popup after login.

## Related Issue

N/A — hotfix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- Redirect unauthenticated portal visitors to `/auth` with a validated `redirect` parameter containing the full requested path, query, and hash.
- Preserve the same return path when an expired token triggers the global `401` handler.
- Use replacement navigation so the failed protected route is not left in browser history.
- Add focused tests for safe return paths and the authentication gate.

## Testing

- [x] Focused portal tests pass (`7 passed`)
- [x] Biome passes for all changed files
- [x] Production portal Docker build succeeds
- [x] Manual Agent Browser testing performed
  - Fresh login returns to `/portal/tech-summit-2025`
  - Expired-token login preserves the popup URL and replaces browser history
  - Tech Summit 2025 renders without browser console or page errors

## Checklist

- [x] My code follows the project's coding standards
- [x] Documentation is not required for this hotfix
- [x] I have added tests for the changed functionality
- [x] Relevant tests pass
- [x] No backend API or generated-client changes
- [x] No database schema or migration changes
