### PR TITLE
fix(tenants): stop offering deleted organizations as a context

### DIFF
--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -164,11 +164,20 @@ async def list_tenants(
     db: SessionDep,
     _: CurrentSuperadmin,
     search: str | None = None,
+    include_deleted: bool = False,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[TenantPublic]:
+    # Deleted organizations are hidden by default: they have no database
+    # credentials left, so offering them as a selectable context only leads to
+    # failing requests. Admin listings opt in to see them.
     tenants, total = crud.find(
-        db, skip=skip, limit=limit, search=search, search_fields=["name"]
+        db,
+        skip=skip,
+        limit=limit,
+        search=search,
+        search_fields=["name"],
+        deleted=None if include_deleted else False,
     )
 
     return ListModel[TenantPublic](

--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -254,6 +254,24 @@ def get_current_tenant(
 CurrentTenant = Annotated["TenantPublic", Depends(get_current_tenant)]
 
 
+def require_active_tenant(db: Session, tenant_id: uuid.UUID) -> None:
+    """Reject tenant-scoped access to a deleted organization.
+
+    Soft-deleting a tenant also revokes its PostgreSQL credentials, so without
+    this guard the request fails later with a misleading "credentials not
+    configured" error instead of saying the organization is gone.
+    """
+    from app.api.tenant.models import Tenants
+
+    tenant = db.get(Tenants, tenant_id)
+
+    if tenant is None or tenant.deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This organization is no longer available",
+        )
+
+
 def get_tenant_session(
     current_user: CurrentUser,
     db: SessionDep,
@@ -276,6 +294,8 @@ def get_tenant_session(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid tenant ID format",
             )
+
+        require_active_tenant(db, tenant_id)
 
         cached_cred = tenant_connection_manager.get_credential(
             db, tenant_id, CredentialType.CRUD
@@ -303,6 +323,8 @@ def get_tenant_session(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User has no tenant assigned",
         )
+
+    require_active_tenant(db, current_user.tenant_id)
 
     credential_type = (
         CredentialType.READONLY
@@ -562,6 +584,8 @@ def get_admin_or_api_key_tenant_session(scope: ApiKeyScope):
                     detail="API key has no tenant context.",
                 )
 
+            require_active_tenant(db, tenant_id)
+
             cached_cred = tenant_connection_manager.get_credential(
                 db, tenant_id, CredentialType.CRUD
             )
@@ -655,6 +679,8 @@ def get_check_in_or_api_key_tenant_session(scope: ApiKeyScope):
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="API key has no tenant context.",
                 )
+
+            require_active_tenant(db, tenant_id)
 
             cached_cred = tenant_connection_manager.get_credential(
                 db, tenant_id, CredentialType.CRUD

--- a/backend/tests/api/tenant/test_deleted_tenant_availability.py
+++ b/backend/tests/api/tenant/test_deleted_tenant_availability.py
@@ -1,0 +1,85 @@
+"""Regression tests: a deleted organization must not stay available.
+
+Two surfaces are covered:
+- GET /tenants hides deleted organizations unless include_deleted is requested,
+  so they never show up as a selectable context.
+- Tenant-scoped requests carrying a deleted X-Tenant-Id fail with an explicit
+  "no longer available" 404 instead of the misleading credentials error raised
+  once soft-delete revoked the tenant's database credentials.
+"""
+
+import uuid
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.tenant.models import Tenants
+
+
+@pytest.fixture
+def deleted_tenant(db: Session) -> Generator[Tenants, None, None]:
+    suffix = uuid.uuid4().hex[:6]
+    tenant = Tenants(
+        name=f"Deleted Org {suffix}",
+        slug=f"deleted-org-{suffix}",
+        deleted=True,
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    yield tenant
+
+    db.delete(tenant)
+    db.commit()
+
+
+def test_list_tenants_hides_deleted_by_default(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.get(
+        "/api/v1/tenants",
+        headers={"Authorization": f"Bearer {superadmin_token}"},
+        params={"limit": 100},
+    )
+
+    assert response.status_code == 200
+    ids = [t["id"] for t in response.json()["results"]]
+    assert str(deleted_tenant.id) not in ids
+
+
+def test_list_tenants_includes_deleted_when_requested(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.get(
+        "/api/v1/tenants",
+        headers={"Authorization": f"Bearer {superadmin_token}"},
+        params={"limit": 100, "include_deleted": True},
+    )
+
+    assert response.status_code == 200
+    ids = [t["id"] for t in response.json()["results"]]
+    assert str(deleted_tenant.id) in ids
+
+
+def test_tenant_scoped_request_rejects_deleted_tenant(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.get(
+        "/api/v1/popups",
+        headers={
+            "Authorization": f"Bearer {superadmin_token}",
+            "X-Tenant-Id": str(deleted_tenant.id),
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "This organization is no longer available"

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -7961,6 +7961,7 @@ export class TenantsService {
      * List Tenants
      * @param data The data for the request.
      * @param data.search
+     * @param data.includeDeleted
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_TenantPublic_ Successful Response
@@ -7972,6 +7973,7 @@ export class TenantsService {
             url: '/api/v1/tenants',
             query: {
                 search: data.search,
+                include_deleted: data.includeDeleted,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -6826,6 +6826,7 @@ export type TenantsGetTenantBySlugData = {
 export type TenantsGetTenantBySlugResponse = (TenantAnonymousPublic);
 
 export type TenantsListTenantsData = {
+    includeDeleted?: boolean;
     /**
      * Maximum number of items to return
      */

--- a/backoffice/src/contexts/WorkspaceContext.tsx
+++ b/backoffice/src/contexts/WorkspaceContext.tsx
@@ -51,19 +51,39 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     },
   )
 
-  // Fetch tenants for superadmin auto-selection
+  // Fetch selectable tenants for superadmins. The endpoint excludes deleted
+  // organizations, so this list also tells us whether a persisted selection is
+  // still valid.
   const { data: tenants, isError: _tenantsError } = useQuery({
     queryKey: ["tenants"],
     queryFn: () => TenantsService.listTenants({ skip: 0, limit: 100 }),
-    enabled: isSuperadmin && !selectedTenantId,
+    enabled: isSuperadmin,
   })
 
-  // Auto-select first tenant for superadmins
+  // Auto-select the first tenant, and drop a selection that is no longer available
   useEffect(() => {
-    if (isSuperadmin && !selectedTenantId && tenants?.results?.length) {
-      const firstTenantId = tenants.results[0].id
-      setSelectedTenantIdState(firstTenantId)
-      localStorage.setItem(TENANT_STORAGE_KEY, firstTenantId)
+    if (!isSuperadmin || !tenants) return
+
+    const available = tenants.results
+    const isStale = selectedTenantId
+      ? !available.some((tenant) => tenant.id === selectedTenantId)
+      : true
+
+    // A truncated page cannot prove a selection is gone — only the first 100
+    // organizations were fetched.
+    const isTruncated = tenants.paging.total > available.length
+    if (!isStale || (selectedTenantId && isTruncated)) return
+
+    const nextTenantId = available[0]?.id ?? null
+    if (nextTenantId === selectedTenantId) return
+
+    setSelectedTenantIdState(nextTenantId)
+    setSelectedPopupIdState(null)
+    localStorage.removeItem(POPUP_STORAGE_KEY)
+    if (nextTenantId) {
+      localStorage.setItem(TENANT_STORAGE_KEY, nextTenantId)
+    } else {
+      localStorage.removeItem(TENANT_STORAGE_KEY)
     }
   }, [isSuperadmin, selectedTenantId, tenants])
 

--- a/backoffice/src/routes/_layout/organizations/index.tsx
+++ b/backoffice/src/routes/_layout/organizations/index.tsx
@@ -28,6 +28,9 @@ function getTenantsQueryOptions(
         skip: page * pageSize,
         limit: pageSize,
         search: search || undefined,
+        // Admin listing keeps deleted organizations visible for auditing;
+        // every other surface only offers selectable ones.
+        includeDeleted: true,
       }),
     queryKey: ["tenants", { page, pageSize, search }],
   }

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -7961,6 +7961,7 @@ export class TenantsService {
      * List Tenants
      * @param data The data for the request.
      * @param data.search
+     * @param data.includeDeleted
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_TenantPublic_ Successful Response
@@ -7972,6 +7973,7 @@ export class TenantsService {
             url: '/api/v1/tenants',
             query: {
                 search: data.search,
+                include_deleted: data.includeDeleted,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -6826,6 +6826,7 @@ export type TenantsGetTenantBySlugData = {
 export type TenantsGetTenantBySlugResponse = (TenantAnonymousPublic);
 
 export type TenantsListTenantsData = {
+    includeDeleted?: boolean;
     /**
      * Maximum number of items to return
      */


### PR DESCRIPTION
## Summary

Deleting an organization left it fully selectable. It stayed in the sidebar organization selector, and picking it as the active context made every tenant-scoped request fail with a misleading `Tenant credentials not configured` error.

Two independent gaps caused this:

- `GET /tenants` never filtered by `deleted`, so soft-deleted organizations kept being offered as a context.
- The tenant-session dependencies only checked whether PostgreSQL credentials existed, never the tenant's `deleted` flag. Since `soft_delete` calls `revoke_tenant_credentials` and removes those rows, the failure surfaced as a credentials error that says nothing about the organization being gone.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- `list_tenants` accepts `include_deleted` (default `false`) and hides deleted organizations otherwise. The Organizations admin table opts in with `includeDeleted: true` so its Status column keeps working as an audit view.
- New `require_active_tenant()` helper rejects deleted organizations with `404 This organization is no longer available`. It runs in both `get_tenant_session` branches and in the two API-key tenant-session factories.
- The backoffice workspace now validates its persisted tenant selection against the active list, drops a selection that is no longer available (clearing the popup selection with it), and falls back to the first active organization. A truncation guard keeps a valid selection from being discarded when more than 100 organizations exist.
- Regenerated the OpenAPI clients for both frontends.

Portal entry points were already safe: `resolve_by_host` and `get_by_domain` filter `deleted == False`, so `get_human_tenant_session` was intentionally left without the extra lookup.

| File | Change |
|------|--------|
| `backend/app/api/tenant/router.py` | `include_deleted` query param on `list_tenants` |
| `backend/app/core/dependencies/users.py` | `require_active_tenant()` helper wired into the four tenant-session paths |
| `backend/tests/api/tenant/test_deleted_tenant_availability.py` | Regression tests for both surfaces |
| `backoffice/src/contexts/WorkspaceContext.tsx` | Drops a stale tenant selection and re-selects an active one |
| `backoffice/src/routes/_layout/organizations/index.tsx` | Opts in to `includeDeleted` to keep the Status column |
| `backoffice/src/client/`, `portal/src/client/` | Regenerated OpenAPI clients |

## Testing

- [x] Backend tests pass (`bash scripts/test.sh`) — 2096 passed, 8 skipped
- [x] Backend linting passes (`bash scripts/lint.sh`)
- [x] Backoffice builds successfully (`pnpm run build`)
- [x] Backoffice linting passes (`pnpm run lint`)
- [x] Portal builds successfully (`pnpm --filter portal run build`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed
- [x] Database migrations are included if schema changed (none needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
