### PR TITLE
fix(portal): render the checkout SSR in the visitor's stored language

### DIFF
--- a/portal/src/app/checkout/[popupSlug]/CheckoutPageClient.test.tsx
+++ b/portal/src/app/checkout/[popupSlug]/CheckoutPageClient.test.tsx
@@ -1,4 +1,8 @@
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
+import {
+  LANGUAGE_STORAGE_KEY,
+  setActiveRequestLanguage,
+} from "@/lib/language-storage"
 import CheckoutPageClient from "./CheckoutPageClient"
 
 const mockUseCheckoutRuntime = vi.fn()
@@ -35,8 +39,22 @@ const runtimeData = {
   ticketing_steps: [],
 }
 
+function lastRuntimeOpts(): {
+  language?: string | null
+  initialDataUpdatedAt?: number
+} {
+  const calls = mockUseCheckoutRuntime.mock.calls
+  return (calls[calls.length - 1]?.[1] ?? {}) as {
+    language?: string | null
+    initialDataUpdatedAt?: number
+  }
+}
+
 describe("CheckoutPageClient", () => {
   beforeEach(() => {
+    localStorage.clear()
+    setActiveRequestLanguage(null)
+    mockUseCheckoutRuntime.mockClear()
     mockUseCheckoutRuntime.mockReturnValue({
       data: runtimeData,
       isLoading: false,
@@ -106,6 +124,78 @@ describe("CheckoutPageClient", () => {
     render(<CheckoutPageClient popupSlug="festival-2026" />)
 
     expect(screen.getByText("runtime:festival-2026")).toBeTruthy()
+  })
+
+  // --- Language / SSR payload agreement ---
+
+  it("keys the runtime query on the stored language", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "en")
+
+    render(<CheckoutPageClient popupSlug="festival-2026" />)
+
+    expect(lastRuntimeOpts().language).toBe("en")
+  })
+
+  it("keeps the server payload fresh when it was fetched in the same language", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "en")
+    const updatedAt = Date.now()
+
+    render(
+      <CheckoutPageClient
+        popupSlug="festival-2026"
+        initialRuntime={runtimeData as never}
+        initialDataUpdatedAt={updatedAt}
+        initialRuntimeLanguage="en"
+      />,
+    )
+
+    expect(lastRuntimeOpts().initialDataUpdatedAt).toBe(updatedAt)
+  })
+
+  it("hands over the server payload already stale when the stored language differs from the one SSR used", () => {
+    // The reported bug: no ?lang, so SSR fetched with no Accept-Language and
+    // returned the popup's source copy, while the visitor's stored choice is
+    // English. Without this the payload stays fresh for the whole staleTime.
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "en")
+
+    render(
+      <CheckoutPageClient
+        popupSlug="festival-2026"
+        initialRuntime={runtimeData as never}
+        initialDataUpdatedAt={Date.now()}
+        initialRuntimeLanguage={null}
+      />,
+    )
+
+    expect(lastRuntimeOpts().language).toBe("en")
+    expect(lastRuntimeOpts().initialDataUpdatedAt).toBe(0)
+  })
+
+  it("keeps the server payload fresh when the visitor has no stored language", () => {
+    render(
+      <CheckoutPageClient
+        popupSlug="festival-2026"
+        initialRuntime={runtimeData as never}
+        initialDataUpdatedAt={1234}
+        initialRuntimeLanguage={null}
+      />,
+    )
+
+    expect(lastRuntimeOpts().language).toBeNull()
+    expect(lastRuntimeOpts().initialDataUpdatedAt).toBe(1234)
+  })
+
+  it("re-keys when the provider switches the on-screen language", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "en")
+
+    render(<CheckoutPageClient popupSlug="festival-2026" />)
+    expect(lastRuntimeOpts().language).toBe("en")
+
+    act(() => {
+      setActiveRequestLanguage("es")
+    })
+
+    expect(lastRuntimeOpts().language).toBe("es")
   })
 
   it("prefilledBuyer is populated when useAuth returns a user", () => {

--- a/portal/src/app/checkout/[popupSlug]/CheckoutPageClient.tsx
+++ b/portal/src/app/checkout/[popupSlug]/CheckoutPageClient.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { CheckoutRuntimeResponse } from "@/client"
 import { CheckoutBackgroundImage } from "@/components/CheckoutBackgroundImage"
@@ -9,27 +10,52 @@ import { SidebarProvider } from "@/components/Sidebar/SidebarComponents"
 import { Loader } from "@/components/ui/Loader"
 import useAuth from "@/hooks/useAuth"
 import { getCheckoutBackground } from "@/lib/background-image"
+import {
+  resolveRequestLanguage,
+  subscribeRequestLanguage,
+} from "@/lib/language-storage"
 import { useCheckoutRuntime } from "./hooks/useCheckoutRuntime"
 
 interface CheckoutPageClientProps {
   popupSlug: string
   initialRuntime?: CheckoutRuntimeResponse
   initialDataUpdatedAt?: number
+  /** Language the server render fetched `initialRuntime` in, if any. */
+  initialRuntimeLanguage?: string | null
 }
 
 export default function CheckoutPageClient({
   popupSlug,
   initialRuntime,
   initialDataUpdatedAt,
+  initialRuntimeLanguage = null,
 }: CheckoutPageClientProps) {
   const { t } = useTranslation()
+  // Resolved in a state initializer rather than an effect so the very first
+  // client render already keys on the right language — the rendered output is
+  // identical either way (initialRuntime drives it), so hydration is safe.
+  // The subscription re-keys on a mid-session switch, which is what keeps a
+  // language's payload from being cached under another language's key.
+  const [language, setLanguage] = useState(resolveRequestLanguage)
+  useEffect(() => {
+    setLanguage(resolveRequestLanguage())
+    return subscribeRequestLanguage(() => setLanguage(resolveRequestLanguage()))
+  }, [])
+
+  // The server had no access to localStorage, so it may have rendered in a
+  // different language than the visitor's stored choice. Keep showing that
+  // payload (a spinner would be worse) but hand it over already stale, so
+  // react-query refetches on mount instead of sitting on it for the staleTime.
+  const initialMatchesLanguage = language === initialRuntimeLanguage
+
   const {
     data: runtime,
     isLoading,
     isError,
   } = useCheckoutRuntime(popupSlug, {
+    language,
     initialData: initialRuntime,
-    initialDataUpdatedAt,
+    initialDataUpdatedAt: initialMatchesLanguage ? initialDataUpdatedAt : 0,
   })
   const { user } = useAuth()
 

--- a/portal/src/app/checkout/[popupSlug]/hooks/useCheckoutRuntime.ts
+++ b/portal/src/app/checkout/[popupSlug]/hooks/useCheckoutRuntime.ts
@@ -11,12 +11,20 @@ import { queryKeys } from "@/lib/query-keys"
 export function useCheckoutRuntime(
   slug: string,
   opts?: {
+    /**
+     * Language the request will carry (see `resolveRequestLanguage`). Part of
+     * the key because the response is translated: without it the server render's
+     * payload stays "fresh" under the same key for the whole staleTime, so a
+     * visitor whose stored language differs from the one SSR used keeps seeing
+     * the wrong language until an unrelated refetch happens to fire.
+     */
+    language?: string | null
     initialData?: CheckoutRuntimeResponse
     initialDataUpdatedAt?: number
   },
 ) {
   return useQuery({
-    queryKey: queryKeys.checkout.runtime(slug),
+    queryKey: queryKeys.checkout.runtime(slug, opts?.language),
     queryFn: () => CheckoutService.getRuntime({ slug }),
     enabled: slug.length > 0,
     staleTime: 30_000,

--- a/portal/src/app/checkout/[popupSlug]/page.tsx
+++ b/portal/src/app/checkout/[popupSlug]/page.tsx
@@ -1,6 +1,11 @@
 export const dynamic = "force-dynamic"
 
+import { cookies } from "next/headers"
 import { fetchCheckoutRuntime } from "@/lib/checkout-runtime"
+import {
+  LANGUAGE_COOKIE_KEY,
+  normalizeLanguageTag,
+} from "@/lib/language-storage"
 import { resolveTenantForMetadata } from "@/lib/tenant-metadata"
 import CheckoutPageClient from "./CheckoutPageClient"
 
@@ -19,10 +24,19 @@ export default async function OpenTicketingCheckoutPage({
     return <CheckoutPageClient popupSlug={popupSlug} />
   }
 
+  // Mirrors the client resolver's precedence: explicit ?lang/?locale first,
+  // then the persisted choice. localStorage is unreachable here, so the cookie
+  // the language provider writes alongside it is what lets the server render
+  // already be in the visitor's language instead of the popup's source copy.
+  const cookieStore = await cookies()
+  const ssrLanguage =
+    normalizeLanguageTag(lang ?? locale) ??
+    normalizeLanguageTag(cookieStore.get(LANGUAGE_COOKIE_KEY)?.value)
+
   const runtime = await fetchCheckoutRuntime(
     popupSlug,
     tenant.id,
-    lang ?? locale,
+    ssrLanguage ?? undefined,
   )
   if (!runtime) {
     return <CheckoutPageClient popupSlug={popupSlug} />
@@ -34,6 +48,7 @@ export default async function OpenTicketingCheckoutPage({
       popupSlug={popupSlug}
       initialRuntime={runtime}
       initialDataUpdatedAt={initialDataUpdatedAt}
+      initialRuntimeLanguage={ssrLanguage}
     />
   )
 }

--- a/portal/src/lib/api-client.ts
+++ b/portal/src/lib/api-client.ts
@@ -1,8 +1,5 @@
 import { OpenAPI } from "@/client"
-import {
-  getActiveRequestLanguage,
-  LANGUAGE_STORAGE_KEY,
-} from "@/lib/language-storage"
+import { resolveRequestLanguage } from "@/lib/language-storage"
 
 if (!process.env.NEXT_PUBLIC_API_URL) {
   throw new Error("NEXT_PUBLIC_API_URL is not configured")
@@ -37,12 +34,10 @@ OpenAPI.interceptors.request.use((config) => {
   // (reading only localStorage raced the provider's write and dropped the
   // header on the first runtime request). The backend overlay is
   // default-agnostic, so an unsupported value simply returns the source.
-  const params = new URLSearchParams(window.location.search)
-  const language =
-    getActiveRequestLanguage() ||
-    params.get("lang") ||
-    params.get("locale") ||
-    localStorage.getItem(LANGUAGE_STORAGE_KEY)
+  //
+  // Shared with the language-dependent query keys via `resolveRequestLanguage`
+  // so a cached response is always labelled with the language it was fetched in.
+  const language = resolveRequestLanguage()
   if (language) {
     config.headers = { ...config.headers, "Accept-Language": language }
   }

--- a/portal/src/lib/language-storage.test.ts
+++ b/portal/src/lib/language-storage.test.ts
@@ -1,0 +1,132 @@
+import {
+  LANGUAGE_COOKIE_KEY,
+  LANGUAGE_STORAGE_KEY,
+  normalizeLanguageTag,
+  persistLanguage,
+  resolveRequestLanguage,
+  setActiveRequestLanguage,
+  subscribeRequestLanguage,
+} from "./language-storage"
+
+function setSearch(search: string) {
+  window.history.replaceState({}, "", `/checkout/festival${search}`)
+}
+
+function clearCookies() {
+  for (const entry of document.cookie.split(";")) {
+    const name = entry.split("=")[0]?.trim()
+    // biome-ignore lint/suspicious/noDocumentCookie: mirrors persistLanguage, which writes cookies the same way
+    if (name) document.cookie = `${name}=; path=/; max-age=0`
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  clearCookies()
+  setSearch("")
+  setActiveRequestLanguage(null)
+})
+
+describe("normalizeLanguageTag", () => {
+  it("reduces a region-qualified tag to its base subtag", () => {
+    expect(normalizeLanguageTag("es-AR")).toBe("es")
+  })
+
+  it("takes the first entry of a full Accept-Language list", () => {
+    expect(normalizeLanguageTag("en-US,en;q=0.9,es;q=0.8")).toBe("en")
+  })
+
+  it("lowercases and trims", () => {
+    expect(normalizeLanguageTag("  EN  ")).toBe("en")
+  })
+
+  it("returns null for empty or missing input", () => {
+    expect(normalizeLanguageTag(null)).toBeNull()
+    expect(normalizeLanguageTag(undefined)).toBeNull()
+    expect(normalizeLanguageTag("")).toBeNull()
+    expect(normalizeLanguageTag("   ")).toBeNull()
+  })
+})
+
+describe("resolveRequestLanguage", () => {
+  it("returns null when nothing is set", () => {
+    expect(resolveRequestLanguage()).toBeNull()
+  })
+
+  it("falls back to the stored language", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "es")
+    expect(resolveRequestLanguage()).toBe("es")
+  })
+
+  it("prefers the ?lang param over the stored language", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "es")
+    setSearch("?lang=en")
+    expect(resolveRequestLanguage()).toBe("en")
+  })
+
+  it("accepts ?locale as an alias for ?lang", () => {
+    setSearch("?locale=zh")
+    expect(resolveRequestLanguage()).toBe("zh")
+  })
+
+  it("prefers the on-screen language over both, so a mid-session switch wins before its ?lang navigation lands", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "es")
+    setSearch("?lang=es")
+    setActiveRequestLanguage("en")
+    expect(resolveRequestLanguage()).toBe("en")
+  })
+
+  it("normalizes whatever it resolves, so one language cannot split the query cache", () => {
+    setSearch("?lang=en-US")
+    expect(resolveRequestLanguage()).toBe("en")
+  })
+})
+
+describe("persistLanguage", () => {
+  it("writes localStorage and the server-readable cookie together", () => {
+    persistLanguage("es")
+
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe("es")
+    expect(document.cookie).toContain(`${LANGUAGE_COOKIE_KEY}=es`)
+  })
+
+  it("overwrites a previous choice in both stores", () => {
+    persistLanguage("es")
+    persistLanguage("en")
+
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe("en")
+    expect(document.cookie).toContain(`${LANGUAGE_COOKIE_KEY}=en`)
+    expect(document.cookie).not.toContain(`${LANGUAGE_COOKIE_KEY}=es`)
+  })
+})
+
+describe("subscribeRequestLanguage", () => {
+  it("notifies listeners when the on-screen language changes", () => {
+    const listener = vi.fn()
+    subscribeRequestLanguage(listener)
+
+    setActiveRequestLanguage("en")
+
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not notify when the language is set to the same value", () => {
+    setActiveRequestLanguage("en")
+    const listener = vi.fn()
+    subscribeRequestLanguage(listener)
+
+    setActiveRequestLanguage("en")
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeRequestLanguage(listener)
+
+    unsubscribe()
+    setActiveRequestLanguage("es")
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/portal/src/lib/language-storage.ts
+++ b/portal/src/lib/language-storage.ts
@@ -4,6 +4,15 @@
 // header, which is what previously broke dynamic translations end to end.
 export const LANGUAGE_STORAGE_KEY = "portal_language_v2"
 
+// Server-readable mirror of the same value. localStorage does not exist during
+// SSR, so without this the checkout server render fetched /runtime with no
+// Accept-Language and shipped the source-language copy — the visitor saw the
+// popup's source language until a client refetch happened to land (up to the
+// 30s staleTime later) and swapped the whole page under them.
+export const LANGUAGE_COOKIE_KEY = "portal_language"
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365
+
 // In-memory mirror of the language currently on screen, set synchronously by
 // the language provider whenever the resolved language changes. The API client
 // interceptor reads this first so a mid-session switch sends the right
@@ -13,10 +22,82 @@ export const LANGUAGE_STORAGE_KEY = "portal_language_v2"
 // first-render / deep-link requests still fall back to the URL param.
 let activeRequestLanguage: string | null = null
 
+const requestLanguageListeners = new Set<() => void>()
+
 export function setActiveRequestLanguage(language: string | null): void {
+  if (activeRequestLanguage === language) return
   activeRequestLanguage = language
+  for (const listener of requestLanguageListeners) {
+    listener()
+  }
 }
 
 export function getActiveRequestLanguage(): string | null {
   return activeRequestLanguage
+}
+
+/**
+ * Subscribe to changes of the on-screen language. Lets language-dependent
+ * query keys re-key on a mid-session switch instead of caching the new
+ * language's payload under the previous language's key.
+ */
+export function subscribeRequestLanguage(listener: () => void): () => void {
+  requestLanguageListeners.add(listener)
+  return () => {
+    requestLanguageListeners.delete(listener)
+  }
+}
+
+/**
+ * Base subtag, lowercased ("es-AR" → "es", "en-US,en;q=0.9" → "en").
+ *
+ * The backend already reduces Accept-Language to its base subtag, so this only
+ * keeps the *client* self-consistent: without it `?lang=en-US` and a stored
+ * `en` would produce two different query keys for byte-identical responses.
+ */
+export function normalizeLanguageTag(
+  raw: string | null | undefined,
+): string | null {
+  if (!raw) return null
+  const base = raw.trim().toLowerCase().split(",")[0]?.split("-")[0]
+  return base ? base : null
+}
+
+/**
+ * The language the API client will actually put on the wire, resolved from the
+ * same inputs and in the same order as the request interceptor. Query keys for
+ * language-dependent endpoints derive from this, so a cache entry can never be
+ * labelled with a language other than the one it was fetched in.
+ *
+ * Returns null during SSR — the server has neither localStorage nor the
+ * in-memory mirror, and reads the cookie instead.
+ */
+export function resolveRequestLanguage(): string | null {
+  if (typeof window === "undefined") return null
+  const params = new URLSearchParams(window.location.search)
+  return normalizeLanguageTag(
+    activeRequestLanguage ||
+      params.get("lang") ||
+      params.get("locale") ||
+      localStorage.getItem(LANGUAGE_STORAGE_KEY),
+  )
+}
+
+/**
+ * Persist an explicitly chosen language to both stores.
+ *
+ * Called only on explicit signals — a manual switch or an incoming ?lang= —
+ * never on auto-resolve, so it cannot clobber the popup default_language. The
+ * cookie is what makes the *next* server render already correct; localStorage
+ * stays the client-side source of truth.
+ */
+export function persistLanguage(language: string): void {
+  if (typeof window === "undefined") return
+  localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
+  // `secure` would make the cookie a no-op on plain-http local dev.
+  const secure = window.location.protocol === "https:" ? "; secure" : ""
+  // biome-ignore lint/suspicious/noDocumentCookie: the Cookie Store API is still missing on Firefox and only landed in Safari 18.4; this cookie has to be set on every browser the portal supports
+  document.cookie = `${LANGUAGE_COOKIE_KEY}=${encodeURIComponent(
+    language,
+  )}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; samesite=lax${secure}`
 }

--- a/portal/src/lib/query-keys.ts
+++ b/portal/src/lib/query-keys.ts
@@ -43,7 +43,14 @@ export const queryKeys = {
     portal: (popupId: string) => ["form-schema", "portal", popupId] as const,
   },
   checkout: {
-    runtime: (slug: string) => ["checkout", "runtime", slug] as const,
+    // The runtime payload is translated server-side from Accept-Language, so
+    // the language is part of the cache identity. Omitting `lang` yields the
+    // language-agnostic prefix, which still matches every language's entry for
+    // invalidation.
+    runtime: (slug: string, lang?: string | null) =>
+      lang
+        ? (["checkout", "runtime", slug, lang] as const)
+        : (["checkout", "runtime", slug] as const),
     coupon: (slug: string, code: string) =>
       ["checkout", "coupon", slug, code] as const,
   },

--- a/portal/src/providers/languageProvider.tsx
+++ b/portal/src/providers/languageProvider.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next"
 import { SUPPORTED_LANGUAGES } from "@/i18n/config"
 import {
   LANGUAGE_STORAGE_KEY,
+  persistLanguage,
   setActiveRequestLanguage,
 } from "@/lib/language-storage"
 import { CityContext } from "./cityProvider"
@@ -128,8 +129,8 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     // class as the manual selector), so persist it: the language must survive
     // in-session navigations that drop the query param, e.g. returning from
     // the payment provider after a cancel.
-    if (urlLanguage && typeof window !== "undefined") {
-      localStorage.setItem(STORAGE_KEY, urlLanguage)
+    if (urlLanguage) {
+      persistLanguage(urlLanguage)
     }
     const storedLanguage =
       typeof window === "undefined"
@@ -152,9 +153,10 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     }
   }, [searchParams, supportedLanguages, defaultLanguage, currentLanguage])
 
-  // localStorage is written only on explicit signals — setLanguage (manual
-  // choice) and an incoming ?lang= param — never by auto-resolve, to avoid
-  // clobbering the popup default and bouncing back on next render.
+  // The stores (localStorage + cookie) are written only on explicit signals —
+  // setLanguage (manual choice) and an incoming ?lang= param — never by
+  // auto-resolve, to avoid clobbering the popup default and bouncing back on
+  // next render.
   useEffect(() => {
     if (i18n.language !== currentLanguage) {
       i18n.changeLanguage(currentLanguage)
@@ -178,9 +180,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const setLanguage = (lang: string) => {
     const resolvedLanguage = resolveLanguageCandidate(lang, supportedLanguages)
     if (!resolvedLanguage) return
-    if (typeof window !== "undefined") {
-      localStorage.setItem(STORAGE_KEY, resolvedLanguage)
-    }
+    persistLanguage(resolvedLanguage)
     // Apply immediately so the UI switches on click instead of waiting for the
     // navigation round-trip. The ?lang write below only keeps the choice
     // forwardable in the URL and persistent across navigations; pendingLanguageRef


### PR DESCRIPTION
## Problema

Entrando al checkout **sin** `?lang`, el selector de idioma muestra inglés (el idioma guardado) pero el contenido de la página se ve en español. Recién varios segundos después, cuando sale el request a `/runtime`, la página salta a inglés.

Afecta al contenido dinámico que traduce el backend (copy de la popup, nombres de productos, labels de steps); los strings estáticos de i18n ya estaban en inglés desde el arranque, de ahí la mezcla.

## Causa raíz

Se apilan tres cosas:

**1. El SSR pide el runtime sin idioma.**
`app/checkout/[popupSlug]/page.tsx` pasaba `lang ?? locale` a `fetchCheckoutRuntime`. Sin param eso es `undefined` → no se manda `Accept-Language` → `parse_accept_language(None)` en el backend → `runtime_for_slug` no aplica overlay y devuelve **el texto fuente**. El idioma persistido vive en `localStorage`, que no existe en el server.

**2. El provider resuelve el idioma pero no invalida nada.**
`LanguageProvider` arranca con `useState(DEFAULT_LANGUAGE)` = `"en"` y resuelve `storedLanguage = "en"`. Como el valor resuelto es **igual al inicial**, no hay cambio de estado, y la guarda de `languageProvider.tsx` es:

```js
if (prevLanguageRef.current && prevLanguageRef.current !== currentLanguage) {
  queryClient.invalidateQueries()
}
```

`prevLanguageRef.current` es `null` en el primer run → nunca invalida.

**3. La query key ignoraba el idioma.**
`queryKeys.checkout.runtime(slug)` no incluía el idioma aunque la respuesta está traducida. Con `initialData` + `initialDataUpdatedAt = Date.now()` + `staleTime: 30_000`, react-query consideraba fresco el payload del SSR durante 30 s. El request que aparecía "varios segundos después" era el primer `refetchOnWindowFocus` que pasaba esa barrera — no un `/runtime` lento.

Efecto lateral de (3): el cache podía servir datos del idioma equivocado al alternar es→en→es.

## Solución

**Cookie para el SSR (ataca la causa).** `persistLanguage()` escribe el idioma en una cookie `portal_language` junto con localStorage, en los mismos signals explícitos que ya usaba el provider — switch manual y `?lang=` entrante, nunca en auto-resolve, para no pisar el `default_language` de la popup. `page.tsx` la lee con `cookies()` cuando no hay `?lang`/`?locale`. El server render ya sale en el idioma correcto: sin flash y sin request de corrección.

**Idioma en la query key (red de seguridad + correctitud de cache).** `queryKeys.checkout.runtime(slug, lang?)` — omitir `lang` sigue dando el prefijo agnóstico, así que el `invalidateQueries` de `checkoutProvider.tsx` sigue matcheando todos los idiomas. Si el idioma del cliente no coincide con el que usó el SSR, el payload se entrega **ya stale** (`initialDataUpdatedAt: 0`): se sigue mostrando (mejor que un spinner) pero react-query refetchea on mount en vez de esperar el staleTime.

`resolveRequestLanguage()` pasa a alimentar tanto el interceptor de `api-client.ts` como la query key, así una entrada de cache nunca queda etiquetada con un idioma distinto al que se pidió. Normaliza al subtag base (`en-US` → `en`) para que un mismo idioma no fragmente el cache.

`CheckoutPageClient` se suscribe a los cambios de idioma para re-keyear en un switch mid-session.

## Comportamiento resultante

| Caso | Antes | Ahora |
|---|---|---|
| Con cookie (ya eligió idioma alguna vez) | SSR en idioma fuente, flip a los ~30 s | SSR ya correcto, 0 requests extra |
| Sin cookie, con localStorage | SSR en idioma fuente, flip a los ~30 s | Refetch inmediato on mount |
| Visitante nuevo sin idioma guardado | default de la popup | default de la popup (sin cambios) |

## Tests

- `src/lib/language-storage.test.ts` (nuevo, 15 casos) — normalización de tags, precedencia de `resolveRequestLanguage` (activo → `?lang` → `?locale` → stored), `persistLanguage` escribiendo ambos stores, y el ciclo subscribe/notify/unsubscribe.
- `CheckoutPageClient.test.tsx` (+6 casos) — keyeo por idioma, `initialDataUpdatedAt` preservado cuando coincide con el SSR, puesto en `0` cuando difiere, y re-key ante un switch mid-session.

## Verificación

- `npx vitest run src/lib/language-storage.test.ts src/app/checkout/[popupSlug]/CheckoutPageClient.test.tsx` → **26/26 pasan**.
- Mutación de control: forzando `initialMatchesLanguage = true` falla exactamente el test de staleness, así que el caso del bug está realmente cubierto.
- `npx tsc --noEmit` → limpio.
- `npx biome lint` sobre los 9 archivos tocados → limpio (los dos warnings de `noDocumentCookie` quedaron suprimidos con justificación: la Cookie Store API todavía no está en Firefox y recién llegó en Safari 18.4).
- Suite completa del portal: 6 archivos fallan (59 tests), **el mismo set exacto que ya falla en `dev`** — verificado contra el árbol limpio. Sin regresiones.

## Nota

La cookie es una preferencia de UI: `path=/`, `samesite=lax`, un año de vida, `secure` solo bajo https para no romper el dev local en http. No lleva datos personales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
