### PR TITLE
fix(tests): deterministic prior-payment pick in supersede equivalence test

### DIFF
--- a/backend/tests/api/payment/test_pending_release_return.py
+++ b/backend/tests/api/payment/test_pending_release_return.py
@@ -313,15 +313,14 @@ class TestSupersedeLocatedPendingCore:
         """
         popup = _make_popup(db, tenant_a, slug_prefix="slp05")
         coupon_a = _make_coupon(db, popup, current_uses=5)
-        coupon_b = _make_coupon(db, popup, current_uses=5)
         human = _make_human(db, tenant_a)
         application = _make_application(db, tenant_a, popup, human)
 
+        # Exactly ONE pending payment per application: the wrapper locates the
+        # prior with an unordered .first(), so a second matching row would make
+        # the pick heap-order dependent (flaky under table churn in CI).
         payment_via_wrapper = _make_pending_payment(
             db, tenant_a, popup, coupon=coupon_a, application_id=application.id
-        )
-        _make_pending_payment(
-            db, tenant_a, popup, coupon=coupon_b, application_id=application.id
         )
 
         def _cancel_mock():


### PR DESCRIPTION
## Summary

Root-causes and fixes the recurring flaky `test_shared_core_equivalence_with_wrapper` (payments supersede suite) that failed CI on unrelated PRs (#517's branch on Jul 24, #520 on Jul 27) with `assert 'pending' == 'cancelled'`, always passing on rerun and in isolation.

## Root cause

The test created two PENDING payments for one application and asserted the wrapper cancelled the first-inserted one. But `supersede_pending_payments` locates the prior payment with an unordered `.first()`, and `payments.application_id` has no index, so the pick follows physical heap order via a sequential scan. Under full-suite churn (the test DB session accumulates rows across the run) plus autovacuum, the free-space map can place the second insert on an earlier heap page, so the wrapper cancels the wrong payment. A fresh table scans in insertion order, which is why the test never fails in isolation and reruns go green. The mechanism was reproduced deterministically before fixing, by engineering the heap state (page fillers, delete, VACUUM, page overflow) to produce the exact CI failure on demand.

## Fix

The test now creates exactly one pending payment per application, which is also the production invariant the wrapper relies on (the supersede pre-step guarantees at most one pending per application, and the pathological two-pending case self-heals through `_check_no_pending_sibling_by_application`). The wrapper itself is deliberately untouched: adding an ORDER BY would be a behavior change out of scope for a test-flakiness fix.

## Test plan
- Engineered-churn reproduction: fails before the fix with the exact CI assertion, passes after.
- `uv run pytest tests/api/payment -q`: 228 passed.
- `scripts/lint.sh` clean. Test-only change, no migrations, no client regeneration.