### PR TITLE
feat(applications): human-field filters and grouped view subgroups

### DIFF
--- a/backend/app/api/application/crud.py
+++ b/backend/app/api/application/crud.py
@@ -16,6 +16,7 @@ from app.api.application.models import (
 )
 from app.api.application.schemas import (
     CUSTOM_FIELD_PREFIX,
+    HUMAN_FILTER_FIELDS,
     VIRTUAL_REVIEWER_FIELDS,
     ApplicationAdminCreate,
     ApplicationCommentCreate,
@@ -120,7 +121,7 @@ def _filter_condition_expression(
             return Applications.status == condition.value
         return Applications.status != condition.value
 
-    if condition.field in ("gender", "age"):
+    if condition.field in HUMAN_FILTER_FIELDS:
         column = col(getattr(Humans, condition.field))
         return text_condition_expression(column, condition.op, condition.value)
 
@@ -176,6 +177,18 @@ def _group_by_expression(group_by: str):
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         detail=f"Grouping by '{group_by}' is not supported.",
     )
+
+
+def _group_scope_clause(group_by: str, group_value: str | None):
+    """Boolean clause selecting one bucket of a grouped view.
+
+    Same NULL/empty-string collapsing as ``count_by_group``: omitting the
+    value selects the NULL bucket. Returns (clause, needs Humans join).
+    """
+    expression, needs_human = _group_by_expression(group_by)
+    bucket = func.nullif(expression, "")
+    clause = bucket.is_(None) if group_value is None else bucket == group_value
+    return clause, needs_human
 
 
 class RedFlaggedHumanError(Exception):
@@ -245,6 +258,8 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         reviewer_id: uuid.UUID | None = None,
         group_by: str | None = None,
         group_value: str | None = None,
+        sub_group_by: str | None = None,
+        sub_group_value: str | None = None,
     ) -> tuple[list[Applications], int]:
         """Find applications by popup_id with optional status filter and eager loading.
 
@@ -253,15 +268,25 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
 
         ``group_by``/``group_value`` scope the list to one bucket of a
         grouped view, using the same field whitelist and NULL/empty-string
-        collapsing as ``count_by_group``. The scope is ANDed with everything
-        else, so it stays correct even when ``filters`` uses match=any.
-        ``group_value`` is ignored when ``group_by`` is not set; with
-        ``group_by`` set and no ``group_value`` the NULL bucket is selected.
+        collapsing as ``count_by_group``; ``sub_group_by``/``sub_group_value``
+        narrow it further to one subgroup bucket. Scopes are ANDed with
+        everything else, so they stay correct even when ``filters`` uses
+        match=any. A value is ignored when its field is not set; with a
+        field set and no value the NULL bucket is selected.
         """
-        group_expression = None
-        group_needs_human = False
-        if group_by is not None:
-            group_expression, group_needs_human = _group_by_expression(group_by)
+        # Each grouped-view scope becomes a plain WHERE clause; either may
+        # require the Humans join.
+        scope_clauses = []
+        scopes_need_human = False
+        for scope_field, scope_value in (
+            (group_by, group_value),
+            (sub_group_by, sub_group_value),
+        ):
+            if scope_field is None:
+                continue
+            clause, needs_human = _group_scope_clause(scope_field, scope_value)
+            scope_clauses.append(clause)
+            scopes_need_human = scopes_need_human or needs_human
 
         base_statement = select(Applications).where(Applications.popup_id == popup_id)
 
@@ -270,10 +295,10 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
                 Applications.status == status_filter.value
             )
 
-        # Join Humans once, whether needed by the group field, text search,
+        # Join Humans once, whether needed by a group scope, text search,
         # a human-field filter condition, or any combination.
         needs_human_join = (
-            group_needs_human
+            scopes_need_human
             or bool(search)
             or bool(filters and filters.references_human_fields())
         )
@@ -301,14 +326,8 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
             if filter_expression is not None:
                 base_statement = base_statement.where(filter_expression)
 
-        if group_expression is not None:
-            # Same bucket shape as count_by_group: NULL and "" collapse into
-            # one None bucket, selected by omitting group_value.
-            bucket = func.nullif(group_expression, "")
-            if group_value is None:
-                base_statement = base_statement.where(bucket.is_(None))
-            else:
-                base_statement = base_statement.where(bucket == group_value)
+        for clause in scope_clauses:
+            base_statement = base_statement.where(clause)
 
         if reviewed_by:
             has_review = (
@@ -349,6 +368,8 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         search: str | None = None,
         filters: ApplicationFilters | None = None,
         reviewer_id: uuid.UUID | None = None,
+        parent_group_by: str | None = None,
+        parent_group_value: str | None = None,
     ) -> list[tuple[str | None, int]]:
         """Count a popup's applications grouped by one field.
 
@@ -357,20 +378,34 @@ class ApplicationsCRUD(BaseCRUD[Applications, ApplicationCreate, ApplicationUpda
         collapse into one None bucket. Rows come back ordered by count
         descending. ``reviewer_id`` resolves the virtual per-user filter
         fields, exactly like the list endpoint.
+
+        ``parent_group_by``/``parent_group_value`` scope the counts to one
+        bucket of an outer grouped view, so a subgrouped view can count
+        within each expanded parent group.
         """
         group_expression, group_needs_human = _group_by_expression(group_by)
         bucket = func.nullif(group_expression, "")
+
+        parent_clause = None
+        parent_needs_human = False
+        if parent_group_by is not None:
+            parent_clause, parent_needs_human = _group_scope_clause(
+                parent_group_by, parent_group_value
+            )
 
         statement = (
             select(bucket, func.count())
             .select_from(Applications)
             .where(Applications.popup_id == popup_id)
         )
+        if parent_clause is not None:
+            statement = statement.where(parent_clause)
 
         # Join Humans once, whether needed by the group field, text search,
         # a human-field filter condition, or any combination.
         needs_human_join = (
             group_needs_human
+            or parent_needs_human
             or bool(search)
             or bool(filters and filters.references_human_fields())
         )

--- a/backend/app/api/application/router.py
+++ b/backend/app/api/application/router.py
@@ -202,6 +202,8 @@ async def list_applications(
     filters: str | None = None,
     group_by: str | None = None,
     group_value: str | None = None,
+    sub_group_by: str | None = None,
+    sub_group_value: str | None = None,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[ApplicationPublic]:
@@ -218,11 +220,17 @@ async def list_applications(
 
     ``group_by``/``group_value`` scope the list to one bucket of a grouped
     view (same whitelist and NULL/empty collapsing as the group-counts
-    endpoint). The scope is ANDed with everything else, so it stays correct
-    even when ``filters`` uses match=any. With ``group_by`` set and no
-    ``group_value``, the NULL bucket is returned; ``group_value`` without
-    ``group_by`` is ignored.
+    endpoint); ``sub_group_by``/``sub_group_value`` narrow it to one
+    subgroup bucket. Scopes are ANDed with everything else, so they stay
+    correct even when ``filters`` uses match=any. With a group field set and
+    no value, the NULL bucket is returned; a value without its field is
+    ignored.
     """
+    if sub_group_by is not None and sub_group_by == group_by:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="The subgroup field must be different from the group field.",
+        )
     parsed_filters = parse_application_filters(filters)
     if popup_id:
         applications, total = crud.applications_crud.find_by_popup(
@@ -237,6 +245,8 @@ async def list_applications(
             reviewer_id=getattr(current_user, "id", None),
             group_by=group_by,
             group_value=group_value,
+            sub_group_by=sub_group_by,
+            sub_group_value=sub_group_value,
         )
     elif human_id:
         applications, total = crud.applications_crud.find_by_human(
@@ -320,6 +330,8 @@ async def get_application_group_counts(
     group_by: str,
     filters: str | None = None,
     search: str | None = None,
+    parent_group_by: str | None = None,
+    parent_group_value: str | None = None,
 ) -> list[ApplicationGroupCount]:
     """Count a popup's applications grouped by one field (BO only).
 
@@ -327,7 +339,17 @@ async def get_application_group_counts(
     ``age``, or ``custom.<field_name>``. ``filters`` and ``search`` behave
     exactly like the list endpoint. NULL and empty values share one bucket
     with ``value: null``; rows are ordered by count descending.
+
+    ``parent_group_by``/``parent_group_value`` scope the counts to one
+    bucket of an outer grouped view (subgrouped views count within each
+    expanded parent group). With ``parent_group_by`` set and no value, the
+    parent NULL bucket is used.
     """
+    if parent_group_by is not None and parent_group_by == group_by:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="The subgroup field must be different from the group field.",
+        )
     parsed_filters = parse_application_filters(filters)
     rows = crud.applications_crud.count_by_group(
         db,
@@ -336,6 +358,8 @@ async def get_application_group_counts(
         search=search,
         filters=parsed_filters,
         reviewer_id=getattr(current_user, "id", None),
+        parent_group_by=parent_group_by,
+        parent_group_value=parent_group_value,
     )
     return [ApplicationGroupCount(value=value, count=count) for value, count in rows]
 

--- a/backend/app/api/application/schemas.py
+++ b/backend/app/api/application/schemas.py
@@ -17,6 +17,7 @@ from sqlmodel import Column, DateTime, Field, SQLModel
 from app.api.application_review.schemas import ReviewDecision
 from app.api.attendee.schemas import AttendeePublic
 from app.api.human.schemas import HumanPublic
+from app.api.shared.enums import HumanRating
 from app.core.filters import (
     DATE_OPS,
     ENUMISH_OPS,
@@ -419,6 +420,15 @@ APPLICATION_FILTER_FIELDS: dict[str, FilterField] = {
     "referral": FilterField("text", TEXT_OPS),
     "gender": FilterField("select", ENUMISH_OPS),
     "age": FilterField("select", ENUMISH_OPS),
+    "residence": FilterField("text", TEXT_OPS),
+    "telegram": FilterField("text", TEXT_OPS),
+    # rating defaults to "unrated", never NULL, so empty ops don't apply.
+    "rating": FilterField(
+        "select",
+        frozenset({"eq", "neq"}),
+        frozenset(r.value for r in HumanRating),
+    ),
+    "scholarship_video_url": FilterField("text", TEXT_OPS),
     "skipped_by_me": FilterField("boolean", frozenset({"eq"})),
     "reviewed_by_me": FilterField("boolean", frozenset({"eq"})),
     "reviewed_by": FilterField("uuid", frozenset({"eq", "neq"})),
@@ -429,6 +439,8 @@ APPLICATION_FILTER_FIELD_OPS: dict[str, set[str]] = {
 }
 # Virtual fields resolved against the calling user's own review/skip rows.
 VIRTUAL_REVIEWER_FIELDS = frozenset({"skipped_by_me", "reviewed_by_me"})
+# Fields stored on the Humans row; filtering by them needs the join.
+HUMAN_FILTER_FIELDS = frozenset({"gender", "age", "residence", "telegram", "rating"})
 CUSTOM_FIELD_PREFIX = "custom."
 _CUSTOM_FIELD_SPEC = FilterField("text", TEXT_OPS)
 
@@ -488,7 +500,7 @@ class ApplicationFilters(FilterGroup):
 
     def references_human_fields(self) -> bool:
         """True when any condition targets a Humans column (needs join)."""
-        return any(c.field in ("gender", "age") for c in self.conditions)
+        return any(c.field in HUMAN_FILTER_FIELDS for c in self.conditions)
 
 
 def parse_application_filters(raw: str | None) -> ApplicationFilters | None:

--- a/backend/tests/api/application/test_group_counts.py
+++ b/backend/tests/api/application/test_group_counts.py
@@ -161,6 +161,41 @@ class TestApplicationGroupCounts:
         )
         assert _buckets(response) == {"female": 2, "male": 1, None: 1}
 
+    def test_parent_scope_counts_within_one_bucket(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        # Subgrouped views count the subgroup field inside one expanded
+        # parent group only.
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        accepted = ApplicationStatus.ACCEPTED.value
+        _make_application(db, tenant_a, popup, status=accepted, gender="female")
+        _make_application(db, tenant_a, popup, status=accepted, gender="female")
+        _make_application(db, tenant_a, popup, status=accepted, gender="male")
+        _make_application(db, tenant_a, popup, gender="female")
+
+        response = _group_counts(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            "gender",
+            parent_group_by="status",
+            parent_group_value=accepted,
+        )
+        assert _buckets(response) == {"female": 2, "male": 1}
+
+    def test_parent_scope_same_field_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _group_counts(
+            client, admin, tenant_a, popup, "status", parent_group_by="status"
+        )
+        assert response.status_code == 422
+
 
 class TestApplicationListGroupScope:
     """GET /applications with group_by/group_value (rows of one bucket)."""
@@ -184,6 +219,39 @@ class TestApplicationListGroupScope:
             group_value="accepted",
         )
         assert _ids(response) == {str(accepted.id)}
+
+    def test_sub_group_scope_narrows_to_one_subgroup(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        accepted = ApplicationStatus.ACCEPTED.value
+        match = _make_application(db, tenant_a, popup, status=accepted, gender="female")
+        _make_application(db, tenant_a, popup, status=accepted, gender="male")
+        _make_application(db, tenant_a, popup, gender="female")
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            group_by="status",
+            group_value="accepted",
+            sub_group_by="gender",
+            sub_group_value="female",
+        )
+        assert _ids(response) == {str(match.id)}
+
+    def test_sub_group_same_field_returns_422(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+
+        response = _list(
+            client, admin, tenant_a, popup, group_by="status", sub_group_by="status"
+        )
+        assert response.status_code == 422
 
     def test_match_any_filters_stay_inside_the_group(
         self, db: Session, tenant_a: Tenants, client: TestClient

--- a/backend/tests/api/application/test_list_filters.py
+++ b/backend/tests/api/application/test_list_filters.py
@@ -45,6 +45,10 @@ def _make_application(
     referral: str | None = None,
     submitted_at: datetime | None = None,
     gender: str | None = None,
+    residence: str | None = None,
+    rating: str | None = None,
+    scholarship_request: bool = False,
+    scholarship_video_url: str | None = None,
 ) -> Applications:
     human = Humans(
         tenant_id=tenant.id,
@@ -52,6 +56,8 @@ def _make_application(
         first_name="Filters",
         last_name="Applicant",
         gender=gender,
+        residence=residence,
+        **({"rating": rating} if rating is not None else {}),
     )
     db.add(human)
     db.flush()
@@ -64,6 +70,8 @@ def _make_application(
         custom_fields=custom_fields or {},
         referral=referral,
         submitted_at=submitted_at,
+        scholarship_request=scholarship_request,
+        scholarship_video_url=scholarship_video_url,
     )
     db.add(application)
     db.commit()
@@ -310,6 +318,82 @@ class TestApplicationListFilters:
             search="Filters",
         )
         assert _ids(response) == {str(match.id)}
+
+    def test_residence_eq_and_contains(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        # residence lives on Humans; eq is exact, contains is case-insensitive.
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        exact = _make_application(db, tenant_a, popup, residence="Argentina")
+        partial = _make_application(
+            db, tenant_a, popup, residence="Buenos Aires, Argentina"
+        )
+        _make_application(db, tenant_a, popup, residence="Lisbon, Portugal")
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("residence", "eq", "Argentina")
+        )
+        assert _ids(response) == {str(exact.id)}
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("residence", "contains", "argentina")
+        )
+        assert _ids(response) == {str(exact.id), str(partial.id)}
+
+    def test_rating_eq_and_neq(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        # rating lives on Humans and defaults to "unrated" (never NULL).
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        flagged = _make_application(db, tenant_a, popup, rating="red_flag")
+        unrated = _make_application(db, tenant_a, popup)
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("rating", "eq", "red_flag")
+        )
+        assert _ids(response) == {str(flagged.id)}
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("rating", "neq", "red_flag")
+        )
+        assert _ids(response) == {str(unrated.id)}
+
+        response = _list(
+            client, admin, tenant_a, popup, _one("rating", "eq", "not-a-rating")
+        )
+        assert response.status_code == 422
+
+    def test_scholarship_video_is_empty(
+        self, db: Session, tenant_a: Tenants, client: TestClient
+    ) -> None:
+        # Scholarship requests without a video are incomplete submissions.
+        popup = _make_popup(db, tenant_a)
+        admin = _make_admin(db, tenant_a)
+        incomplete = _make_application(db, tenant_a, popup, scholarship_request=True)
+        _make_application(
+            db,
+            tenant_a,
+            popup,
+            scholarship_request=True,
+            scholarship_video_url="https://example.com/video",
+        )
+
+        response = _list(
+            client,
+            admin,
+            tenant_a,
+            popup,
+            {
+                "match": "all",
+                "conditions": [
+                    {"field": "scholarship_request", "op": "eq", "value": True},
+                    {"field": "scholarship_video_url", "op": "is_empty", "value": None},
+                ],
+            },
+        )
+        assert _ids(response) == {str(incomplete.id)}
 
     def test_empty_conditions_is_noop(
         self, db: Session, tenant_a: Tenants, client: TestClient

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -394,10 +394,11 @@ export class ApplicationsService {
      *
      * ``group_by``/``group_value`` scope the list to one bucket of a grouped
      * view (same whitelist and NULL/empty collapsing as the group-counts
-     * endpoint). The scope is ANDed with everything else, so it stays correct
-     * even when ``filters`` uses match=any. With ``group_by`` set and no
-     * ``group_value``, the NULL bucket is returned; ``group_value`` without
-     * ``group_by`` is ignored.
+     * endpoint); ``sub_group_by``/``sub_group_value`` narrow it to one
+     * subgroup bucket. Scopes are ANDed with everything else, so they stay
+     * correct even when ``filters`` uses match=any. With a group field set and
+     * no value, the NULL bucket is returned; a value without its field is
+     * ignored.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId
@@ -407,6 +408,8 @@ export class ApplicationsService {
      * @param data.filters
      * @param data.groupBy
      * @param data.groupValue
+     * @param data.subGroupBy
+     * @param data.subGroupValue
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -429,6 +432,8 @@ export class ApplicationsService {
                 filters: data.filters,
                 group_by: data.groupBy,
                 group_value: data.groupValue,
+                sub_group_by: data.subGroupBy,
+                sub_group_value: data.subGroupValue,
                 skip: data.skip,
                 limit: data.limit
             },
@@ -473,11 +478,18 @@ export class ApplicationsService {
      * ``age``, or ``custom.<field_name>``. ``filters`` and ``search`` behave
      * exactly like the list endpoint. NULL and empty values share one bucket
      * with ``value: null``; rows are ordered by count descending.
+     *
+     * ``parent_group_by``/``parent_group_value`` scope the counts to one
+     * bucket of an outer grouped view (subgrouped views count within each
+     * expanded parent group). With ``parent_group_by`` set and no value, the
+     * parent NULL bucket is used.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.groupBy
      * @param data.filters
      * @param data.search
+     * @param data.parentGroupBy
+     * @param data.parentGroupValue
      * @param data.xTenantId
      * @returns ApplicationGroupCount Successful Response
      * @throws ApiError
@@ -493,7 +505,9 @@ export class ApplicationsService {
                 popup_id: data.popupId,
                 group_by: data.groupBy,
                 filters: data.filters,
-                search: data.search
+                search: data.search,
+                parent_group_by: data.parentGroupBy,
+                parent_group_value: data.parentGroupValue
             },
             errors: {
                 422: 'Validation Error'

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -4586,6 +4586,8 @@ export type ApplicationsListApplicationsData = {
      */
     skip?: number;
     statusFilter?: (ApplicationStatus | null);
+    subGroupBy?: (string | null);
+    subGroupValue?: (string | null);
     xTenantId?: (string | null);
 };
 
@@ -4601,6 +4603,8 @@ export type ApplicationsCreateApplicationAdminResponse = (ApplicationPublic);
 export type ApplicationsGetApplicationGroupCountsData = {
     filters?: (string | null);
     groupBy: string;
+    parentGroupBy?: (string | null);
+    parentGroupValue?: (string | null);
     popupId: string;
     search?: (string | null);
     xTenantId?: (string | null);

--- a/backoffice/src/components/applications/ApplicationFilterBuilder.tsx
+++ b/backoffice/src/components/applications/ApplicationFilterBuilder.tsx
@@ -6,6 +6,7 @@ import {
   type FilterMatch,
   FULL_TEXT_OPS,
 } from "@/components/Common/FilterBuilder"
+import { RATING_OPTIONS } from "@/components/Humans/humanFields"
 
 export {
   type FilterCondition,
@@ -36,6 +37,7 @@ function baseFieldDef(
   key: string,
   label: string,
   baseFieldOptions: Record<string, string[]>,
+  textOps: string[] = EMPTYABLE_TEXT_OPS,
 ): FilterFieldDef {
   const options = baseFieldOptions[key]
   if (options?.length) {
@@ -47,7 +49,7 @@ function baseFieldDef(
       options: options.map((opt) => ({ value: opt, label: opt })),
     }
   }
-  return { key, label, kind: "text", ops: EMPTYABLE_TEXT_OPS }
+  return { key, label, kind: "text", ops: textOps }
 }
 
 function buildFieldDefs(
@@ -78,6 +80,22 @@ function buildFieldDefs(
       options: SCHOLARSHIP_STATUS_OPTIONS,
     },
     {
+      key: "scholarship_video_url",
+      label: "Scholarship video",
+      kind: "text",
+      ops: FULL_TEXT_OPS,
+    },
+    {
+      key: "rating",
+      label: "Rating",
+      kind: "select",
+      ops: ["eq", "neq"],
+      options: RATING_OPTIONS.map((opt) => ({
+        value: opt.value,
+        label: opt.label,
+      })),
+    },
+    {
       key: "skipped_by_me",
       label: "Skipped by me",
       kind: "boolean",
@@ -105,6 +123,8 @@ function buildFieldDefs(
     { key: "referral", label: "Referral", kind: "text", ops: FULL_TEXT_OPS },
     baseFieldDef("gender", "Gender", baseFieldOptions),
     baseFieldDef("age", "Age", baseFieldOptions),
+    baseFieldDef("residence", "Residence", baseFieldOptions, FULL_TEXT_OPS),
+    { key: "telegram", label: "Telegram", kind: "text", ops: FULL_TEXT_OPS },
   ]
   const custom: FilterFieldDef[] = customFields.map((field) => ({
     key: `custom.${field.name}`,

--- a/backoffice/src/components/applications/ApplicationsGroupedView.tsx
+++ b/backoffice/src/components/applications/ApplicationsGroupedView.tsx
@@ -4,7 +4,11 @@ import type { ColumnDef } from "@tanstack/react-table"
 import { ChevronRight } from "lucide-react"
 import { useMemo, useState } from "react"
 
-import { type ApplicationPublic, ApplicationsService } from "@/client"
+import {
+  type ApplicationGroupCount,
+  type ApplicationPublic,
+  ApplicationsService,
+} from "@/client"
 import {
   type FilterCondition,
   type FilterMatch,
@@ -18,26 +22,90 @@ import { cn } from "@/lib/utils"
 const EMPTY_GROUP_KEY = "__empty__"
 const GROUP_PAGE_SIZE = 25
 
+// NULL bucket last; known values follow the preferred order, the rest keep
+// the backend count-desc order after them.
+function orderGroups(
+  counts: ApplicationGroupCount[],
+  valueOrder?: string[],
+): ApplicationGroupCount[] {
+  const valued = counts.filter((group) => group.value != null)
+  const empty = counts.filter((group) => group.value == null)
+  if (valueOrder?.length) {
+    const rank = new Map(valueOrder.map((value, index) => [value, index]))
+    valued.sort(
+      (a, b) =>
+        (rank.get(a.value as string) ?? rank.size) -
+        (rank.get(b.value as string) ?? rank.size),
+    )
+  }
+  return [...valued, ...empty]
+}
+
+function GroupHeader({
+  field,
+  value,
+  count,
+  open,
+  onToggle,
+}: {
+  field: string
+  value: string | null
+  count: number
+  open: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-expanded={open}
+      className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted/50"
+      onClick={onToggle}
+    >
+      <ChevronRight
+        className={cn(
+          "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+          open && "rotate-90",
+        )}
+      />
+      {value === null ? (
+        <span className="text-sm text-muted-foreground">No value</span>
+      ) : field === "status" ? (
+        <StatusBadge status={value} />
+      ) : (
+        <span className="truncate text-sm font-medium">{value}</span>
+      )}
+      <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">
+        {count}
+      </span>
+    </button>
+  )
+}
+
 interface ApplicationsGroupedViewProps {
   popupId: string
   groupBy: string
+  /** Optional second grouping level rendered inside each expanded group. */
+  subGroupBy?: string
   columns: ColumnDef<ApplicationPublic>[]
   filterMatch: FilterMatch
   filterConditions: FilterCondition[]
   search: string
   /** Preferred group ordering (status flow, custom field options). */
   valueOrder?: string[]
+  subValueOrder?: string[]
   hiddenOnMobile?: string[]
 }
 
 export function ApplicationsGroupedView({
   popupId,
   groupBy,
+  subGroupBy,
   columns,
   filterMatch,
   filterConditions,
   search,
   valueOrder,
+  subValueOrder,
   hiddenOnMobile,
 }: ApplicationsGroupedViewProps) {
   const completeConditions = useMemo(
@@ -74,25 +142,13 @@ export function ApplicationsGroupedView({
     placeholderData: keepPreviousData,
   })
 
-  const groups = useMemo(() => {
-    if (!counts) return []
-    const valued = counts.filter((group) => group.value != null)
-    const empty = counts.filter((group) => group.value == null)
-    if (valueOrder?.length) {
-      const rank = new Map(valueOrder.map((value, index) => [value, index]))
-      // Stable sort: values outside the known order keep the backend
-      // count-desc order after the known ones.
-      valued.sort(
-        (a, b) =>
-          (rank.get(a.value as string) ?? rank.size) -
-          (rank.get(b.value as string) ?? rank.size),
-      )
-    }
-    return [...valued, ...empty]
-  }, [counts, valueOrder])
+  const groups = useMemo(
+    () => (counts ? orderGroups(counts, valueOrder) : []),
+    [counts, valueOrder],
+  )
 
-  // Collapsed by default. The caller keys this component by groupBy, so
-  // switching the grouped field starts from a fully collapsed state again.
+  // Collapsed by default. The caller keys this component by the group
+  // fields, so switching either one starts fully collapsed again.
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
   if (isLoading) return <Skeleton className="h-40 w-full" />
@@ -119,40 +175,152 @@ export function ApplicationsGroupedView({
         const open = !!expanded[key]
         return (
           <div key={key} className="rounded-lg border">
-            <button
-              type="button"
-              aria-expanded={open}
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-muted/50"
-              onClick={() =>
+            <GroupHeader
+              field={groupBy}
+              value={value}
+              count={group.count}
+              open={open}
+              onToggle={() =>
                 setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))
               }
-            >
-              <ChevronRight
-                className={cn(
-                  "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                  open && "rotate-90",
-                )}
-              />
-              {value === null ? (
-                <span className="text-sm text-muted-foreground">No value</span>
-              ) : groupBy === "status" ? (
-                <StatusBadge status={value} />
-              ) : (
-                <span className="truncate text-sm font-medium">{value}</span>
-              )}
-              <span className="ml-auto shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">
-                {group.count}
-              </span>
-            </button>
+            />
             {open && (
               <div className="border-t px-3 pb-3 pt-2">
-                {/* Remount on filter/search edits so the page index cannot
-                    strand past the new last page. */}
+                {subGroupBy ? (
+                  <SubGroupsList
+                    key={`${baseFiltersJson ?? ""}|${search}`}
+                    popupId={popupId}
+                    groupBy={groupBy}
+                    groupValue={value}
+                    subGroupBy={subGroupBy}
+                    columns={columns}
+                    filterMatch={filterMatch}
+                    completeConditions={completeConditions}
+                    baseFiltersJson={baseFiltersJson}
+                    search={search}
+                    subValueOrder={subValueOrder}
+                    hiddenOnMobile={hiddenOnMobile}
+                  />
+                ) : (
+                  /* Remount on filter/search edits so the page index cannot
+                     strand past the new last page. */
+                  <GroupRowsTable
+                    key={`${baseFiltersJson ?? ""}|${search}`}
+                    popupId={popupId}
+                    groupBy={groupBy}
+                    value={value}
+                    columns={columns}
+                    filterMatch={filterMatch}
+                    completeConditions={completeConditions}
+                    search={search}
+                    hiddenOnMobile={hiddenOnMobile}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// Second grouping level inside one expanded parent group: same collapsed
+// group rows, with counts scoped to the parent bucket.
+function SubGroupsList({
+  popupId,
+  groupBy,
+  groupValue,
+  subGroupBy,
+  columns,
+  filterMatch,
+  completeConditions,
+  baseFiltersJson,
+  search,
+  subValueOrder,
+  hiddenOnMobile,
+}: {
+  popupId: string
+  groupBy: string
+  groupValue: string | null
+  subGroupBy: string
+  columns: ColumnDef<ApplicationPublic>[]
+  filterMatch: FilterMatch
+  completeConditions: FilterCondition[]
+  baseFiltersJson?: string
+  search: string
+  subValueOrder?: string[]
+  hiddenOnMobile?: string[]
+}) {
+  const {
+    data: counts,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: [
+      "applications",
+      popupId,
+      "group-counts",
+      {
+        groupBy: subGroupBy,
+        parentGroupBy: groupBy,
+        parentGroupValue: groupValue,
+        filters: baseFiltersJson,
+        search,
+      },
+    ],
+    queryFn: () =>
+      ApplicationsService.getApplicationGroupCounts({
+        popupId,
+        groupBy: subGroupBy,
+        parentGroupBy: groupBy,
+        parentGroupValue: groupValue ?? undefined,
+        filters: baseFiltersJson,
+        search: search || undefined,
+      }),
+    placeholderData: keepPreviousData,
+  })
+
+  const groups = useMemo(
+    () => (counts ? orderGroups(counts, subValueOrder) : []),
+    [counts, subValueOrder],
+  )
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+
+  if (isLoading) return <Skeleton className="h-24 w-full" />
+  if (isError) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Unable to load the subgroups. Try a different field.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {groups.map((group) => {
+        const value = group.value ?? null
+        const key = value ?? EMPTY_GROUP_KEY
+        const open = !!expanded[key]
+        return (
+          <div key={key} className="rounded-lg border">
+            <GroupHeader
+              field={subGroupBy}
+              value={value}
+              count={group.count}
+              open={open}
+              onToggle={() =>
+                setExpanded((prev) => ({ ...prev, [key]: !prev[key] }))
+              }
+            />
+            {open && (
+              <div className="border-t px-3 pb-3 pt-2">
                 <GroupRowsTable
-                  key={`${baseFiltersJson ?? ""}|${search}`}
                   popupId={popupId}
                   groupBy={groupBy}
-                  value={value}
+                  value={groupValue}
+                  subGroupBy={subGroupBy}
+                  subValue={value}
                   columns={columns}
                   filterMatch={filterMatch}
                   completeConditions={completeConditions}
@@ -172,6 +340,8 @@ function GroupRowsTable({
   popupId,
   groupBy,
   value,
+  subGroupBy,
+  subValue,
   columns,
   filterMatch,
   completeConditions,
@@ -181,6 +351,8 @@ function GroupRowsTable({
   popupId: string
   groupBy: string
   value: string | null
+  subGroupBy?: string
+  subValue?: string | null
   columns: ColumnDef<ApplicationPublic>[]
   filterMatch: FilterMatch
   completeConditions: FilterCondition[]
@@ -214,6 +386,8 @@ function GroupRowsTable({
         filters: filtersJson,
         groupBy,
         groupValue: value,
+        subGroupBy,
+        subGroupValue: subValue,
       },
     ],
     queryFn: () =>
@@ -225,6 +399,8 @@ function GroupRowsTable({
         filters: filtersJson,
         groupBy,
         groupValue: value ?? undefined,
+        subGroupBy,
+        subGroupValue: subValue ?? undefined,
       }),
     placeholderData: keepPreviousData,
   })

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -14,11 +14,13 @@ import {
   ListChecks,
   MessageSquare,
   Plus,
+  Rows3,
   Search,
   SkipForward,
   Star,
   ThumbsDown,
   ThumbsUp,
+  Trash2,
   Users,
   X,
 } from "lucide-react"
@@ -314,47 +316,133 @@ function buildGroupByCustomFields(
     }))
 }
 
-function GroupBySelect({
+// One row of the group popover: field picker plus a remove button.
+function GroupFieldSelect({
   value,
   onChange,
   customFields,
+  excludeKey,
+  placeholder,
 }: {
   value?: string
-  onChange: (value: string | undefined) => void
+  onChange: (value: string) => void
   customFields: GroupByField[]
+  excludeKey?: string
+  placeholder: string
 }) {
-  const activeLabel =
-    FIXED_GROUP_BY_OPTIONS.find((option) => option.value === value)?.label ??
-    customFields.find((field) => field.key === value)?.label
   return (
-    <Select
-      value={value ?? "none"}
-      onValueChange={(next) => onChange(next === "none" ? undefined : next)}
-    >
-      <SelectTrigger className="h-9 w-[190px]">
-        <SelectValue>
-          {value ? `Group: ${activeLabel ?? value}` : "Group by"}
-        </SelectValue>
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="h-8 flex-1">
+        <SelectValue placeholder={placeholder} />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="none">No grouping</SelectItem>
-        {FIXED_GROUP_BY_OPTIONS.map((option) => (
+        {FIXED_GROUP_BY_OPTIONS.filter(
+          (option) => option.value !== excludeKey,
+        ).map((option) => (
           <SelectItem key={option.value} value={option.value}>
             {option.label}
           </SelectItem>
         ))}
-        {customFields.length > 0 && (
+        {customFields.some((field) => field.key !== excludeKey) && (
           <SelectGroup>
             <SelectLabel>Form fields</SelectLabel>
-            {customFields.map((field) => (
-              <SelectItem key={field.key} value={field.key}>
-                {field.label}
-              </SelectItem>
-            ))}
+            {customFields
+              .filter((field) => field.key !== excludeKey)
+              .map((field) => (
+                <SelectItem key={field.key} value={field.key}>
+                  {field.label}
+                </SelectItem>
+              ))}
           </SelectGroup>
         )}
       </SelectContent>
     </Select>
+  )
+}
+
+function GroupByControl({
+  groupBy,
+  subGroupBy,
+  onChangeGroupBy,
+  onChangeSubGroupBy,
+  customFields,
+}: {
+  groupBy?: string
+  subGroupBy?: string
+  onChangeGroupBy: (value: string | undefined) => void
+  onChangeSubGroupBy: (value: string | undefined) => void
+  customFields: GroupByField[]
+}) {
+  const activeCount = (groupBy ? 1 : 0) + (subGroupBy ? 1 : 0)
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="h-9">
+          <Rows3 className="mr-2 h-4 w-4" />
+          Group by
+          {activeCount > 0 && (
+            <span className="ml-1.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary/10 px-1.5 text-xs font-medium text-primary tabular-nums">
+              {activeCount}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[320px] p-3">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <GroupFieldSelect
+              value={groupBy}
+              onChange={onChangeGroupBy}
+              customFields={customFields}
+              excludeKey={subGroupBy}
+              placeholder="Group by field"
+            />
+            {groupBy && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 text-muted-foreground"
+                aria-label="Remove grouping"
+                onClick={() => onChangeGroupBy(undefined)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+          {groupBy && subGroupBy && (
+            <div className="flex items-center gap-2">
+              <GroupFieldSelect
+                value={subGroupBy}
+                onChange={onChangeSubGroupBy}
+                customFields={customFields}
+                excludeKey={groupBy}
+                placeholder="Subgroup field"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 text-muted-foreground"
+                aria-label="Remove subgroup"
+                onClick={() => onChangeSubGroupBy(undefined)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+          {groupBy && !subGroupBy && (
+            <div className="flex items-center gap-2">
+              <GroupFieldSelect
+                value={undefined}
+                onChange={onChangeSubGroupBy}
+                customFields={customFields}
+                excludeKey={groupBy}
+                placeholder="Add subgroup..."
+              />
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -436,6 +524,7 @@ type ApplicationsSearchParams = TableSearchParams & {
   match?: FilterMatch
   filters?: FilterCondition[]
   groupBy?: string
+  subGroupBy?: string
 }
 
 export const Route = createFileRoute("/_layout/applications/")({
@@ -463,6 +552,16 @@ export const Route = createFileRoute("/_layout/applications/")({
         raw.groupBy.startsWith("custom."))
         ? raw.groupBy
         : undefined
+    // One optional subgroup level; it needs a primary group and a
+    // different field.
+    const subGroupBy =
+      groupBy &&
+      typeof raw.subGroupBy === "string" &&
+      raw.subGroupBy !== groupBy &&
+      (VALID_GROUP_BY_FIELDS.has(raw.subGroupBy) ||
+        raw.subGroupBy.startsWith("custom."))
+        ? raw.subGroupBy
+        : undefined
     return {
       ...validateTableSearch(raw),
       ...(raw.match === "any" && filters.length
@@ -470,6 +569,7 @@ export const Route = createFileRoute("/_layout/applications/")({
         : {}),
       ...(filters.length ? { filters } : {}),
       ...(groupBy ? { groupBy } : {}),
+      ...(subGroupBy ? { subGroupBy } : {}),
     }
   },
   head: () => ({
@@ -1066,6 +1166,7 @@ function ApplicationsTableContent({
         match: undefined,
         filters: undefined,
         groupBy: undefined,
+        subGroupBy: undefined,
         search: undefined,
         sortBy: undefined,
         sortOrder: undefined,
@@ -1082,6 +1183,28 @@ function ApplicationsTableContent({
         search: (prev: Record<string, unknown>) => ({
           ...prev,
           groupBy: value,
+          // The subgroup only makes sense under a primary group and must
+          // stay a different field.
+          subGroupBy:
+            value && prev.subGroupBy !== value
+              ? (prev.subGroupBy as string | undefined)
+              : undefined,
+          page: 0,
+        }),
+        replace: true,
+      })
+    },
+    [navigate],
+  )
+
+  const setSubGroupBy = useCallback(
+    (value: string | undefined) => {
+      navigate({
+        to: "/applications",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          subGroupBy:
+            prev.groupBy && value !== prev.groupBy ? value : undefined,
           page: 0,
         }),
         replace: true,
@@ -1099,6 +1222,9 @@ function ApplicationsTableContent({
     }
     if (filterConditions.length) config.filters = filterConditions
     if (searchParams.groupBy) config.groupBy = searchParams.groupBy
+    if (searchParams.groupBy && searchParams.subGroupBy) {
+      config.subGroupBy = searchParams.subGroupBy
+    }
     if (searchParams.sortBy) {
       config.sortBy = searchParams.sortBy
       config.sortOrder = searchParams.sortOrder
@@ -1107,6 +1233,7 @@ function ApplicationsTableContent({
   }, [
     searchParams.match,
     searchParams.groupBy,
+    searchParams.subGroupBy,
     searchParams.sortBy,
     searchParams.sortOrder,
     filterConditions,
@@ -1122,6 +1249,14 @@ function ApplicationsTableContent({
         (VALID_GROUP_BY_FIELDS.has(config.groupBy) ||
           config.groupBy.startsWith("custom."))
           ? config.groupBy
+          : undefined
+      const subGroupByValue =
+        groupByValue &&
+        typeof config.subGroupBy === "string" &&
+        config.subGroupBy !== groupByValue &&
+        (VALID_GROUP_BY_FIELDS.has(config.subGroupBy) ||
+          config.subGroupBy.startsWith("custom."))
+          ? config.subGroupBy
           : undefined
       const sortOrder: "asc" | "desc" | undefined =
         config.sortOrder === "asc" || config.sortOrder === "desc"
@@ -1140,6 +1275,7 @@ function ApplicationsTableContent({
               : undefined,
           filters: filters.length ? filters : undefined,
           groupBy: groupByValue,
+          subGroupBy: subGroupByValue,
           sortBy:
             typeof config.sortBy === "string" && config.sortBy
               ? config.sortBy
@@ -1155,25 +1291,54 @@ function ApplicationsTableContent({
   // Grouping needs a selected popup; the counts endpoint is popup-scoped.
   const groupBy =
     selectedPopupId && searchParams.groupBy ? searchParams.groupBy : undefined
+  const subGroupBy = groupBy ? searchParams.subGroupBy : undefined
 
   // Drop custom group fields that no longer exist in the schema (e.g. after
   // switching gatherings).
   useEffect(() => {
-    if (!isSchemaLoaded || !groupBy?.startsWith("custom.")) return
-    if (!groupByCustomFields.some((field) => field.key === groupBy)) {
+    if (!isSchemaLoaded) return
+    if (
+      groupBy?.startsWith("custom.") &&
+      !groupByCustomFields.some((field) => field.key === groupBy)
+    ) {
       setGroupBy(undefined)
+      return
     }
-  }, [isSchemaLoaded, groupBy, groupByCustomFields, setGroupBy])
+    if (
+      subGroupBy?.startsWith("custom.") &&
+      !groupByCustomFields.some((field) => field.key === subGroupBy)
+    ) {
+      setSubGroupBy(undefined)
+    }
+  }, [
+    isSchemaLoaded,
+    groupBy,
+    subGroupBy,
+    groupByCustomFields,
+    setGroupBy,
+    setSubGroupBy,
+  ])
 
-  const groupValueOrder = useMemo(() => {
-    if (groupBy === "status") {
-      return APPLICATION_STATUS_OPTIONS.map((option) => option.value)
-    }
-    if (groupBy?.startsWith("custom.")) {
-      return groupByCustomFields.find((field) => field.key === groupBy)?.options
-    }
-    return undefined
-  }, [groupBy, groupByCustomFields])
+  const groupValueOrderFor = useCallback(
+    (field: string | undefined) => {
+      if (field === "status") {
+        return APPLICATION_STATUS_OPTIONS.map((option) => option.value)
+      }
+      if (field?.startsWith("custom.")) {
+        return groupByCustomFields.find((item) => item.key === field)?.options
+      }
+      return undefined
+    },
+    [groupByCustomFields],
+  )
+  const groupValueOrder = useMemo(
+    () => groupValueOrderFor(groupBy),
+    [groupBy, groupValueOrderFor],
+  )
+  const subGroupValueOrder = useMemo(
+    () => groupValueOrderFor(subGroupBy),
+    [subGroupBy, groupValueOrderFor],
+  )
 
   const { data: applications } = useQuery({
     ...getApplicationsQueryOptions(
@@ -1365,9 +1530,11 @@ function ApplicationsTableContent({
         conditions={filterConditions}
         onChange={setFilters}
       />
-      <GroupBySelect
-        value={searchParams.groupBy}
-        onChange={setGroupBy}
+      <GroupByControl
+        groupBy={searchParams.groupBy}
+        subGroupBy={searchParams.subGroupBy}
+        onChangeGroupBy={setGroupBy}
+        onChangeSubGroupBy={setSubGroupBy}
         customFields={groupByCustomFields}
       />
       {selectedPopupId && (
@@ -1405,14 +1572,16 @@ function ApplicationsTableContent({
           </div>
         </div>
         <ApplicationsGroupedView
-          key={groupBy}
+          key={`${groupBy}|${subGroupBy ?? ""}`}
           popupId={selectedPopupId}
           groupBy={groupBy}
+          subGroupBy={subGroupBy}
           columns={columns}
           filterMatch={filterMatch}
           filterConditions={filterConditions}
           search={search}
           valueOrder={groupValueOrder}
+          subValueOrder={subGroupValueOrder}
           hiddenOnMobile={hiddenOnMobile}
         />
       </div>

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -394,10 +394,11 @@ export class ApplicationsService {
      *
      * ``group_by``/``group_value`` scope the list to one bucket of a grouped
      * view (same whitelist and NULL/empty collapsing as the group-counts
-     * endpoint). The scope is ANDed with everything else, so it stays correct
-     * even when ``filters`` uses match=any. With ``group_by`` set and no
-     * ``group_value``, the NULL bucket is returned; ``group_value`` without
-     * ``group_by`` is ignored.
+     * endpoint); ``sub_group_by``/``sub_group_value`` narrow it to one
+     * subgroup bucket. Scopes are ANDed with everything else, so they stay
+     * correct even when ``filters`` uses match=any. With a group field set and
+     * no value, the NULL bucket is returned; a value without its field is
+     * ignored.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.humanId
@@ -407,6 +408,8 @@ export class ApplicationsService {
      * @param data.filters
      * @param data.groupBy
      * @param data.groupValue
+     * @param data.subGroupBy
+     * @param data.subGroupValue
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @param data.xTenantId
@@ -429,6 +432,8 @@ export class ApplicationsService {
                 filters: data.filters,
                 group_by: data.groupBy,
                 group_value: data.groupValue,
+                sub_group_by: data.subGroupBy,
+                sub_group_value: data.subGroupValue,
                 skip: data.skip,
                 limit: data.limit
             },
@@ -473,11 +478,18 @@ export class ApplicationsService {
      * ``age``, or ``custom.<field_name>``. ``filters`` and ``search`` behave
      * exactly like the list endpoint. NULL and empty values share one bucket
      * with ``value: null``; rows are ordered by count descending.
+     *
+     * ``parent_group_by``/``parent_group_value`` scope the counts to one
+     * bucket of an outer grouped view (subgrouped views count within each
+     * expanded parent group). With ``parent_group_by`` set and no value, the
+     * parent NULL bucket is used.
      * @param data The data for the request.
      * @param data.popupId
      * @param data.groupBy
      * @param data.filters
      * @param data.search
+     * @param data.parentGroupBy
+     * @param data.parentGroupValue
      * @param data.xTenantId
      * @returns ApplicationGroupCount Successful Response
      * @throws ApiError
@@ -493,7 +505,9 @@ export class ApplicationsService {
                 popup_id: data.popupId,
                 group_by: data.groupBy,
                 filters: data.filters,
-                search: data.search
+                search: data.search,
+                parent_group_by: data.parentGroupBy,
+                parent_group_value: data.parentGroupValue
             },
             errors: {
                 422: 'Validation Error'

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -4586,6 +4586,8 @@ export type ApplicationsListApplicationsData = {
      */
     skip?: number;
     statusFilter?: (ApplicationStatus | null);
+    subGroupBy?: (string | null);
+    subGroupValue?: (string | null);
     xTenantId?: (string | null);
 };
 
@@ -4601,6 +4603,8 @@ export type ApplicationsCreateApplicationAdminResponse = (ApplicationPublic);
 export type ApplicationsGetApplicationGroupCountsData = {
     filters?: (string | null);
     groupBy: string;
+    parentGroupBy?: (string | null);
+    parentGroupValue?: (string | null);
     popupId: string;
     search?: (string | null);
     xTenantId?: (string | null);


### PR DESCRIPTION
## Summary

Two additions to the applications table, both building on the existing filter/group engine.

### New filterable fields
- **Residence** (Humans): full text operators — `contains "Argentina"` matches "Buenos Aires, Argentina". If the popup configures residence with fixed options, the filter offers a value picker.
- **Telegram** (Humans): `is empty` finds applicants without a telegram handle (the event's primary comms channel).
- **Rating** (Humans): value picker with the human rating options (No rating / Red Flag / etc.), validated against the `HumanRating` enum server-side. `is`/`is not` only — rating is never NULL.
- **Scholarship video** (Applications): `is empty` + `Scholarship requested is true` surfaces incomplete scholarship requests.

Human-stored fields reuse the existing Humans join through a shared `HUMAN_FILTER_FIELDS` set; adding the next one is a one-line change. First/last name and email were deliberately skipped (the search box already covers exactly those columns).

### Grouped view: one optional subgroup (NocoDB-style)
- The group-by select becomes a popover: primary group + optional subgroup (max one level), remove per row, count badge on the button.
- Expanded groups list their subgroup buckets with counts; expanding a bucket shows its rows.
- **No new endpoints**: `group-counts` gains a parent scope (`parent_group_by`/`parent_group_value`) and the list gains a second group scope (`sub_group_by`/`sub_group_value`), ANDed like the existing scope so match=any filters cannot leak rows.
- `subGroupBy` travels in the URL and persists in saved views. Same field twice → 422.
- Out of scope by design: more than one subgroup level, per-group sort, hide-empty toggle.

## Test plan
- [x] Backend: 41 tests across `test_list_filters.py` / `test_group_counts.py` (new: residence eq/contains, rating eq/neq + invalid value 422, scholarship video is_empty, parent-scope counts, sub-scope rows, same-field 422 on both endpoints)
- [x] OpenAPI clients regenerated; backoffice and portal builds pass
- [ ] Manual: group by Status, add subgroup Gender, expand accepted → subgroup counts; save as view and reapply

No migrations.