### PR TITLE
release: dev to main v1.40.0

### DIFF
--- a/backend/app/alembic/versions/a7f2c9e4b183_tenant_help_button.py
+++ b/backend/app/alembic/versions/a7f2c9e4b183_tenant_help_button.py
@@ -1,0 +1,37 @@
+"""Add portal help button config to tenants.
+
+Revision ID: a7f2c9e4b183
+Revises: 2b03f8cf7cdd
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a7f2c9e4b183"
+down_revision: str | Sequence[str] | None = "2b03f8cf7cdd"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Opt-in: existing tenants start with the help button off, so nobody
+    # inherits it until an admin enables it and sets a destination address.
+    op.add_column(
+        "tenants",
+        sa.Column(
+            "help_enabled",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "tenants", sa.Column("help_email", sa.String(length=255), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("tenants", "help_email")
+    op.drop_column("tenants", "help_enabled")

--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -164,11 +164,20 @@ async def list_tenants(
     db: SessionDep,
     _: CurrentSuperadmin,
     search: str | None = None,
+    include_deleted: bool = False,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[TenantPublic]:
+    # Deleted organizations are hidden by default: they have no database
+    # credentials left, so offering them as a selectable context only leads to
+    # failing requests. Admin listings opt in to see them.
     tenants, total = crud.find(
-        db, skip=skip, limit=limit, search=search, search_fields=["name"]
+        db,
+        skip=skip,
+        limit=limit,
+        search=search,
+        search_fields=["name"],
+        deleted=None if include_deleted else False,
     )
 
     return ListModel[TenantPublic](

--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -332,12 +332,37 @@ async def update_tenant(
                 ),
             )
 
+    # 7b. Merged-state validation for the portal help button.
+    # The schema validator only sees the payload, so it cannot judge
+    # PATCH {"help_enabled": true} against a row that has no help_email, nor
+    # PATCH {"help_email": null} against a row that already has help enabled.
+    effective_help_enabled = (
+        tenant_in.help_enabled
+        if tenant_in.help_enabled is not None
+        else tenant.help_enabled
+    )
+    effective_help_email = (
+        tenant_in.help_email
+        if "help_email" in tenant_in.model_fields_set
+        else tenant.help_email
+    )
+    if effective_help_enabled and not (effective_help_email or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "help_enabled requires a help_email. Set a help email before "
+                "enabling the portal help button."
+            ),
+        )
+
     # 8. Snapshot old domain and fields for cache invalidation after update
     old_domain = tenant.custom_domain
     old_landing_mode = tenant.landing_mode
     old_custom_domain_active = tenant.custom_domain_active
     old_meta_tracking_enabled = tenant.meta_tracking_enabled
     old_meta_pixel_id = tenant.meta_pixel_id
+    old_help_enabled = tenant.help_enabled
+    old_help_email = tenant.help_email
 
     # CDN image ingestion: rewrite external image URLs to CDN before commit.
     # Pattern B (async hook). Fail-open: any per-URL failure keeps the original URL.
@@ -410,6 +435,8 @@ async def update_tenant(
     new_custom_domain_active = updated.custom_domain_active
     new_meta_tracking_enabled = updated.meta_tracking_enabled
     new_meta_pixel_id = updated.meta_pixel_id
+    new_help_enabled = updated.help_enabled
+    new_help_email = updated.help_email
 
     domains_to_invalidate: set[str] = set()
 
@@ -429,6 +456,12 @@ async def update_tenant(
     if (
         new_meta_tracking_enabled != old_meta_tracking_enabled
         or new_meta_pixel_id != old_meta_pixel_id
+    ) and new_domain:
+        domains_to_invalidate.add(new_domain)
+
+    # Invalidate current domain when the public help-button config changes.
+    if (
+        new_help_enabled != old_help_enabled or new_help_email != old_help_email
     ) and new_domain:
         domains_to_invalidate.add(new_domain)
 

--- a/backend/app/api/tenant/schemas.py
+++ b/backend/app/api/tenant/schemas.py
@@ -55,6 +55,22 @@ class TenantBase(SQLModel):
     meta_pixel_id: str | None = Field(default=None, max_length=64)
     ga_tracking_enabled: bool = False
     ga_measurement_id: str | None = Field(default=None, max_length=64)
+    help_enabled: bool = False
+    help_email: EmailStr | None = Field(default=None, max_length=255)
+
+
+def _validate_help_settings(help_enabled: bool | None, help_email: str | None) -> None:
+    """Reject a help button that is on but has nowhere to send mail.
+
+    Only meaningful when both values represent the *effective* state. Callers
+    holding a partial payload (``TenantUpdate``) must merge against the DB row
+    first — see the router's merged-state check.
+    """
+    if help_enabled and not (help_email or "").strip():
+        raise ValueError(
+            "help_enabled requires a help_email. "
+            "Set a help email before enabling the portal help button."
+        )
 
 
 class TenantCreate(SQLModel):
@@ -69,6 +85,8 @@ class TenantCreate(SQLModel):
     meta_pixel_id: str | None = Field(default=None, max_length=64)
     ga_tracking_enabled: bool = False
     ga_measurement_id: str | None = Field(default=None, max_length=64)
+    help_enabled: bool = False
+    help_email: EmailStr | None = None
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: int | None = 587
     smtp_user: str | None = Field(default=None, max_length=255)
@@ -99,6 +117,12 @@ class TenantCreate(SQLModel):
         )
         return self
 
+    @model_validator(mode="after")
+    def validate_help(self) -> Self:
+        # Create carries the complete state, so this is the definitive check.
+        _validate_help_settings(self.help_enabled, self.help_email)
+        return self
+
 
 class TenantUpdate(SQLModel):
     name: str | None = None
@@ -115,6 +139,8 @@ class TenantUpdate(SQLModel):
     meta_capi_access_token: str | None = Field(default=None, exclude=True)
     ga_tracking_enabled: bool | None = None
     ga_measurement_id: str | None = Field(default=None, max_length=64)
+    help_enabled: bool | None = None
+    help_email: EmailStr | None = None
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: int | None = None
     smtp_user: str | None = Field(default=None, max_length=255)
@@ -147,6 +173,25 @@ class TenantUpdate(SQLModel):
         _validate_smtp_common(
             self.smtp_host, self.smtp_port, self.smtp_tls, self.smtp_ssl
         )
+        return self
+
+    @model_validator(mode="after")
+    def validate_help(self) -> Self:
+        """Reject enabling the help button while clearing its address.
+
+        Payload-level only. ``None`` means "unchanged", so a payload that just
+        flips ``help_enabled`` on cannot be judged here — the router performs
+        the definitive merged-state check against the DB row.
+        """
+        if (
+            self.help_enabled is True
+            and "help_email" in self.model_fields_set
+            and self.help_email is None
+        ):
+            raise ValueError(
+                "help_enabled requires a help_email. "
+                "Set a help email before enabling the portal help button."
+            )
         return self
 
     @model_validator(mode="after")

--- a/backend/app/core/dependencies/users.py
+++ b/backend/app/core/dependencies/users.py
@@ -254,6 +254,24 @@ def get_current_tenant(
 CurrentTenant = Annotated["TenantPublic", Depends(get_current_tenant)]
 
 
+def require_active_tenant(db: Session, tenant_id: uuid.UUID) -> None:
+    """Reject tenant-scoped access to a deleted organization.
+
+    Soft-deleting a tenant also revokes its PostgreSQL credentials, so without
+    this guard the request fails later with a misleading "credentials not
+    configured" error instead of saying the organization is gone.
+    """
+    from app.api.tenant.models import Tenants
+
+    tenant = db.get(Tenants, tenant_id)
+
+    if tenant is None or tenant.deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This organization is no longer available",
+        )
+
+
 def get_tenant_session(
     current_user: CurrentUser,
     db: SessionDep,
@@ -276,6 +294,8 @@ def get_tenant_session(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid tenant ID format",
             )
+
+        require_active_tenant(db, tenant_id)
 
         cached_cred = tenant_connection_manager.get_credential(
             db, tenant_id, CredentialType.CRUD
@@ -303,6 +323,8 @@ def get_tenant_session(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User has no tenant assigned",
         )
+
+    require_active_tenant(db, current_user.tenant_id)
 
     credential_type = (
         CredentialType.READONLY
@@ -562,6 +584,8 @@ def get_admin_or_api_key_tenant_session(scope: ApiKeyScope):
                     detail="API key has no tenant context.",
                 )
 
+            require_active_tenant(db, tenant_id)
+
             cached_cred = tenant_connection_manager.get_credential(
                 db, tenant_id, CredentialType.CRUD
             )
@@ -655,6 +679,8 @@ def get_check_in_or_api_key_tenant_session(scope: ApiKeyScope):
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="API key has no tenant context.",
                 )
+
+            require_active_tenant(db, tenant_id)
 
             cached_cred = tenant_connection_manager.get_credential(
                 db, tenant_id, CredentialType.CRUD

--- a/backend/tests/api/tenant/test_deleted_tenant_availability.py
+++ b/backend/tests/api/tenant/test_deleted_tenant_availability.py
@@ -1,0 +1,85 @@
+"""Regression tests: a deleted organization must not stay available.
+
+Two surfaces are covered:
+- GET /tenants hides deleted organizations unless include_deleted is requested,
+  so they never show up as a selectable context.
+- Tenant-scoped requests carrying a deleted X-Tenant-Id fail with an explicit
+  "no longer available" 404 instead of the misleading credentials error raised
+  once soft-delete revoked the tenant's database credentials.
+"""
+
+import uuid
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.api.tenant.models import Tenants
+
+
+@pytest.fixture
+def deleted_tenant(db: Session) -> Generator[Tenants, None, None]:
+    suffix = uuid.uuid4().hex[:6]
+    tenant = Tenants(
+        name=f"Deleted Org {suffix}",
+        slug=f"deleted-org-{suffix}",
+        deleted=True,
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    yield tenant
+
+    db.delete(tenant)
+    db.commit()
+
+
+def test_list_tenants_hides_deleted_by_default(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.get(
+        "/api/v1/tenants",
+        headers={"Authorization": f"Bearer {superadmin_token}"},
+        params={"limit": 100},
+    )
+
+    assert response.status_code == 200
+    ids = [t["id"] for t in response.json()["results"]]
+    assert str(deleted_tenant.id) not in ids
+
+
+def test_list_tenants_includes_deleted_when_requested(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.get(
+        "/api/v1/tenants",
+        headers={"Authorization": f"Bearer {superadmin_token}"},
+        params={"limit": 100, "include_deleted": True},
+    )
+
+    assert response.status_code == 200
+    ids = [t["id"] for t in response.json()["results"]]
+    assert str(deleted_tenant.id) in ids
+
+
+def test_tenant_scoped_request_rejects_deleted_tenant(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.get(
+        "/api/v1/popups",
+        headers={
+            "Authorization": f"Bearer {superadmin_token}",
+            "X-Tenant-Id": str(deleted_tenant.id),
+        },
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "This organization is no longer available"

--- a/backend/tests/api/tenant/test_tenant_help_button.py
+++ b/backend/tests/api/tenant/test_tenant_help_button.py
@@ -1,0 +1,217 @@
+"""Tests for the per-tenant portal help button config (help_enabled / help_email).
+
+Covers the three validation layers:
+- TenantBase / TenantCreate: complete state, definitive schema check
+- TenantUpdate: payload-level check (enable + explicit clear in one request)
+- PATCH router: merged-state check against the DB row
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+from sqlmodel import Session
+
+from app.api.tenant.models import Tenants
+from app.api.tenant.schemas import TenantBase, TenantCreate, TenantUpdate
+
+# --- Defaults: opt-in, off for everyone until configured ---
+
+
+def test_tenant_base_help_defaults_off() -> None:
+    tenant = TenantBase(name="Test", slug="test")
+    assert tenant.help_enabled is False
+    assert tenant.help_email is None
+
+
+def test_tenant_create_help_defaults_off() -> None:
+    tenant = TenantCreate(name="Test")
+    assert tenant.help_enabled is False
+    assert tenant.help_email is None
+
+
+def test_tenant_base_accepts_enabled_with_email() -> None:
+    tenant = TenantBase(
+        name="Test", slug="test", help_enabled=True, help_email="help@example.com"
+    )
+    assert tenant.help_enabled is True
+    assert tenant.help_email == "help@example.com"
+
+
+# --- TenantCreate: complete state, so the schema check is definitive ---
+
+
+def test_tenant_create_rejects_enabled_without_email() -> None:
+    with pytest.raises(ValidationError, match="help_enabled requires a help_email"):
+        TenantCreate(name="Test", help_enabled=True)
+
+
+def test_tenant_create_rejects_enabled_with_blank_email() -> None:
+    """A whitespace-only address is not a destination."""
+    with pytest.raises(ValidationError):
+        TenantCreate(name="Test", help_enabled=True, help_email="   ")
+
+
+def test_tenant_create_accepts_enabled_with_email() -> None:
+    tenant = TenantCreate(name="Test", help_enabled=True, help_email="help@example.com")
+    assert tenant.help_enabled is True
+
+
+def test_tenant_create_accepts_email_without_enabling() -> None:
+    """Configuring the address while leaving the button off is a valid state."""
+    tenant = TenantCreate(name="Test", help_email="help@example.com")
+    assert tenant.help_enabled is False
+
+
+# --- TenantUpdate: payload-level only (None means "unchanged") ---
+
+
+def test_tenant_update_help_defaults_none() -> None:
+    update = TenantUpdate()
+    assert update.help_enabled is None
+    assert update.help_email is None
+
+
+def test_tenant_update_rejects_enable_while_clearing_email() -> None:
+    """Enabling and explicitly nulling the address in one payload is incoherent."""
+    with pytest.raises(ValidationError, match="help_enabled requires a help_email"):
+        TenantUpdate(help_enabled=True, help_email=None)
+
+
+def test_tenant_update_allows_enable_without_mentioning_email() -> None:
+    """Omitted help_email means "unchanged" — the router decides against the DB row."""
+    update = TenantUpdate(help_enabled=True)
+    assert update.help_enabled is True
+    assert "help_email" not in update.model_fields_set
+
+
+def test_tenant_update_allows_disable_and_clear_together() -> None:
+    update = TenantUpdate(help_enabled=False, help_email=None)
+    assert update.help_enabled is False
+
+
+def test_tenant_update_rejects_invalid_email() -> None:
+    with pytest.raises(ValidationError):
+        TenantUpdate(help_enabled=True, help_email="not-an-email")
+
+
+# --- PATCH router: merged-state check ---
+
+
+def _admin_headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_patch_rejects_enable_when_row_has_no_email(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    """PATCH {help_enabled: true} alone cannot be judged by the schema — the row has no email."""
+    tenant_a.help_enabled = False
+    tenant_a.help_email = None
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": True},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 422, resp.text
+    assert "help_enabled requires a help_email" in resp.text
+
+    db.refresh(tenant_a)
+    assert tenant_a.help_enabled is False
+
+
+def test_patch_rejects_clearing_email_while_enabled(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    """The inverse gap: nulling the address on a row that already has help enabled."""
+    tenant_a.help_enabled = True
+    tenant_a.help_email = "help@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_email": None},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 422, resp.text
+
+    db.refresh(tenant_a)
+    assert tenant_a.help_email == "help@example.com"
+
+
+def test_patch_accepts_enable_with_email_in_same_payload(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    tenant_a.help_enabled = False
+    tenant_a.help_email = None
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": True, "help_email": "support@example.com"},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["help_enabled"] is True
+    assert data["help_email"] == "support@example.com"
+
+
+def test_patch_accepts_enable_when_row_already_has_email(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    """Address configured earlier, button flipped on later — merged state is valid."""
+    tenant_a.help_enabled = False
+    tenant_a.help_email = "support@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": True},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["help_enabled"] is True
+
+
+def test_patch_allows_disabling_and_clearing(
+    client: TestClient, tenant_a: Tenants, admin_token_tenant_a: str, db: Session
+) -> None:
+    tenant_a.help_enabled = True
+    tenant_a.help_email = "support@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.patch(
+        f"/api/v1/tenants/{tenant_a.id}",
+        json={"help_enabled": False, "help_email": None},
+        headers=_admin_headers(admin_token_tenant_a),
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["help_enabled"] is False
+    assert data["help_email"] is None
+
+
+# --- Portal exposure: the anonymous payload must carry both fields ---
+
+
+def test_public_slug_endpoint_exposes_help_config(
+    client: TestClient, tenant_a: Tenants, db: Session
+) -> None:
+    """The portal reads these from the unauthenticated endpoint."""
+    tenant_a.help_enabled = True
+    tenant_a.help_email = "support@example.com"
+    db.add(tenant_a)
+    db.commit()
+
+    resp = client.get(f"/api/v1/tenants/public/{tenant_a.slug}")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["help_enabled"] is True
+    assert data["help_email"] == "support@example.com"

--- a/backend/tests/core/dependencies/test_tenants.py
+++ b/backend/tests/core/dependencies/test_tenants.py
@@ -53,6 +53,8 @@ def _make_tenant(tenant_id: uuid.UUID = _TENANT_A_ID) -> MagicMock:
     t.meta_pixel_id = None
     t.ga_tracking_enabled = False
     t.ga_measurement_id = None
+    t.help_enabled = False
+    t.help_email = None
     t.active_popup_slug = None  # computed projection — not a DB column
     t.third_party_key_prefix = None  # third-party OTP display fragment
     return t
@@ -67,7 +69,8 @@ def _make_tenant_public_json(tenant_id: uuid.UUID = _TENANT_A_ID) -> str:
         f'"custom_domain":null,"custom_domain_active":false,'
         f'"landing_mode":"portal","meta_tracking_enabled":false,'
         f'"meta_pixel_id":null,"ga_tracking_enabled":false,'
-        f'"ga_measurement_id":null,"active_popup_slug":null}}'
+        f'"ga_measurement_id":null,"help_enabled":false,"help_email":null,'
+        f'"active_popup_slug":null}}'
     )
 
 

--- a/backoffice/src/client/schemas.gen.ts
+++ b/backoffice/src/client/schemas.gen.ts
@@ -18875,6 +18875,24 @@ export const TenantAnonymousPublicSchema = {
             ],
             title: 'Ga Measurement Id'
         },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -18998,6 +19016,23 @@ export const TenantCreateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [
@@ -19231,6 +19266,24 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         id: {
             type: 'string',
@@ -19541,6 +19594,29 @@ export const TenantUpdateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Enabled'
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -7961,6 +7961,7 @@ export class TenantsService {
      * List Tenants
      * @param data The data for the request.
      * @param data.search
+     * @param data.includeDeleted
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_TenantPublic_ Successful Response
@@ -7972,6 +7973,7 @@ export class TenantsService {
             url: '/api/v1/tenants',
             query: {
                 search: data.search,
+                include_deleted: data.includeDeleted,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -3838,6 +3838,8 @@ export type TenantAnonymousPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     active_popup_slug?: (string | null);
 };
@@ -3854,6 +3856,8 @@ export type TenantCreate = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);
@@ -3885,6 +3889,8 @@ export type TenantPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     meta_capi_configured?: boolean;
     is_trial?: boolean;
@@ -3923,6 +3929,8 @@ export type TenantUpdate = {
     meta_capi_access_token?: (string | null);
     ga_tracking_enabled?: (boolean | null);
     ga_measurement_id?: (string | null);
+    help_enabled?: (boolean | null);
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -6826,6 +6826,7 @@ export type TenantsGetTenantBySlugData = {
 export type TenantsGetTenantBySlugResponse = (TenantAnonymousPublic);
 
 export type TenantsListTenantsData = {
+    includeDeleted?: boolean;
     /**
      * Maximum number of items to return
      */

--- a/backoffice/src/components/forms/TenantForm.help-button.test.tsx
+++ b/backoffice/src/components/forms/TenantForm.help-button.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for TenantForm — portal help button config (help_enabled / help_email)
+ *
+ * Covers:
+ * - the toggle and address round-trip into the PATCH payload
+ * - enabling without an address blocks the save (no PATCH fired)
+ * - an invalid address blocks the save
+ * - a blank address is sent as null when the button stays off
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/client", () => ({
+  TenantsService: {
+    createTenant: vi.fn(),
+    updateTenant: vi.fn(),
+    deleteTenant: vi.fn(),
+    sendSmtpTestEmail: vi.fn(),
+  },
+  PopupsService: {
+    listPopups: vi.fn(),
+  },
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({
+    isSuperadmin: true,
+    isAdmin: true,
+    user: { email: "admin@acme.com" },
+  }),
+}))
+
+vi.mock("@/hooks/useCustomToast", () => ({
+  default: () => ({
+    showSuccessToast: vi.fn(),
+    showErrorToast: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/useUnsavedChanges", () => ({
+  useUnsavedChanges: () => ({ state: "unblocked" }),
+  UnsavedChangesDialog: () => null,
+}))
+
+vi.mock("@/components/ui/image-upload", () => ({
+  ImageUpload: () => null,
+}))
+
+vi.mock("@/components/forms/TenantCredentialsSection", () => ({
+  TenantCredentialsSection: () => null,
+}))
+
+import { PopupsService, TenantsService } from "@/client"
+import { TenantForm } from "./TenantForm"
+
+const mockListPopups = vi.mocked(PopupsService.listPopups)
+const mockUpdateTenant = vi.mocked(TenantsService.updateTenant)
+
+const BASE_TENANT = {
+  id: "tenant-1",
+  name: "Acme Events",
+  slug: "acme",
+  custom_domain: null,
+  custom_domain_active: false,
+  landing_mode: "portal" as const,
+  sender_email: null,
+  sender_name: null,
+  image_url: null,
+  icon_url: null,
+  logo_url: null,
+  deleted: false,
+  help_enabled: false,
+  help_email: null,
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+async function save(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: "Save Changes" }))
+}
+
+describe("TenantForm — portal help button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockListPopups.mockResolvedValue({
+      results: [],
+      paging: { offset: 0, limit: 100, total: 0 },
+    } as Awaited<ReturnType<typeof PopupsService.listPopups>>)
+    mockUpdateTenant.mockResolvedValue({} as never)
+  })
+
+  it("sends help_enabled and help_email in the PATCH payload", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await user.click(screen.getByRole("switch", { name: "Help Button" }))
+    await user.type(
+      screen.getByPlaceholderText("support@acme.com"),
+      "support@acme.com",
+    )
+    await save(user)
+
+    await waitFor(() => {
+      expect(mockUpdateTenant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: expect.objectContaining({
+            help_enabled: true,
+            help_email: "support@acme.com",
+          }),
+        }),
+      )
+    })
+  })
+
+  it("blocks the save when the button is enabled with no address", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await user.click(screen.getByRole("switch", { name: "Help Button" }))
+    await save(user)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Help email is required when the help button is enabled",
+        ),
+      ).toBeTruthy()
+    })
+    expect(mockUpdateTenant).not.toHaveBeenCalled()
+  })
+
+  it("blocks the save when the address is malformed", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await user.click(screen.getByRole("switch", { name: "Help Button" }))
+    await user.type(screen.getByPlaceholderText("support@acme.com"), "nope")
+    await save(user)
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid email address")).toBeTruthy()
+    })
+    expect(mockUpdateTenant).not.toHaveBeenCalled()
+  })
+
+  it("sends help_email as null when the button stays off", async () => {
+    const user = userEvent.setup()
+    render(<TenantForm defaultValues={BASE_TENANT} onSuccess={vi.fn()} />, {
+      wrapper: makeWrapper(),
+    })
+
+    await save(user)
+
+    await waitFor(() => {
+      expect(mockUpdateTenant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: expect.objectContaining({
+            help_enabled: false,
+            help_email: null,
+          }),
+        }),
+      )
+    })
+  })
+
+  it("prefills both fields from the tenant", () => {
+    render(
+      <TenantForm
+        defaultValues={{
+          ...BASE_TENANT,
+          help_enabled: true,
+          help_email: "existing@acme.com",
+        }}
+        onSuccess={vi.fn()}
+      />,
+      { wrapper: makeWrapper() },
+    )
+
+    expect(screen.getByRole("switch", { name: "Help Button" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    )
+    expect(screen.getByPlaceholderText("support@acme.com")).toHaveValue(
+      "existing@acme.com",
+    )
+  })
+})

--- a/backoffice/src/components/forms/TenantForm.tsx
+++ b/backoffice/src/components/forms/TenantForm.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   Copy,
   Globe,
+  HelpCircle,
   Image,
   Info,
   Lock,
@@ -174,6 +175,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
       meta_capi_access_token: "",
       ga_tracking_enabled: defaultValues?.ga_tracking_enabled ?? false,
       ga_measurement_id: defaultValues?.ga_measurement_id ?? "",
+      help_enabled: defaultValues?.help_enabled ?? false,
+      help_email: defaultValues?.help_email ?? "",
       smtp_host: defaultValues?.smtp_host ?? "",
       smtp_port: defaultValues?.smtp_port ?? 587,
       smtp_user: defaultValues?.smtp_user ?? "",
@@ -199,6 +202,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           meta_pixel_id: value.meta_pixel_id || null,
           ga_tracking_enabled: value.ga_tracking_enabled,
           ga_measurement_id: value.ga_measurement_id || null,
+          help_enabled: value.help_enabled,
+          help_email: value.help_email || null,
           smtp_host: smtpHost || null,
           smtp_port: value.smtp_port || null,
           smtp_user: smtpUser || null,
@@ -233,6 +238,8 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
           meta_pixel_id: value.meta_pixel_id || undefined,
           ga_tracking_enabled: value.ga_tracking_enabled,
           ga_measurement_id: value.ga_measurement_id || undefined,
+          help_enabled: value.help_enabled,
+          help_email: value.help_email || undefined,
           smtp_host: smtpHost || undefined,
           smtp_port: value.smtp_port || undefined,
           smtp_user: smtpUser || undefined,
@@ -899,6 +906,65 @@ export function TenantForm({ defaultValues, onSuccess }: TenantFormProps) {
               </LoadingButton>
             </InlineRow>
           )}
+        </InlineSection>
+
+        <Separator />
+
+        {/* Portal Help Button */}
+        <InlineSection title="Portal Help Button">
+          <form.Field name="help_enabled">
+            {(field) => (
+              <InlineRow
+                icon={<HelpCircle className="h-4 w-4 text-muted-foreground" />}
+                label="Help Button"
+                description="Show a floating help button on every portal page."
+              >
+                <Switch
+                  id="help_enabled"
+                  aria-label="Help Button"
+                  checked={field.state.value}
+                  onCheckedChange={field.handleChange}
+                />
+              </InlineRow>
+            )}
+          </form.Field>
+
+          <form.Field
+            name="help_email"
+            validators={{
+              onBlur: ({ value, fieldApi }) => {
+                const enabled = fieldApi.form.getFieldValue("help_enabled")
+                if (enabled && !value)
+                  return "Help email is required when the help button is enabled"
+                if (value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+                  return "Invalid email address"
+                }
+                return undefined
+              },
+            }}
+          >
+            {(field) => (
+              <div>
+                <InlineRow
+                  icon={
+                    <HelpCircle className="h-4 w-4 text-muted-foreground" />
+                  }
+                  label="Help Email"
+                  description="Where portal help requests are sent."
+                >
+                  <Input
+                    placeholder="support@acme.com"
+                    type="email"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    className="max-w-xs text-sm"
+                  />
+                </InlineRow>
+                <FieldError errors={field.state.meta.errors} />
+              </div>
+            )}
+          </form.Field>
         </InlineSection>
 
         <Separator />

--- a/backoffice/src/contexts/WorkspaceContext.tsx
+++ b/backoffice/src/contexts/WorkspaceContext.tsx
@@ -51,19 +51,39 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     },
   )
 
-  // Fetch tenants for superadmin auto-selection
+  // Fetch selectable tenants for superadmins. The endpoint excludes deleted
+  // organizations, so this list also tells us whether a persisted selection is
+  // still valid.
   const { data: tenants, isError: _tenantsError } = useQuery({
     queryKey: ["tenants"],
     queryFn: () => TenantsService.listTenants({ skip: 0, limit: 100 }),
-    enabled: isSuperadmin && !selectedTenantId,
+    enabled: isSuperadmin,
   })
 
-  // Auto-select first tenant for superadmins
+  // Auto-select the first tenant, and drop a selection that is no longer available
   useEffect(() => {
-    if (isSuperadmin && !selectedTenantId && tenants?.results?.length) {
-      const firstTenantId = tenants.results[0].id
-      setSelectedTenantIdState(firstTenantId)
-      localStorage.setItem(TENANT_STORAGE_KEY, firstTenantId)
+    if (!isSuperadmin || !tenants) return
+
+    const available = tenants.results
+    const isStale = selectedTenantId
+      ? !available.some((tenant) => tenant.id === selectedTenantId)
+      : true
+
+    // A truncated page cannot prove a selection is gone — only the first 100
+    // organizations were fetched.
+    const isTruncated = tenants.paging.total > available.length
+    if (!isStale || (selectedTenantId && isTruncated)) return
+
+    const nextTenantId = available[0]?.id ?? null
+    if (nextTenantId === selectedTenantId) return
+
+    setSelectedTenantIdState(nextTenantId)
+    setSelectedPopupIdState(null)
+    localStorage.removeItem(POPUP_STORAGE_KEY)
+    if (nextTenantId) {
+      localStorage.setItem(TENANT_STORAGE_KEY, nextTenantId)
+    } else {
+      localStorage.removeItem(TENANT_STORAGE_KEY)
     }
   }, [isSuperadmin, selectedTenantId, tenants])
 

--- a/backoffice/src/routes/_layout/organizations/index.tsx
+++ b/backoffice/src/routes/_layout/organizations/index.tsx
@@ -28,6 +28,9 @@ function getTenantsQueryOptions(
         skip: page * pageSize,
         limit: pageSize,
         search: search || undefined,
+        // Admin listing keeps deleted organizations visible for auditing;
+        // every other surface only offers selectable ones.
+        includeDeleted: true,
       }),
     queryKey: ["tenants", { page, pageSize, search }],
   }

--- a/portal/src/client/schemas.gen.ts
+++ b/portal/src/client/schemas.gen.ts
@@ -18875,6 +18875,24 @@ export const TenantAnonymousPublicSchema = {
             ],
             title: 'Ga Measurement Id'
         },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
+        },
         id: {
             type: 'string',
             format: 'uuid',
@@ -18998,6 +19016,23 @@ export const TenantCreateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [
@@ -19231,6 +19266,24 @@ export const TenantPublicSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            type: 'boolean',
+            title: 'Help Enabled',
+            default: false
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    maxLength: 255,
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         id: {
             type: 'string',
@@ -19541,6 +19594,29 @@ export const TenantUpdateSchema = {
                 }
             ],
             title: 'Ga Measurement Id'
+        },
+        help_enabled: {
+            anyOf: [
+                {
+                    type: 'boolean'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Enabled'
+        },
+        help_email: {
+            anyOf: [
+                {
+                    type: 'string',
+                    format: 'email'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Help Email'
         },
         smtp_host: {
             anyOf: [

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -7961,6 +7961,7 @@ export class TenantsService {
      * List Tenants
      * @param data The data for the request.
      * @param data.search
+     * @param data.includeDeleted
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_TenantPublic_ Successful Response
@@ -7972,6 +7973,7 @@ export class TenantsService {
             url: '/api/v1/tenants',
             query: {
                 search: data.search,
+                include_deleted: data.includeDeleted,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -3838,6 +3838,8 @@ export type TenantAnonymousPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     active_popup_slug?: (string | null);
 };
@@ -3854,6 +3856,8 @@ export type TenantCreate = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);
@@ -3885,6 +3889,8 @@ export type TenantPublic = {
     meta_pixel_id?: (string | null);
     ga_tracking_enabled?: boolean;
     ga_measurement_id?: (string | null);
+    help_enabled?: boolean;
+    help_email?: (string | null);
     id: string;
     meta_capi_configured?: boolean;
     is_trial?: boolean;
@@ -3923,6 +3929,8 @@ export type TenantUpdate = {
     meta_capi_access_token?: (string | null);
     ga_tracking_enabled?: (boolean | null);
     ga_measurement_id?: (string | null);
+    help_enabled?: (boolean | null);
+    help_email?: (string | null);
     smtp_host?: (string | null);
     smtp_port?: (number | null);
     smtp_user?: (string | null);

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -6826,6 +6826,7 @@ export type TenantsGetTenantBySlugData = {
 export type TenantsGetTenantBySlugResponse = (TenantAnonymousPublic);
 
 export type TenantsListTenantsData = {
+    includeDeleted?: boolean;
     /**
      * Maximum number of items to return
      */

--- a/portal/src/components/HelpButton.test.tsx
+++ b/portal/src/components/HelpButton.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.popup ? `${key}:${opts.popup}` : key,
+  }),
+}))
+
+let tenantState: {
+  help_enabled?: boolean | null
+  help_email?: string | null
+  sender_email?: string | null
+}
+vi.mock("@/providers/tenantProvider", () => ({
+  useTenant: () => ({ tenant: tenantState }),
+}))
+
+let popupState: { name?: string } | null
+vi.mock("@/providers/cityProvider", () => ({
+  useCityProvider: () => ({ getCity: () => popupState }),
+}))
+
+import HelpButton from "./HelpButton"
+
+describe("HelpButton", () => {
+  beforeEach(() => {
+    popupState = { name: "Tech Summit" }
+  })
+
+  it("renders nothing when the tenant has help disabled", () => {
+    tenantState = { help_enabled: false, help_email: "support@acme.com" }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders nothing when help is enabled but no help_email is set", () => {
+    tenantState = { help_enabled: true, help_email: null }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders nothing when help_email is only whitespace", () => {
+    tenantState = { help_enabled: true, help_email: "   " }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("does not fall back to sender_email", () => {
+    tenantState = {
+      help_enabled: true,
+      help_email: null,
+      sender_email: "noreply@acme.com",
+    }
+    render(<HelpButton />)
+    expect(screen.queryByRole("button")).toBeNull()
+  })
+
+  it("renders the button when help is enabled and an address is configured", () => {
+    tenantState = { help_enabled: true, help_email: "support@acme.com" }
+    render(<HelpButton />)
+    expect(screen.getByRole("button", { name: "help.aria_label" })).toBeTruthy()
+  })
+})

--- a/portal/src/components/HelpButton.tsx
+++ b/portal/src/components/HelpButton.tsx
@@ -14,17 +14,17 @@ import { useTenant } from "@/providers/tenantProvider"
 
 /**
  * Floating help button shown on every portal page. Opens a small popover that
- * lets the visitor email support. The destination is the tenant's configured
- * `sender_email`; when the tenant has no address the button is not rendered.
- * Must be mounted inside both `CityProvider` and `TenantProvider` (see
- * `Providers.tsx`).
+ * lets the visitor email support. Both the button and its destination are
+ * configured per organization in the backoffice: it renders only when the
+ * tenant has `help_enabled` and a `help_email`. Must be mounted inside both
+ * `CityProvider` and `TenantProvider` (see `Providers.tsx`).
  */
 const HelpButton = () => {
   const { t } = useTranslation()
   const { tenant } = useTenant()
   const { getCity } = useCityProvider()
 
-  const email = tenant?.sender_email?.trim()
+  const email = tenant?.help_enabled ? tenant.help_email?.trim() : undefined
   if (!email) {
     return null
   }


### PR DESCRIPTION
Release de `dev` a `main`. Contiene dos PRs.

## Incluye

**[#532](https://github.com/p2p-lanes/edgeos-monorepo/pull/532) — `feat(tenant)`: el botón de ayuda del portal es configurable por organización**

El botón flotante de ayuda estaba hardcodeado al `sender_email` del tenant y aparecía para cualquier organización que tuviera uno. Ahora se configura desde el backoffice: `help_enabled` para mostrarlo u ocultarlo, y `help_email` para el destino. El portal ya no cae a `sender_email`.

Arranca **apagado para todos los tenants existentes** (opt-in). Un botón prendido sin dirección se rechaza en tres capas: `TenantCreate` (estado completo), `TenantUpdate` (payload) y el router con estado mergeado contra la fila de la DB.

**[#531](https://github.com/p2p-lanes/edgeos-monorepo/pull/531) — `fix(tenants)`: dejar de ofrecer organizaciones borradas como contexto**

Las organizaciones borradas ya no aparecen como contexto seleccionable; quedan detrás de un `include_deleted` opt-in.

## Migración de base de datos

Este release **requiere `alembic upgrade head`**. Una sola migración:

- `a7f2c9e4b183_tenant_help_button` — agrega `tenants.help_enabled` (`boolean NOT NULL default false`) y `tenants.help_email` (`varchar(255)` nullable)

Aditiva, sin backfill y sin reescritura de datos. Verificada en local: `alembic current` = `a7f2c9e4b183 (head)`, head único, y los tenants existentes quedaron todos con `help_enabled = false`.

## Cambio de comportamiento visible

Como todos los tenants arrancan en `help_enabled = false`, **el botón de ayuda desaparece del portal hasta que cada organización lo configure**. Es el comportamiento pedido, pero si alguna organización lo venía usando vía `sender_email`, conviene avisarle antes de mergear.

## Verificación

Ambos checks de CI pasaron en #532 sobre el merge de dev: `Backend (lint + tests)` y `Frontend (biome + tsc)`.

Local, sobre el mismo árbol:

- **Backend: 83 pasan** (`tests/api/tenant/` + `tests/core/dependencies/test_tenants.py`)
- **Backoffice: 33/33** en `src/components/forms/`
- **Portal: 540 pasan**

Sobre el portal: hay **59 tests fallando en 6 archivos** (`StepperCheckoutFlow` 42/42, `events/page`, `thank-you/page`, `useTicketsStep`, `VariantPatronPreset`, `events/new/page`). Están **preexistentes en `dev` y no los introduce este release** — verificado corriendo el suite en `origin/dev` antes del merge: mismas 59 fallas en los mismos 6 archivos, la única diferencia son los 5 tests nuevos de `HelpButton` (535 → 540 pasando). Ninguna toca lo que cambió acá, pero vale mirarlas aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
