### PR TITLE
feat(applications): column reorder menu and columns in saved views

### DIFF
--- a/backoffice/src/components/Common/DataTable.tsx
+++ b/backoffice/src/components/Common/DataTable.tsx
@@ -1,4 +1,20 @@
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import {
+  type Column,
   type ColumnDef,
   type ExpandedState,
   flexRender,
@@ -9,6 +25,7 @@ import {
   type Row,
   type RowSelectionState,
   type SortingState,
+  type Table as TanstackTable,
   useReactTable,
   type VisibilityState,
 } from "@tanstack/react-table"
@@ -21,13 +38,13 @@ import {
   ChevronsLeft,
   ChevronsRight,
   Columns3,
+  GripVertical,
   Search,
   X,
 } from "lucide-react"
 import {
   Fragment,
   type ReactNode,
-  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -35,15 +52,13 @@ import {
 } from "react"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
 import {
   Select,
   SelectContent,
@@ -51,6 +66,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import {
   Table,
   TableBody,
@@ -65,6 +81,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { useIsMobile } from "@/hooks/useMobile"
+import {
+  applyUserColumnOrder,
+  columnDefId,
+  type TableColumnPrefs,
+  useTableColumnPrefs,
+} from "@/hooks/useTableColumnPrefs"
+import { cn } from "@/lib/utils"
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -118,6 +141,12 @@ interface DataTableProps<TData, TValue> {
   hiddenOnMobile?: string[]
   tableId?: string
   /**
+   * Externally-owned column visibility and order state. Lets a page share
+   * the preferences across several DataTable instances or feed them into
+   * saved views. Defaults to internal tableId-persisted state.
+   */
+  columnPrefs?: TableColumnPrefs
+  /**
    * Suppress the built-in toolbar (search, filter bar, column toggle) while
    * keeping the tableId-based column visibility preferences. Useful when
    * several tables share one external toolbar, as in grouped views.
@@ -131,19 +160,6 @@ interface DataTableProps<TData, TValue> {
    * working without needing `stopPropagation` everywhere.
    */
   onRowClick?: (row: TData) => void
-}
-
-function loadColumnVisibility(tableId: string): VisibilityState {
-  try {
-    const raw = localStorage.getItem(`table-columns-${tableId}`)
-    return raw ? JSON.parse(raw) : {}
-  } catch {
-    return {}
-  }
-}
-
-function saveColumnVisibility(tableId: string, state: VisibilityState) {
-  localStorage.setItem(`table-columns-${tableId}`, JSON.stringify(state))
 }
 
 function SortableHeader({
@@ -178,6 +194,175 @@ function SortableHeader({
 
 export { SortableHeader }
 
+/**
+ * Column settings menu: search, toggle visibility with a switch, and drag
+ * the handle to reorder. Hidden columns keep their slot so they come back
+ * where they were left.
+ */
+function ColumnPrefsMenu<TData>({
+  table,
+  prefs,
+}: {
+  table: TanstackTable<TData>
+  prefs: TableColumnPrefs
+}) {
+  const [query, setQuery] = useState("")
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  )
+
+  const orderableColumns = table
+    .getAllLeafColumns()
+    .filter(
+      (col) =>
+        col.columnDef.meta?.toggleable !== false && col.columnDef.meta?.label,
+    )
+  const orderedIds = applyUserColumnOrder(
+    orderableColumns.map((col) => col.id),
+    prefs.order,
+  )
+  const rank = new Map(orderedIds.map((id, index) => [id, index]))
+  const orderedColumns = [...orderableColumns].sort(
+    (a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0),
+  )
+
+  const search = query.trim().toLowerCase()
+  const visibleRows = search
+    ? orderedColumns.filter((col) =>
+        col.columnDef.meta?.label?.toLowerCase().includes(search),
+      )
+    : orderedColumns
+  // Reordering a filtered list is ambiguous; drag only on the full list.
+  const dndEnabled = !search
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    if (!event.over || event.active.id === event.over.id) return
+    const oldIndex = orderedIds.indexOf(String(event.active.id))
+    const newIndex = orderedIds.indexOf(String(event.over.id))
+    if (oldIndex === -1 || newIndex === -1) return
+    prefs.setOrder(arrayMove(orderedIds, oldIndex, newIndex))
+  }
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              aria-label="Columns"
+            >
+              <Columns3 className="h-4 w-4" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>Columns</p>
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent align="end" className="w-64 p-0">
+        <div className="border-b p-2">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Search columns..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="h-8 pl-8 text-sm"
+            />
+          </div>
+        </div>
+        <div className="max-h-[60vh] overflow-y-auto p-1">
+          {visibleRows.length === 0 ? (
+            <p className="px-2 py-3 text-center text-sm text-muted-foreground">
+              No columns found.
+            </p>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={visibleRows.map((col) => col.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {visibleRows.map((col) => (
+                  <ColumnPrefsRow
+                    key={col.id}
+                    column={col}
+                    dndEnabled={dndEnabled}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function ColumnPrefsRow<TData>({
+  column,
+  dndEnabled,
+}: {
+  column: Column<TData, unknown>
+  dndEnabled: boolean
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: column.id, disabled: !dndEnabled })
+  const label = column.columnDef.meta?.label ?? column.id
+  const switchId = `column-toggle-${column.id}`
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Translate.toString(transform), transition }}
+      className={cn(
+        "flex items-center gap-2 rounded-sm px-1.5 py-1 hover:bg-muted",
+        isDragging && "relative z-10 bg-background shadow-md",
+      )}
+    >
+      <button
+        type="button"
+        aria-label={`Drag to reorder ${label}`}
+        disabled={!dndEnabled}
+        className={cn(
+          "flex h-6 w-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground/40 transition-colors",
+          dndEnabled
+            ? "cursor-grab hover:text-muted-foreground active:cursor-grabbing"
+            : "opacity-30",
+        )}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </button>
+      <Label
+        htmlFor={switchId}
+        className="min-w-0 flex-1 cursor-pointer truncate text-sm font-normal"
+        title={label}
+      >
+        {label}
+      </Label>
+      <Switch
+        id={switchId}
+        checked={column.getIsVisible()}
+        onCheckedChange={(value) => column.toggleVisibility(!!value)}
+      />
+    </div>
+  )
+}
+
 export function DataTable<TData, TValue>({
   columns,
   data,
@@ -192,6 +377,7 @@ export function DataTable<TData, TValue>({
   bulkActions,
   hiddenOnMobile,
   tableId,
+  columnPrefs,
   hideToolbar,
   renderSubComponent,
   onRowClick,
@@ -227,29 +413,16 @@ export function DataTable<TData, TValue>({
     }, 300)
   }
 
-  // User column visibility preferences (persisted in localStorage)
-  const [userVisibility, setUserVisibility] = useState<VisibilityState>(() =>
-    tableId ? loadColumnVisibility(tableId) : {},
-  )
-
-  const handleColumnVisibilityChange = useCallback(
-    (
-      updater: VisibilityState | ((prev: VisibilityState) => VisibilityState),
-    ) => {
-      setUserVisibility((prev) => {
-        const next = typeof updater === "function" ? updater(prev) : updater
-        if (tableId) saveColumnVisibility(tableId, next)
-        return next
-      })
-    },
-    [tableId],
-  )
+  // User column preferences (persisted in localStorage), unless the caller
+  // owns them via the columnPrefs prop.
+  const internalPrefs = useTableColumnPrefs(tableId)
+  const prefs = columnPrefs ?? internalPrefs
 
   // Merge: defaultHidden from meta → user preferences → mobile overrides (highest priority)
   const columnVisibility = useMemo<VisibilityState>(() => {
     const defaultHidden: VisibilityState = {}
     for (const col of columns) {
-      const id = "accessorKey" in col ? String(col.accessorKey) : col.id
+      const id = columnDefId(col)
       if (id && col.meta?.defaultHidden) {
         defaultHidden[id] = false
       }
@@ -262,8 +435,8 @@ export function DataTable<TData, TValue>({
       }
     }
 
-    return { ...defaultHidden, ...userVisibility, ...mobileOverrides }
-  }, [columns, isMobile, hiddenOnMobile, userVisibility])
+    return { ...defaultHidden, ...prefs.visibility, ...mobileOverrides }
+  }, [columns, isMobile, hiddenOnMobile, prefs.visibility])
 
   const allColumns = useMemo(() => {
     if (!selectable) return columns
@@ -291,6 +464,25 @@ export function DataTable<TData, TValue>({
     return [selectColumn, ...columns]
   }, [columns, selectable])
 
+  // Full column order for the table: fixed columns (select, sticky identity,
+  // actions) keep their slots, the user-orderable ones follow the saved order.
+  const columnOrder = useMemo(() => {
+    const entries = allColumns.map((col) => ({
+      id: columnDefId(col),
+      orderable: col.meta?.toggleable !== false && !!col.meta?.label,
+    }))
+    const orderableIds = entries
+      .filter((entry) => entry.orderable && entry.id)
+      .map((entry) => entry.id as string)
+    const sorted = applyUserColumnOrder(orderableIds, prefs.order)
+    let cursor = 0
+    return entries
+      .map((entry) =>
+        entry.orderable && entry.id ? sorted[cursor++] : entry.id,
+      )
+      .filter((id): id is string => !!id)
+  }, [allColumns, prefs.order])
+
   const isServerPaginated = !!serverPagination
 
   const table = useReactTable({
@@ -308,13 +500,14 @@ export function DataTable<TData, TValue>({
       getRowCanExpand: () => true,
     }),
     onSortingChange: handleSortingChange,
-    ...(tableId && { onColumnVisibilityChange: handleColumnVisibilityChange }),
+    onColumnVisibilityChange: prefs.setVisibility,
     ...(selectable && {
       onRowSelectionChange: setRowSelection,
     }),
     state: {
       sorting,
       columnVisibility,
+      columnOrder,
       ...(renderSubComponent && { expanded }),
       ...(selectable && { rowSelection }),
       ...(isServerPaginated && {
@@ -390,55 +583,7 @@ export function DataTable<TData, TValue>({
               </div>
             )}
           </div>
-          {tableId && (
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="h-9 w-9 shrink-0"
-                      aria-label="Toggle columns"
-                    >
-                      <Columns3 className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p>Toggle columns</p>
-                </TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent
-                align="end"
-                className="max-h-[70vh] w-56 overflow-y-auto"
-              >
-                <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                {table
-                  .getAllColumns()
-                  .filter(
-                    (col) =>
-                      col.columnDef.meta?.toggleable !== false &&
-                      col.columnDef.meta?.label,
-                  )
-                  .map((col) => (
-                    <DropdownMenuCheckboxItem
-                      key={col.id}
-                      checked={col.getIsVisible()}
-                      onCheckedChange={(value) => col.toggleVisibility(!!value)}
-                    >
-                      <span
-                        className="truncate"
-                        title={col.columnDef.meta?.label}
-                      >
-                        {col.columnDef.meta?.label}
-                      </span>
-                    </DropdownMenuCheckboxItem>
-                  ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+          {tableId && <ColumnPrefsMenu table={table} prefs={prefs} />}
         </div>
       )}
 

--- a/backoffice/src/components/Common/SavedViewsMenu.tsx
+++ b/backoffice/src/components/Common/SavedViewsMenu.tsx
@@ -188,8 +188,8 @@ export function SavedViewsMenu({
             <DialogHeader>
               <DialogTitle>Save current view</DialogTitle>
               <DialogDescription>
-                Saves the current filters, grouping and sorting so the whole
-                team can reuse them.
+                Saves the current list setup, including filters, columns,
+                grouping and sorting, so the whole team can reuse it.
               </DialogDescription>
             </DialogHeader>
             <div className="flex flex-col gap-2">

--- a/backoffice/src/components/applications/ApplicationsGroupedView.tsx
+++ b/backoffice/src/components/applications/ApplicationsGroupedView.tsx
@@ -17,6 +17,7 @@ import {
 import { DataTable } from "@/components/Common/DataTable"
 import { StatusBadge } from "@/components/Common/StatusBadge"
 import { Skeleton } from "@/components/ui/skeleton"
+import type { TableColumnPrefs } from "@/hooks/useTableColumnPrefs"
 import { cn } from "@/lib/utils"
 
 const EMPTY_GROUP_KEY = "__empty__"
@@ -94,6 +95,7 @@ interface ApplicationsGroupedViewProps {
   valueOrder?: string[]
   subValueOrder?: string[]
   hiddenOnMobile?: string[]
+  columnPrefs?: TableColumnPrefs
 }
 
 export function ApplicationsGroupedView({
@@ -107,6 +109,7 @@ export function ApplicationsGroupedView({
   valueOrder,
   subValueOrder,
   hiddenOnMobile,
+  columnPrefs,
 }: ApplicationsGroupedViewProps) {
   const completeConditions = useMemo(
     () => filterConditions.filter(isCompleteCondition),
@@ -200,6 +203,7 @@ export function ApplicationsGroupedView({
                     search={search}
                     subValueOrder={subValueOrder}
                     hiddenOnMobile={hiddenOnMobile}
+                    columnPrefs={columnPrefs}
                   />
                 ) : (
                   /* Remount on filter/search edits so the page index cannot
@@ -214,6 +218,7 @@ export function ApplicationsGroupedView({
                     completeConditions={completeConditions}
                     search={search}
                     hiddenOnMobile={hiddenOnMobile}
+                    columnPrefs={columnPrefs}
                   />
                 )}
               </div>
@@ -239,6 +244,7 @@ function SubGroupsList({
   search,
   subValueOrder,
   hiddenOnMobile,
+  columnPrefs,
 }: {
   popupId: string
   groupBy: string
@@ -251,6 +257,7 @@ function SubGroupsList({
   search: string
   subValueOrder?: string[]
   hiddenOnMobile?: string[]
+  columnPrefs?: TableColumnPrefs
 }) {
   const {
     data: counts,
@@ -326,6 +333,7 @@ function SubGroupsList({
                   completeConditions={completeConditions}
                   search={search}
                   hiddenOnMobile={hiddenOnMobile}
+                  columnPrefs={columnPrefs}
                 />
               </div>
             )}
@@ -347,6 +355,7 @@ function GroupRowsTable({
   completeConditions,
   search,
   hiddenOnMobile,
+  columnPrefs,
 }: {
   popupId: string
   groupBy: string
@@ -358,6 +367,7 @@ function GroupRowsTable({
   completeConditions: FilterCondition[]
   search: string
   hiddenOnMobile?: string[]
+  columnPrefs?: TableColumnPrefs
 }) {
   const navigate = useNavigate()
   const [pagination, setPagination] = useState({
@@ -412,6 +422,7 @@ function GroupRowsTable({
       columns={columns}
       data={applications.results}
       tableId="applications"
+      columnPrefs={columnPrefs}
       hideToolbar
       hiddenOnMobile={hiddenOnMobile}
       onRowClick={(application) =>

--- a/backoffice/src/hooks/useTableColumnPrefs.ts
+++ b/backoffice/src/hooks/useTableColumnPrefs.ts
@@ -1,0 +1,119 @@
+import type { ColumnDef, VisibilityState } from "@tanstack/react-table"
+import { useCallback, useMemo, useState } from "react"
+
+/**
+ * Resolve the id TanStack Table assigns to a column definition: an explicit
+ * id wins, otherwise the accessorKey with dots replaced by underscores.
+ */
+export function columnDefId<TData, TValue>(
+  col: ColumnDef<TData, TValue>,
+): string | undefined {
+  if (col.id) return col.id
+  if ("accessorKey" in col && col.accessorKey != null) {
+    return String(col.accessorKey).replace(/\./g, "_")
+  }
+  return undefined
+}
+
+/** Ids of the columns users can toggle and reorder, in definition order. */
+export function orderableColumnIds<TData, TValue>(
+  columns: ColumnDef<TData, TValue>[],
+): string[] {
+  return columns
+    .filter((col) => col.meta?.toggleable !== false && col.meta?.label)
+    .map(columnDefId)
+    .filter((id): id is string => !!id)
+}
+
+/**
+ * Reorder ids per the user preference: known ids follow the saved order,
+ * anything the preference does not mention (e.g. new custom fields) keeps
+ * its natural relative order at the end.
+ */
+export function applyUserColumnOrder(
+  ids: string[],
+  userOrder: string[],
+): string[] {
+  if (!userOrder.length) return ids
+  const present = new Set(ids)
+  const ordered = userOrder.filter((id) => present.has(id))
+  const orderedSet = new Set(ordered)
+  return [...ordered, ...ids.filter((id) => !orderedSet.has(id))]
+}
+
+export interface TableColumnPrefs {
+  visibility: VisibilityState
+  order: string[]
+  setVisibility: (
+    updater: VisibilityState | ((prev: VisibilityState) => VisibilityState),
+  ) => void
+  setOrder: (order: string[]) => void
+  /** True once the user diverged from the default columns in any way. */
+  isCustomized: boolean
+}
+
+function load<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? JSON.parse(raw) : fallback
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Column visibility and order preferences for a table, persisted per tableId
+ * in localStorage. Without a tableId the state is kept in memory only.
+ */
+export function useTableColumnPrefs(tableId?: string): TableColumnPrefs {
+  const [visibility, setVisibilityState] = useState<VisibilityState>(() =>
+    tableId ? load(`table-columns-${tableId}`, {}) : {},
+  )
+  const [order, setOrderState] = useState<string[]>(() => {
+    const stored = tableId
+      ? load<unknown>(`table-column-order-${tableId}`, [])
+      : []
+    return Array.isArray(stored)
+      ? stored.filter((id): id is string => typeof id === "string")
+      : []
+  })
+
+  const setVisibility = useCallback(
+    (
+      updater: VisibilityState | ((prev: VisibilityState) => VisibilityState),
+    ) => {
+      setVisibilityState((prev) => {
+        const next = typeof updater === "function" ? updater(prev) : updater
+        if (tableId) {
+          localStorage.setItem(`table-columns-${tableId}`, JSON.stringify(next))
+        }
+        return next
+      })
+    },
+    [tableId],
+  )
+
+  const setOrder = useCallback(
+    (next: string[]) => {
+      setOrderState(next)
+      if (tableId) {
+        localStorage.setItem(
+          `table-column-order-${tableId}`,
+          JSON.stringify(next),
+        )
+      }
+    },
+    [tableId],
+  )
+
+  return useMemo(
+    () => ({
+      visibility,
+      order,
+      setVisibility,
+      setOrder,
+      isCustomized: order.length > 0 || Object.keys(visibility).length > 0,
+    }),
+    [visibility, order, setVisibility, setOrder],
+  )
+}

--- a/backoffice/src/routes/_layout/applications/index.tsx
+++ b/backoffice/src/routes/_layout/applications/index.tsx
@@ -5,7 +5,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
-import type { ColumnDef } from "@tanstack/react-table"
+import type { ColumnDef, VisibilityState } from "@tanstack/react-table"
 import {
   ClipboardList,
   Download,
@@ -107,6 +107,12 @@ import {
 import { useWorkspace } from "@/contexts/WorkspaceContext"
 import useAuth from "@/hooks/useAuth"
 import useCustomToast from "@/hooks/useCustomToast"
+import {
+  applyUserColumnOrder,
+  columnDefId,
+  orderableColumnIds,
+  useTableColumnPrefs,
+} from "@/hooks/useTableColumnPrefs"
 import {
   type TableSearchParams,
   useTableSearchParams,
@@ -1213,80 +1219,9 @@ function ApplicationsTableContent({
     [navigate],
   )
 
-  // The saved-view config only captures explicit choices; defaults stay out
-  // so applying a view produces a minimal URL.
-  const savedViewConfig = useMemo(() => {
-    const config: Record<string, unknown> = {}
-    if (searchParams.match === "any" && filterConditions.length) {
-      config.match = "any"
-    }
-    if (filterConditions.length) config.filters = filterConditions
-    if (searchParams.groupBy) config.groupBy = searchParams.groupBy
-    if (searchParams.groupBy && searchParams.subGroupBy) {
-      config.subGroupBy = searchParams.subGroupBy
-    }
-    if (searchParams.sortBy) {
-      config.sortBy = searchParams.sortBy
-      config.sortOrder = searchParams.sortOrder
-    }
-    return config
-  }, [
-    searchParams.match,
-    searchParams.groupBy,
-    searchParams.subGroupBy,
-    searchParams.sortBy,
-    searchParams.sortOrder,
-    filterConditions,
-  ])
-
-  // Saved-view configs are team-authored server data: revalidate every field
-  // with the same rules validateSearch applies before touching the URL.
-  const applySavedView = useCallback(
-    (config: Record<string, unknown>) => {
-      const filters = sanitizeFilterConditions(config.filters)
-      const groupByValue =
-        typeof config.groupBy === "string" &&
-        (VALID_GROUP_BY_FIELDS.has(config.groupBy) ||
-          config.groupBy.startsWith("custom."))
-          ? config.groupBy
-          : undefined
-      const subGroupByValue =
-        groupByValue &&
-        typeof config.subGroupBy === "string" &&
-        config.subGroupBy !== groupByValue &&
-        (VALID_GROUP_BY_FIELDS.has(config.subGroupBy) ||
-          config.subGroupBy.startsWith("custom."))
-          ? config.subGroupBy
-          : undefined
-      const sortOrder: "asc" | "desc" | undefined =
-        config.sortOrder === "asc" || config.sortOrder === "desc"
-          ? config.sortOrder
-          : undefined
-      navigate({
-        to: "/applications",
-        search: (prev: Record<string, unknown>) => ({
-          ...prev,
-          status: undefined,
-          reviewerId: undefined,
-          page: 0,
-          match:
-            config.match === "any" && filters.length
-              ? ("any" as const)
-              : undefined,
-          filters: filters.length ? filters : undefined,
-          groupBy: groupByValue,
-          subGroupBy: subGroupByValue,
-          sortBy:
-            typeof config.sortBy === "string" && config.sortBy
-              ? config.sortBy
-              : undefined,
-          sortOrder,
-        }),
-        replace: true,
-      })
-    },
-    [navigate],
-  )
+  // Column visibility and order live here (not inside DataTable) so saved
+  // views can capture and restore them, shared with the grouped view tables.
+  const columnPrefs = useTableColumnPrefs("applications")
 
   // Grouping needs a selected popup; the counts endpoint is popup-scoped.
   const groupBy =
@@ -1494,12 +1429,129 @@ function ApplicationsTableContent({
   })
 
   const isWeightedVoting = approvalStrategy?.strategy_type === "weighted"
-  const columns = getColumns(
-    isWeightedVoting,
-    !!reviewerFilter && reviewerFilter !== "custom",
-    customColumns,
+  const showReviewerDecision = !!reviewerFilter && reviewerFilter !== "custom"
+  const columns = useMemo(
+    () => getColumns(isWeightedVoting, showReviewerDecision, customColumns),
+    [isWeightedVoting, showReviewerDecision, customColumns],
   )
   const canBulkReview = isOperatorOrAbove && !isWeightedVoting
+
+  // Every toggleable column id, independent of which conditional columns are
+  // currently rendered, so applying a view can also hide the missing ones.
+  const allToggleableIds = useMemo(
+    () => orderableColumnIds(getColumns(true, true, customColumns)),
+    [customColumns],
+  )
+
+  // Ids of the columns currently on screen, in their visual order.
+  const visibleColumnIds = useMemo(() => {
+    const orderable = columns.filter(
+      (col) => col.meta?.toggleable !== false && col.meta?.label,
+    )
+    const byId = new Map(orderable.map((col) => [columnDefId(col), col]))
+    return applyUserColumnOrder(
+      orderableColumnIds(columns),
+      columnPrefs.order,
+    ).filter((id) => {
+      const pref = columnPrefs.visibility[id]
+      if (pref !== undefined) return pref
+      return !byId.get(id)?.meta?.defaultHidden
+    })
+  }, [columns, columnPrefs.order, columnPrefs.visibility])
+
+  // The saved-view config only captures explicit choices; defaults stay out
+  // so applying a view produces a minimal URL. Columns are captured only
+  // once the user diverged from the default set or order.
+  const savedViewConfig = useMemo(() => {
+    const config: Record<string, unknown> = {}
+    if (searchParams.match === "any" && filterConditions.length) {
+      config.match = "any"
+    }
+    if (filterConditions.length) config.filters = filterConditions
+    if (searchParams.groupBy) config.groupBy = searchParams.groupBy
+    if (searchParams.groupBy && searchParams.subGroupBy) {
+      config.subGroupBy = searchParams.subGroupBy
+    }
+    if (searchParams.sortBy) {
+      config.sortBy = searchParams.sortBy
+      config.sortOrder = searchParams.sortOrder
+    }
+    if (columnPrefs.isCustomized) config.columns = visibleColumnIds
+    return config
+  }, [
+    searchParams.match,
+    searchParams.groupBy,
+    searchParams.subGroupBy,
+    searchParams.sortBy,
+    searchParams.sortOrder,
+    filterConditions,
+    columnPrefs.isCustomized,
+    visibleColumnIds,
+  ])
+
+  // Saved-view configs are team-authored server data: revalidate every field
+  // with the same rules validateSearch applies before touching the URL.
+  const applySavedView = useCallback(
+    (config: Record<string, unknown>) => {
+      const filters = sanitizeFilterConditions(config.filters)
+      const groupByValue =
+        typeof config.groupBy === "string" &&
+        (VALID_GROUP_BY_FIELDS.has(config.groupBy) ||
+          config.groupBy.startsWith("custom."))
+          ? config.groupBy
+          : undefined
+      const subGroupByValue =
+        groupByValue &&
+        typeof config.subGroupBy === "string" &&
+        config.subGroupBy !== groupByValue &&
+        (VALID_GROUP_BY_FIELDS.has(config.subGroupBy) ||
+          config.subGroupBy.startsWith("custom."))
+          ? config.subGroupBy
+          : undefined
+      const sortOrder: "asc" | "desc" | undefined =
+        config.sortOrder === "asc" || config.sortOrder === "desc"
+          ? config.sortOrder
+          : undefined
+      // Views saved without columns leave the current columns untouched.
+      if (Array.isArray(config.columns)) {
+        const savedColumns = config.columns.filter(
+          (id): id is string =>
+            typeof id === "string" && allToggleableIds.includes(id),
+        )
+        if (savedColumns.length) {
+          columnPrefs.setOrder(savedColumns)
+          const visibility: VisibilityState = {}
+          for (const id of allToggleableIds) {
+            visibility[id] = savedColumns.includes(id)
+          }
+          columnPrefs.setVisibility(visibility)
+        }
+      }
+      navigate({
+        to: "/applications",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          status: undefined,
+          reviewerId: undefined,
+          page: 0,
+          match:
+            config.match === "any" && filters.length
+              ? ("any" as const)
+              : undefined,
+          filters: filters.length ? filters : undefined,
+          groupBy: groupByValue,
+          subGroupBy: subGroupByValue,
+          sortBy:
+            typeof config.sortBy === "string" && config.sortBy
+              ? config.sortBy
+              : undefined,
+          sortOrder,
+        }),
+        replace: true,
+      })
+    },
+    [navigate, allToggleableIds, columnPrefs],
+  )
 
   const hiddenOnMobile = [
     "attendees",
@@ -1583,6 +1635,7 @@ function ApplicationsTableContent({
           valueOrder={groupValueOrder}
           subValueOrder={subGroupValueOrder}
           hiddenOnMobile={hiddenOnMobile}
+          columnPrefs={columnPrefs}
         />
       </div>
     )
@@ -1595,6 +1648,7 @@ function ApplicationsTableContent({
       columns={columns}
       data={applications.results}
       tableId="applications"
+      columnPrefs={columnPrefs}
       searchPlaceholder="Search by name or email..."
       hiddenOnMobile={hiddenOnMobile}
       searchValue={search}


### PR DESCRIPTION
## Summary

- Replaces the toggle-columns dropdown in `DataTable` with a reorderable column menu: each column row has a drag handle, a visibility switch and there is a search box on top. Order and visibility persist per table in localStorage via a new shared `useTableColumnPrefs` hook. All backoffice tables inherit the new menu.
- Saved views for applications now capture the visible columns in their current order (`config.columns`) and restore both when a view is applied, so column layouts can be shared across the team. Views saved before this change have no `columns` key and leave the current columns untouched.
- The applications page lifts the column preferences so the grouped view tables share the same state, and applying a saved view updates them live.
- Fixes a latent bug in the default-hidden merge: it used the raw `accessorKey` (`human.email`) while TanStack derives column ids with dots replaced by underscores (`human_email`).

Columns are only captured into a view once the user diverges from the default set or order. Fixed columns (select, sticky Name, actions) keep their slots and cannot be reordered. No backend changes: `saved_view.config` is a free-form dict.

## Test plan

- [x] `pnpm --filter backoffice run build`
- [x] `pnpm run lint` (Biome)
- [ ] Manual: drag columns in the menu, toggle visibility, save a view, change columns, re-apply the view (flat and grouped views)