### PR TITLE
feat(backoffice): clear view button on the applications list

### DIFF
--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -1148,6 +1148,34 @@ function ApplicationsTableContent({
     [upsertQuickFilter],
   )
 
+  const hasActiveView = Boolean(
+    filterConditions.length ||
+      search ||
+      searchParams.groupBy ||
+      searchParams.sortBy,
+  )
+
+  // Back to the pristine list: filters, search, grouping, sorting and the
+  // legacy params all reset in one navigation.
+  const clearView = useCallback(() => {
+    navigate({
+      to: "/applications",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        status: undefined,
+        reviewerId: undefined,
+        match: undefined,
+        filters: undefined,
+        groupBy: undefined,
+        search: undefined,
+        sortBy: undefined,
+        sortOrder: undefined,
+        page: 0,
+      }),
+      replace: true,
+    })
+  }, [navigate])
+
   const setGroupBy = useCallback(
     (value: string | undefined) => {
       navigate({
@@ -1455,6 +1483,16 @@ function ApplicationsTableContent({
           currentConfig={savedViewConfig}
           onApply={applySavedView}
         />
+      )}
+      {hasActiveView && (
+        <Button
+          variant="ghost"
+          className="h-9 text-muted-foreground"
+          onClick={clearView}
+        >
+          <X className="h-4 w-4" />
+          Clear
+        </Button>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Adds a "Clear" button to the applications list toolbar, visible only while filters, search, grouping or sorting are active. One click resets all of them (plus the legacy `status`/`reviewerId` params) back to the pristine list in a single navigation. Both search inputs (flat table and grouped mode) sync from the URL, so the reset propagates everywhere.

Follow-up to #519; this commit was originally pushed to that branch after it had merged, so it lands here on its own.

## Test plan
- Biome and `tsc` build pass locally; the 111-test vitest suite passed on this exact change before the cherry-pick.
- Manual: build a filtered, grouped, sorted view with a search term, hit Clear, verify the list and URL are pristine and the button disappears.