### PR TITLE
feat(tenant): make the portal help button configurable per organization

### DIFF
--- a/backend/app/alembic/versions/a7f2c9e4b183_tenant_help_button.py
+++ b/backend/app/alembic/versions/a7f2c9e4b183_tenant_help_button.py
@@ -1,0 +1,37 @@
+"""Add portal help button config to tenants.
+
+Revision ID: a7f2c9e4b183
+Revises: 2b03f8cf7cdd
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7f2c9e4b183"
+down_revision: str | Sequence[str] | None = "2b03f8cf7cdd"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Opt-in: existing tenants start with the help button off, so nobody
+    # inherits it until an admin enables it and sets a destination address.
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "help_enabled",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "tenants", sa.Column("help_email", sa.String(length=255), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenants", "help_email")
+    op.drop_column("tenants", "help_enabled")

--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -332,12 +332,37 @@ async def update_tenant(
                 ),
             )
 
+    # 7b. Merged-state validation for the portal help button.
+    # The schema validator only sees the payload, so it cannot judge
+    # PATCH {"help_enabled": true} against a row that has no help_email, nor
+    # PATCH {"help_email": null} against a row that already has help enabled.
+    effective_help_enabled = (
+        tenant_in.help_enabled
+        if tenant_in.help_enabled is not None
+        else tenant.help_enabled
+    )
+    effective_help_email = (
+        tenant_in.help_email
+        if "help_email" in tenant_in.model_fields_set
+        else tenant.help_email
+    )
+    if effective_help_enabled and not (effective_help_email or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "help_enabled requires a help_email. Set a help email before "
+                "enabling the portal help button."
+            ),
+        )
+
     # 8. Snapshot old domain and fields for cache invalidation after update
     old_domain = tenant.custom_domain
     old_landing_mode = tenant.landing_mode
     old_custom_domain_active = tenant.custom_domain_active
     old_meta_tracking_enabled = tenant.meta_tracking_enabled
     old_meta_pixel_id = tenant.meta_pixel_id
+    old_help_enabled = tenant.help_enabled
+    old_help_email = tenant.help_email
 
     # CDN image ingestion: rewrite external image URLs to CDN before commit.
     # Pattern B (async hook). Fail-open: any per-URL failure keeps the original URL.
@@ -410,6 +435,8 @@ async def update_tenant(
     new_custom_domain_active = updated.custom_domain_active
     new_meta_tracking_enabled = updated.meta_tracking_enabled
     new_meta_pixel_id = updated.meta_pixel_id
+    new_help_enabled = updated.help_enabled
+    new_help_email = updated.help_email
 
     domains_to_invalidate: set[str] = set()
 
@@ -429,6 +456,12 @@ async def update_tenant(
     if (
         new_meta_tracking_enabled != old_meta_tracking_enabled
         or new_meta_pixel_id != old_meta_pixel_id
+    ) and new_domain:
+        domains_to_invalidate.add(new_domain)
+
+    # Invalidate current domain when the public help-button config changes.
+    if (
+        new_help_enabled != old_help_enabled or new_help_email != old_help_email
     ) and new_domain:
         domains_to_invalidate.add(new_domain)
 

--- a/backend/app/api/tenant/schemas.py
+++ b/backend/app/api/tenant/schemas.py
@@ -55,6 +55,22 @@ class TenantBase(SQLModel):
     meta_pixel_id: str | None = Field(default=None, max_length=64)
     ga_tracking_enabled: bool = False
     ga_measurement_id: str | None = Field(default=None, max_length=64)
+    help_enabled: bool = False
+    help_email: EmailStr | None = Field(default=None, max_length=255)
+
+
+def _validate_help_settings(help_enabled: bool | None, help_email: str | None) -> None:
+    """Reject a help button that is on but has nowhere to send mail.
+
+    Only meaningful when both values represent the *effective* state. Callers
+    holding a partial payload (``TenantUpdate``) must merge against the DB row
+    first — see the router's merged-state check.
+    """
+    if help_enabled and not (help_email or "").strip():
+        raise ValueError(
+            "help_enabled requires a help_email. "
+            "Set a help email before enabling the portal help button."
+        )
 
 
 class TenantCreate(SQLModel):
@@ -69,6 +85,8 @@ class TenantCreate(SQLModel):
     meta_pixel_id: str | None = Field(default=None, max_length=64)
     ga_tracking_enabled: bool = False
     ga_measurement_id: str | None = Field(default=None, max_length=64)
+    help_enabled: bool = False
+    help_email: EmailStr | None = None
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: int | None = 587
     smtp_user: str | None = Field(default=None, max_length=255)
@@ -99,6 +117,12 @@ class TenantCreate(SQLModel):
         )
         return self
 
+    @model_validator(mode="after")
+    def validate_help(self) -> Self:
+        # Create carries the complete state, so this is the definitive check.
+        _validate_help_settings(self.help_enabled, self.help_email)
+        return self
+
 
 class TenantUpdate(SQLModel):
     name: str | None = None
@@ -115,6 +139,8 @@ class TenantUpdate(SQLModel):
     meta_capi_access_token: str | None = Field(default=None, exclude=True)
     ga_tracking_enabled: bool | None = None
     ga_measurement_id: str | None = Field(default=None, max_length=64)
+    help_enabled: bool | None = None
+    help_email: EmailStr | None = None
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: int | None = None
     smtp_user: str | None = Field(default=None, max_length=255)
@@ -147,6 +173,25 @@ class TenantUpdate(SQLModel):
         _validate_smtp_common(
             self.smtp_host, self.smtp_port, self.smtp_tls, self.smtp_ssl
         )
+        return self
+
+    @model_validator(mode="after")
+    def validate_help(self) -> Self:
+        """Reject enabling the help button while clearing its address.
+
+        Payload-level only. ``None`` means "unchanged", so a payload that just
+        flips ``help_enabled`` on cannot be judged here — the router performs
+        the definitive merged-state check against the DB row.
+        """
+        if (
+            self.help_enabled is True
+            and "help_email" in self.model_fields_set
+            and self.help_email is None
+        ):
+            raise ValueError(
+                "help_enabled requires a help_email. "
+                "Set a help email before enabling the portal help button."
+            )
         return self
 
     @model_validator(mode="after")

--- a/backend/tests/api/tenant/test_tenant_help_button.py
+++ b/backend/tests/api/tenant/test_tenant_help_button.py
@@ -1,0 +1,217 @@
+"""Tests for the per-tenant portal help button config (help_enabled / help_email).
+
+Covers the three validation layers:
+- TenantBase / TenantCreate: complete state, definitive schema check
+- TenantUpdate: payload-level check (enable + explicit clear in one request)
+- PATCH router: merged-state check against the DB row
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+from sqlmodel import Session
+
+from app.api.tenant.models import Tenants
+from app.api.tenant.schemas import TenantBase, TenantCreate, TenantUpdate
+
+# --- Defaults: opt-in, off for everyone until configured ---
+
+
+def test_tenant_base_help_defaults_off() -> None:
+    tenant = TenantBase(name="Test", slug="test")
+    assert tenant.help_enabled is False
+    assert tenant.help_email is None
+
+
+def test_tenant_create_help_defaults_off() -> None:
+    tenant = TenantCreate(name="Test")
+    assert tenant.help_enabled is False
+    assert tenant.help_email is None
+
+
+def test_tenant_base_accepts_enabled_with_email() -> None:
+    tenant = TenantBase(
+        name="Test", slug="test", help_enabled=True, help_email="help@example.com"
+    )
+    assert tenant.help_enabled is True
+    assert tenant.help_email == "help@example.com"
+
+
+# --- TenantCreate: complete state, so the schema check is definitive ---
+
+
+def test_tenant_create_rejects_enabled_without_email() -> None:
+    with pytest.raises(ValidationError, match="help_enabled requires a help_email"):
+        TenantCreate(name="Test", help_enabled=True)
+
+
+def test_tenant_create_rejects_enabled_with_blank_email() -> None:
+    """A whitespace-only address is not a destination."""
+    with pytest.raises(ValidationError):
+        TenantCreate(name="Test", help_enabled=True, help_email="   ")
+
+
+def test_tenant_create_accepts_enabled_with_email() -> None:
+    tenant = TenantCreate(name="Test", help_enabled=True, help_email="help@example.com")
+    assert tenant.help_enabled is True
+
+
+def test_tenant_create_accepts_email_without_enabling() -> None:
+    """Configuring the address while leaving the button off is a valid state."""
+    tenant = TenantCreate(name="Test", help_email="help@example.com")
+    assert tenant.help_enabled is False
+
+
+# --- TenantUpdate: payload-level only (None means "unchanged") ---
+
+
+def test_tenant_update_help_defaults_none() -> None:
+    update = TenantUpdate()
+    assert update.help_enabled is None
+    assert update.help_email is None
+
+
+def test_tenant_update_rejects_enable_while_clearing_email() -> None:
+    """Enabling and explicitly nulling the address in one payload is incoherent."""
+    with pytest.raises(ValidationError, match="help_enabled requires a help_email"):
+        TenantUpdate(help_enabled=True, help_email=None)
+
+
+def test_tenant_update_allows_enable_without_mentioning_email() -> None:
+    """Omitted help_email means "unchanged" — the router decides against the DB row."""
+    update = TenantUpdate(help_enabled=True)
+    assert update.help_enabled is True
+    assert "help_email" not in update.model_fields_set
+
+
+def test_tenant_update_allows_disable_and_clear_together() -> None:
+    update = TenantUpdate(help_enabled=False, help_email=None)
+    assert update.help_enabled is False
+
+
+def test_tenant_update_rejects_invalid_email() -> None:
+    with pytest.raises(ValidationError):
+        TenantUpdate(help_enabled=True, help_email="not-an-email")
+
+
+# --- PATCH router: merged-state check ---
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_patch_rejects_enable_when_row_has_no_email(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    """PATCH {help_enabled: true} alone cannot be judged by the schema — the row has no email."""
+    tenant_a.help_enabled = False
+    tenant_a.help_email = None
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": True},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 422, resp.text
+    assert "help_enabled requires a help_email" in resp.text
+
+    db.refresh(tenant_a)
+    assert tenant_a.help_enabled is False
+
+
+def test_patch_rejects_clearing_email_while_enabled(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    """The inverse gap: nulling the address on a row that already has help enabled."""
+    tenant_a.help_enabled = True
+    tenant_a.help_email = "help@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_email": None},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 422, resp.text
+
+    db.refresh(tenant_a)
+    assert tenant_a.help_email == "help@example.com"
+
+
+def test_patch_accepts_enable_with_email_in_same_payload(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    tenant_a.help_enabled = False
+    tenant_a.help_email = None
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": True, "help_email": "support@example.com"},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["help_enabled"] is True
+    assert data["help_email"] == "support@example.com"
+
+
+def test_patch_accepts_enable_when_row_already_has_email(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    """Address configured earlier, button flipped on later — merged state is valid."""
+    tenant_a.help_enabled = False
+    tenant_a.help_email = "support@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": True},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["help_enabled"] is True
+
+
+def test_patch_allows_disabling_and_clearing(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    tenant_a.help_enabled = True
+    tenant_a.help_email = "support@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": False, "help_email": None},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["help_enabled"] is False
+    assert data["help_email"] is None
+
+
+# --- Portal exposure: the anonymous payload must carry both fields ---
+
+
+def test_public_slug_endpoint_exposes_help_config(
+    client: TestClient, tenant_a: Tenants, db: Session
+) -> None:
+    """The portal reads these from the unauthenticated endpoint."""
+    tenant_a.help_enabled = True
+    tenant_a.help_email = "support@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.get(f"/api/v1/tenants/public/{tenant_a.slug}")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["help_enabled"] is True
+    assert data["help_email"] == "support@example.com"

--- a/backend/tests/core/dependencies/test_tenants.py
+++ b/backend/tests/core/dependencies/test_tenants.py
@@ -53,6 +53,8 @@ def _make_tenant(tenant_id: uuid.UUID = _TENANT_A_ID) -> MagicMock:
     t.meta_pixel_id = None
     t.ga_tracking_enabled = False
     t.ga_measurement_id = None
+    t.help_enabled = False
+    t.help_email = None
     t.active_popup_slug = None  # computed projection — not a DB column
     t.third_party_key_prefix = None  # third-party OTP display fragment
     return t
@@ -67,7 +69,8 @@ def _make_tenant_public_json(tenant_id: uuid.UUID = _TENANT_A_ID) -> str:
         f'"custom_domain":null,"custom_domain_active":false,'
         f'"landing_mode":"portal","meta_tracking_enabled":false,'
         f'"meta_pixel_id":null,"ga_tracking_enabled":false,'
-        f'"ga_measurement_id":null,"active_popup_slug":null}}'
+        f'"ga_measurement_id":null,"help_enabled":false,"help_email":null,'
+        f'"active_popup_slug":null}}'
     )
 
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -18875,6 +18875,24 @@ export const TenantAnonymousPublicSchema = {
             ],
             title: 'Ga Measurement Id'
         },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -18998,6 +19016,23 @@ export const TenantCreateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [
@@ -19231,6 +19266,24 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         id: {
             type: 'string',
@@ -19541,6 +19594,29 @@ export const TenantUpdateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Enabled'
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -3838,6 +3838,8 @@ export type TenantAnonymousPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     active_popup_slug?: (string | null);
 };
@@ -3854,6 +3856,8 @@ export type TenantCreate = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);
@@ -3885,6 +3889,8 @@ export type TenantPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     meta_capi_configured?: boolean;
     is_trial?: boolean;
@@ -3923,6 +3929,8 @@ export type TenantUpdate = {
     meta_capi_access_token?: (string | null);
     ga_tracking_enabled?: (boolean | null);
     ga_measurement_id?: (string | null);
+    help_enabled?: (boolean | null);
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);

--- a/backoffice/src/components/forms/TenantForm.help-button.test.tsx
+++ b/backoffice/src/components/forms/TenantForm.help-button.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for TenantForm — portal help button config (help_enabled / help_email)
+ *
+ * Covers:
+ * - the toggle and address round-trip into the PATCH payload
+ * - enabling without an address blocks the save (no PATCH fired)
+ * - an invalid address blocks the save
+ * - a blank address is sent as null when the button stays off
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/client", () => ({
+  TenantsService: {
+    createTenant: vi.fn(),
+    updateTenant: vi.fn(),
+    deleteTenant: vi.fn(),
+    sendSmtpTestEmail: vi.fn(),
+  },
+  PopupsService: {
+    listPopups: vi.fn(),
+  },
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({
+    isSuperadmin: true,
+    isAdmin: true,
+    user: { email: "admin@acme.com" },
+  }),
+}))
+
+vi.mock("@/hooks/useCustomToast", () => ({
+  default: () => ({
+    showSuccessToast: vi.fn(),
+    showErrorToast: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/useUnsavedChanges", () => ({
+  useUnsavedChanges: () => ({ state: "unblocked" }),
+  UnsavedChangesDialog: () => null,
+}))
+
+vi.mock("@/components/ui/image-upload", () => ({
+  ImageUpload: () => null,
+}))
+
+vi.mock("@/components/forms/TenantCredentialsSection", () => ({
+  TenantCredentialsSection: () => null,
+}))
+
+import { PopupsService, TenantsService } from "@/client"
+import { TenantForm } from "./TenantForm"
+
+const mockListPopups = vi.mocked(PopupsService.listPopups)
+const mockUpdateTenant = vi.mocked(TenantsService.updateTenant)
+
+const BASE_TENANT = {
+  id: "tenant-1",
+  name: "Acme Events",
+  slug: "acme",
+  custom_domain: null,
+  custom_domain_active: false,
+  landing_mode: "portal" as const,
+  sender_email: null,
+  sender_name: null,
+  image_url: null,
+  icon_url: null,
+  logo_url: null,
+  deleted: false,
+  help_enabled: false,
+  help_email: null,
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+async function save(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Save Changes" }))
+}
+
+describe("TenantForm — portal help button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListPopups.mockResolvedValue({
+      results: [],
+      paging: { offset: 0, limit: 100, total: 0 },
+    } as Awaited<ReturnType<typeof PopupsService.listPopups>>)
+    mockUpdateTenant.mockResolvedValue({} as never)
+  })
+
+  it("sends help_enabled and help_email in the PATCH payload", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await user.click(screen.getByRole("switch", { name: "Help Button" }))
+    await user.type(
+      screen.getByPlaceholderText("support@acme.com"),
+      "support@acme.com",
+    )
+    await save(user)
+
+    await waitFor(() => {
+      expect(mockUpdateTenant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: expect.objectContaining({
+            help_enabled: true,
+            help_email: "support@acme.com",
+          }),
+        }),
+      )
+    })
+  })
+
+  it("blocks the save when the button is enabled with no address", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await user.click(screen.getByRole("switch", { name: "Help Button" }))
+    await save(user)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Help email is required when the help button is enabled",
+        ),
+      ).toBeTruthy()
+    })
+    expect(mockUpdateTenant).not.toHaveBeenCalled()
+  })
+
+  it("blocks the save when the address is malformed", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await user.click(screen.getByRole("switch", { name: "Help Button" }))
+    await user.type(screen.getByPlaceholderText("support@acme.com"), "nope")
+    await save(user)
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid email address")).toBeTruthy()
+    })
+    expect(mockUpdateTenant).not.toHaveBeenCalled()
+  })
+
+  it("sends help_email as null when the button stays off", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await save(user)
+
+    await waitFor(() => {
+      expect(mockUpdateTenant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: expect.objectContaining({
+            help_enabled: false,
+            help_email: null,
+          }),
+        }),
+      )
+    })
+  })
+
+  it("prefills both fields from the tenant", () => {
+    render(
+      <TenantForm
+        defaultValues={{
+          ...BASE_TENANT,
+          help_enabled: true,
+          help_email: "existing@acme.com",
+        }}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    expect(screen.getByRole("switch", { name: "Help Button" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    )
+    expect(screen.getByPlaceholderText("support@acme.com")).toHaveValue(
+      "existing@acme.com",
+    )
+  })
+})

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Copy,
   Globe,
+  HelpCircle,
   Image,
   Info,
   Lock,
@@ -174,6 +175,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
       meta_capi_access_token: "",
       ga_tracking_enabled: defaultValues?.ga_tracking_enabled ?? false,
       ga_measurement_id: defaultValues?.ga_measurement_id ?? "",
+      help_enabled: defaultValues?.help_enabled ?? false,
+      help_email: defaultValues?.help_email ?? "",
       smtp_host: defaultValues?.smtp_host ?? "",
       smtp_port: defaultValues?.smtp_port ?? 587,
       smtp_user: defaultValues?.smtp_user ?? "",
@@ -199,6 +202,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           meta_pixel_id: value.meta_pixel_id || null,
           ga_tracking_enabled: value.ga_tracking_enabled,
           ga_measurement_id: value.ga_measurement_id || null,
+          help_enabled: value.help_enabled,
+          help_email: value.help_email || null,
           smtp_host: smtpHost || null,
           smtp_port: value.smtp_port || null,
           smtp_user: smtpUser || null,
@@ -233,6 +238,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           meta_pixel_id: value.meta_pixel_id || undefined,
           ga_tracking_enabled: value.ga_tracking_enabled,
           ga_measurement_id: value.ga_measurement_id || undefined,
+          help_enabled: value.help_enabled,
+          help_email: value.help_email || undefined,
           smtp_host: smtpHost || undefined,
           smtp_port: value.smtp_port || undefined,
           smtp_user: smtpUser || undefined,
@@ -899,6 +906,65 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
               </LoadingButton>
             </InlineRow>
           )}
+        </InlineSection>
+
+        <Separator />
+
+        {/* Portal Help Button */}
+        <InlineSection title="Portal Help Button">
+          <form.Field name="help_enabled">
+            {(field) => (
+              <InlineRow
+                icon={<HelpCircle className="h-4 w-4 text-muted-foreground" />}
+                label="Help Button"
+                description="Show a floating help button on every portal page."
+              >
+                <Switch
+                  id="help_enabled"
+                  aria-label="Help Button"
+                  checked={field.state.value}
+                  onCheckedChange={field.handleChange}
+                />
+              </InlineRow>
+            )}
+          </form.Field>
+
+          <form.Field
+            name="help_email"
+            validators={{
+              onBlur: ({ value, fieldApi }) => {
+                const enabled = fieldApi.form.getFieldValue("help_enabled")
+                if (enabled && !value)
+                  return "Help email is required when the help button is enabled"
+                if (value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+                  return "Invalid email address"
+                }
+                return undefined
+              },
+            }}
+          >
+            {(field) => (
+              <div>
+                <InlineRow
+                  icon={
+                    <HelpCircle className="h-4 w-4 text-muted-foreground" />
+                  }
+                  label="Help Email"
+                  description="Where portal help requests are sent."
+                >
+                  <Input
+                    placeholder="support@acme.com"
+                    type="email"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    className="max-w-xs text-sm"
+                  />
+                </InlineRow>
+                <FieldError errors={field.state.meta.errors} />
+              </div>
+            )}
+          </form.Field>
         </InlineSection>
 
         <Separator />

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -18875,6 +18875,24 @@ export const TenantAnonymousPublicSchema = {
             ],
             title: 'Ga Measurement Id'
         },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -18998,6 +19016,23 @@ export const TenantCreateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [
@@ -19231,6 +19266,24 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         id: {
             type: 'string',
@@ -19541,6 +19594,29 @@ export const TenantUpdateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Enabled'
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -3838,6 +3838,8 @@ export type TenantAnonymousPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     active_popup_slug?: (string | null);
 };
@@ -3854,6 +3856,8 @@ export type TenantCreate = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);
@@ -3885,6 +3889,8 @@ export type TenantPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     meta_capi_configured?: boolean;
     is_trial?: boolean;
@@ -3923,6 +3929,8 @@ export type TenantUpdate = {
     meta_capi_access_token?: (string | null);
     ga_tracking_enabled?: (boolean | null);
     ga_measurement_id?: (string | null);
+    help_enabled?: (boolean | null);
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);

--- a/portal/src/components/HelpButton.test.tsx
+++ b/portal/src/components/HelpButton.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.popup ? `${key}:${opts.popup}` : key,
+  }),
+}))
+
+let tenantState: {
+  help_enabled?: boolean | null
+  help_email?: string | null
+  sender_email?: string | null
+}
+vi.mock("@/providers/tenantProvider", () => ({
+  useTenant: () => ({ tenant: tenantState }),
+}))
+
+let popupState: { name?: string } | null
+vi.mock("@/providers/cityProvider", () => ({
+  useCityProvider: () => ({ getCity: () => popupState }),
+}))
+
+import HelpButton from "./HelpButton"
+
+describe("HelpButton", () => {
+  beforeEach(() => {
+    popupState = { name: "Tech Summit" }
+  })
+
+  it("renders nothing when the tenant has help disabled", () => {
+    tenantState = { help_enabled: false, help_email: "support@acme.com" }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders nothing when help is enabled but no help_email is set", () => {
+    tenantState = { help_enabled: true, help_email: null }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders nothing when help_email is only whitespace", () => {
+    tenantState = { help_enabled: true, help_email: "   " }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("does not fall back to sender_email", () => {
+    tenantState = {
+      help_enabled: true,
+      help_email: null,
+      sender_email: "noreply@acme.com",
+    }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders the button when help is enabled and an address is configured", () => {
+    tenantState = { help_enabled: true, help_email: "support@acme.com" }
+    render(<HelpButton />)
+    expect(screen.getByRole("button", { name: "help.aria_label" })).toBeTruthy()
+  })
+})

--- a/portal/src/components/HelpButton.tsx
+++ b/portal/src/components/HelpButton.tsx
@@ -14,17 +14,17 @@ import { useTenant } from "@/providers/tenantProvider"
 
 /**
  * Floating help button shown on every portal page. Opens a small popover that
- * lets the visitor email support. The destination is the tenant's configured
- * `sender_email`; when the tenant has no address the button is not rendered.
- * Must be mounted inside both `CityProvider` and `TenantProvider` (see
- * `Providers.tsx`).
+ * lets the visitor email support. Both the button and its destination are
+ * configured per organization in the backoffice: it renders only when the
+ * tenant has `help_enabled` and a `help_email`. Must be mounted inside both
+ * `CityProvider` and `TenantProvider` (see `Providers.tsx`).
  */
 const HelpButton = () => {
   const { t } = useTranslation()
   const { tenant } = useTenant()
   const { getCity } = useCityProvider()
 
-  const email = tenant?.sender_email?.trim()
+  const email = tenant?.help_enabled ? tenant.help_email?.trim() : undefined
   if (!email) {
     return null
   }


### PR DESCRIPTION
## Qué hace

El botón flotante de ayuda del portal estaba hardcodeado al `sender_email` del tenant y aparecía para cualquier organización que tuviera uno. Ahora ambas cosas —**si el botón se muestra** y **a qué dirección escribe**— se configuran por organización desde el backoffice.

## Decisiones

**Opt-in puro.** `help_enabled` arranca en `false` para todos los tenants existentes: nadie hereda el botón, hay que prenderlo explícitamente. Verificado en la DB local: 0 de 1 tenants quedó con el botón prendido tras migrar.

**El portal ya no cae a `sender_email`.** Renderiza solo con `help_enabled` y un `help_email` no vacío, y manda el mail ahí. El botón sigue siendo un `mailto:` — no hay endpoint de envío involucrado.

**No se puede guardar en estado roto.** Un botón prendido sin destino se rechaza en tres capas, porque un PATCH parcial no alcanza para juzgarlo solo:

- `TenantCreate` lleva el estado completo → su validador es definitivo
- `TenantUpdate` rechaza prender y vaciar el email en el mismo payload
- el router mergea el payload sobre la fila de la DB y valida eso, que es lo que atrapa los dos casos reales: `{help_enabled: true}` sobre una fila sin dirección, y `{help_email: null}` sobre una fila que ya lo tenía prendido

## Detalles de implementación

Los campos van en `TenantBase`, así que llegan al portal solos vía `TenantAnonymousPublic` (el endpoint anónimo que ya consume `tenantProvider`). No hay nada sensible acá, así que exponerlos es seguro.

Ambos viajan en el payload cacheado de ese endpoint, así que el PATCH ahora invalida el cache de dominio cuando cambia cualquiera de los dos — sin eso, prender el botón no se veía hasta que expirara el cache.

Migración `a7f2c9e4b183` sobre el head `2b03f8cf7cdd`, siguiendo `c58bb16def73_tenant_ga_tracking.py`.

## Verificación

- **Backend: 80 pasan** (`tests/api/tenant/` + `tests/core/dependencies/test_tenants.py`), incluidos 18 nuevos. Entre los actualizados está el test que asegura el JSON serializado exacto del payload anónimo, que rompe con cualquier campo nuevo en `TenantBase`.
- **Portal: 5/5** nuevos en `HelpButton.test.tsx`; `tsc --noEmit` con 0 errores en todo el portal.
- **Backoffice: 33/33** en todos los forms (5 nuevos); mis archivos limpios en `tsc`, `biome lint` y `biome format`.
- **Ruff**: `All checks passed`.
- **Migración aplicada** en la DB local: `alembic current` = `a7f2c9e4b183 (head)`, `help_enabled boolean NOT NULL default false`, `help_email varchar(255)` nullable.

Los dos tests de "bloquea el guardado" asertan `expect(mockUpdateTenant).not.toHaveBeenCalled()`, así que el bloqueo está verificado y no asumido: TanStack Form re-valida los validadores `onBlur` en submit, sin necesidad de un validador a nivel form.

## Para el reviewer

Los diffs de `src/client/*.gen.ts` son generados por `scripts/generate-client.sh` y son puramente aditivos (168 líneas, solo los dos campos en los 4 schemas de tenant). Ojo con ese script: corre biome `--unsafe` en todo el repo y toca ~225 archivos con cambios de line endings. Stageé solo los 13 archivos del feature.

## Despliegue

Necesita `alembic upgrade head` en cada ambiente. Sin datos que backfillear: todos los tenants arrancan con el botón apagado, lo que significa que **el botón desaparece del portal hasta que cada organización lo configure** — es el comportamiento pedido, pero vale avisarlo si alguna organización lo estaba usando vía `sender_email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
