### PR TITLE
fix(tenants): make deleted organizations fully unavailable

### DIFF
--- a/backend/app/api/tenant/router.py
+++ b/backend/app/api/tenant/router.py
@@ -164,20 +164,18 @@ async def list_tenants(
     db: SessionDep,
     _: CurrentSuperadmin,
     search: str | None = None,
-    include_deleted: bool = False,
     skip: PaginationSkip = 0,
     limit: PaginationLimit = 100,
 ) -> ListModel[TenantPublic]:
-    # Deleted organizations are hidden by default: they have no database
-    # credentials left, so offering them as a selectable context only leads to
-    # failing requests. Admin listings opt in to see them.
+    # Deleted organizations are never listed: their database credentials are
+    # revoked on delete, so nothing can be done with them anymore.
     tenants, total = crud.find(
         db,
         skip=skip,
         limit=limit,
         search=search,
         search_fields=["name"],
-        deleted=None if include_deleted else False,
+        deleted=False,
     )
 
     return ListModel[TenantPublic](
@@ -209,6 +207,12 @@ async def get_tenant(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tenant not found",
+        )
+
+    if tenant.deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This organization is no longer available",
         )
 
     return TenantPublic.model_validate(tenant)
@@ -271,6 +275,12 @@ async def update_tenant(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tenant not found",
+        )
+
+    if tenant.deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This organization is no longer available",
         )
 
     # 3. ADMIN cannot set custom_domain_active (only SUPERADMIN may)
@@ -492,7 +502,7 @@ async def delete_tenant(
 ) -> None:
     tenant = crud.get(db, tenant_id)
 
-    if tenant is None:
+    if tenant is None or tenant.deleted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tenant not found",

--- a/backend/tests/api/tenant/test_deleted_tenant_availability.py
+++ b/backend/tests/api/tenant/test_deleted_tenant_availability.py
@@ -1,8 +1,8 @@
 """Regression tests: a deleted organization must not stay available.
 
 Two surfaces are covered:
-- GET /tenants hides deleted organizations unless include_deleted is requested,
-  so they never show up as a selectable context.
+- GET /tenants never returns deleted organizations, so they never show up as a
+  selectable context or in the admin listing.
 - Tenant-scoped requests carrying a deleted X-Tenant-Id fail with an explicit
   "no longer available" 404 instead of the misleading credentials error raised
   once soft-delete revoked the tenant's database credentials.
@@ -36,7 +36,7 @@ def deleted_tenant(db: Session) -> Generator[Tenants, None, None]:
     db.commit()
 
 
-def test_list_tenants_hides_deleted_by_default(
+def test_list_tenants_never_returns_deleted(
     client: TestClient,
     superadmin_token: str,
     deleted_tenant: Tenants,
@@ -52,20 +52,46 @@ def test_list_tenants_hides_deleted_by_default(
     assert str(deleted_tenant.id) not in ids
 
 
-def test_list_tenants_includes_deleted_when_requested(
+def test_get_deleted_tenant_returns_404(
     client: TestClient,
     superadmin_token: str,
     deleted_tenant: Tenants,
 ) -> None:
     response = client.get(
-        "/api/v1/tenants",
+        f"/api/v1/tenants/{deleted_tenant.id}",
         headers={"Authorization": f"Bearer {superadmin_token}"},
-        params={"limit": 100, "include_deleted": True},
     )
 
-    assert response.status_code == 200
-    ids = [t["id"] for t in response.json()["results"]]
-    assert str(deleted_tenant.id) in ids
+    assert response.status_code == 404
+    assert response.json()["detail"] == "This organization is no longer available"
+
+
+def test_patch_deleted_tenant_returns_404(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.patch(
+        f"/api/v1/tenants/{deleted_tenant.id}",
+        headers={"Authorization": f"Bearer {superadmin_token}"},
+        json={"name": "Should Not Update"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "This organization is no longer available"
+
+
+def test_delete_already_deleted_tenant_returns_404(
+    client: TestClient,
+    superadmin_token: str,
+    deleted_tenant: Tenants,
+) -> None:
+    response = client.delete(
+        f"/api/v1/tenants/{deleted_tenant.id}",
+        headers={"Authorization": f"Bearer {superadmin_token}"},
+    )
+
+    assert response.status_code == 404
 
 
 def test_tenant_scoped_request_rejects_deleted_tenant(

--- a/backoffice/src/client/sdk.gen.ts
+++ b/backoffice/src/client/sdk.gen.ts
@@ -7975,7 +7975,6 @@ export class TenantsService {
      * List Tenants
      * @param data The data for the request.
      * @param data.search
-     * @param data.includeDeleted
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_TenantPublic_ Successful Response
@@ -7987,7 +7986,6 @@ export class TenantsService {
             url: '/api/v1/tenants',
             query: {
                 search: data.search,
-                include_deleted: data.includeDeleted,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/backoffice/src/client/types.gen.ts
+++ b/backoffice/src/client/types.gen.ts
@@ -6838,7 +6838,6 @@ export type TenantsGetTenantBySlugData = {
 export type TenantsGetTenantBySlugResponse = (TenantAnonymousPublic);
 
 export type TenantsListTenantsData = {
-    includeDeleted?: boolean;
     /**
      * Maximum number of items to return
      */

--- a/backoffice/src/routes/_layout/organizations/index.tsx
+++ b/backoffice/src/routes/_layout/organizations/index.tsx
@@ -8,7 +8,6 @@ import { type TenantPublic, TenantsService } from "@/client"
 import { DataTable, SortableHeader } from "@/components/Common/DataTable"
 import { EmptyState } from "@/components/Common/EmptyState"
 import { QueryErrorBoundary } from "@/components/Common/QueryErrorBoundary"
-import { StatusBadge } from "@/components/Common/StatusBadge"
 import { Button } from "@/components/ui/button"
 
 import { Skeleton } from "@/components/ui/skeleton"
@@ -28,9 +27,6 @@ function getTenantsQueryOptions(
         skip: page * pageSize,
         limit: pageSize,
         search: search || undefined,
-        // Admin listing keeps deleted organizations visible for auditing;
-        // every other surface only offers selectable ones.
-        includeDeleted: true,
       }),
     queryKey: ["tenants", { page, pageSize, search }],
   }
@@ -70,13 +66,6 @@ const columns: ColumnDef<TenantPublic>[] = [
       </span>
     ),
   },
-  {
-    accessorKey: "deleted",
-    header: "Status",
-    cell: ({ row }) => (
-      <StatusBadge status={row.original.deleted ? "deleted" : "active"} />
-    ),
-  },
 ]
 
 function TenantsTableContent() {
@@ -103,7 +92,7 @@ function TenantsTableContent() {
       columns={columns}
       data={tenants.results}
       searchPlaceholder="Search by name..."
-      hiddenOnMobile={["sender_email", "deleted"]}
+      hiddenOnMobile={["sender_email"]}
       searchValue={search}
       onSearchChange={setSearch}
       onRowClick={(tenant) =>

--- a/portal/src/client/sdk.gen.ts
+++ b/portal/src/client/sdk.gen.ts
@@ -7975,7 +7975,6 @@ export class TenantsService {
      * List Tenants
      * @param data The data for the request.
      * @param data.search
-     * @param data.includeDeleted
      * @param data.skip Number of items to skip
      * @param data.limit Maximum number of items to return
      * @returns ListModel_TenantPublic_ Successful Response
@@ -7987,7 +7986,6 @@ export class TenantsService {
             url: '/api/v1/tenants',
             query: {
                 search: data.search,
-                include_deleted: data.includeDeleted,
                 skip: data.skip,
                 limit: data.limit
             },

--- a/portal/src/client/types.gen.ts
+++ b/portal/src/client/types.gen.ts
@@ -6838,7 +6838,6 @@ export type TenantsGetTenantBySlugData = {
 export type TenantsGetTenantBySlugResponse = (TenantAnonymousPublic);
 
 export type TenantsListTenantsData = {
-    includeDeleted?: boolean;
     /**
      * Maximum number of items to return
      */


### PR DESCRIPTION
## Summary

Follow-up to #531. Deleted organizations were still visible in the Organizations admin table (behind an `include_deleted` opt-in kept for an "audit view") and could still be fetched and edited through `GET`/`PATCH /tenants/{id}`.

Since no restore action exists for a deleted organization (its database credentials are revoked on delete), showing or editing one serves no purpose. This PR makes deleted organizations fully unavailable everywhere.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Changes Made

- `list_tenants` always filters out deleted organizations; the `include_deleted` query param introduced in #531 is removed.
- `GET`, `PATCH` and `DELETE` on a deleted organization return `404 This organization is no longer available` (plain 404 for the double-delete case).
- The Organizations table drops the Status column, which could only ever show "active" now, and no longer opts in to deleted rows.
- Regenerated the OpenAPI clients for both frontends.

| File | Change |
|------|--------|
| `backend/app/api/tenant/router.py` | Always-on deleted filter in list; deleted guards on get, patch and delete |
| `backend/tests/api/tenant/test_deleted_tenant_availability.py` | Regression tests for list, get, patch and double delete |
| `backoffice/src/routes/_layout/organizations/index.tsx` | Removed `includeDeleted` opt-in and the Status column |
| `backoffice/src/client/`, `portal/src/client/` | Regenerated OpenAPI clients |

## Testing

- [x] Backend tests pass (`uv run pytest tests/api/tenant tests/core/dependencies/test_tenants.py` — 85 passed)
- [x] Backend linting passes (`bash scripts/lint.sh`)
- [x] Backoffice builds successfully (`pnpm run build`)
- [x] Backoffice linting passes (`pnpm run lint`)
- [ ] Manual testing performed

## Checklist

- [x] My code follows the project's coding standards
- [x] I have updated documentation if needed
- [x] I have added tests for new functionality
- [x] All new and existing tests pass
- [x] I have regenerated the OpenAPI client if backend API changed
- [x] Database migrations are included if schema changed (none needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
