### PR TITLE
feat(applications): offer fixed option values in advanced filters

### DIFF
--- a/backoffice/src/components/ApplicationDetail.tsx
+++ b/backoffice/src/components/ApplicationDetail.tsx
@@ -885,7 +885,7 @@ export function ApplicationDetail({
   const { isAdmin, isOperatorOrAbove } = useAuth()
 
   const { data: schema } = useQuery({
-    queryKey: ["form-fields-schema", application.popup_id],
+    queryKey: ["form-fields", "schema", application.popup_id],
     queryFn: async () => {
       const result = await FormFieldsService.getApplicationSchema({
         popupId: application.popup_id,

--- a/backoffice/src/components/Common/FilterBuilder.tsx
+++ b/backoffice/src/components/Common/FilterBuilder.tsx
@@ -65,13 +65,14 @@ export const FULL_TEXT_OPS = [
   "not_empty",
 ]
 
+// New and reset rows start without a value so an incomplete condition
+// never filters anything; the user must pick the value explicitly.
 function defaultValueFor(
   def: FilterFieldDef,
   op: string,
 ): FilterCondition["value"] {
   if (NO_VALUE_OPS.has(op)) return null
-  if (def.kind === "boolean") return true
-  if (def.kind === "select") return def.options?.[0]?.value ?? ""
+  if (def.kind === "boolean") return null
   return ""
 }
 
@@ -152,13 +153,15 @@ function ConditionValueInput({
   if (NO_VALUE_OPS.has(condition.op)) return null
 
   if (def.kind === "boolean") {
+    const current =
+      typeof condition.value === "boolean" ? String(condition.value) : undefined
     return (
       <Select
-        value={condition.value === false ? "false" : "true"}
+        value={current}
         onValueChange={(v) => onValueChange(v === "true")}
       >
         <SelectTrigger className="h-8 flex-1">
-          <SelectValue />
+          <SelectValue placeholder="Value" />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="true">Yes</SelectItem>

--- a/backoffice/src/components/applications/ApplicationFilterBuilder.tsx
+++ b/backoffice/src/components/applications/ApplicationFilterBuilder.tsx
@@ -30,10 +30,31 @@ const SCHOLARSHIP_STATUS_OPTIONS = [
   { value: "rejected", label: "Rejected" },
 ]
 
+// Base fields configured as selects in the form builder carry fixed
+// options; surface them as a value picker instead of free text.
+function baseFieldDef(
+  key: string,
+  label: string,
+  baseFieldOptions: Record<string, string[]>,
+): FilterFieldDef {
+  const options = baseFieldOptions[key]
+  if (options?.length) {
+    return {
+      key,
+      label,
+      kind: "select",
+      ops: EMPTYABLE_TEXT_OPS,
+      options: options.map((opt) => ({ value: opt, label: opt })),
+    }
+  }
+  return { key, label, kind: "text", ops: EMPTYABLE_TEXT_OPS }
+}
+
 function buildFieldDefs(
   statusOptions: { value: string; label: string }[],
   customFields: CustomFilterField[],
   reviewerOptions: { value: string; label: string }[] = [],
+  baseFieldOptions: Record<string, string[]> = {},
 ): FilterFieldDef[] {
   const fixed: FilterFieldDef[] = [
     {
@@ -82,8 +103,8 @@ function buildFieldDefs(
     { key: "submitted_at", label: "Submitted", kind: "date", ops: DATE_OPS },
     { key: "accepted_at", label: "Accepted", kind: "date", ops: DATE_OPS },
     { key: "referral", label: "Referral", kind: "text", ops: FULL_TEXT_OPS },
-    { key: "gender", label: "Gender", kind: "text", ops: EMPTYABLE_TEXT_OPS },
-    { key: "age", label: "Age", kind: "text", ops: EMPTYABLE_TEXT_OPS },
+    baseFieldDef("gender", "Gender", baseFieldOptions),
+    baseFieldDef("age", "Age", baseFieldOptions),
   ]
   const custom: FilterFieldDef[] = customFields.map((field) => ({
     key: `custom.${field.name}`,
@@ -102,6 +123,7 @@ export function ApplicationFilterBuilder({
   statusOptions,
   customFields,
   reviewerOptions,
+  baseFieldOptions,
   match,
   conditions,
   onChange,
@@ -109,13 +131,19 @@ export function ApplicationFilterBuilder({
   statusOptions: { value: string; label: string }[]
   customFields: CustomFilterField[]
   reviewerOptions?: { value: string; label: string }[]
+  baseFieldOptions?: Record<string, string[]>
   match: FilterMatch
   conditions: FilterCondition[]
   onChange: (match: FilterMatch, conditions: FilterCondition[]) => void
 }) {
   return (
     <FilterBuilder
-      fields={buildFieldDefs(statusOptions, customFields, reviewerOptions)}
+      fields={buildFieldDefs(
+        statusOptions,
+        customFields,
+        reviewerOptions,
+        baseFieldOptions,
+      )}
       match={match}
       conditions={conditions}
       onChange={onChange}

--- a/backoffice/src/components/forms/ApplicationForm.tsx
+++ b/backoffice/src/components/forms/ApplicationForm.tsx
@@ -80,7 +80,7 @@ export function ApplicationForm({ onSuccess }: ApplicationFormProps) {
     isLoading: schemaLoading,
     isError: _schemaError,
   } = useQuery({
-    queryKey: ["form-fields-schema", selectedPopupId],
+    queryKey: ["form-fields", "schema", selectedPopupId],
     queryFn: async () => {
       if (!selectedPopupId) return null
       const result = await FormFieldsService.getApplicationSchema({

--- a/backoffice/src/contexts/WorkspaceContext.tsx
+++ b/backoffice/src/contexts/WorkspaceContext.tsx
@@ -93,7 +93,6 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
             "popups",
             "humans",
             "form-fields",
-            "form-fields-schema",
             "approval-strategies",
             "popup-reviewers",
             "application-reviews",

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -116,6 +116,14 @@ import { createErrorHandler } from "@/utils"
 
 /** Schema shape returned by FormFieldsService.getApplicationSchema */
 interface ApplicationSchema {
+  base_fields?: Record<
+    string,
+    {
+      type?: string
+      options?: string[]
+      [key: string]: unknown
+    }
+  >
   custom_fields: Record<
     string,
     {
@@ -219,6 +227,16 @@ const APPLICATION_STATUS_OPTIONS: {
   { value: "rejected", label: "Rejected" },
 ]
 
+// Field types whose answers come from a closed option list. All of them
+// store the selected option string(s), so filters can match exact values.
+const OPTION_FIELD_TYPES = new Set([
+  "select",
+  "select_cards",
+  "radio",
+  "multiselect",
+  "multiselect_detailed",
+])
+
 // Custom form fields become filterable attributes; select-like fields keep
 // their options so the value input can offer them.
 function buildCustomFilterFields(
@@ -237,9 +255,22 @@ function buildCustomFilterFields(
       label: def.short_label || def.label || name,
       options: def.options,
       isSelect:
-        (def.type === "select" || def.type === "multiselect") &&
+        OPTION_FIELD_TYPES.has(def.type ?? "") &&
         (def.options?.length ?? 0) > 0,
     }))
+}
+
+// Base fields with fixed options (e.g. gender configured as a select in the
+// form builder) feed the matching filters a value picker.
+function buildBaseFieldOptions(
+  formSchema?: ApplicationSchema,
+): Record<string, string[]> {
+  const baseFields = formSchema?.base_fields ?? {}
+  return Object.fromEntries(
+    Object.entries(baseFields)
+      .filter(([, def]) => (def.options?.length ?? 0) > 0)
+      .map(([name, def]) => [name, def.options as string[]]),
+  )
 }
 
 /** Custom form-builder field usable as a grouping attribute. */
@@ -269,9 +300,7 @@ function buildGroupByCustomFields(
   return Object.entries(customFields)
     .filter(
       ([, def]) =>
-        def.type === "select" ||
-        def.type === "multiselect" ||
-        def.type === "boolean",
+        OPTION_FIELD_TYPES.has(def.type ?? "") || def.type === "boolean",
     )
     .sort(
       ([, a], [, b]) =>
@@ -952,11 +981,13 @@ const getColumns = (
 function ApplicationsTableContent({
   customColumns,
   customFilterFields,
+  baseFieldOptions,
   groupByCustomFields,
   isSchemaLoaded,
 }: {
   customColumns: ColumnDef<ApplicationPublic>[]
   customFilterFields: CustomFilterField[]
+  baseFieldOptions: Record<string, string[]>
   groupByCustomFields: GroupByField[]
   isSchemaLoaded: boolean
 }) {
@@ -1324,6 +1355,7 @@ function ApplicationsTableContent({
             : APPLICATION_STATUS_OPTIONS
         }
         customFields={customFilterFields}
+        baseFieldOptions={baseFieldOptions}
         reviewerOptions={reviewers.map((reviewer) => ({
           value: reviewer.user_id,
           label:
@@ -1493,7 +1525,7 @@ function Applications() {
   }, [])
 
   const { data: formSchema } = useQuery({
-    queryKey: ["form-fields-schema", selectedPopupId],
+    queryKey: ["form-fields", "schema", selectedPopupId],
     queryFn: async () => {
       const result = await FormFieldsService.getApplicationSchema({
         popupId: selectedPopupId!,
@@ -1510,6 +1542,11 @@ function Applications() {
 
   const customFilterFields = useMemo(
     () => buildCustomFilterFields(formSchema),
+    [formSchema],
+  )
+
+  const baseFieldOptions = useMemo(
+    () => buildBaseFieldOptions(formSchema),
     [formSchema],
   )
 
@@ -1671,6 +1708,7 @@ function Applications() {
             <ApplicationsTableContent
               customColumns={customColumns}
               customFilterFields={customFilterFields}
+              baseFieldOptions={baseFieldOptions}
               groupByCustomFields={groupByCustomFields}
               isSchemaLoaded={!!formSchema}
             />

--- a/backoffice/src/routes/_layout/form-builder/index.tsx
+++ b/backoffice/src/routes/_layout/form-builder/index.tsx
@@ -309,6 +309,7 @@ function FormBuilderContent({ popupId }: { popupId: string }) {
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["form-sections"] })
+      queryClient.invalidateQueries({ queryKey: ["form-fields"] })
     },
     onError: createErrorHandler(showErrorToast),
   })
@@ -329,6 +330,7 @@ function FormBuilderContent({ popupId }: { popupId: string }) {
     onSuccess: () => {
       showSuccessToast("Section deleted")
       queryClient.invalidateQueries({ queryKey: ["form-sections"] })
+      queryClient.invalidateQueries({ queryKey: ["form-fields"] })
     },
     onError: createErrorHandler(showErrorToast),
   })


### PR DESCRIPTION
## Summary

Advanced filters in the applications table now offer a value picker whenever the field has a closed option list, instead of a free-text input. Also fixes two related UX/caching issues found along the way.

### Fixed option values in filters
- Base fields (**gender**, **age**) configured as selects in the form builder now surface their per-popup options in the filter value input. Options come from the schema (`base_fields`), so admin edits propagate automatically; fields configured without options keep the free-text input.
- All closed-option field types are now covered: `select_cards` (Single select with visible options), `radio` and `multiselect_detailed` were previously falling back to free text because the check only accepted `select`/`multiselect`. The same gap excluded them from **Group by**.

### Add filter no longer auto-applies
New filter rows start without a value, so clicking **Add filter** no longer instantly applies "Status is Draft" (first field + first option made the condition complete at birth). All consumers already exclude incomplete conditions via `isCompleteCondition`, so unset rows are inert. Boolean values also start unset with a "Value" placeholder instead of implying Yes.

### Form builder edits now reach the filters without a hard refresh
The schema query was keyed `["form-fields-schema", popupId]` while every form builder mutation invalidates the `["form-fields"]` prefix, which never matched it (and the global 30s `staleTime` blocked refetch on mount). The schema is now keyed `["form-fields", "schema", popupId]` so existing invalidations cover it. Section create/delete now also invalidate fields, since the schema embeds the sections list.

## Test plan
- [ ] Add a filter on Gender/Age: value input is a select with the form builder options
- [ ] Filter on a `select_cards` custom field (e.g. Duration): value input is a select
- [ ] Click Add filter: no filter applied, badge stays at 0 until a value is picked
- [ ] Add an option to gender in the form builder, go to Applications: new option appears without refresh
- [ ] Group by offers select_cards/radio/multiselect_detailed custom fields

Frontend only, no backend or client regeneration needed. `pnpm --filter backoffice run build` and biome pass.