### PR TITLE
fix(portal): preserve the query string on custom-domain root rewrites

### DIFF
--- a/portal/src/proxy.test.ts
+++ b/portal/src/proxy.test.ts
@@ -108,6 +108,21 @@ describe("checkout mode with active popup", () => {
     expect(result.url.pathname).toBe("/checkout/summer-fest")
   })
 
+  it("M-1b: preserves the query string when rewriting / to /checkout/summer-fest", async () => {
+    // A ?lang= deep link lands on the custom-domain root. Dropping the query
+    // here strips the language before SSR and the client ever see it, so the
+    // checkout silently falls back to the popup default_language.
+    const req = makeRequest(
+      "https://tickets.example.com/?lang=en&utm_source=newsletter",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string; url: URL }
+
+    expect(result.type).toBe("rewrite")
+    expect(result.url.pathname).toBe("/checkout/summer-fest")
+    expect(result.url.search).toBe("?lang=en&utm_source=newsletter")
+  })
+
   it("M-2: rewrites /thank-you to /checkout/summer-fest/thank-you preserving query", async () => {
     const req = makeRequest(
       "https://tickets.example.com/thank-you?payment_id=42",
@@ -157,6 +172,18 @@ describe("checkout mode with no active popup", () => {
 
     expect(result.type).toBe("rewrite")
     expect(result.url.pathname).toBe("/coming-soon")
+  })
+
+  it("M-3b: preserves the query string when rewriting / to /coming-soon", async () => {
+    const req = makeRequest(
+      "https://tickets.example.com/?lang=en",
+      "tickets.example.com",
+    )
+    const result = (await proxy(req)) as unknown as { type: string; url: URL }
+
+    expect(result.type).toBe("rewrite")
+    expect(result.url.pathname).toBe("/coming-soon")
+    expect(result.url.search).toBe("?lang=en")
   })
 
   it("passes through non-root paths in no-popup checkout mode", async () => {

--- a/portal/src/proxy.ts
+++ b/portal/src/proxy.ts
@@ -70,7 +70,14 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
       const slug = tenantData.active_popup_slug
 
       if (pathname === "/") {
-        const rewriteUrl = new URL(`/checkout/${slug}`, request.url)
+        // Carry the query across the rewrite: `new URL(path, base)` resets the
+        // search, so an unqualified path silently drops ?lang=/?utm_*. Losing
+        // ?lang here strips the language before SSR or the client can read it
+        // and the checkout falls back to the popup default_language.
+        const rewriteUrl = new URL(
+          `/checkout/${slug}${request.nextUrl.search}`,
+          request.url,
+        )
         return NextResponse.rewrite(rewriteUrl, {
           request: { headers: requestHeaders },
         })
@@ -88,7 +95,10 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
     } else {
       // No active popup — show Coming Soon page.
       if (pathname === "/") {
-        const rewriteUrl = new URL("/coming-soon", request.url)
+        const rewriteUrl = new URL(
+          `/coming-soon${request.nextUrl.search}`,
+          request.url,
+        )
         return NextResponse.rewrite(rewriteUrl, {
           request: { headers: requestHeaders },
         })


### PR DESCRIPTION
## Problema

Entrando al checkout con `?lang=en` desde la raíz de un dominio custom, el portal ignora el parámetro y renderiza el `default_language` de la popup (`es`).

## Causa raíz

`portal/src/proxy.ts` — el rewrite de `/` descartaba el query string:

```js
const rewriteUrl = new URL(`/checkout/${slug}`, request.url)  // ← pierde ?lang=en
```

`new URL(path, base)` resetea el `search` cuando el primer argumento es un path absoluto. La rama de `/thank-you` ya concatenaba `request.nextUrl.search`; las de `/` → `/checkout/<slug>` y `/` → `/coming-soon` no.

Con `landing_mode = checkout`, entrar a `https://<dominio-custom>/?lang=en` reescribía a `/checkout/<slug>` **sin** `lang`, y a partir de ahí:

1. **SSR** — `app/checkout/[popupSlug]/page.tsx` recibe `searchParams` vacío → `fetchCheckoutRuntime(slug, tenant, undefined)` → sin `Accept-Language` → el backend devuelve el contenido en el idioma fuente.
2. **Cliente** — `searchParams.get("lang")` es `null` en `languageProvider.tsx:112` → el resolver cae a `defaultLanguage` de la popup.

El `LanguageProvider` ya prioriza correctamente `?lang` sobre localStorage, default de popup y locale del browser; el parámetro nunca le llegaba. Los `utm_*` de links de campaña se perdían por el mismo motivo.

## Cambio

Se propaga `request.nextUrl.search` en ambos rewrites de `/` (checkout y coming-soon), igual que ya hacía `/thank-you`.

## Tests

Dos casos nuevos en `portal/src/proxy.test.ts`:

- `M-1b` — preserva el query al reescribir `/` → `/checkout/summer-fest` (`?lang=en&utm_source=newsletter`)
- `M-3b` — preserva el query al reescribir `/` → `/coming-soon`

Ambos fallaban antes del fix (`expected '' to be '?lang=en&utm_source=newsletter'`).

## Verificación

- `npx vitest run src/proxy.test.ts` → **10/10 pasan**
- `npx biome lint src/proxy.ts src/proxy.test.ts` → limpio
- Suite completa del portal: 6 archivos fallan (59 tests), **todos preexistentes en `dev`** — confirmado corriendo esos mismos archivos sobre el árbol limpio. Ninguno toca `proxy.ts`.

## Alcance

Solo afecta el path de dominio custom con `landing_mode = checkout`. Entrar directo a `/checkout/<slug>?lang=en` (subdominio) nunca pasó por este rewrite y ya funcionaba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
